### PR TITLE
Document inverse `order_by` filter in description

### DIFF
--- a/docs/source/specs/openapi.json
+++ b/docs/source/specs/openapi.json
@@ -1708,7 +1708,7 @@
         "in": "query",
         "name": "order_by",
         "required": false,
-        "description": "Parameter for ordering resource by value.",
+        "description": "Parameter for ordering resource by value. For inverse ordering, supply '-' before the param value, such as: ?order_by=-name",
         "schema": {
           "type": "string"
         }
@@ -2312,10 +2312,10 @@
           {
             "type": "object",
             "required": [
-              "policyCount", 
-              "accessCount", 
-              "applications", 
-              "system", 
+              "policyCount",
+              "accessCount",
+              "applications",
+              "system",
               "platform_default"
             ],
             "properties": {


### PR DESCRIPTION
Adds to the `order_by` description to communicate how to invert the `order_by`
filter response.