### PR TITLE
Access endpoint query performance

### DIFF
--- a/rbac/management/querysets.py
+++ b/rbac/management/querysets.py
@@ -135,7 +135,8 @@ def get_access_queryset(request):
     return get_object_principal_queryset(request,
                                          PRINCIPAL_SCOPE,
                                          Access,
-                                         **{APPLICATION_KEY: app})
+                                         **{APPLICATION_KEY: app,
+                                            'prefetch_lookups': 'resourceDefinitions'})
 
 
 def get_object_principal_queryset(request, scope, clazz, **kwargs):
@@ -154,4 +155,4 @@ def get_object_principal_queryset(request, scope, clazz, **kwargs):
     object_principal_func = PRINCIPAL_QUERYSET_MAP.get(clazz.__name__)
     principal = get_principal_from_request(request)
     objects = object_principal_func(principal, **kwargs)
-    return queryset_by_id(objects, clazz)
+    return queryset_by_id(objects, clazz, **kwargs)

--- a/rbac/management/querysets.py
+++ b/rbac/management/querysets.py
@@ -136,7 +136,8 @@ def get_access_queryset(request):
                                          PRINCIPAL_SCOPE,
                                          Access,
                                          **{APPLICATION_KEY: app,
-                                            'prefetch_lookups': 'resourceDefinitions'})
+                                            'prefetch_lookups_for_ids': 'resourceDefinitions',
+                                            'prefetch_lookups_for_groups': 'policies__roles__access'})
 
 
 def get_object_principal_queryset(request, scope, clazz, **kwargs):

--- a/rbac/management/utils.py
+++ b/rbac/management/utils.py
@@ -74,8 +74,8 @@ def access_for_roles(roles, application):
 
 def groups_for_principal(principal, **kwargs):
     """Gathers all groups for a principal, including the default."""
-    assigned_group_set = principal.group.all()
-    platform_default_group_set = Group.objects.filter(platform_default=True)
+    assigned_group_set = principal.group.prefetch_related('policies__roles__access').all()
+    platform_default_group_set = Group.objects.prefetch_related('policies__roles__access').filter(platform_default=True)
     return set(assigned_group_set | platform_default_group_set)
 
 

--- a/rbac/management/utils.py
+++ b/rbac/management/utils.py
@@ -74,27 +74,33 @@ def access_for_roles(roles, application):
 
 def groups_for_principal(principal, **kwargs):
     """Gathers all groups for a principal, including the default."""
-    assigned_group_set = principal.group.prefetch_related('policies__roles__access').all()
-    platform_default_group_set = Group.objects.prefetch_related('policies__roles__access').filter(platform_default=True)
+    assigned_group_set = principal.group.all()
+    platform_default_group_set = Group.objects.filter(platform_default=True)
+    prefetch_lookups = kwargs.get('prefetch_lookups_for_groups')
+
+    if prefetch_lookups:
+        assigned_group_set = assigned_group_set.prefetch_related(prefetch_lookups)
+        platform_default_group_set = platform_default_group_set.prefetch_related(prefetch_lookups)
+
     return set(assigned_group_set | platform_default_group_set)
 
 
 def policies_for_principal(principal, **kwargs):
     """Gathers all policies for a principal."""
-    groups = groups_for_principal(principal)
+    groups = groups_for_principal(principal, **kwargs)
     return policies_for_groups(groups)
 
 
 def roles_for_principal(principal, **kwargs):
     """Gathers all roles for a principal."""
-    policies = policies_for_principal(principal)
+    policies = policies_for_principal(principal, **kwargs)
     return roles_for_policies(policies)
 
 
 def access_for_principal(principal, **kwargs):
     """Gathers all access for a principal for an application."""
     application = kwargs.get(APPLICATION_KEY)
-    roles = roles_for_principal(principal)
+    roles = roles_for_principal(principal, **kwargs)
     access = access_for_roles(roles, application)
     return access
 
@@ -102,7 +108,7 @@ def access_for_principal(principal, **kwargs):
 def queryset_by_id(objects, clazz, **kwargs):
     """Return a queryset of from the class ordered by id."""
     wanted_ids = [obj.id for obj in objects]
-    prefetch_lookups = kwargs.get('prefetch_lookups')
+    prefetch_lookups = kwargs.get('prefetch_lookups_for_ids')
     query = clazz.objects.filter(id__in=wanted_ids).order_by('id')
 
     if prefetch_lookups:

--- a/rbac/management/utils.py
+++ b/rbac/management/utils.py
@@ -99,7 +99,13 @@ def access_for_principal(principal, **kwargs):
     return access
 
 
-def queryset_by_id(objects, clazz):
+def queryset_by_id(objects, clazz, **kwargs):
     """Return a queryset of from the class ordered by id."""
     wanted_ids = [obj.id for obj in objects]
-    return clazz.objects.filter(id__in=wanted_ids).order_by('id')
+    prefetch_lookups = kwargs.get('prefetch_lookups')
+    query = clazz.objects.filter(id__in=wanted_ids).order_by('id')
+
+    if prefetch_lookups:
+        query = query.prefetch_related(prefetch_lookups)
+
+    return query


### PR DESCRIPTION
This PR addresses some n+1 queries related to the `/access/` endpoint, which 
exist due to the nested relationship queries, by eager loading some of the
associations where possible.

Since we reuse a handful of the methods for getting data by principal, by abstracting 
two lookup options:
```
prefetch_lookups_for_ids
prefetch_lookups_for_groups
```
we can specify what data we'd like to preload. This PR just covers the `/access/`
eager loading, by preloading `policies`, `roles` and `access` when we get groups during
the access chain, via `prefetch_lookups_for_groups`.

We don't want to always eager load these relations though, since we can also get
just `groups`, or `roles` scoped to a `principal`, which reuses those methods. That
would cause those queries to respond slower.

As a follow-up, we can look at adding any other eager loading for those scoped
endpoints for `groups` and `roles`.

The other option: `prefetch_lookups_for_ids` specifies which relation(s) to load when
we resort the queryset of objects by ID. 

**Note:** we are currently doubling some DB hits because of this additional sort. 
We get the objects via a queryset, put them in a unique set (which means we no 
longer have the queryset), and then query again from that set to get a sorted queryset. 
It appears we should be able to improve this as well.

**Local data setup:**
--
**Principal Count:** 1
**Group Count:** 2
**Policy Count:** 20
**Role Count:** 850
**Access Count:** 85,000 (same application)
**Resource Definition Count:** 85,000 (same application)

**Results:**
--
**Before:**
```
/access/?application=<app_name>&limit=10
2.165s average response time

/access/?application=<app_name>&limit=<total_count>
5.174s average response time
```

**After:**
```
/access/?application=<app_name>&limit=10
576ms average response time (73.4% improvement)

/access/?application=<app_name>&limit=<total_count>
2.146s average response time (58.5% improvement, with a payload of 1.5mb)
```