### PR TITLE
Add more default role definitions

### DIFF
--- a/rbac/management/role/definitions/compliance.json
+++ b/rbac/management/role/definitions/compliance.json
@@ -1,0 +1,18 @@
+{
+  "roles": [
+    {
+      "name": "Compliance Access",
+      "description": "An all access role which grants read and write permissions.",
+      "system": true,
+      "version": 2,
+      "access": [
+        {
+          "permission": "compliance:*:*"
+        },
+        {
+          "permission": "inventory:*:*"
+        }
+      ]
+    }
+  ]
+}

--- a/rbac/management/role/definitions/drift.json
+++ b/rbac/management/role/definitions/drift.json
@@ -1,0 +1,18 @@
+{
+  "roles": [
+    {
+      "name": "Drift Access",
+      "description": "An all access role which grants read and write permissions.",
+      "system": true,
+      "version": 2,
+      "access": [
+        {
+          "permission": "drift:*:*"
+        },
+        {
+          "permission": "inventory:*:*"
+        }
+      ]
+    }
+  ]
+}

--- a/rbac/management/role/definitions/insights.json
+++ b/rbac/management/role/definitions/insights.json
@@ -1,0 +1,18 @@
+{
+  "roles": [
+    {
+      "name": "Insights Access",
+      "description": "An all access role which grants read and write permissions.",
+      "system": true,
+      "version": 2,
+      "access": [
+        {
+          "permission": "insights:*:*"
+        },
+        {
+          "permission": "inventory:*:*"
+        }
+      ]
+    }
+  ]
+}

--- a/rbac/management/role/definitions/vulnerability.json
+++ b/rbac/management/role/definitions/vulnerability.json
@@ -1,0 +1,18 @@
+{
+  "roles": [
+    {
+      "name": "Vulnerability Access",
+      "description": "An all access role which grants read and write permissions.",
+      "system": true,
+      "version": 2,
+      "access": [
+        {
+          "permission": "vulnerability:*:*"
+        },
+        {
+          "permission": "inventory:*:*"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
**Note:** _We are in the process of exploring migrating all default definitions to another
repository. In the meantime, this should continue to be the source of truth._

This PR adds default role definitions for the following applications:

- Compliance
- Insights
- Drift
- Vulnerability

Each of these applications needs a base, global read/write permission for
itself, as well as inventory, which is a dependent service which will be
receiving permissions from the upstream service. These permissions are set on
a base role for each application.