### PR TITLE
Add pagination to GET `/groups/:uuid/roles/`

### DIFF
--- a/docs/source/specs/openapi.json
+++ b/docs/source/specs/openapi.json
@@ -552,6 +552,12 @@
               "type": "string",
               "format": "uuid"
             }
+          },
+          {
+            "$ref": "#/components/parameters/QueryLimit"
+          },
+          {
+            "$ref": "#/components/parameters/QueryOffset"
           }
         ],
         "responses": {
@@ -560,7 +566,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/GroupRolesOut"
+                  "$ref": "#/components/schemas/GroupRolesPagination"
                 }
               }
             }
@@ -1702,12 +1708,15 @@
           }
         ]
       },
-      "GroupRolesOut": {
+      "GroupRolesPagination": {
         "allOf": [
+          {
+            "$ref": "#/components/schemas/ListPagination"
+          },
           {
             "type": "object",
             "required": [
-              "roles"
+              "data"
             ],
             "properties": {
               "data": {

--- a/rbac/management/group/serializer.py
+++ b/rbac/management/group/serializer.py
@@ -108,7 +108,15 @@ class GroupPrincipalInputSerializer(serializers.Serializer):
         fields = ('principals',)
 
 
-class GroupRoleSerializer(serializers.Serializer):
+class GroupRoleSerializerOut(serializers.Serializer):
+    """Serializer for getting roles for a group."""
+
+    def to_representation(self, obj):
+        """Return the collection to be serialized."""
+        return obj
+
+
+class GroupRoleSerializerIn(serializers.Serializer):
     """Serializer for managing roles for a group."""
 
     roles = serializers.ListField(child=serializers.UUIDField())

--- a/tests/management/group/test_view.py
+++ b/tests/management/group/test_view.py
@@ -296,7 +296,7 @@ class GroupViewsetTests(IdentityRequest):
 
         response = client.post(url, test_data, format='json', **self.headers)
 
-        roles = response.data.get('roles')
+        roles = response.data.get('data')
         system_policies = Policy.objects.filter(system=True)
         system_policy = system_policies.get(group=self.group)
 
@@ -344,7 +344,7 @@ class GroupViewsetTests(IdentityRequest):
 
         response = client.post(url, test_data, format='json', **self.headers)
 
-        roles = response.data.get('roles')
+        roles = response.data.get('data')
         system_policies = Policy.objects.filter(system=True, group=self.group)
         system_policy = system_policies.first()
 


### PR DESCRIPTION
This adds the standard RBAC API pagination to the GET response, allowing for
the option of passing in an `offset` and `limit` param as well.

```
{
  "meta": {
    "count": 2,
    "limit": 10,
    "offset": 0
  },
  "links": {
    "first": "/api/rbac/v1/groups/ba1d75a7-2506-49cd-a372-2297e55f9274/roles/?limit=10&offset=0",
    "next": null,
    "previous": null,
    "last": "/api/rbac/v1/groups/ba1d75a7-2506-49cd-a372-2297e55f9274/roles/?limit=10&offset=0"
  },
  "data": [
    {
      "uuid": "9d648462-6372-4f6a-b274-5d6e28c7ec99",
      "name": "Role 1",
      "description": "Admin Role",
      "created": "2019-11-15T19:11:49.118129Z",
      "modified": "2019-11-15T19:11:49.118894Z"
    },
    {
      "uuid": "5d921465-0b9e-42a7-bab6-341b49f72c91",
      "name": "Role 2",
      "description": "Non Admin Role",
      "created": "2019-11-15T19:11:49.186746Z",
      "modified": "2019-11-15T19:11:49.187667Z"
    }
  ]
}
```