### PR TITLE
Fix apidoc comments

### DIFF
--- a/rbac/management/access/view.py
+++ b/rbac/management/access/view.py
@@ -26,8 +26,8 @@ from rest_framework.views import APIView
 
 
 class AccessView(APIView):
-    """Obtain principal access list.
-
+    """Obtain principal access list."""
+    """
     @api {get} /api/v1/access/   Obtain principal access list
     @apiName getPrincipalAccess
     @apiGroup Access

--- a/rbac/management/access/view.py
+++ b/rbac/management/access/view.py
@@ -27,6 +27,7 @@ from rest_framework.views import APIView
 
 class AccessView(APIView):
     """Obtain principal access list."""
+
     """
     @api {get} /api/v1/access/   Obtain principal access list
     @apiName getPrincipalAccess

--- a/rbac/management/principal/view.py
+++ b/rbac/management/principal/view.py
@@ -29,6 +29,7 @@ USERNAMES_KEY = 'usernames'
 
 class PrincipalView(APIView):
     """Obtain the list of principals for the tenant."""
+
     """
     @api {get} /api/v1/principals/   Obtain a list of principals
     @apiName getPrincipals

--- a/rbac/management/principal/view.py
+++ b/rbac/management/principal/view.py
@@ -28,8 +28,8 @@ USERNAMES_KEY = 'usernames'
 
 
 class PrincipalView(APIView):
-    """Obtain the list of principals for the tenant.
-
+    """Obtain the list of principals for the tenant."""
+    """
     @api {get} /api/v1/principals/   Obtain a list of principals
     @apiName getPrincipals
     @apiGroup Principal


### PR DESCRIPTION
This helps format the rendering of the Django REST framework UI for the api.

**Before:**
![before](https://user-images.githubusercontent.com/1641557/70326234-091b3280-1802-11ea-872f-ca6381fdca7e.png)


**After:**
<img width="1184" alt="after" src="https://user-images.githubusercontent.com/1641557/70326229-06204200-1802-11ea-844c-629812c1a167.png">
