### PR TITLE
Update 403 error for openapi

### DIFF
--- a/docs/source/specs/openapi.json
+++ b/docs/source/specs/openapi.json
@@ -110,6 +110,16 @@
           "401": {
             "description": "Unauthorized"
           },
+          "403": {
+            "description": "Insufficient permissions to list principals",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error403"
+                }
+              }
+            }
+          },
           "500": {
             "description": "Unexpected Error",
             "content": {
@@ -154,6 +164,16 @@
           },
           "401": {
             "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Insufficient permissions to create group",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error403"
+                }
+              }
+            }
           },
           "500": {
             "description": "Unexpected Error",
@@ -213,6 +233,16 @@
           "401": {
             "description": "Unauthorized"
           },
+          "403": {
+            "description": "Insufficient permissions to list groups",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error403"
+                }
+              }
+            }
+          },
           "500": {
             "description": "Unexpected Error",
             "content": {
@@ -258,6 +288,16 @@
           },
           "401": {
             "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Insufficient permissions to get group",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error403"
+                }
+              }
+            }
           },
           "404": {
             "description": "Not Found",
@@ -325,11 +365,11 @@
             "description": "Unauthorized"
           },
           "403": {
-            "description": "Insufficent permissions to update group",
+            "description": "Insufficient permissions to update group",
             "content": {
-              "*/*": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/Error403"
                 }
               }
             }
@@ -382,11 +422,11 @@
             "description": "Unauthorized"
           },
           "403": {
-            "description": "Insufficent permissions to delete group",
+            "description": "Insufficient permissions to delete group",
             "content": {
-              "*/*": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/Error403"
                 }
               }
             }
@@ -453,6 +493,16 @@
           "401": {
             "description": "Unauthorized"
           },
+          "403": {
+            "description": "Insufficient permissions to update principals in group",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error403"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Not Found",
             "content": {
@@ -511,6 +561,16 @@
           },
           "401": {
             "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Insufficient permissions to remove principals from group",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error403"
+                }
+              }
+            }
           },
           "404": {
             "description": "Not Found",
@@ -574,6 +634,16 @@
           "401": {
             "description": "Unauthorized"
           },
+          "403": {
+            "description": "Insufficient permissions to list roles for group",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error403"
+                }
+              }
+            }
+          },
           "500": {
             "description": "Unexpected Error",
             "content": {
@@ -635,6 +705,16 @@
           "401": {
             "description": "Unauthorized"
           },
+          "403": {
+            "description": "Insufficient permissions to update roles for group",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error403"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Not Found",
             "content": {
@@ -694,6 +774,16 @@
           "401": {
             "description": "Unauthorized"
           },
+          "403": {
+            "description": "Insufficient permissions to remove roles from group",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error403"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Not Found",
             "content": {
@@ -749,6 +839,16 @@
           "401": {
             "description": "Unauthorized"
           },
+          "403": {
+            "description": "Insufficient permissions to create role",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error403"
+                }
+              }
+            }
+          },
           "500": {
             "description": "Unexpected Error",
             "content": {
@@ -798,6 +898,16 @@
           "401": {
             "description": "Unauthorized"
           },
+          "403": {
+            "description": "Insufficient permissions to list roles",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error403"
+                }
+              }
+            }
+          },
           "500": {
             "description": "Unexpected Error",
             "content": {
@@ -843,6 +953,16 @@
           },
           "401": {
             "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Insufficient permissions to get role",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error403"
+                }
+              }
+            }
           },
           "404": {
             "description": "Not Found",
@@ -890,6 +1010,16 @@
           },
           "401": {
             "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Insufficient permissions to delete role",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error403"
+                }
+              }
+            }
           },
           "404": {
             "description": "Not Found",
@@ -948,6 +1078,16 @@
           },
           "401": {
             "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Insufficient permissions to update role",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error403"
+                }
+              }
+            }
           },
           "404": {
             "description": "Not Found",
@@ -1437,6 +1577,24 @@
               "example": {
                 "detail": "Not Found.",
                 "status": 404
+              }
+            }
+          }
+        }
+      },
+      "Error403": {
+        "required": [
+          "errors"
+        ],
+        "properties": {
+          "errors": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "example": {
+                "detail": "You do not have permission to perform this action.",
+                "source": "detail",
+                "status": 403
               }
             }
           }


### PR DESCRIPTION
When request with insufficent permission is made, 403 error is returned.
Which is not described in the openapi.json. This PR is to fix this.