### PR TITLE
Seed default group when tenant is created

### DIFF
--- a/rbac/management/group/definer.py
+++ b/rbac/management/group/definer.py
@@ -1,0 +1,88 @@
+#
+# Copyright 2019 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+"""Handler for system defined group."""
+import logging
+
+from django.core.exceptions import ValidationError
+from management.group.model import Group
+from management.policy.model import Policy
+from management.role.model import Role
+from tenant_schemas.utils import tenant_context
+
+logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
+
+
+def seed_group(tenant):
+    """For a tenant create or update default group."""
+    with tenant_context(tenant):
+        name = 'Platform group'
+        group_description = 'Default group that contains default permissions for new users.'
+
+        group, group_created = Group.objects.get_or_create(
+            platform_default=True,
+            defaults={
+                'description': group_description,
+                'name': name,
+                'system': True
+            }
+        )
+
+        if group.system:
+            platform_roles = Role.objects.filter(platform_default=True).values_list('uuid', flat=True)
+            add_roles(group, platform_roles, replace=True)
+            logger.info('Finished seeding default group %s for tenant %s.', name, tenant.schema_name)
+        else:
+            logger.info('Default group %s is managed by tenant %s.', name, tenant.schema_name)
+    return tenant
+
+
+def add_roles(group, roles, replace=False):
+    """Process list of roles and add them to the group."""
+    system_policy_name = 'System Policy for Group {}'.format(group.uuid)
+    system_policy, system_policy_created = Policy.objects.get_or_create(system=True,
+                                                                        group=group,
+                                                                        name=system_policy_name)
+    if system_policy_created:
+        logger.info('Created new system policy for tenant.')
+    else:
+        if replace:
+            system_policy.roles.clear()
+
+    for role_id in roles:
+        try:
+            role = Role.objects.get(uuid=role_id)
+            system_policy.roles.add(role)
+        except (Role.DoesNotExist, ValidationError):
+            logger.info('No role with id %s to save to group.', role_id)
+
+    system_policy.save()
+
+
+def remove_roles(group, role_ids):
+    """Process list of roles and remove them from the group."""
+    roles = []
+    for role_id in role_ids:
+        try:
+            role = Role.objects.get(uuid=role_id)
+            roles.append(role)
+        except (Role.DoesNotExist, ValidationError):
+            logger.info('No role with id %s to delete from group.', role_id)
+
+    for policy in group.policies.all():
+        policy.roles.remove(*roles)
+        policy.save()

--- a/rbac/rbac/middleware.py
+++ b/rbac/rbac/middleware.py
@@ -31,9 +31,10 @@ from tenant_schemas.utils import tenant_context
 from api.common import RH_IDENTITY_HEADER, RH_INSIGHTS_REQUEST_ID
 from api.models import Tenant, User
 from api.serializers import UserSerializer, create_schema_name, extract_header
-from management.utils import APPLICATION_KEY, access_for_principal  # noqa: I100, I201
+from management.group.definer import seed_group  # noqa: I100, I201
 from management.models import Principal  # noqa: I100, I201
 from management.role.definer import seed_roles
+from management.utils import APPLICATION_KEY, access_for_principal  # noqa: I100, I201
 
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
@@ -116,6 +117,7 @@ class IdentityHeaderMiddleware(MiddlewareMixin):  # pylint: disable=R0903
                 tenant.save()
                 logger.info('Created new tenant from account_id %s.', account)
                 seed_roles(tenant=tenant, update=False)
+                seed_group(tenant=tenant)
         except IntegrityError:
             tenant = Tenant.objects.filter(schema_name=schema_name).get()
 

--- a/tests/management/group/test_definer.py
+++ b/tests/management/group/test_definer.py
@@ -1,0 +1,79 @@
+#
+# Copyright 2019 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""Test the group definer."""
+from management.group.definer import seed_group, add_roles, remove_roles
+from management.group.view import GroupViewSet
+from management.role.definer import seed_roles
+from tests.identity_request import IdentityRequest
+from tenant_schemas.utils import tenant_context
+from management.models import Group, Role
+
+class GroupDefinerTests(IdentityRequest):
+    """Test the group definer functions."""
+
+    def setUp(self):
+        """Set up the group definer tests."""
+        super().setUp()
+        seed_roles(self.tenant, update=True)
+        seed_group(self.tenant)
+
+    def test_default_group_seeding_properly(self):
+        """Test that default group are seeded properly."""
+        with tenant_context(self.tenant):
+            group = Group.objects.get(platform_default=True)
+            self.assertEqual(group.platform_default, True)
+            self.assertEqual(group.system, True)
+            self.assertEqual(group.policies.get(name='System Policy for Group {}'.format(group.uuid)).system, True)
+
+    def test_default_group_seeding_skips(self):
+        """Test that default groups with system flag false will be skipped during seeding"""
+
+        self.modify_default_group(system=False)
+
+        try:
+            seed_group(self.tenant)
+        except Exception:
+            self.fail(msg='update seed_group encountered an exception')
+
+        with tenant_context(self.tenant):
+            group = Group.objects.get(platform_default=True)
+            self.assertEqual(group.system, False)
+            group.roles().get(name="RBAC Administrator")
+
+    def test_default_group_seeding_reassign_roles(self):
+        """Test that previous assigned roles would be eliminated before assigning new roles."""
+        self.modify_default_group()
+
+        try:
+            seed_group(self.tenant)
+        except Exception:
+            self.fail(msg='update seed_group encountered an exception')
+
+        with tenant_context(self.tenant):
+            group = Group.objects.get(platform_default=True)
+            self.assertEqual(group.system, True)
+            self.assertRaises(Role.DoesNotExist, group.roles().get, name="RBAC Administrator")
+
+    def modify_default_group(self, system=True):
+        """ Add a role to the default group and/or change the system flag"""
+        with tenant_context(self.tenant):
+            group = Group.objects.get(platform_default=True)
+            roles = Role.objects.filter(name="RBAC Administrator").values_list('uuid', flat=True)
+            add_roles(group, roles)
+
+            group.system = system
+            group.save()


### PR DESCRIPTION
When a tenant gets created, a default group would be created for the tenant.
All tenant would be under this group initially. And platform roles would be
assigned to the group through a specific platform policy.

Update would be in a following PR.