### PR TITLE
Ensure /role/?username= returns count data

### DIFF
--- a/rbac/management/querysets.py
+++ b/rbac/management/querysets.py
@@ -78,15 +78,22 @@ def get_group_queryset(request):
     return Group.objects.none()
 
 
+def annotate_roles_with_counts(queryset):
+    """Annotate the queryset for roles with counts."""
+    return queryset.annotate(policyCount=Count('policies', distinct=True),
+                             accessCount=Count('access', distinct=True))
+
+
 def get_role_queryset(request):
     """Obtain the queryset for roles."""
     scope = request.query_params.get(SCOPE_KEY, ACCOUNT_SCOPE)
-    base_query = Role.objects.prefetch_related('access').annotate(policyCount=Count('policies', distinct=True),
-                                                                  accessCount=Count('access', distinct=True))
+    base_query = annotate_roles_with_counts(Role.objects.prefetch_related('access'))
+
     if scope != ACCOUNT_SCOPE:
-        return get_object_principal_queryset(request, scope, Role,
-                                             **{'prefetch_lookups_for_ids': 'access',
-                                                'prefetch_lookups_for_groups': 'policies__roles'})
+        queryset = get_object_principal_queryset(request, scope, Role,
+                                                 **{'prefetch_lookups_for_ids': 'access',
+                                                    'prefetch_lookups_for_groups': 'policies__roles'})
+        return annotate_roles_with_counts(queryset)
 
     username = request.query_params.get('username')
     if username:
@@ -99,8 +106,7 @@ def get_role_queryset(request):
                                                      **{'prefetch_lookups_for_ids': 'access',
                                                         'prefetch_lookups_for_groups': 'policies__roles'})
 
-            return queryset.annotate(policyCount=Count('policies', distinct=True),
-                                     accessCount=Count('access', distinct=True))
+            return annotate_roles_with_counts(queryset)
 
     if ENVIRONMENT.get_value('ALLOW_ANY', default=False, cast=bool):
         return base_query

--- a/rbac/management/querysets.py
+++ b/rbac/management/querysets.py
@@ -95,9 +95,12 @@ def get_role_queryset(request):
         if username != identity_username and not request.user.admin:
             return Role.objects.none()
         else:
-            return get_object_principal_queryset(request, PRINCIPAL_SCOPE, Role,
-                                                 **{'prefetch_lookups_for_ids': 'access',
-                                                    'prefetch_lookups_for_groups': 'policies__roles'})
+            queryset = get_object_principal_queryset(request, PRINCIPAL_SCOPE, Role,
+                                                     **{'prefetch_lookups_for_ids': 'access',
+                                                        'prefetch_lookups_for_groups': 'policies__roles'})
+
+            return queryset.annotate(policyCount=Count('policies', distinct=True),
+                                     accessCount=Count('access', distinct=True))
 
     if ENVIRONMENT.get_value('ALLOW_ANY', default=False, cast=bool):
         return base_query

--- a/tests/management/test_querysets.py
+++ b/tests/management/test_querysets.py
@@ -209,8 +209,11 @@ class QuerySetTest(TestCase):
         user = Mock(spec=User, admin=True, identity_header=identity_header)
         req = Mock(user=user, method='GET', query_params={'username': 'test_user2'})
         queryset = get_role_queryset(req)
+        role = queryset.last()
         self.assertEquals(list(queryset), [roles.first()])
         self.assertEquals(queryset.count(), 1)
+        self.assertTrue(hasattr(role, 'accessCount'))
+        self.assertTrue(hasattr(role, 'policyCount'))
 
     def test_get_role_queryset_admin_username_different(self):
         """Test get_role_queryset as an admin supplying a different username."""

--- a/tests/management/test_querysets.py
+++ b/tests/management/test_querysets.py
@@ -215,6 +215,28 @@ class QuerySetTest(TestCase):
         self.assertTrue(hasattr(role, 'accessCount'))
         self.assertTrue(hasattr(role, 'policyCount'))
 
+    def test_get_role_queryset_principal_scope(self):
+        """Test get_role_queryset with principal scope."""
+        roles = self._setup_roles_for_role_username_queryset_tests()
+        identity_header = {
+            'decoded': {
+                'identity': {
+                    'user': {
+                        'username': 'test_user2'
+                    }
+                }
+            }
+        }
+
+        user = Mock(spec=User, admin=True, identity_header=identity_header)
+        req = Mock(user=user, method='GET', query_params={SCOPE_KEY: PRINCIPAL_SCOPE, 'username': 'test_user2'})
+        queryset = get_role_queryset(req)
+        role = queryset.last()
+        self.assertEquals(list(queryset), [roles.first()])
+        self.assertEquals(queryset.count(), 1)
+        self.assertTrue(hasattr(role, 'accessCount'))
+        self.assertTrue(hasattr(role, 'policyCount'))
+
     def test_get_role_queryset_admin_username_different(self):
         """Test get_role_queryset as an admin supplying a different username."""
         roles = self._setup_roles_for_role_username_queryset_tests()


### PR DESCRIPTION
A bug was discovered where `accessCount` and `policyCount` data was missing from
the dataset when `?username=` was supplied on the `/role/` GET endpoint.

This is because of the fact that the queryset is different based on whether or
not that username param is supplied. The annotations for those two fields need
to be added.