### PR TITLE
Update the access username param description

### DIFF
--- a/docs/source/specs/openapi.json
+++ b/docs/source/specs/openapi.json
@@ -1245,7 +1245,7 @@
         "tags": [
           "Access"
         ],
-        "summary": "Get the permitted access for a principal in the tenant",
+        "summary": "Get the permitted access for a principal in the tenant (defaults to principal from the identity header)",
         "operationId": "getPrincipalAccess",
         "parameters": [
           {
@@ -1260,7 +1260,7 @@
           {
             "name": "username",
             "in": "query",
-            "description": "Unique username of the principal to obtain access for",
+            "description": "Unique username of the principal to obtain access for (only available for admins, and if supplied, takes precedence over the identity header).",
             "required": false,
             "schema": {
               "type": "string"


### PR DESCRIPTION
Clarify that it is only available for admins, and takes precedence over the
principal from the identity header.

<img width="831" alt="Screen Shot 2019-12-16 at 1 25 43 PM" src="https://user-images.githubusercontent.com/1641557/70932516-eb22ae80-2007-11ea-931b-020f39457a05.png">
