### PR TITLE
Refactor AutoDateTimeField out of management.utils

### DIFF
--- a/rbac/management/group/model.py
+++ b/rbac/management/group/model.py
@@ -21,7 +21,7 @@ from uuid import uuid4
 from django.db import models
 from django.utils import timezone
 from management.principal.model import Principal
-from management.utils import AutoDateTimeField
+from management.rbac_fields import AutoDateTimeField
 
 
 class Group(models.Model):

--- a/rbac/management/migrations/0004_auto_20190318_2359.py
+++ b/rbac/management/migrations/0004_auto_20190318_2359.py
@@ -32,7 +32,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='group',
             name='modified',
-            field=management.utils.AutoDateTimeField(default=django.utils.timezone.now),
+            field=management.rbac_fields.AutoDateTimeField(default=django.utils.timezone.now),
         ),
         migrations.AddField(
             model_name='policy',
@@ -42,7 +42,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='policy',
             name='modified',
-            field=management.utils.AutoDateTimeField(default=django.utils.timezone.now),
+            field=management.rbac_fields.AutoDateTimeField(default=django.utils.timezone.now),
         ),
         migrations.AddField(
             model_name='role',
@@ -52,6 +52,6 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='role',
             name='modified',
-            field=management.utils.AutoDateTimeField(default=django.utils.timezone.now),
+            field=management.rbac_fields.AutoDateTimeField(default=django.utils.timezone.now),
         ),
     ]

--- a/rbac/management/policy/model.py
+++ b/rbac/management/policy/model.py
@@ -22,7 +22,7 @@ from django.db import models
 from django.utils import timezone
 from management.group.model import Group
 from management.role.model import Role
-from management.utils import AutoDateTimeField
+from management.rbac_fields import AutoDateTimeField
 
 
 class Policy(models.Model):

--- a/rbac/management/rbac_fields.py
+++ b/rbac/management/rbac_fields.py
@@ -1,0 +1,27 @@
+#
+# Copyright 2019 Red Hat, Inc.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+from django.db import models
+from django.utils import timezone
+
+
+class AutoDateTimeField(models.DateTimeField):
+    """Class that defines is pre_save value."""
+
+    def pre_save(self, model_instance, add):
+        """Save its time as now."""
+        return timezone.now()

--- a/rbac/management/role/model.py
+++ b/rbac/management/role/model.py
@@ -21,7 +21,7 @@ from uuid import uuid4
 from django.contrib.postgres.fields import JSONField
 from django.db import models
 from django.utils import timezone
-from management.utils import AutoDateTimeField
+from management.rbac_fields import AutoDateTimeField
 
 
 class Role(models.Model):

--- a/rbac/management/utils.py
+++ b/rbac/management/utils.py
@@ -103,11 +103,3 @@ def queryset_by_id(objects, clazz):
     """Return a queryset of from the class ordered by id."""
     wanted_ids = [obj.id for obj in objects]
     return clazz.objects.filter(id__in=wanted_ids).order_by('id')
-
-
-class AutoDateTimeField(models.DateTimeField):
-    """Class that defines is pre_save value."""
-
-    def pre_save(self, model_instance, add):
-        """Save its time as now."""
-        return timezone.now()


### PR DESCRIPTION
To enable some other fixes coming down the line, we need to pull AutoDateTimeField out of management.utils to avoid circular dependencies.

Signed-off-by: Chris Mitchell <cmitchel@redhat.com>