### PR TITLE
Block API role creation for non-cost-mgmt

### DIFF
--- a/rbac/management/role/view.py
+++ b/rbac/management/role/view.py
@@ -16,6 +16,8 @@
 #
 
 """View for role management."""
+import os
+
 from django.db import transaction
 from django.db.models.aggregates import Count
 from django.shortcuts import get_object_or_404
@@ -29,7 +31,8 @@ from rest_framework.filters import OrderingFilter
 from .model import Role
 from .serializer import RoleSerializer
 
-APP_WHITELIST = ['app', 'cost-management']
+TESTING_APP = os.getenv('TESTING_APPLICATION', '')
+APP_WHITELIST = [TESTING_APP, 'cost-management']
 
 
 class RoleFilter(filters.FilterSet):

--- a/rbac/management/role/view.py
+++ b/rbac/management/role/view.py
@@ -123,7 +123,7 @@ class RoleViewSet(mixins.CreateModelMixin,
                 ]
             }
         """
-        for perm in request.data.get('access') or []:
+        for perm in request.data.get('access', []):
             app = perm.get('permission').split(':')[0]
             if app not in APP_WHITELIST:
                 key = 'role'
@@ -153,8 +153,7 @@ class RoleViewSet(mixins.CreateModelMixin,
         @apiSuccess {Object} links  The object containing links of results.
         @apiSuccess {Object[]} data  The array of results.
 
-        @apiSuccessExample {json} Success-Re
-        sponse:
+        @apiSuccessExample {json} Success-Response:
             HTTP/1.1 200 OK
             {
                 'meta': {

--- a/rbac/management/role/view.py
+++ b/rbac/management/role/view.py
@@ -29,6 +29,8 @@ from rest_framework.filters import OrderingFilter
 from .model import Role
 from .serializer import RoleSerializer
 
+APP_WHITELIST = ['app', 'cost-management']
+
 
 class RoleFilter(filters.FilterSet):
     """Filter for role."""
@@ -121,6 +123,15 @@ class RoleViewSet(mixins.CreateModelMixin,
                 ]
             }
         """
+        for perm in request.data.get('access') or []:
+            app = perm.get('permission').split(':')[0]
+            if app not in APP_WHITELIST:
+                key = 'role'
+                message = 'Custom roles cannot be created for {}'.format(app)
+                error = {
+                    key: [_(message)]
+                }
+                raise serializers.ValidationError(error)
         return super().create(request=request, args=args, kwargs=kwargs)
 
     def list(self, request, *args, **kwargs):
@@ -142,7 +153,8 @@ class RoleViewSet(mixins.CreateModelMixin,
         @apiSuccess {Object} links  The object containing links of results.
         @apiSuccess {Object[]} data  The array of results.
 
-        @apiSuccessExample {json} Success-Response:
+        @apiSuccessExample {json} Success-Re
+        sponse:
             HTTP/1.1 200 OK
             {
                 'meta': {

--- a/rbac/management/role/view.py
+++ b/rbac/management/role/view.py
@@ -31,7 +31,7 @@ from rest_framework.filters import OrderingFilter
 from .model import Role
 from .serializer import RoleSerializer
 
-TESTING_APP = os.getenv('TESTING_APPLICATION', '')
+TESTING_APP = os.getenv('TESTING_APPLICATION')
 APP_WHITELIST = [TESTING_APP, 'cost-management']
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -26,6 +26,7 @@ setenv =
   DATABASE_USER=rbac_tester
   DATABASE_PASSWORD={env:DATABASE_PASSWORD:''}
   PGPASSWORD=postgres
+  TESTING_APPLICATION=app
 deps =
   pipenv
   codecov


### PR DESCRIPTION
Taking a swing at preventing role creation involving permissions for
apps other than cost-management.

Signed-off-by: Chris Mitchell <cmitchel@redhat.com>