### PR TITLE
Add group roles endpoint

### DIFF
--- a/docs/source/specs/openapi.json
+++ b/docs/source/specs/openapi.json
@@ -442,7 +442,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/GroupWithPrincipals"
+                  "$ref": "#/components/schemas/GroupWithPrincipalsAndRoles"
                 }
               }
             }
@@ -607,7 +607,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/GroupRolesOut"
+                  "$ref": "#/components/schemas/GroupWithPrincipalsAndRoles"
                 }
               }
             }
@@ -1702,7 +1702,7 @@
               "roles"
             ],
             "properties": {
-              "roles": {
+              "data": {
                 "type": "array",
                 "items": {
                   "$ref": "#/components/schemas/Role"

--- a/docs/source/specs/openapi.json
+++ b/docs/source/specs/openapi.json
@@ -9,10 +9,13 @@
       "url": "https://opensource.org/licenses/AGPL-3.0"
     }
   },
-  "security": [{
-    "basic_auth": []
-  }],
-  "tags": [{
+  "security": [
+    {
+      "basic_auth": []
+    }
+  ],
+  "tags": [
+    {
       "name": "Principal",
       "description": "Operations about principals"
     },
@@ -76,7 +79,8 @@
         ],
         "summary": "List the principals for a tenant",
         "operationId": "listPrincipals",
-        "parameters": [{
+        "parameters": [
+          {
             "$ref": "#/components/parameters/QueryLimit"
           },
           {
@@ -169,7 +173,8 @@
         ],
         "summary": "List the groups for a tenant",
         "operationId": "listGroups",
-        "parameters": [{
+        "parameters": [
+          {
             "$ref": "#/components/parameters/QueryLimit"
           },
           {
@@ -228,16 +233,18 @@
         ],
         "summary": "Get a group in the tenant",
         "operationId": "getGroup",
-        "parameters": [{
-          "name": "uuid",
-          "in": "path",
-          "description": "ID of group to get",
-          "required": true,
-          "schema": {
-            "type": "string",
-            "format": "uuid"
+        "parameters": [
+          {
+            "name": "uuid",
+            "in": "path",
+            "description": "ID of group to get",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
           }
-        }],
+        ],
         "responses": {
           "200": {
             "description": "A Group object",
@@ -280,16 +287,18 @@
         ],
         "summary": "Udate a group in the tenant",
         "operationId": "updateGroup",
-        "parameters": [{
-          "name": "uuid",
-          "in": "path",
-          "description": "ID of group to update",
-          "required": true,
-          "schema": {
-            "type": "string",
-            "format": "uuid"
+        "parameters": [
+          {
+            "name": "uuid",
+            "in": "path",
+            "description": "ID of group to update",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
           }
-        }],
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -353,16 +362,18 @@
         ],
         "summary": "Delete a group in the tenant",
         "operationId": "deleteGroup",
-        "parameters": [{
-          "name": "uuid",
-          "in": "path",
-          "description": "ID of group to delete",
-          "required": true,
-          "schema": {
-            "type": "string",
-            "format": "uuid"
+        "parameters": [
+          {
+            "name": "uuid",
+            "in": "path",
+            "description": "ID of group to delete",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
           }
-        }],
+        ],
         "responses": {
           "204": {
             "description": "Group deleted"
@@ -410,16 +421,18 @@
         ],
         "summary": "Add a principal to a group in the tenant",
         "operationId": "addPrincipalToGroup",
-        "parameters": [{
-          "name": "uuid",
-          "in": "path",
-          "description": "ID of group to update",
-          "required": true,
-          "schema": {
-            "type": "string",
-            "format": "uuid"
+        "parameters": [
+          {
+            "name": "uuid",
+            "in": "path",
+            "description": "ID of group to update",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
           }
-        }],
+        ],
         "requestBody": {
           "$ref": "#/components/requestBodies/GroupPrincipalIn"
         },
@@ -468,7 +481,8 @@
         ],
         "summary": "Remove a principal from a group in the tenant",
         "operationId": "deletePrincipalFromGroup",
-        "parameters": [{
+        "parameters": [
+          {
             "name": "uuid",
             "in": "path",
             "description": "ID of group to update",
@@ -571,7 +585,8 @@
         ],
         "summary": "List the roles for a tenant",
         "operationId": "listRoles",
-        "parameters": [{
+        "parameters": [
+          {
             "$ref": "#/components/parameters/QueryLimit"
           },
           {
@@ -621,16 +636,18 @@
         ],
         "summary": "Get a role in the tenant",
         "operationId": "getRole",
-        "parameters": [{
-          "name": "uuid",
-          "in": "path",
-          "description": "ID of role to get",
-          "required": true,
-          "schema": {
-            "type": "string",
-            "format": "uuid"
+        "parameters": [
+          {
+            "name": "uuid",
+            "in": "path",
+            "description": "ID of role to get",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
           }
-        }],
+        ],
         "responses": {
           "200": {
             "description": "A Role object",
@@ -673,16 +690,18 @@
         ],
         "summary": "Delete a role in the tenant",
         "operationId": "deleteRole",
-        "parameters": [{
-          "name": "uuid",
-          "in": "path",
-          "description": "ID of role to delete",
-          "required": true,
-          "schema": {
-            "type": "string",
-            "format": "uuid"
+        "parameters": [
+          {
+            "name": "uuid",
+            "in": "path",
+            "description": "ID of role to delete",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
           }
-        }],
+        ],
         "responses": {
           "204": {
             "description": "Role deleted"
@@ -718,16 +737,18 @@
         ],
         "summary": "Update a Role in the tenant",
         "operationId": "updateRole",
-        "parameters": [{
-          "name": "uuid",
-          "in": "path",
-          "description": "ID of role to update",
-          "required": true,
-          "schema": {
-            "type": "string",
-            "format": "uuid"
+        "parameters": [
+          {
+            "name": "uuid",
+            "in": "path",
+            "description": "ID of role to update",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
           }
-        }],
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -819,7 +840,8 @@
         ],
         "summary": "List the policies in the tenant",
         "operationId": "listPolicies",
-        "parameters": [{
+        "parameters": [
+          {
             "$ref": "#/components/parameters/QueryLimit"
           },
           {
@@ -875,16 +897,18 @@
         ],
         "summary": "Get a policy in the tenant",
         "operationId": "getPolicy",
-        "parameters": [{
-          "name": "uuid",
-          "in": "path",
-          "description": "ID of policy to get",
-          "required": true,
-          "schema": {
-            "type": "string",
-            "format": "uuid"
+        "parameters": [
+          {
+            "name": "uuid",
+            "in": "path",
+            "description": "ID of policy to get",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
           }
-        }],
+        ],
         "responses": {
           "200": {
             "description": "A Policy object",
@@ -927,16 +951,18 @@
         ],
         "summary": "Update a policy in the tenant",
         "operationId": "updatePolicy",
-        "parameters": [{
-          "name": "uuid",
-          "in": "path",
-          "description": "ID of policy to update",
-          "required": true,
-          "schema": {
-            "type": "string",
-            "format": "uuid"
+        "parameters": [
+          {
+            "name": "uuid",
+            "in": "path",
+            "description": "ID of policy to update",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
           }
-        }],
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -990,16 +1016,18 @@
         ],
         "summary": "Delete a policy in the tenant",
         "operationId": "deletePolicy",
-        "parameters": [{
-          "name": "uuid",
-          "in": "path",
-          "description": "ID of policy to delete",
-          "required": true,
-          "schema": {
-            "type": "string",
-            "format": "uuid"
+        "parameters": [
+          {
+            "name": "uuid",
+            "in": "path",
+            "description": "ID of policy to delete",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
           }
-        }],
+        ],
         "responses": {
           "204": {
             "description": "Policy deleted"
@@ -1037,7 +1065,8 @@
         ],
         "summary": "Get the permitted access for a principal in the tenant",
         "operationId": "getPrincipalAccess",
-        "parameters": [{
+        "parameters": [
+          {
             "name": "application",
             "in": "query",
             "description": "The application name to obtain access for the principal",
@@ -1100,9 +1129,11 @@
       }
     }
   },
-  "servers": [{
-    "url": "/api/rbac/v1"
-  }],
+  "servers": [
+    {
+      "url": "/api/rbac/v1"
+    }
+  ],
   "components": {
     "parameters": {
       "QueryOffset": {
@@ -1330,7 +1361,8 @@
         }
       },
       "PrincipalOut": {
-        "allOf": [{
+        "allOf": [
+          {
             "$ref": "#/components/schemas/Principal"
           },
           {
@@ -1339,7 +1371,8 @@
         ]
       },
       "PrincipalPagination": {
-        "allOf": [{
+        "allOf": [
+          {
             "$ref": "#/components/schemas/ListPagination"
           },
           {
@@ -1374,7 +1407,8 @@
         }
       },
       "GroupOut": {
-        "allOf": [{
+        "allOf": [
+          {
             "$ref": "#/components/schemas/Group"
           },
           {
@@ -1409,7 +1443,8 @@
         }
       },
       "GroupWithPrincipals": {
-        "allOf": [{
+        "allOf": [
+          {
             "$ref": "#/components/schemas/Group"
           },
           {
@@ -1435,7 +1470,8 @@
         ]
       },
       "GroupWithPrincipalsAndRoles": {
-        "allOf": [{
+        "allOf": [
+          {
             "$ref": "#/components/schemas/Group"
           },
           {
@@ -1468,7 +1504,8 @@
         ]
       },
       "GroupPagination": {
-        "allOf": [{
+        "allOf": [
+          {
             "$ref": "#/components/schemas/ListPagination"
           },
           {
@@ -1555,7 +1592,8 @@
         }
       },
       "RoleIn": {
-        "allOf": [{
+        "allOf": [
+          {
             "$ref": "#/components/schemas/Role"
           },
           {
@@ -1575,7 +1613,8 @@
         ]
       },
       "RolePagination": {
-        "allOf": [{
+        "allOf": [
+          {
             "$ref": "#/components/schemas/ListPagination"
           },
           {
@@ -1595,7 +1634,8 @@
         ]
       },
       "RoleOut": {
-        "allOf": [{
+        "allOf": [
+          {
             "$ref": "#/components/schemas/Role"
           },
           {
@@ -1624,7 +1664,8 @@
         }
       },
       "RoleWithAccess": {
-        "allOf": [{
+        "allOf": [
+          {
             "$ref": "#/components/schemas/Role"
           },
           {
@@ -1665,7 +1706,8 @@
         }
       },
       "PolicyIn": {
-        "allOf": [{
+        "allOf": [
+          {
             "$ref": "#/components/schemas/Policy"
           },
           {
@@ -1693,7 +1735,8 @@
         ]
       },
       "PolicyExtended": {
-        "allOf": [{
+        "allOf": [
+          {
             "$ref": "#/components/schemas/Policy"
           },
           {
@@ -1723,7 +1766,8 @@
         ]
       },
       "PolicyPagination": {
-        "allOf": [{
+        "allOf": [
+          {
             "$ref": "#/components/schemas/ListPagination"
           },
           {
@@ -1743,7 +1787,8 @@
         ]
       },
       "AccessPagination": {
-        "allOf": [{
+        "allOf": [
+          {
             "$ref": "#/components/schemas/ListPagination"
           },
           {

--- a/docs/source/specs/openapi.json
+++ b/docs/source/specs/openapi.json
@@ -535,6 +535,171 @@
         }
       }
     },
+    "/groups/{uuid}/roles/": {
+      "get": {
+        "tags": [
+          "Group"
+        ],
+        "summary": "List the roles for a group in the tenant",
+        "operationId": "listRolesForGroup",
+        "parameters": [
+          {
+            "name": "uuid",
+            "in": "path",
+            "description": "ID of group",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A list of roles for a group",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GroupRolesOut"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "500": {
+            "description": "Unexpected Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Group"
+        ],
+        "summary": "Add a role to a group in the tenant",
+        "operationId": "addRoleToGroup",
+        "parameters": [
+          {
+            "name": "uuid",
+            "in": "path",
+            "description": "ID of group to update",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/GroupRoleIn"
+        },
+        "responses": {
+          "200": {
+            "description": "Group updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GroupRolesOut"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Input"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Group"
+        ],
+        "summary": "Remove a role from a group in the tenant",
+        "operationId": "deleteRoleFromGroup",
+        "parameters": [
+          {
+            "name": "uuid",
+            "in": "path",
+            "description": "ID of group to update",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "roles",
+            "in": "query",
+            "description": "A comma separated list of role UUIDs for roles to remove from the group",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Roles removed from group"
+          },
+          "400": {
+            "description": "Bad Input"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/roles/": {
       "post": {
         "tags": [
@@ -1222,6 +1387,17 @@
         },
         "description": "Principal to add to a group",
         "required": true
+      },
+      "GroupRoleIn": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/GroupRoleIn"
+            }
+          }
+        },
+        "description": "Role to add to a group",
+        "required": true
       }
     },
     "securitySchemes": {
@@ -1442,6 +1618,21 @@
           }
         }
       },
+      "GroupRoleIn": {
+        "required": [
+          "roles"
+        ],
+        "properties": {
+          "roles": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid",
+              "example": "94846f2f-cced-474f-b7f3-47e2ec51dd11"
+            }
+          }
+        }
+      },
       "GroupWithPrincipals": {
         "allOf": [
           {
@@ -1493,6 +1684,24 @@
                   "$ref": "#/components/schemas/Principal"
                 }
               },
+              "roles": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Role"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "GroupRolesOut": {
+        "allOf": [
+          {
+            "type": "object",
+            "required": [
+              "roles"
+            ],
+            "properties": {
               "roles": {
                 "type": "array",
                 "items": {

--- a/rbac/management/group/serializer.py
+++ b/rbac/management/group/serializer.py
@@ -110,4 +110,4 @@ class GroupRoleSerializer(serializers.Serializer):
     def to_representation(self, obj):
         """Convert representation to dictionary object."""
         serialized_roles = [RoleMinimumSerializer(role).data for role in obj.roles()]
-        return {'roles': serialized_roles}
+        return {'data': serialized_roles}

--- a/rbac/management/group/serializer.py
+++ b/rbac/management/group/serializer.py
@@ -100,3 +100,14 @@ class GroupPrincipalInputSerializer(serializers.Serializer):
         """Metadata for the serializer."""
 
         fields = ('principals',)
+
+
+class GroupRoleSerializer(serializers.Serializer):
+    """Serializer for managing roles for a group."""
+
+    roles = serializers.ListField(child=serializers.UUIDField())
+
+    def to_representation(self, obj):
+        """Convert representation to dictionary object."""
+        serialized_roles = [RoleMinimumSerializer(role).data for role in obj.roles()]
+        return {'roles': serialized_roles}

--- a/rbac/management/group/view.py
+++ b/rbac/management/group/view.py
@@ -453,9 +453,12 @@ class GroupViewSet(mixins.CreateModelMixin,
         @apiSuccessExample {json} Success-Response:
             HTTP/1.1 204 NO CONTENT
         """
-        roles = request.data.pop(ROLES_KEY, [])
+        roles = []
         group = self.get_object()
         if request.method == 'POST':
+            serializer = GroupRoleSerializer(data=request.data)
+            if serializer.is_valid(raise_exception=True):
+                roles = request.data.pop(ROLES_KEY, [])
             self.add_roles(group, roles)
             response_data = GroupRoleSerializer(group)
         elif request.method == 'GET':
@@ -465,9 +468,12 @@ class GroupViewSet(mixins.CreateModelMixin,
                 key = 'detail'
                 message = 'Query parameter {} is required.'.format(ROLES_KEY)
                 raise serializers.ValidationError({key: _(message)})
-            role_ids = request.query_params.get(ROLES_KEY, '')
 
-            self.remove_roles(group, role_ids.split(','))
+            role_ids = request.query_params.get(ROLES_KEY, '').split(',')
+            serializer = GroupRoleSerializer(data={'roles': role_ids})
+            if serializer.is_valid(raise_exception=True):
+                self.remove_roles(group, role_ids)
+
             return Response(status=status.HTTP_204_NO_CONTENT)
 
         return Response(status=status.HTTP_200_OK, data=response_data.data)

--- a/rbac/management/group/view.py
+++ b/rbac/management/group/view.py
@@ -351,7 +351,10 @@ class GroupViewSet(mixins.CreateModelMixin,
 
     def add_roles(self, group, roles):
         """Process list of roles and add them to the group."""
-        system_policy, system_policy_created = Policy.objects.get_or_create(system=True, group=group)
+        system_policy_name = 'System Policy for Group {}'.format(group.uuid)
+        system_policy, system_policy_created = Policy.objects.get_or_create(system=True,
+                                                                            group=group,
+                                                                            name=system_policy_name)
         if system_policy_created:
             logger.info('Created new system policy for tenant.')
 

--- a/rbac/management/group/view.py
+++ b/rbac/management/group/view.py
@@ -395,13 +395,11 @@ class GroupViewSet(mixins.CreateModelMixin,
 
         @apiParam (Path) {String} id Group unique identifier.
 
-        @apiSuccess {String} uuid Group unique identifier
-        @apiSuccess {String} name Group name
-        @apiSuccess {Array} roles Array of roles
+        @apiSuccess {Array} data Array of roles
         @apiSuccessExample {json} Success-Response:
             HTTP/1.1 200 OK
             {
-                "roles": [
+                "data": [
                     {
                         "name": "RoleA",
                         "uuid": "4df211e0-2d88-49a4-8802-728630224d15",
@@ -431,6 +429,8 @@ class GroupViewSet(mixins.CreateModelMixin,
         @apiSuccessExample {json} Success-Response:
             HTTP/1.1 200 OK
             {
+                "uuid": "16fd2706-8baf-433b-82eb-8c7fada847da",
+                "name": "GroupA",
                 "roles": [
                     {
                         "name": "RoleA",
@@ -463,7 +463,7 @@ class GroupViewSet(mixins.CreateModelMixin,
             if serializer.is_valid(raise_exception=True):
                 roles = request.data.pop(ROLES_KEY, [])
             self.add_roles(group, roles)
-            response_data = GroupRoleSerializer(group)
+            response_data = GroupSerializer(group)
         elif request.method == 'GET':
             response_data = GroupRoleSerializer(group)
         else:

--- a/tests/management/group/test_view.py
+++ b/tests/management/group/test_view.py
@@ -248,7 +248,7 @@ class GroupViewsetTests(IdentityRequest):
         url = reverse('group-roles', kwargs={'uuid': self.group.uuid})
         client = APIClient()
         response = client.get(url, **self.headers)
-        roles = response.data.get('roles')
+        roles = response.data.get('data')
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(roles), 1)


### PR DESCRIPTION
This PR adds the following endpoints:

**GET /api/rbac/v1/groups/:uuid/roles/**
```
# note, pagination will be added in a follow up PR for this GET
# returns a list of roles for the group:

{
  "data": [
    {
      "name": "RoleA",
      "description": "A description of RoleA"
    }
  ]
}
```

**POST /api/rbac/v1/groups/:uuid/roles/**
```
# takes a request body of an array of role UUIDs:
{
  "roles": [
    "94846f2f-cced-474f-b7f3-47e2ec51dd11"
  ]
}

# returns the group object, including all roles for the group:
{
  "uuid": "16fd2706-8baf-433b-82eb-8c7fada847da",
  "name": "GroupA",
  "roles": [
    {
      "name": "RoleA",
      "uuid": "4df211e0-2d88-49a4-8802-728630224d15",
      "description": "RoleA Description"
    }
  ]
}
```

**DELETE /api/rbac/v1/groups/:uuid/roles/**
```
# takes a comma-separated query string of role UUIDs on `roles`:
?roles=abc123,def456
```
Changes are reflected in the `openapi.json` spec at: `/api/rbac/v1/openapi.json`

- [x] account for unique constraint on policy name