### PR TITLE
Principals inherit default access

### DIFF
--- a/rbac/management/utils.py
+++ b/rbac/management/utils.py
@@ -17,7 +17,7 @@
 """Helper utilities for management module."""
 from django.core.exceptions import PermissionDenied
 from django.utils.translation import gettext as _
-from management.models import Principal
+from management.models import Group, Principal
 from rest_framework import serializers
 
 USERNAME_KEY = 'username'
@@ -73,8 +73,10 @@ def access_for_roles(roles, application):
 
 
 def groups_for_principal(principal, **kwargs):
-    """Gathers all groups for a principal."""
-    return set(principal.group.all())
+    """Gathers all groups for a principal, including the default."""
+    principal_groups = principal.group.all()
+    platform_default_set = Group.objects.filter(platform_default=True)
+    return set(principal_groups | platform_default_set)
 
 
 def policies_for_principal(principal, **kwargs):

--- a/rbac/management/utils.py
+++ b/rbac/management/utils.py
@@ -74,9 +74,9 @@ def access_for_roles(roles, application):
 
 def groups_for_principal(principal, **kwargs):
     """Gathers all groups for a principal, including the default."""
-    principal_groups = principal.group.all()
-    platform_default_set = Group.objects.filter(platform_default=True)
-    return set(principal_groups | platform_default_set)
+    assigned_group_set = principal.group.all()
+    platform_default_group_set = Group.objects.filter(platform_default=True)
+    return set(assigned_group_set | platform_default_group_set)
 
 
 def policies_for_principal(principal, **kwargs):

--- a/tests/management/test_utils.py
+++ b/tests/management/test_utils.py
@@ -18,7 +18,10 @@
 from tenant_schemas.utils import tenant_context
 
 from management.models import Group, Principal, Policy, Role, Access
-from management.utils import access_for_principal
+from management.utils import (access_for_principal,
+                              groups_for_principal,
+                              policies_for_principal,
+                              roles_for_principal)
 from tests.identity_request import IdentityRequest
 
 
@@ -75,3 +78,21 @@ class UtilsTests(IdentityRequest):
             kwargs = {'application': 'app'}
             access = access_for_principal(self.principal, **kwargs)
             self.assertCountEqual(access, [self.accessA, self.default_access])
+
+    def test_groups_for_principal(self):
+        """Test that we get the correct groups for a principal."""
+        with tenant_context(self.tenant):
+            groups = groups_for_principal(self.principal)
+            self.assertCountEqual(groups, [self.groupA, self.default_group])
+
+    def test_policies_for_principal(self):
+        """Test that we get the correct groups for a principal."""
+        with tenant_context(self.tenant):
+            policies = policies_for_principal(self.principal)
+            self.assertCountEqual(policies, [self.policyA, self.default_policy])
+
+    def test_roles_for_principal(self):
+        """Test that we get the correct groups for a principal."""
+        with tenant_context(self.tenant):
+            roles = roles_for_principal(self.principal)
+            self.assertCountEqual(roles, [self.roleA, self.default_role])

--- a/tests/management/test_utils.py
+++ b/tests/management/test_utils.py
@@ -33,9 +33,9 @@ class UtilsTests(IdentityRequest):
             # setup principal
             self.principal = Principal.objects.create(username='principalA')
 
-            # setup data for principal
+            # setup data for the principal
             self.roleA = Role.objects.create(name='roleA')
-            self.accessA = Access.objects.create(permission="app:*:*", role=self.roleA)
+            self.accessA = Access.objects.create(permission='app:*:*', role=self.roleA)
             self.policyA = Policy.objects.create(name='policyA')
             self.policyA.roles.add(self.roleA)
             self.groupA = Group.objects.create(name='groupA')
@@ -44,11 +44,20 @@ class UtilsTests(IdentityRequest):
 
             # setup data the principal does not have access to
             self.roleB = Role.objects.create(name='roleB')
-            self.accessB = Access.objects.create(permission="app:*:*", role=self.roleB)
+            self.accessB = Access.objects.create(permission='app:*:*', role=self.roleB)
             self.policyB = Policy.objects.create(name='policyB')
             self.policyB.roles.add(self.roleB)
             self.groupB = Group.objects.create(name='groupB')
             self.groupB.policies.add(self.policyB)
+
+            # setup default group/role which all tenant users
+            # should inherit without explicit association
+            self.default_role = Role.objects.create(name='default role', platform_default=True, system=True)
+            self.default_access = Access.objects.create(permission='app:*:*', role=self.default_role)
+            self.default_policy = Policy.objects.create(name='default policy', system=True)
+            self.default_policy.roles.add(self.default_role)
+            self.default_group = Group.objects.create(name='default group', system=True, platform_default=True)
+            self.default_group.policies.add(self.default_policy)
 
 
     def tearDown(self):
@@ -65,4 +74,4 @@ class UtilsTests(IdentityRequest):
         with tenant_context(self.tenant):
             kwargs = {'application': 'app'}
             access = access_for_principal(self.principal, **kwargs)
-            self.assertEquals(access, [self.accessA])
+            self.assertCountEqual(access, [self.accessA, self.default_access])

--- a/tests/management/test_utils.py
+++ b/tests/management/test_utils.py
@@ -1,0 +1,68 @@
+#
+# Copyright 2019 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""Test the utils module."""
+from tenant_schemas.utils import tenant_context
+
+from management.models import Group, Principal, Policy, Role, Access
+from management.utils import access_for_principal
+from tests.identity_request import IdentityRequest
+
+
+class UtilsTests(IdentityRequest):
+    """Test the utils module."""
+
+    def setUp(self):
+        """Set up the utils tests."""
+        super().setUp()
+
+        with tenant_context(self.tenant):
+            # setup principal
+            self.principal = Principal.objects.create(username='principalA')
+
+            # setup data for principal
+            self.roleA = Role.objects.create(name='roleA')
+            self.accessA = Access.objects.create(permission="app:*:*", role=self.roleA)
+            self.policyA = Policy.objects.create(name='policyA')
+            self.policyA.roles.add(self.roleA)
+            self.groupA = Group.objects.create(name='groupA')
+            self.groupA.policies.add(self.policyA)
+            self.groupA.principals.add(self.principal)
+
+            # setup data the principal does not have access to
+            self.roleB = Role.objects.create(name='roleB')
+            self.accessB = Access.objects.create(permission="app:*:*", role=self.roleB)
+            self.policyB = Policy.objects.create(name='policyB')
+            self.policyB.roles.add(self.roleB)
+            self.groupB = Group.objects.create(name='groupB')
+            self.groupB.policies.add(self.policyB)
+
+
+    def tearDown(self):
+        """Tear down the utils tests."""
+        with tenant_context(self.tenant):
+            Group.objects.all().delete()
+            Principal.objects.all().delete()
+            Policy.objects.all().delete()
+            Role.objects.all().delete()
+            Access.objects.all().delete()
+
+    def test_access_for_principal(self):
+        """Test that we get the correct access for a principal."""
+        with tenant_context(self.tenant):
+            kwargs = {'application': 'app'}
+            access = access_for_principal(self.principal, **kwargs)
+            self.assertEquals(access, [self.accessA])


### PR DESCRIPTION
This PR ensures that the group access for a principal is the union of groups
that they've been explicitly assigned to, as well as the tenant's `platform_default`
group.

This will cascade to the policy/role/access methods for a principal to ensure
that the access for all users of a tenant includes roles defined as part of
the `platform_default` group.

Since the management of this `platform_default` group will be determined by the
`system` flag, even once an org_admin changes the roles within this group, all
principals will continue to inherit its roles and access.

This also adds tests around other `*_for_principal` methods, with the expectation
that they will now inherit from the platform defaults.

**Testing:**
- for a new tenant, ensure the schema has a `platform_default` group, and at least one `platform_default` role
- visit: `http://localhost:8000/api/rbac/v1/access/?offset=0&limit=10&application=<application for the platform role>`
- note that you should have permission/access data in the response
- note that there should not be any `group_principal` records, confirming this permission is coming from the default group
- add the principal to another, non `platform_default` group
- add a role to the group
- visit the access link again, scoped to the app for the role you've added this time
- note that you have the new role access