### PR TITLE
Add active flag to principal response

### DIFF
--- a/docs/source/specs/openapi.json
+++ b/docs/source/specs/openapi.json
@@ -1928,6 +1928,9 @@
           "last_name": {
             "type": "string",
             "example": "Smith"
+          },
+          "is_active": {
+            "type": "boolean"
           }
         }
       },

--- a/rbac/management/principal/proxy.py
+++ b/rbac/management/principal/proxy.py
@@ -86,7 +86,8 @@ class PrincipalProxy:  # pylint: disable=too-few-public-methods
             'username': item.get('username'),
             'email': item.get('email'),
             'first_name': item.get('first_name'),
-            'last_name': item.get('last_name')
+            'last_name': item.get('last_name'),
+            'is_active': item.get('is_active')
         }
         return processed_item
 

--- a/tests/management/principal/test_proxy.py
+++ b/tests/management/principal/test_proxy.py
@@ -62,7 +62,8 @@ def mocked_requests_get_200_json(*args, **kwargs):  # pylint: disable=unused-arg
         'username': 'test_user1',
         'email': 'test_user1@email.foo',
         'first_name': 'test',
-        'last_name': 'user1'
+        'last_name': 'user1',
+        'is_active': 'true'
         }
     json_response = [user]
     return MockResponse(json_response, status.HTTP_200_OK)
@@ -73,13 +74,15 @@ def mocked_requests_get_200_json_count(*args, **kwargs): # pylint: disable=unuse
         'username': 'test_user1',
         'email': 'test_user1@email.foo',
         'first_name': 'test',
-        'last_name': 'user1'
+        'last_name': 'user1',
+        'is_active': 'true'
         }
     user2 = {
         'username': 'test_user2',
         'email': 'test_user2@email.foo',
         'first_name': 'test',
-        'last_name': 'user2'
+        'last_name': 'user2',
+        'is_active': 'true'
         }
     json_response = {"userCount": 2, "users": [user1, user2]}
     return MockResponse(json_response, status.HTTP_200_OK)
@@ -169,7 +172,8 @@ class PrincipalProxyTest(TestCase):
             'username': 'test_user1',
             'email': 'test_user1@email.foo',
             'first_name': 'test',
-            'last_name': 'user1'
+            'last_name': 'user1',
+            'is_active': 'true'
         }
         expected = {
             'data': [user],
@@ -186,13 +190,15 @@ class PrincipalProxyTest(TestCase):
             'username': 'test_user1',
             'email': 'test_user1@email.foo',
             'first_name': 'test',
-            'last_name': 'user1'
+            'last_name': 'user1',
+            'is_active': 'true'
         }
         user2 = {
             'username': 'test_user2',
             'email': 'test_user2@email.foo',
             'first_name': 'test',
-            'last_name': 'user2'
+            'last_name': 'user2',
+            'is_active': 'true'
         }
         expected = {
             'data': {"userCount": 2, "users": [user1, user2]},


### PR DESCRIPTION
This adds the `is_active` flag from the BOP to the `/principals/` GET response:

```json
{
  "meta": {
    "count": 1
  },
  "links": {
    "first": "/api/rbac/v1/principals/?limit=1&offset=0",
    "next": null,
    "previous": null,
    "last": null
  },
  "data": [
    {
      "username": "red_hat_user",
      "email": "red_hat_user@redhat.com",
      "first_name": "Red Hat",
      "last_name": "User",
      "is_active": true
    }
  ]
}
```
