### PR TITLE
Fix policy output for list and get and update openapi.json. Closes #30. Closes #31.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,8 @@ OC_DATA_DIR	= ${HOME}/.oc/openshift.local.data
 
 PGSQL_VERSION   = 9.6
 
+PORT=8000
+
 OS := $(shell uname)
 ifeq ($(OS),Darwin)
 	PREFIX	=
@@ -118,7 +120,7 @@ requirements:
 	pipenv lock -r > docs/rtd_requirements.txt
 
 serve:
-	DJANGO_READ_DOT_ENV_FILE=True $(PYTHON) $(PYDIR)/manage.py runserver
+	DJANGO_READ_DOT_ENV_FILE=True $(PYTHON) $(PYDIR)/manage.py runserver $(PORT)
 
 serve-with-oc: oc-forward-ports
 	sleep 3

--- a/docs/source/specs/openapi.json
+++ b/docs/source/specs/openapi.json
@@ -948,6 +948,17 @@
             "format": "uuid"
           }
         }],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PolicyIn"
+              }
+            }
+          },
+          "description": "Policy to update",
+          "required": true
+        },
         "responses": {
           "200": {
             "description": "A Policy object",
@@ -1599,7 +1610,7 @@
               "data": {
                 "type": "array",
                 "items": {
-                  "$ref": "#/components/schemas/PolicyOut"
+                  "$ref": "#/components/schemas/PolicyExtended"
                 }
               }
             }

--- a/docs/source/specs/openapi.json
+++ b/docs/source/specs/openapi.json
@@ -1397,7 +1397,8 @@
           "operation": {
             "type": "string",
             "enum": [
-              "equal"
+              "equal",
+              "includes"
             ]
           },
           "value": {

--- a/rbac/management/policy/serializer.py
+++ b/rbac/management/policy/serializer.py
@@ -17,10 +17,10 @@
 
 """Serializer for policy management."""
 from management.group.model import Group
-from management.group.serializer import GroupSerializer
+from management.group.serializer import GroupInputSerializer
 from management.policy.model import Policy
 from management.role.model import Role
-from management.role.serializer import RoleSerializer
+from management.role.serializer import RoleMinimumSerializer
 from rest_framework import serializers
 
 
@@ -118,10 +118,10 @@ class PolicyInputSerializer(serializers.ModelSerializer):
 
     def to_representation(self, obj):
         """Convert representation to dictionary object."""
-        group = GroupSerializer(obj.group)
+        group = GroupInputSerializer(obj.group)
         roles = []
         for role in obj.roles.all():
-            serializer = RoleSerializer(role)
+            serializer = RoleMinimumSerializer(role)
             roles.append(serializer.data)
         return {
             'uuid': obj.uuid,
@@ -138,8 +138,8 @@ class PolicySerializer(serializers.ModelSerializer):
     uuid = serializers.UUIDField(read_only=True)
     name = serializers.CharField(required=True, max_length=150)
     description = serializers.CharField(allow_null=True, required=False)
-    group = GroupSerializer(required=True)
-    roles = RoleSerializer(many=True, required=True)
+    group = GroupInputSerializer(required=True)
+    roles = RoleMinimumSerializer(many=True, required=True)
 
     class Meta:
         """Metadata for the serializer."""
@@ -149,10 +149,10 @@ class PolicySerializer(serializers.ModelSerializer):
 
     def to_representation(self, obj):
         """Convert representation to dictionary object."""
-        group = GroupSerializer(obj.group)
+        group = GroupInputSerializer(obj.group)
         roles = []
         for role in obj.roles.all():
-            serializer = RoleSerializer(role)
+            serializer = RoleMinimumSerializer(role)
             roles.append(serializer.data)
         return {
             'uuid': obj.uuid,

--- a/rbac/management/role/serializer.py
+++ b/rbac/management/role/serializer.py
@@ -91,3 +91,17 @@ class RoleSerializer(serializers.ModelSerializer):
 
         instance.save()
         return instance
+
+
+class RoleMinimumSerializer(serializers.ModelSerializer):
+    """Serializer for the Role model that doesn't return access info."""
+
+    uuid = serializers.UUIDField(read_only=True)
+    name = serializers.CharField(required=True, max_length=150)
+    description = serializers.CharField(allow_null=True, required=False)
+
+    class Meta:
+        """Metadata for the serializer."""
+
+        model = Role
+        fields = ('uuid', 'name', 'description')


### PR DESCRIPTION
Updated output:
```
{
    "meta": {
        "count": 1
    },
    "links": {
        "first": "/r/insights/platform/rbac/v1/policies/?limit=10&offset=0",
        "next": null,
        "previous": null,
        "last": "/r/insights/platform/rbac/v1/policies/?limit=10&offset=0"
    },
    "data": [
        {
            "uuid": "9e681eb1-7d72-40f8-a6bc-e078c99c6b52",
            "name": "PolicyA",
            "description": "policy a",
            "group": {
                "uuid": "648f5029-573a-442d-a20a-1953e9e7d5fb",
                "name": "GroupA",
                "description": "groupA"
            },
            "roles": [
                {
                    "uuid": "34d9e042-c065-4d96-b946-22171273988e",
                    "name": "RoleA",
                    "description": "role a"
                }
            ]
        }
    ]
}
```

Also added `includes` operation.