### PR TITLE
Remove default roles for CP and MA

### DIFF
--- a/rbac/management/migrations/0014_remove_unnecessary_platform_default_role.py
+++ b/rbac/management/migrations/0014_remove_unnecessary_platform_default_role.py
@@ -1,0 +1,22 @@
+# Generated manually to remove some platform default roles
+
+from django.db import migrations
+
+def remove_unnecessary_platform_default_role(apps, schema_editor):
+  role_names_to_remove = [
+    'Custom Policies Access',
+    'Migration Analytics Access'
+  ]
+
+  Role = apps.get_model('management', 'Role')
+  Role.objects.filter(system=True, name__in=role_names_to_remove).delete()
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('management', '0013_auto_20200128_2030'),
+    ]
+
+    operations = [
+      migrations.RunPython(remove_unnecessary_platform_default_role),
+    ]


### PR DESCRIPTION
Remove default roles for apps not integrating with RBAC Lite part 2,
custom-policies and migration-analytics will not be ready.

Depends on: https://github.com/RedHatInsights/rbac-config/pull/22