### PR TITLE
Put properties inside allOf

### DIFF
--- a/docs/source/specs/openapi.json
+++ b/docs/source/specs/openapi.json
@@ -1777,26 +1777,28 @@
           },
           {
             "$ref": "#/components/schemas/Timestamped"
+          },
+          {
+            "properties": {
+              "principalCount": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "roleCount": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "system": {
+                "type": "boolean",
+                "default": false
+              },
+              "platform_default": {
+                "type": "boolean",
+                "default": false
+              }
+            }
           }
-        ],
-        "properties": {
-          "principalCount": {
-            "type": "integer",
-            "minimum": 0
-          },
-          "roleCount": {
-            "type": "integer",
-            "minimum": 0
-          },
-          "system": {
-            "type": "boolean",
-            "default": false
-          },
-          "platform_default": {
-            "type": "boolean",
-            "default": false
-          }
-        }
+        ]
       },
       "GroupPrincipalIn": {
         "required": [


### PR DESCRIPTION
If the properties is outside 'allOf', the openapi generator will ignore it.