### PR TITLE
Move OneOf Access defintion to separate component

### DIFF
--- a/docs/source/specs/openapi.json
+++ b/docs/source/specs/openapi.json
@@ -1429,14 +1429,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/AccessNoPagination"
-                    },
-                    {
-                      "$ref": "#/components/schemas/AccessPagination"
-                    }
-                  ]
+                  "$ref" : "#/components/schemas/OneOfAccessPagination"
                 },
                 "examples": {
                   "AccessNoPagination": {
@@ -2223,6 +2216,7 @@
           }
         ]
       },
+      
       "AccessPagination": {
         "allOf": [
           {
@@ -2259,6 +2253,16 @@
                 }
               }
             }
+          }
+        ]
+      },
+      "OneOfAccessPagination" : {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/AccessNoPagination"
+          },
+          {
+            "$ref": "#/components/schemas/AccessPagination"
           }
         ]
       },


### PR DESCRIPTION
The inline specification of OneOf model does not play nice with client generator for golang, 
and is blocking [patchman-engine](https://github.com/RedHatInsights/patchman-engine) integration.

Semantics before and after the change are the same.