### PR TITLE
Add role access GET endpoint: /roles/<uuid>/access/

### DIFF
--- a/docs/source/specs/openapi.json
+++ b/docs/source/specs/openapi.json
@@ -1122,6 +1122,89 @@
         }
       }
     },
+    "/roles/{uuid}/access/": {
+      "get": {
+        "tags": [
+          "Role"
+        ],
+        "summary": "Get access for a role in the tenant",
+        "operationId": "getRoleAccess",
+        "parameters": [
+          {
+            "name": "uuid",
+            "in": "path",
+            "description": "ID of the role",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/QueryLimit"
+          },
+          {
+            "$ref": "#/components/parameters/QueryOffset"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A paginated list of the access objects for a role",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/AccessPagination"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Insufficient permissions to get access for role",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error403"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/policies/": {
       "post": {
         "tags": [

--- a/rbac/management/role/view.py
+++ b/rbac/management/role/view.py
@@ -332,10 +332,9 @@ class RoleViewSet(mixins.CreateModelMixin,
         except (Role.DoesNotExist, ValidationError):
             raise Http404
 
-        if role:
-            access = AccessSerializer(role.access, many=True).data
-            page = self.paginate_queryset(access)
-            return self.get_paginated_response(page)
+        access = AccessSerializer(role.access, many=True).data
+        page = self.paginate_queryset(access)
+        return self.get_paginated_response(page)
 
     def validate_and_get_access_list(self, data):
         """Validate if input data contains valid access list and return."""

--- a/rbac/management/role/view.py
+++ b/rbac/management/role/view.py
@@ -18,14 +18,17 @@
 """View for role management."""
 import os
 
+from django.core.exceptions import ValidationError
 from django.db import transaction
 from django.db.models.aggregates import Count
+from django.http import Http404
 from django.utils.translation import gettext as _
 from django_filters import rest_framework as filters
 from management.permissions import RoleAccessPermission
 from management.querysets import get_role_queryset
 from management.role.serializer import AccessSerializer, RoleMinimumSerializer
 from rest_framework import mixins, serializers, viewsets
+from rest_framework.decorators import action
 from rest_framework.filters import OrderingFilter
 
 from .model import Role
@@ -320,6 +323,19 @@ class RoleViewSet(mixins.CreateModelMixin,
             }
         """
         return super().update(request=request, args=args, kwargs=kwargs)
+
+    @action(detail=True, methods=['get'])
+    def access(self, request, uuid=None):
+        """Return access objects for specified role."""
+        try:
+            role = Role.objects.get(uuid=uuid)
+        except (Role.DoesNotExist, ValidationError):
+            raise Http404
+
+        if role:
+            access = AccessSerializer(role.access, many=True).data
+            page = self.paginate_queryset(access)
+            return self.get_paginated_response(page)
 
     def validate_and_get_access_list(self, data):
         """Validate if input data contains valid access list and return."""

--- a/tests/management/role/test_view.py
+++ b/tests/management/role/test_view.py
@@ -26,7 +26,7 @@ from rest_framework.test import APIClient
 from tenant_schemas.utils import tenant_context
 
 from api.models import User
-from management.models import Group, Principal, Role
+from management.models import Group, Principal, Role, Access
 from tests.identity_request import IdentityRequest
 
 
@@ -65,6 +65,8 @@ class RoleViewsetTests(IdentityRequest):
 
             self.defRole = Role(**def_role_config)
             self.defRole.save()
+
+            self.access = Access.objects.create(permission='app:*:*', role=self.defRole)
 
     def tearDown(self):
         """Tear down role viewset tests."""
@@ -218,6 +220,32 @@ class RoleViewsetTests(IdentityRequest):
     def test_read_role_invalid(self):
         """Test that reading an invalid role returns an error."""
         url = reverse('role-detail', kwargs={'uuid': uuid4()})
+        client = APIClient()
+        response = client.get(url, **self.headers)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_read_role_access_success(self):
+        """Test that reading a valid role returns access."""
+        url = reverse('role-access', kwargs={'uuid': self.defRole.uuid})
+        client = APIClient()
+        response = client.get(url, **self.headers)
+
+        for keyname in ['meta', 'links', 'data']:
+            self.assertIn(keyname, response.data)
+        self.assertIsInstance(response.data.get('data'), list)
+        self.assertEqual(len(response.data.get('data')), 1)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_read_role_access_invalid_uuid(self):
+        """Test that reading a non-existent role uuid returns an error."""
+        url = reverse('role-access', kwargs={'uuid': 'abc-123'})
+        client = APIClient()
+        response = client.get(url, **self.headers)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_read_role_access_not_found_uuid(self):
+        """Test that reading an invalid role uuid returns an error."""
+        url = reverse('role-access', kwargs={'uuid': uuid4()})
         client = APIClient()
         response = client.get(url, **self.headers)
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)


### PR DESCRIPTION
This add the `GET` endpoint: `/roles/<uuid>/access/` to the API. While the access objects are currently returned as a nested resource within `/roles/<uuid>/`, the UI is requesting that we provide an explicit endpoint for retrieving access objects for a given role, in order to paginate and eventually filter on this data directly.

The payload will look like:
```
{
  "meta": {
    "count": 2,
    "limit": 10,
    "offset": 0
  },
  "links": {
    "first": "/api/rbac/v1/roles/3ecac858-4f48-4393-a26b-914ba73477aa/access/?limit=10&offset=0",
    "next": null,
    "previous": null,
    "last": "/api/rbac/v1/roles/3ecac858-4f48-4393-a26b-914ba73477aa/access/?limit=10&offset=0"
  },
  "data": [
    {
      "permission": "inventory:*:*",
      "resourceDefinitions": []
    },
    {
      "permission": "ansible-automation:*:*",
      "resourceDefinitions": []
    }
  ]
}
```

And is represented in the openapi.json spec:
<img width="779" alt="Screen Shot 2020-02-06 at 10 15 37 AM" src="https://user-images.githubusercontent.com/1641557/73951175-284e4300-48cb-11ea-8267-aed6381f4bda.png">

Currently there is no filtering on this endpoint, only pagination.