### PR TITLE
Fix the additional group in spec file

### DIFF
--- a/docs/source/specs/openapi.json
+++ b/docs/source/specs/openapi.json
@@ -1953,9 +1953,6 @@
         }
       },
       "AdditionalGroup": {
-        "required": [
-          "name"
-        ],
         "properties": {
           "name": {
             "type": "string",


### PR DESCRIPTION
This AdditionalGroup is an optional return. If the name is set as
required. Empty return of group list would cause error.