### PR TITLE
Add x-rh-identity security scheme

### DIFF
--- a/docs/source/specs/openapi.json
+++ b/docs/source/specs/openapi.json
@@ -12,6 +12,9 @@
   "security": [
     {
       "basic_auth": []
+    },
+    {
+      "identity_auth": []
     }
   ],
   "tags": [
@@ -1681,6 +1684,12 @@
         "type": "http",
         "description": "The userid/password is needed when accessing this API externally",
         "scheme": "basic"
+      },
+      "identity_auth": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "x-rh-identity",
+        "description": "Internal authorization scheme for cross-service communication"
       }
     },
     "schemas": {


### PR DESCRIPTION
Adds a new security scheme which denotes requirement of sending `x-rh-identity` header.
Requirement for automatically generated clients to work.

Same approach is taken by [host based inventory](https://github.com/RedHatInsights/insights-host-inventory/blob/b21784c73528cc64773efee11ea5820b5e8cb109/swagger/api.spec.yaml#L345).