### PR TITLE
Add platform_default attribute when seeding roles

### DIFF
--- a/rbac/management/role/definer.py
+++ b/rbac/management/role/definer.py
@@ -35,6 +35,7 @@ def _make_role(tenant, data, update=False):
         access_list = data.pop('access')
         version = data.pop('version', 1)
         version_diff = False
+        is_platform_default = data.pop('platform_default', False)
         if update:
             role, created = Role.objects.filter(name=name).get_or_create(name=name)
             version_diff = version != role.version
@@ -43,13 +44,15 @@ def _make_role(tenant, data, update=False):
                 role.description = description
                 role.system = True
                 role.version = version
+                role.platform_default = is_platform_default
                 role.save()
                 role.access.all().delete()
         else:
             role = Role.objects.create(name=name,
                                        description=description,
                                        system=True,
-                                       version=version)
+                                       version=version,
+                                       platform_default=is_platform_default)
             logger.info('Creating role %s for tenant %s.', name, tenant.schema_name)
         if not update or (update and version_diff):
             for access_item in access_list:

--- a/rbac/management/role/definitions/ansible-automation.json
+++ b/rbac/management/role/definitions/ansible-automation.json
@@ -1,0 +1,19 @@
+{
+    "roles": [
+        {
+            "name": "Ansible Automation Access",
+            "description": "An all access role which grants read and write permissions.",
+            "system": true,
+            "platform_default": true,
+            "version": 2,
+            "access": [
+                {
+                    "permission": "ansible-automation:*:*"
+                },
+                {
+                    "permission": "inventory:*:*"
+                }
+            ]
+        }
+    ]
+}

--- a/tests/management/group/test_definer.py
+++ b/tests/management/group/test_definer.py
@@ -38,6 +38,9 @@ class GroupDefinerTests(IdentityRequest):
             self.assertEqual(group.platform_default, True)
             self.assertEqual(group.system, True)
             self.assertEqual(group.policies.get(name='System Policy for Group {}'.format(group.uuid)).system, True)
+            # only platform_default roles would be assigned to the default group
+            for role in group.roles():
+                self.assertTrue(role.platform_default)
 
     def test_default_group_seeding_skips(self):
         """Test that default groups with system flag false will be skipped during seeding"""
@@ -67,6 +70,8 @@ class GroupDefinerTests(IdentityRequest):
             group = Group.objects.get(platform_default=True)
             self.assertEqual(group.system, True)
             self.assertRaises(Role.DoesNotExist, group.roles().get, name="RBAC Administrator")
+            for role in group.roles():
+                self.assertTrue(role.platform_default)
 
     def modify_default_group(self, system=True):
         """ Add a role to the default group and/or change the system flag"""

--- a/tests/management/role/test_definer.py
+++ b/tests/management/role/test_definer.py
@@ -15,8 +15,11 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 """Test the role definer."""
+from tenant_schemas.utils import tenant_context
+
 from management.role.definer import seed_roles
 from tests.identity_request import IdentityRequest
+from management.models import Role
 
 
 class RoleDefinerTests(IdentityRequest):
@@ -26,9 +29,45 @@ class RoleDefinerTests(IdentityRequest):
         """Set up the role definer tests."""
         super().setUp()
 
+    def test_role_create(self):
+        """ Test that we can run a role seeding update. """
+        self.try_seed_roles()
+
+        with tenant_context(self.tenant):
+            roles = Role.objects.filter(platform_default=True)
+            self.assertTrue(len(roles))
+            self.assertFalse(Role.objects.get(name="RBAC Administrator").platform_default)
+
     def test_role_update(self):
-        """Test that we can run a role seeding update."""
-        try:
+        """ Test that role seeding update will re-create the roles. """
+        self.try_seed_roles()
+
+        # delete all the roles and re-create roles again when seed_roles is called
+        with tenant_context(self.tenant):
+            Role.objects.all().delete()
+            roles = Role.objects.filter(platform_default=True)
+            self.assertFalse(len(roles))
+
             seed_roles(self.tenant, update=True)
+            roles = Role.objects.filter(platform_default=True)
+            self.assertTrue(len(roles))
+
+    def test_role_update_version_diff(self):
+        """ Test that role seeding updates attribute when version is changed. """
+        self.try_seed_roles()
+
+        # set the version to zero, so it would update attribute when seed_roles is called
+        with tenant_context(self.tenant):
+            roles = Role.objects.filter(platform_default=True).update(version=0, platform_default=False)
+            self.assertFalse(len(Role.objects.filter(platform_default=True)))
+
+            seed_roles(self.tenant, update=True)
+            roles = Role.objects.filter(platform_default=True)
+            self.assertTrue(len(roles))
+
+    def try_seed_roles(self):
+        """ Try to seed roles """
+        try:
+            seed_roles(self.tenant, update=False)
         except Exception:
-            self.fail(msg='seed_roles encountere an exception')
+            self.fail(msg='seed_roles encountered an exception')


### PR DESCRIPTION
We have added platform_default for roles which would be part of the platform default group.
This PR is to add platform_default attribute for roles to distinguish them.