### PR TITLE
Scoped roles endpoint query performance

### DIFF
--- a/rbac/management/group/model.py
+++ b/rbac/management/group/model.py
@@ -42,6 +42,10 @@ class Group(models.Model):
         """Roles for a group."""
         return Role.objects.filter(policies__in=self.__policy_ids()).distinct()
 
+    def roles_with_access(self):
+        """Queryset for roles with access data prefetched."""
+        return self.roles().prefetch_related('access')
+
     def role_count(self):
         """Role count for a group."""
         return self.roles().count()

--- a/rbac/management/group/serializer.py
+++ b/rbac/management/group/serializer.py
@@ -93,7 +93,7 @@ class GroupSerializer(serializers.ModelSerializer):
 
     def get_roles(self, obj):
         """Role constructor for the serializer."""
-        serialized_roles = [RoleMinimumSerializer(role).data for role in obj.roles()]
+        serialized_roles = [RoleMinimumSerializer(role).data for role in obj.roles().prefetch_related('access')]
         return serialized_roles
 
 
@@ -123,5 +123,5 @@ class GroupRoleSerializerIn(serializers.Serializer):
 
     def to_representation(self, obj):
         """Convert representation to dictionary object."""
-        serialized_roles = [RoleMinimumSerializer(role).data for role in obj.roles()]
+        serialized_roles = [RoleMinimumSerializer(role).data for role in obj.roles().prefetch_related('access')]
         return {'data': serialized_roles}

--- a/rbac/management/group/serializer.py
+++ b/rbac/management/group/serializer.py
@@ -93,7 +93,7 @@ class GroupSerializer(serializers.ModelSerializer):
 
     def get_roles(self, obj):
         """Role constructor for the serializer."""
-        serialized_roles = [RoleMinimumSerializer(role).data for role in obj.roles().prefetch_related('access')]
+        serialized_roles = [RoleMinimumSerializer(role).data for role in obj.roles_with_access()]
         return serialized_roles
 
 
@@ -123,5 +123,5 @@ class GroupRoleSerializerIn(serializers.Serializer):
 
     def to_representation(self, obj):
         """Convert representation to dictionary object."""
-        serialized_roles = [RoleMinimumSerializer(role).data for role in obj.roles().prefetch_related('access')]
+        serialized_roles = [RoleMinimumSerializer(role).data for role in obj.roles_with_access()]
         return {'data': serialized_roles}

--- a/rbac/management/group/view.py
+++ b/rbac/management/group/view.py
@@ -451,7 +451,7 @@ class GroupViewSet(mixins.CreateModelMixin,
             set_system_flag_post_update(group)
             response_data = GroupRoleSerializerIn(group)
         elif request.method == 'GET':
-            serialized_roles = [RoleMinimumSerializer(role).data for role in group.roles()]
+            serialized_roles = [RoleMinimumSerializer(role).data for role in group.roles().prefetch_related('access')]
             page = self.paginate_queryset(serialized_roles)
             serializer = self.get_serializer(page, many=True)
             return self.get_paginated_response(serializer.data)

--- a/rbac/management/group/view.py
+++ b/rbac/management/group/view.py
@@ -451,7 +451,7 @@ class GroupViewSet(mixins.CreateModelMixin,
             set_system_flag_post_update(group)
             response_data = GroupRoleSerializerIn(group)
         elif request.method == 'GET':
-            serialized_roles = [RoleMinimumSerializer(role).data for role in group.roles().prefetch_related('access')]
+            serialized_roles = [RoleMinimumSerializer(role).data for role in group.roles_with_access()]
             page = self.paginate_queryset(serialized_roles)
             serializer = self.get_serializer(page, many=True)
             return self.get_paginated_response(serializer.data)

--- a/rbac/management/querysets.py
+++ b/rbac/management/querysets.py
@@ -81,12 +81,15 @@ def get_group_queryset(request):
 def get_role_queryset(request):
     """Obtain the queryset for roles."""
     scope = request.query_params.get(SCOPE_KEY, ACCOUNT_SCOPE)
+    base_query = Role.objects.prefetch_related('access').annotate(policyCount=Count('policies', distinct=True))
     if scope != ACCOUNT_SCOPE:
-        return get_object_principal_queryset(request, scope, Role)
+        return get_object_principal_queryset(request, scope, Role,
+                                             **{'prefetch_lookups_for_ids': 'access',
+                                                'prefetch_lookups_for_groups': 'policies__roles'})
     if ENVIRONMENT.get_value('ALLOW_ANY', default=False, cast=bool):
-        return Role.objects.annotate(policyCount=Count('policies', distinct=True))
+        return base_query
     if request.user.admin:
-        return Role.objects.annotate(policyCount=Count('policies', distinct=True))
+        return base_query
     access = request.user.access
     access_op = 'read'
     if request.method in ('POST', 'PUT'):
@@ -95,8 +98,8 @@ def get_role_queryset(request):
     if not res_list:
         return Role.objects.none()
     if '*' in res_list:
-        return Role.objects.annotate(policyCount=Count('policies', distinct=True))
-    return Role.objects.filter(uuid__in=res_list).annotate(policyCount=Count('policies', distinct=True))
+        return base_query
+    return base_query.filter(uuid__in=res_list)
 
 
 def get_policy_queryset(request):


### PR DESCRIPTION
**Address n+1 queries in GET `/roles/?scope=principal`** (47f32e4)
Similar to #172, when roles are scoped to principal, we end up running into
n+1 issues due to needing the policy/role records for the groups for a principal.

This resolves that by added the necessary prefetch lookups on the `get_role_queryset`
calls, and sets up a base query to be reused/extended upon.

We can also setup a `base_query` queryset to build upon in `get_role_queryset`.

---

**Optimize role serializer queries** (b7f299c)
We can remove n+1 queries for roles by prefetching `access` records in the queries
where the serializer is being used on roles.

We don't want to add this to the default query in `group#roles()` because we also use that method for getting the count, in which case we'd be prematurely fetching unnecessary data.

--- 

**Results:** _(same dataset as #172)_
--
**Before:**
```
/roles/?scope=principal
2.79s average response time

/groups/<uuid>/roles/
2.72s average response time
```

**After:**
```
/roles/?scope=principal
729ms average response time (73.87% improvement)

/groups/<uuid>/roles/
978ms average response time (64.04% improvement)
```