### PR TITLE
Add url filters to /groups/<uuid>/roles/

### DIFF
--- a/docs/source/specs/openapi.json
+++ b/docs/source/specs/openapi.json
@@ -624,6 +624,24 @@
             }
           },
           {
+            "name": "role_name",
+            "in": "query",
+            "required": false,
+            "description": "Parameter for filtering group roles by role `name` using string contains search.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "role_description",
+            "in": "query",
+            "required": false,
+            "description": "Parameter for filtering group roles by role `description` using string contains search.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
             "$ref": "#/components/parameters/QueryLimit"
           },
           {

--- a/rbac/management/group/view.py
+++ b/rbac/management/group/view.py
@@ -44,6 +44,7 @@ USERNAMES_KEY = 'usernames'
 ROLES_KEY = 'roles'
 EXCLUDE_KEY = 'exclude'
 VALID_EXCLUDE_VALUES = ['true', 'false']
+VALID_GROUP_ROLE_FILTERS = ['role_name', 'role_description']
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
 
@@ -482,6 +483,16 @@ class GroupViewSet(mixins.CreateModelMixin,
 
         return Response(status=status.HTTP_200_OK, data=response_data.data)
 
+    def filtered_roles(self, roles, request):
+        """Return filtered roles for group from query params."""
+        role_filters = {}
+        for param_name, param_value in request.query_params.items():
+            if param_name in VALID_GROUP_ROLE_FILTERS:
+                attr_filter_name = param_name.replace('role_', '')
+                role_filters[f'{attr_filter_name}__icontains'] = param_value
+
+        return roles.filter(**role_filters)
+
     def obtain_roles(self, request, group):
         """Obtain roles based on request, supports exclusion."""
         exclude = self.validate_and_get_exclude_key(request.query_params)
@@ -489,7 +500,9 @@ class GroupViewSet(mixins.CreateModelMixin,
         roles = (group.roles_with_access() if exclude == 'false'
                  else self.obtain_roles_with_exclusion(request, group))
 
-        return [RoleMinimumSerializer(role).data for role in roles]
+        filtered_roles = self.filtered_roles(roles, request)
+
+        return [RoleMinimumSerializer(role).data for role in filtered_roles]
 
     def obtain_roles_with_exclusion(self, request, group):
         """Obtain the queryset for roles based on scope."""

--- a/tests/management/group/test_view.py
+++ b/tests/management/group/test_view.py
@@ -48,7 +48,7 @@ class GroupViewsetTests(IdentityRequest):
             self.principal.save()
             self.group = Group(name='groupA')
             self.group.save()
-            self.role = Role.objects.create(name='roleA')
+            self.role = Role.objects.create(name='roleA', description='A role for a group.')
             self.policy = Policy.objects.create(name='policyA', group=self.group)
             self.policy.roles.add(self.role)
             self.policy.save()
@@ -358,6 +358,75 @@ class GroupViewsetTests(IdentityRequest):
         response = client.get(url, **self.headers)
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_role_name_filter_for_group_roles_no_match(self):
+        """Test role_name filter for getting roles for a group."""
+        url = reverse('group-roles', kwargs={'uuid': self.group.uuid})
+        url = '{}?role_name=test'.format(url)
+        client = APIClient()
+        response = client.get(url, **self.headers)
+        roles = response.data.get('data')
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(roles), 0)
+
+    def test_role_name_filter_for_group_roles_match(self):
+        """Test role_name filter for getting roles for a group."""
+        url = reverse('group-roles', kwargs={'uuid': self.group.uuid})
+        url = '{}?role_name={}'.format(url, self.role.name)
+        client = APIClient()
+        response = client.get(url, **self.headers)
+        roles = response.data.get('data')
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(roles), 1)
+        self.assertEqual(roles[0].get('uuid'), str(self.role.uuid))
+
+    def test_role_description_filter_for_group_roles_no_match(self):
+        """Test role_description filter for getting roles for a group."""
+        url = reverse('group-roles', kwargs={'uuid': self.group.uuid})
+        url = '{}?role_description=test'.format(url)
+        client = APIClient()
+        response = client.get(url, **self.headers)
+        roles = response.data.get('data')
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(roles), 0)
+
+    def test_role_description_filter_for_group_roles_match(self):
+        """Test role_description filter for getting roles for a group."""
+        url = reverse('group-roles', kwargs={'uuid': self.group.uuid})
+        url = '{}?role_description={}'.format(url, self.role.description)
+        client = APIClient()
+        response = client.get(url, **self.headers)
+        roles = response.data.get('data')
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(roles), 1)
+        self.assertEqual(roles[0].get('uuid'), str(self.role.uuid))
+
+    def test_all_role_filters_for_group_roles_no_match(self):
+        """Test role filters for getting roles for a group."""
+        url = reverse('group-roles', kwargs={'uuid': self.group.uuid})
+        url = '{}?role_description=test&role_name=test'.format(url)
+        client = APIClient()
+        response = client.get(url, **self.headers)
+        roles = response.data.get('data')
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(roles), 0)
+
+    def test_all_role_filters_for_group_roles_match(self):
+        """Test role filters for getting roles for a group."""
+        url = reverse('group-roles', kwargs={'uuid': self.group.uuid})
+        url = '{}?role_description={}&role_name={}'.format(url, self.role.description, self.role.name)
+        client = APIClient()
+        response = client.get(url, **self.headers)
+        roles = response.data.get('data')
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(roles), 1)
+        self.assertEqual(roles[0].get('uuid'), str(self.role.uuid))
 
     def test_add_group_roles_system_policy_create_success(self):
         """Test that adding a role to a group without a system policy returns successfully."""


### PR DESCRIPTION
This adds the following url param filters to roles for groups:

```
/api/rbac/v1/groups/<uuid>/roles/?role_name=
/api/rbac/v1/groups/<uuid>/roles/?role_description=
```

Using filters prefixed with `role_` for clarity within the group view, as well
as the fact that there would be a naming collision within DRF with the existing
group ordering fields being used, primarily for `name`.