### PR TITLE
Ensure default groups are returned using `username` filter on `/groups/`

### DIFF
--- a/rbac/management/group/model.py
+++ b/rbac/management/group/model.py
@@ -50,6 +50,10 @@ class Group(models.Model):
         """Role count for a group."""
         return self.roles().count()
 
+    def platform_default_set():
+        """Queryset for platform default group."""
+        return Group.objects.filter(platform_default=True)
+
     def __policy_ids(self):
         """Policy IDs for a group."""
         return self.policies.values_list('id', flat=True)

--- a/rbac/management/group/view.py
+++ b/rbac/management/group/view.py
@@ -51,8 +51,14 @@ logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 class GroupFilter(filters.FilterSet):
     """Filter for group."""
 
+    def username_filter(queryset, field, value):
+        """Filter for group username lookup."""
+        filters = {'{}__username__icontains'.format(field): value}
+        filtered_set = queryset.filter(**filters)
+        return filtered_set | Group.platform_default_set()
+
     name = filters.CharFilter(field_name='name', lookup_expr='icontains')
-    username = filters.CharFilter(field_name='principals', lookup_expr='username__icontains')
+    username = filters.CharFilter(field_name='principals', method=username_filter)
 
     class Meta:
         model = Group

--- a/rbac/management/querysets.py
+++ b/rbac/management/querysets.py
@@ -63,7 +63,7 @@ def get_group_queryset(request):
         if username != identity_username:
             return Group.objects.none()
         else:
-            return Group.objects.filter(principals__username=username) | Group.platform_default_set()
+            return Group.objects.filter(principals__username=username)
     access = request.user.access
     access_op = 'read'
     if request.method in ('POST', 'PUT'):

--- a/rbac/management/querysets.py
+++ b/rbac/management/querysets.py
@@ -63,7 +63,7 @@ def get_group_queryset(request):
         if username != identity_username:
             return Group.objects.none()
         else:
-            return Group.objects.filter(principals__username=username)
+            return Group.objects.filter(principals__username=username) | Group.platform_default_set()
     access = request.user.access
     access_op = 'read'
     if request.method in ('POST', 'PUT'):

--- a/rbac/management/utils.py
+++ b/rbac/management/utils.py
@@ -75,7 +75,7 @@ def access_for_roles(roles, application):
 def groups_for_principal(principal, **kwargs):
     """Gathers all groups for a principal, including the default."""
     assigned_group_set = principal.group.all()
-    platform_default_group_set = Group.objects.filter(platform_default=True)
+    platform_default_group_set = Group.platform_default_set()
     prefetch_lookups = kwargs.get('prefetch_lookups_for_groups')
 
     if prefetch_lookups:

--- a/tests/management/group/test_view.py
+++ b/tests/management/group/test_view.py
@@ -299,7 +299,7 @@ class GroupViewsetTests(IdentityRequest):
         url = '{}?username={}'.format(url, uuid4())
         client = APIClient()
         response = client.get(url, **self.headers)
-        self.assertEqual(response.data.get('meta').get('count'), 0)
+        self.assertEqual(response.data.get('meta').get('count'), 1)
 
     def test_get_group_roles_success(self):
         """Test that getting roles for a group returns successfully."""


### PR DESCRIPTION
This fixes a bug where the platform default group for a tenant was not being
returned when the `?username=` filter is used.

There are two reasons this is occurring. First is that the queryset being build
when a username filter is used does not include the default groups. Second is that
the current filter lookup builds the query to filter on the principal relationship
with groups, by principal username. Since the platform default groups aren't related
directly to principal records, they will always be excluded from the queryset.

To resolve this, we should always merge the platform default group set in on the
queryset as well as the filter, similar to what we do when we get groups for a principal.

- sets up a helper on the Group model to get the `platform_default_set`
- reuses helper in utils, the group view, and the group queryset
- implements a custom filter for the group username filter to also include the
  platform default group set