### PR TITLE
Return roles without permission

### DIFF
--- a/docs/source/specs/openapi.json
+++ b/docs/source/specs/openapi.json
@@ -1701,7 +1701,7 @@
               "roles": {
                 "type": "array",
                 "items": {
-                  "$ref": "#/components/schemas/Role"
+                  "$ref": "#/components/schemas/RoleOut"
                 }
               }
             }
@@ -1722,7 +1722,7 @@
               "data": {
                 "type": "array",
                 "items": {
-                  "$ref": "#/components/schemas/Role"
+                  "$ref": "#/components/schemas/RoleOut"
                 }
               }
             }
@@ -1869,36 +1869,36 @@
           },
           {
             "$ref": "#/components/schemas/Timestamped"
-          }
-        ],
-        "properties": {
-          "policyCount": {
-            "type": "integer",
-            "minimum": 0
           },
-          "applications": {
-            "type": "array",
-            "items": {
-              "type": "string",
-              "example": "catalog"
+          {
+            "properties": {
+              "policyCount": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "applications": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "example": "catalog"
+                }
+              },
+              "system": {
+                "type": "boolean",
+                "default": false
+              },
+              "platform_default": {
+                "type": "boolean",
+                "default": false
+              }
             }
-          },
-          "system": {
-            "type": "boolean",
-            "default": false
           }
-        }
+        ]
       },
       "RoleWithAccess": {
         "allOf": [
           {
-            "$ref": "#/components/schemas/Role"
-          },
-          {
-            "$ref": "#/components/schemas/UUID"
-          },
-          {
-            "$ref": "#/components/schemas/Timestamped"
+            "$ref": "#/components/schemas/RoleOut"
           },
           {
             "type": "object",

--- a/rbac/management/role/serializer.py
+++ b/rbac/management/role/serializer.py
@@ -88,13 +88,7 @@ class RoleSerializer(serializers.ModelSerializer):
 
     def get_applications(self, obj):
         """Get the list of applications in the role."""
-        apps = []
-        for access_item in obj.access.all():
-            perm_list = access_item.permission.split(':')
-            perm_len = len(perm_list)
-            if perm_len == 3:
-                apps.append(perm_list[0])
-        return list(set(apps))
+        obtain_applications(obj)
 
     def create(self, validated_data):
         """Create the role object in the database."""
@@ -147,9 +141,29 @@ class RoleMinimumSerializer(serializers.ModelSerializer):
     description = serializers.CharField(allow_null=True, required=False)
     created = serializers.DateTimeField(read_only=True)
     modified = serializers.DateTimeField(read_only=True)
+    policyCount = serializers.IntegerField(read_only=True)
+    applications = serializers.SerializerMethodField()
+    system = serializers.BooleanField(read_only=True)
+    platform_default = serializers.BooleanField(read_only=True)
 
     class Meta:
         """Metadata for the serializer."""
 
         model = Role
-        fields = ('uuid', 'name', 'description', 'created', 'modified')
+        fields = ('uuid', 'name', 'description', 'created', 'modified', 'policyCount',
+                  'applications', 'system', 'platform_default')
+
+    def get_applications(self, obj):
+        """Get the list of applications in the role."""
+        return obtain_applications(obj)
+
+
+def obtain_applications(obj):
+    """Shared function to get the list of applications in the role."""
+    apps = []
+    for access_item in obj.access.all():
+        perm_list = access_item.permission.split(':')
+        perm_len = len(perm_list)
+        if perm_len == 3:
+            apps.append(perm_list[0])
+    return list(set(apps))

--- a/rbac/management/role/view.py
+++ b/rbac/management/role/view.py
@@ -25,6 +25,7 @@ from django.utils.translation import gettext as _
 from django_filters import rest_framework as filters
 from management.permissions import RoleAccessPermission
 from management.querysets import get_role_queryset
+from management.role.serializer import RoleMinimumSerializer
 from rest_framework import mixins, serializers, viewsets
 from rest_framework.filters import OrderingFilter
 
@@ -70,6 +71,12 @@ class RoleViewSet(mixins.CreateModelMixin,
     def get_queryset(self):
         """Obtain queryset for requesting user based on access."""
         return get_role_queryset(self.request)
+
+    def get_serializer_class(self):
+        """Get serializer based on route."""
+        if self.request.path.endswith('roles/') and self.request.method == 'GET':
+            return RoleMinimumSerializer
+        return RoleSerializer
 
     def create(self, request, *args, **kwargs):
         """Create a roles.


### PR DESCRIPTION
According to https://github.com/RedHatInsights/insights-rbac/blob/master/docs/source/specs/openapi.json#L187
The roles returned should be without permission.

Fixing the returned object because if return all permission for all roles slows down the api performance