### PR TITLE
Add exclude option for group principals

### DIFF
--- a/docs/source/specs/openapi.json
+++ b/docs/source/specs/openapi.json
@@ -550,6 +550,16 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "exclude",
+            "in": "query",
+            "description": "If this is set to true, the result would be principals excluding the ones in the group",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
           }
         ],
         "responses": {

--- a/tests/management/role/test_view.py
+++ b/tests/management/role/test_view.py
@@ -28,7 +28,6 @@ from tenant_schemas.utils import tenant_context
 from api.models import User
 from management.models import Group, Principal, Role, Access
 from tests.identity_request import IdentityRequest
-import pdb
 
 
 class RoleViewsetTests(IdentityRequest):


### PR DESCRIPTION
Adding an exclude option for group principals so that one api call
should be able to find all principals excluding the ones under this
group.