### PR TITLE
Add validation for access list

### DIFF
--- a/rbac/management/role/view.py
+++ b/rbac/management/role/view.py
@@ -25,7 +25,7 @@ from django.utils.translation import gettext as _
 from django_filters import rest_framework as filters
 from management.permissions import RoleAccessPermission
 from management.querysets import get_role_queryset
-from management.role.serializer import RoleMinimumSerializer
+from management.role.serializer import AccessSerializer, RoleMinimumSerializer
 from rest_framework import mixins, serializers, viewsets
 from rest_framework.filters import OrderingFilter
 
@@ -136,7 +136,8 @@ class RoleViewSet(mixins.CreateModelMixin,
                 ]
             }
         """
-        for perm in request.data.get('access', []):
+        access_list = self.validate_and_get_access_list(request.data)
+        for perm in access_list:
             app = perm.get('permission').split(':')[0]
             if app not in APP_WHITELIST:
                 key = 'role'
@@ -320,3 +321,17 @@ class RoleViewSet(mixins.CreateModelMixin,
             }
         """
         return super().update(request=request, args=args, kwargs=kwargs)
+
+    def validate_and_get_access_list(self, data):
+        """Validate if input data contains valid access list and return."""
+        access_list = data.get('access')
+        if not isinstance(access_list, list):
+            key = 'access'
+            message = 'A list of access is expected, but {} is found.'.format(type(access_list).__name__)
+            error = {
+                key: [_(message)]
+            }
+            raise serializers.ValidationError(error)
+        for access in access_list:
+            AccessSerializer(data=access).is_valid(raise_exception=True)
+        return access_list

--- a/tests/management/role/test_view.py
+++ b/tests/management/role/test_view.py
@@ -76,7 +76,7 @@ class RoleViewsetTests(IdentityRequest):
 
     def create_role(self, role_name, in_access_data=None):
         """Create a role."""
-        access_data = {
+        access_data = [{
             'permission': 'app:*:*',
             'resourceDefinitions': [
                 {
@@ -87,12 +87,12 @@ class RoleViewsetTests(IdentityRequest):
                     }
                 }
             ]
-        }
+        }]
         if in_access_data:
             access_data = in_access_data
         test_data = {
             'name': role_name,
-            'access': [access_data]
+            'access': access_data
         }
 
         # create a role
@@ -104,7 +104,7 @@ class RoleViewsetTests(IdentityRequest):
     def test_create_role_success(self):
         """Test that we can create a role."""
         role_name = 'roleA'
-        access_data = {
+        access_data = [{
             'permission': 'app:*:*',
             'resourceDefinitions': [
                 {
@@ -115,7 +115,7 @@ class RoleViewsetTests(IdentityRequest):
                     }
                 }
             ]
-        }
+        }]
         response = self.create_role(role_name, access_data)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
@@ -128,7 +128,7 @@ class RoleViewsetTests(IdentityRequest):
         self.assertIsNotNone(response.data.get('name'))
         self.assertEqual(role_name, response.data.get('name'))
         self.assertIsInstance(response.data.get('access'), list)
-        self.assertEqual(access_data, response.data.get('access')[0])
+        self.assertEqual(access_data, response.data.get('access'))
 
     def test_create_role_invalid(self):
         """Test that creating an invalid role returns an error."""
@@ -157,7 +157,7 @@ class RoleViewsetTests(IdentityRequest):
     def test_create_role_whitelist(self):
         """Test that we can create a role in a whitelisted application via API."""
         role_name = 'C-MRole'
-        access_data = {
+        access_data = [{
             'permission': 'cost-management:*:*',
             'resourceDefinitions': [
                 {
@@ -168,7 +168,7 @@ class RoleViewsetTests(IdentityRequest):
                     }
                 }
             ]
-        }
+        }]
         response = self.create_role(role_name, access_data)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
@@ -181,12 +181,12 @@ class RoleViewsetTests(IdentityRequest):
         self.assertIsNotNone(response.data.get('name'))
         self.assertEqual(role_name, response.data.get('name'))
         self.assertIsInstance(response.data.get('access'), list)
-        self.assertEqual(access_data, response.data.get('access')[0])
+        self.assertEqual(access_data, response.data.get('access'))
 
     def test_create_role_whitelist_fail(self):
         """Test that we cannot create a role for a non-whitelisted app."""
         role_name = 'roleFail'
-        access_data = {
+        access_data = [{
             'permission': 'someApp:*:*',
             'resourceDefinitions': [
                 {
@@ -197,7 +197,21 @@ class RoleViewsetTests(IdentityRequest):
                     }
                 }
             ]
-        }
+        }]
+        response = self.create_role(role_name, access_data)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+ 
+    def test_create_role_fail_with_access_not_list(self):
+        """Test that we cannot create a role for a non-whitelisted app."""
+        role_name = 'AccessNotList'
+        access_data = 'some data'
+        response = self.create_role(role_name, access_data)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_create_role_fail_with_invalid_access(self):
+        """Test that we cannot create a role for invalid access data."""
+        role_name = 'AccessInvalid'
+        access_data = [{'per': 'some data'}]
         response = self.create_role(role_name, access_data)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 


### PR DESCRIPTION
Input of access is not a list would cause 500 instead of 400.
This should be fix and warn customers about it.
Also, if access object is not wel-defined, it should be 400.