### PR TITLE
Converting is_admin header value to bool

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ services:
     - POSTGRES_USER=postgres
     - POSTGRES_PASSWORD=postgres
     ports:
-      - "15423:5432"
+      - "15425:5432"
     volumes:
       - ./pg_data:/var/lib/pgsql/data
 

--- a/rbac/rbac/middleware.py
+++ b/rbac/rbac/middleware.py
@@ -227,7 +227,11 @@ class IdentityHeaderMiddleware(MiddlewareMixin):  # pylint: disable=R0903
             rh_auth_header, json_rh_auth = extract_header(request, self.header)
             username = json_rh_auth.get('identity', {}).get('user', {}).get('username')
             account = json_rh_auth.get('identity', {}).get('account_number')
-            is_admin = json_rh_auth.get('identity', {}).get('user', {}).get('is_org_admin')
+            is_admin_string = json_rh_auth.\
+                get('identity', {}).\
+                get('user', {}).\
+                get('is_org_admin', 'False')
+            is_admin = (is_admin_string.lower() in ('t', 'true'))
         except (KeyError, JSONDecodeError):
             logger.warning('Could not obtain identity on request.')
             return

--- a/tests/api/common/test_pagination.py
+++ b/tests/api/common/test_pagination.py
@@ -28,17 +28,17 @@ class PaginationTest(TestCase):
     def test_link_rewrite(self):
         """Test the link rewrite."""
         request = Mock()
-        request.META = {PATH_INFO: '/v1/providers/'}
-        link = 'http://localhost:8000/v1/providers/?offset=20'
-        expected = '/v1/providers/?offset=20'
+        request.META = {PATH_INFO: '/v1/access/'}
+        link = 'http://localhost:8000/v1/access/?offset=20'
+        expected = '/v1/access/?offset=20'
         result = StandardResultsSetPagination.link_rewrite(request, link)
         self.assertEqual(expected, result)
 
     def test_link_rewrite_err(self):
         """Test the link rewrite."""
         request = Mock()
-        request.META = {PATH_INFO: 'https://localhost:8000/providers/'}
-        link = 'http://localhost:8000/providers/?offset=20'
+        request.META = {PATH_INFO: 'https://localhost:8000/access/'}
+        link = 'http://localhost:8000/access/?offset=20'
         result = StandardResultsSetPagination.link_rewrite(request, link)
         self.assertEqual(link, result)
 
@@ -46,7 +46,7 @@ class PaginationTest(TestCase):
         """Test the no link rewrite."""
         request = Mock()
         request.META = {}
-        link = 'http://localhost:8000/api/v1/providers/?offset=20'
+        link = 'http://localhost:8000/api/v1/access/?offset=20'
         result = StandardResultsSetPagination.link_rewrite(request, link)
         self.assertEqual(link, result)
 
@@ -69,7 +69,7 @@ class PaginationTest(TestCase):
     @patch('api.common.pagination.LimitOffsetPagination.get_next_link')
     def test_get_next_link_value(self, mock_super):
         """Test the get next link method when super returns a value."""
-        expected = 'http://localhost:8000/api/v1/providers/?offset=20'
+        expected = 'http://localhost:8000/api/v1/access/?offset=20'
         mock_super.return_value = expected
         paginator = StandardResultsSetPagination()
         paginator.request = Mock
@@ -80,7 +80,7 @@ class PaginationTest(TestCase):
     @patch('api.common.pagination.LimitOffsetPagination.get_previous_link')
     def test_get_previous_link_value(self, mock_super):
         """Test the get previous link method when super returns a value."""
-        expected = 'http://localhost:8000/api/v1/providers/?offset=20'
+        expected = 'http://localhost:8000/api/v1/access/?offset=20'
         mock_super.return_value = expected
         paginator = StandardResultsSetPagination()
         paginator.request = Mock

--- a/tests/identity_request.py
+++ b/tests/identity_request.py
@@ -93,7 +93,7 @@ class IdentityRequest(TestCase):
 
     @classmethod
     def _create_request_context(cls, customer_data, user_data,
-                                create_customer=True, create_tenant=False):
+                                create_customer=True, create_tenant=False, is_admin=True):
         """Create the request context for a user."""
         customer = customer_data
         account = customer.get('account_id')
@@ -109,7 +109,7 @@ class IdentityRequest(TestCase):
                 'user': {
                     'username': user_data['username'],
                     'email': user_data['email'],
-                    'is_org_admin': True
+                    'is_org_admin': str(is_admin)
                 }
             }
         }


### PR DESCRIPTION
When the Authorization header contains `is_org_admin:False` the middleware was treating this as `True` since the header string was never converted to a boolean.  This means that `IdentityHeaderMiddleware._get_access_for_user` was never called 

I also put in some simple string replacement cleanup to cleanup after repo was created.

**Testing**
1. Configure rbac service and access `v1/access/?application=cost-management` as a principal non-admin user.  Ensure that `is_org_admin` is not provided in authentication header.

```
rbac-server_1  | [2019-04-05 18:37:54,673] INFO: API: /r/insights/platform/rbac/v1/access/?application=cost-management -- ACCOUNT: 1001 USER: docurtis ADMIN: False
rbac-server_1  | [2019-04-05 18:37:54,730] INFO: "GET /r/insights/platform/rbac/v1/access/?application=cost-management HTTP/1.1" 200 8594
```

2. Repeat step 1 with `is_org_admin:False`.
```
rbac-server_1  | [2019-04-05 18:39:25,740] INFO: API: /r/insights/platform/rbac/v1/access/?application=cost-management -- ACCOUNT: 1001 USER: docurtis ADMIN: False
rbac-server_1  | [2019-04-05 18:39:25,794] INFO: "GET /r/insights/platform/rbac/v1/access/?application=cost-management HTTP/1.1" 200 8594
```

3. Repeat step 1 with `is_org_admin:True`
```
rbac-server_1  | [2019-04-05 18:45:01,268] INFO: API: /r/insights/platform/rbac/v1/access/?application=cost-management -- ACCOUNT: 1001 USER: docurtis ADMIN: True
rbac-server_1  | [2019-04-05 18:45:01,317] INFO: "GET /r/insights/platform/rbac/v1/access/?application=cost-management HTTP/1.1" 200 8594
```