### PR TITLE
Add access count to `/roles/` and `/roles/<uuid>/` endpoints

### DIFF
--- a/docs/source/specs/openapi.json
+++ b/docs/source/specs/openapi.json
@@ -2057,6 +2057,10 @@
                 "type": "integer",
                 "minimum": 0
               },
+              "accessCount": {
+                "type": "integer",
+                "minimum": 0
+              },
               "applications": {
                 "type": "array",
                 "items": {

--- a/rbac/management/querysets.py
+++ b/rbac/management/querysets.py
@@ -81,7 +81,8 @@ def get_group_queryset(request):
 def get_role_queryset(request):
     """Obtain the queryset for roles."""
     scope = request.query_params.get(SCOPE_KEY, ACCOUNT_SCOPE)
-    base_query = Role.objects.prefetch_related('access').annotate(policyCount=Count('policies', distinct=True))
+    base_query = Role.objects.prefetch_related('access').annotate(policyCount=Count('policies', distinct=True),
+                                                                  accessCount=Count('access', distinct=True))
     if scope != ACCOUNT_SCOPE:
         return get_object_principal_queryset(request, scope, Role,
                                              **{'prefetch_lookups_for_ids': 'access',

--- a/rbac/management/role/serializer.py
+++ b/rbac/management/role/serializer.py
@@ -70,6 +70,7 @@ class RoleSerializer(serializers.ModelSerializer):
     description = serializers.CharField(allow_null=True, required=False)
     access = AccessSerializer(many=True)
     policyCount = serializers.IntegerField(read_only=True)
+    accessCount = serializers.IntegerField(read_only=True)
     applications = serializers.SerializerMethodField()
     system = serializers.BooleanField(read_only=True)
     platform_default = serializers.BooleanField(read_only=True)
@@ -81,7 +82,7 @@ class RoleSerializer(serializers.ModelSerializer):
 
         model = Role
         fields = ('uuid', 'name', 'description',
-                  'access', 'policyCount',
+                  'access', 'policyCount', 'accessCount',
                   'applications', 'system',
                   'platform_default', 'created',
                   'modified')
@@ -142,6 +143,7 @@ class RoleMinimumSerializer(serializers.ModelSerializer):
     created = serializers.DateTimeField(read_only=True)
     modified = serializers.DateTimeField(read_only=True)
     policyCount = serializers.IntegerField(read_only=True)
+    accessCount = serializers.IntegerField(read_only=True)
     applications = serializers.SerializerMethodField()
     system = serializers.BooleanField(read_only=True)
     platform_default = serializers.BooleanField(read_only=True)
@@ -151,7 +153,7 @@ class RoleMinimumSerializer(serializers.ModelSerializer):
 
         model = Role
         fields = ('uuid', 'name', 'description', 'created', 'modified', 'policyCount',
-                  'applications', 'system', 'platform_default')
+                  'accessCount', 'applications', 'system', 'platform_default')
 
     def get_applications(self, obj):
         """Get the list of applications in the role."""

--- a/tests/management/role/test_view.py
+++ b/tests/management/role/test_view.py
@@ -200,7 +200,7 @@ class RoleViewsetTests(IdentityRequest):
         }]
         response = self.create_role(role_name, access_data)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
- 
+
     def test_create_role_fail_with_access_not_list(self):
         """Test that we cannot create a role for a non-whitelisted app."""
         role_name = 'AccessNotList'
@@ -245,6 +245,7 @@ class RoleViewsetTests(IdentityRequest):
         for iterRole in response.data.get('data'):
             self.assertIsNotNone(iterRole.get('name'))
             if iterRole.get('name') == role_name:
+                self.assertEqual(iterRole.get('accessCount'), 1)
                 role = iterRole
                 break
         self.assertEqual(role.get('name'), role_name)

--- a/tests/management/test_querysets.py
+++ b/tests/management/test_querysets.py
@@ -209,6 +209,7 @@ class QuerySetTest(TestCase):
         req = Mock(user=user, query_params={})
         queryset = get_role_queryset(req)
         self.assertEquals(queryset.count(), 5)
+        self.assertIsNotNone(queryset.last().accessCount)
 
     def test_get_role_queryset_get_all(self):
         """Test get_role_queryset as a user with all access."""


### PR DESCRIPTION
This adds an `accessCount` field to the `/roles/` and `/roles/<uuid>/` endpoints, to show the number of permission/access objects contained within each role.

To do so, we're annotating the base query for roles with the access count, and including it as a read-only value in the serializers.

**New Response for `/roles/`**
```
{
  "meta": {
    "count": 2508,
    "limit": 1,
    "offset": 0
  },
  "links": {
    "first": "/api/rbac/v1/roles/?limit=1&offset=0",
    "next": "/api/rbac/v1/roles/?limit=1&offset=1",
    "previous": null,
    "last": "/api/rbac/v1/roles/?limit=1&offset=2507"
  },
  "data": [
    {
      "uuid": "3ecac858-4f48-4393-a26b-914ba73477aa",
      "name": "Ansible Automation Access",
      "description": "An all access role which grants read and write permissions.",
      "created": "2020-01-31T16:44:43.919593Z",
      "modified": "2020-01-31T16:44:43.946095Z",
      "policyCount": 1,
      "accessCount": 2,
      "applications": [
        "inventory",
        "ansible-automation"
      ],
      "system": true,
      "platform_default": true
    }
  ]
}
```
<img width="771" alt="Screen Shot 2020-02-04 at 12 41 25 PM" src="https://user-images.githubusercontent.com/1641557/73771268-0ed2bd00-474c-11ea-965e-968b34acde6e.png">


**New Response for `/roles/<uuid>/`**
```
{
  "uuid": "3ecac858-4f48-4393-a26b-914ba73477aa",
  "name": "Ansible Automation Access",
  "description": "An all access role which grants read and write permissions.",
  "access": [
    {
      "permission": "inventory:*:*",
      "resourceDefinitions": []
    },
    {
      "permission": "ansible-automation:*:*",
      "resourceDefinitions": []
    }
  ],
  "policyCount": 1,
  "accessCount": 2,
  "applications": null,
  "system": true,
  "platform_default": true,
  "created": "2020-01-31T16:44:43.919593Z",
  "modified": "2020-01-31T16:44:43.946095Z"
}
```
<img width="799" alt="Screen Shot 2020-02-04 at 12 41 40 PM" src="https://user-images.githubusercontent.com/1641557/73771288-1b571580-474c-11ea-874b-3afe72bd99f8.png">
