### PR TITLE
Fix count bug on retriving user count from proxy

### DIFF
--- a/rbac/management/principal/proxy.py
+++ b/rbac/management/principal/proxy.py
@@ -146,9 +146,10 @@ class PrincipalProxy:  # pylint: disable=too-few-public-methods
                 data = response.json()
                 if isinstance(data, dict):
                     userList = self._process_data(data.get('users'), account, account_filter)
+                    resp['data'] = {'userCount': data.get('userCount'), 'users': userList}
                 else:
                     userList = self._process_data(data, account, account_filter)
-                resp['data'] = userList
+                    resp['data'] = userList
             except ValueError:
                 resp['status_code'] = status.HTTP_500_INTERNAL_SERVER_ERROR
                 error = unexpected_error

--- a/tests/management/principal/test_proxy.py
+++ b/tests/management/principal/test_proxy.py
@@ -67,6 +67,22 @@ def mocked_requests_get_200_json(*args, **kwargs):  # pylint: disable=unused-arg
     json_response = [user]
     return MockResponse(json_response, status.HTTP_200_OK)
 
+def mocked_requests_get_200_json_count(*args, **kwargs): # pylint: disable=unused-argument
+    """Mock valid response that returns json with usercount."""
+    user1 = {
+        'username': 'test_user1',
+        'email': 'test_user1@email.foo',
+        'first_name': 'test',
+        'last_name': 'user1'
+        }
+    user2 = {
+        'username': 'test_user2',
+        'email': 'test_user2@email.foo',
+        'first_name': 'test',
+        'last_name': 'user2'
+        }
+    json_response = {"userCount": 2, "users": [user1, user2]}
+    return MockResponse(json_response, status.HTTP_200_OK)
 
 def mocked_requests_get_200_except(*args, **kwargs):  # pylint: disable=unused-argument
     """Mock valid response that returns exception on json."""
@@ -157,6 +173,29 @@ class PrincipalProxyTest(TestCase):
         }
         expected = {
             'data': [user],
+            'status_code': 200
+        }
+        self.assertEqual(expected, result)
+
+    def test__request_principals_200_count(self):
+        """Test request with 200 and good data including userCount."""
+        proxy = PrincipalProxy()
+        result = proxy._request_principals(url='http://localhost:8080/v1/users',
+                                           method=mocked_requests_get_200_json_count)
+        user1 = {
+            'username': 'test_user1',
+            'email': 'test_user1@email.foo',
+            'first_name': 'test',
+            'last_name': 'user1'
+        }
+        user2 = {
+            'username': 'test_user2',
+            'email': 'test_user2@email.foo',
+            'first_name': 'test',
+            'last_name': 'user2'
+        }
+        expected = {
+            'data': {"userCount": 2, "users": [user1, user2]},
             'status_code': 200
         }
         self.assertEqual(expected, result)


### PR DESCRIPTION
The way we were passing the user list through to _process_data was consuming the user count and not readding it afterwards, resulting in count always coming back None. In testing this seems to clear that up!

Signed-off-by: Chris Mitchell <cmitchel@redhat.com>