### PR TITLE
Add username filter on groups principals get

### DIFF
--- a/docs/source/specs/openapi.json
+++ b/docs/source/specs/openapi.json
@@ -544,6 +544,15 @@
               "type": "string",
               "format": "uuid"
             }
+          },
+          {
+            "name": "principal_username",
+            "in": "query",
+            "required": false,
+            "description": "Parameter for filtering group principals by principal `username` using string contains search.",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {


### PR DESCRIPTION
This reuses a similar pattern added for filtering roles on groups, so it's now
broken out into a helper to build the filters for nested resources on groups.

Now, a filter `?principal_username=` is supported on /groups/<uuid>/principals/
in order to return principal details for a group, filtered by username.