### PR TITLE
Support passing sort_order as parameter

### DIFF
--- a/docs/source/specs/openapi.json
+++ b/docs/source/specs/openapi.json
@@ -94,7 +94,17 @@
             "schema": {
               "type": "string"
             }
-          }
+          },
+          {
+            "name": "sort_order",
+            "in": "query",
+            "description": "The sort order of the query, either ascending or descending",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": ["asc", "desc"]
+            }
+          }          
         ],
         "responses": {
           "200": {

--- a/rbac/management/group/view.py
+++ b/rbac/management/group/view.py
@@ -36,6 +36,7 @@ from management.principal.proxy import PrincipalProxy
 from management.principal.serializer import PrincipalSerializer
 from management.querysets import get_group_queryset, get_object_principal_queryset
 from management.role.model import Role
+from management.utils import validate_and_get_key
 from rest_framework import mixins, serializers, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.filters import OrderingFilter
@@ -616,16 +617,3 @@ class GroupViewSet(mixins.CreateModelMixin,
         # Exclude the roles in the group
         roles_for_group = group.roles().values('uuid')
         return roles.exclude(uuid__in=roles_for_group)
-
-
-def validate_and_get_key(params, query_key, valid_values, default_value):
-    """Validate the key."""
-    value = params.get(query_key, default_value).lower()
-    if value not in valid_values:
-        key = 'detail'
-        message = '{} query parameter value {} is invalid. {} are valid inputs.'.format(
-            query_key,
-            value,
-            valid_values)
-        raise serializers.ValidationError({key: _(message)})
-    return value

--- a/rbac/management/principal/proxy.py
+++ b/rbac/management/principal/proxy.py
@@ -59,13 +59,19 @@ class PrincipalProxy:  # pylint: disable=too-few-public-methods
         self.client_cert = os.path.join(settings.BASE_DIR, 'management', 'principal', 'certs', 'client.pem')
 
     @staticmethod
-    def _create_params(limit=None, offset=None):
+    def _create_params(limit=None, offset=None, sort_order=None):
         """Create query parameters."""
         params = {}
         if limit:
             params['limit'] = limit
         if offset:
             params['offset'] = offset
+        if sort_order:
+            # BOP only accepts 'des'
+            if sort_order == 'desc':
+                sort_order = 'des'
+            params['sortOrder'] = sort_order
+
         return params
 
     def _process_data(self, data, account, account_filter):
@@ -167,11 +173,11 @@ class PrincipalProxy:  # pylint: disable=too-few-public-methods
             resp['errors'] = [error]
         return resp
 
-    def request_principals(self, account, limit=None, offset=None):
+    def request_principals(self, account, limit=None, offset=None, sort_order=None):
         """Request principals for an account."""
         account_principals_path = '/v2/accounts/{}/users'.format(account)
 
-        params = self._create_params(limit=limit, offset=offset)
+        params = self._create_params(limit=limit, offset=offset, sort_order=sort_order)
         url = '{}://{}:{}{}{}'.format(self.protocol,
                                       self.host,
                                       self.port,
@@ -181,7 +187,7 @@ class PrincipalProxy:  # pylint: disable=too-few-public-methods
         # For v2 account users endpoints are already filtered by account
         return self._request_principals(url, params=params, account_filter=False)
 
-    def request_filtered_principals(self, principals, account=None, limit=None, offset=None):
+    def request_filtered_principals(self, principals, account=None, limit=None, offset=None, sort_order=None):
         """Request specific principals for an account."""
         if account is None:
             account_filter = False
@@ -190,7 +196,7 @@ class PrincipalProxy:  # pylint: disable=too-few-public-methods
         if not principals:
             return {'status_code': status.HTTP_200_OK, 'data': []}
         filtered_principals_path = '/v1/users'
-        params = self._create_params(limit=limit, offset=offset)
+        params = self._create_params(limit=limit, offset=offset, sort_order=sort_order)
         payload = {
             'users': principals,
             'include_permissions': False

--- a/rbac/management/principal/view.py
+++ b/rbac/management/principal/view.py
@@ -16,6 +16,7 @@
 #
 
 """View for principal management."""
+from management.utils import validate_and_get_key
 from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -25,6 +26,8 @@ from .proxy import PrincipalProxy
 from ..permissions.admin_access import AdminAccessPermission
 
 USERNAMES_KEY = 'usernames'
+SORTORDER_KEY = 'sort_order'
+VALID_SORTORDER_VALUE = ['asc', 'desc']
 
 
 class PrincipalView(APIView):
@@ -87,6 +90,11 @@ class PrincipalView(APIView):
             limit = int(query_params.get('limit', default_limit))
             offset = int(query_params.get('offset', 0))
             usernames = query_params.get(USERNAMES_KEY)
+            sort_order = validate_and_get_key(
+                query_params,
+                SORTORDER_KEY,
+                VALID_SORTORDER_VALUE,
+                'asc')
         except ValueError:
             error = {
                 'detail': 'Values for limit and offset must be positive numbers.',
@@ -106,12 +114,14 @@ class PrincipalView(APIView):
             resp = proxy.request_filtered_principals(principals,
                                                      user.account,
                                                      limit=limit,
-                                                     offset=offset)
+                                                     offset=offset,
+                                                     sort_order=sort_order)
             usernames_filter = f'&usernames={usernames}'
         else:
             resp = proxy.request_principals(user.account,
                                             limit=limit,
-                                            offset=offset)
+                                            offset=offset,
+                                            sort_order=sort_order)
         status_code = resp.get('status_code')
         response_data = {}
         if status_code == status.HTTP_200_OK:

--- a/rbac/management/utils.py
+++ b/rbac/management/utils.py
@@ -131,3 +131,16 @@ def queryset_by_id(objects, clazz, **kwargs):
         query = query.prefetch_related(prefetch_lookups)
 
     return query
+
+
+def validate_and_get_key(params, query_key, valid_values, default_value):
+    """Validate the key."""
+    value = params.get(query_key, default_value).lower()
+    if value not in valid_values:
+        key = 'detail'
+        message = '{} query parameter value {} is invalid. {} are valid inputs.'.format(
+            query_key,
+            value,
+            valid_values)
+        raise serializers.ValidationError({key: _(message)})
+    return value

--- a/tests/management/role/test_view.py
+++ b/tests/management/role/test_view.py
@@ -28,7 +28,6 @@ from tenant_schemas.utils import tenant_context
 from api.models import User
 from management.models import Group, Principal, Role, Access
 from tests.identity_request import IdentityRequest
-import pdb
 
 
 class RoleViewsetTests(IdentityRequest):


### PR DESCRIPTION
BOP now supports sort order parameter. This PR adds that parameter
when sending request to BOP.

Either ascending or desending is supported. If no order is specified,
ascending is default.