### PR TITLE
Add exclude option for group roles endpoint

### DIFF
--- a/docs/source/specs/openapi.json
+++ b/docs/source/specs/openapi.json
@@ -614,6 +614,16 @@
             }
           },
           {
+            "name": "exclude",
+            "in": "query",
+            "description": "If this is set to true, the result would be roles excluding the ones in the group",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
             "$ref": "#/components/parameters/QueryLimit"
           },
           {


### PR DESCRIPTION
Add an option to exclude the roles for GET /groups/{uuid}/roles
so that it supports excluding the roles originally get from this
endpoint.

Exclude could be used as /groups/{:uuid}/roles?exclude=true