### PR TITLE
Revert "Add x-rh-identity security scheme"

### DIFF
--- a/docs/source/specs/openapi.json
+++ b/docs/source/specs/openapi.json
@@ -12,9 +12,6 @@
   "security": [
     {
       "basic_auth": []
-    },
-    {
-      "identity_auth": []
     }
   ],
   "tags": [
@@ -1733,12 +1730,6 @@
         "type": "http",
         "description": "The userid/password is needed when accessing this API externally",
         "scheme": "basic"
-      },
-      "identity_auth": {
-        "type": "apiKey",
-        "in": "header",
-        "name": "x-rh-identity",
-        "description": "Internal authorization scheme for cross-service communication"
       }
     },
     "schemas": {


### PR DESCRIPTION
Reverts RedHatInsights/insights-rbac#206

Based on a conversation with @mkanoor and @semtexzv, we'll need to revert this change to unblock an issue it introduces with the x-rh-identity header for the generated Ruby client.

We should consider a uniform, consistent documentation approach across the platform with regard to these external vs internal request requirements in the future.