### PR TITLE
Ensure the default group query for a tenant returns the system groups

### DIFF
--- a/rbac/management/group/model.py
+++ b/rbac/management/group/model.py
@@ -52,7 +52,7 @@ class Group(models.Model):
 
     def platform_default_set():
         """Queryset for platform default group."""
-        return Group.objects.filter(platform_default=True)
+        return Group.objects.filter(system=True)
 
     def __policy_ids(self):
         """Policy IDs for a group."""

--- a/tests/management/group/test_model.py
+++ b/tests/management/group/test_model.py
@@ -31,7 +31,8 @@ class GroupModelTests(IdentityRequest):
         super().setUp()
 
         with tenant_context(self.tenant):
-            self.group = Group.objects.create(name='groupA')
+            self.group = Group.objects.create(name='groupA', platform_default=True, system=True)
+            self.groupB = Group.objects.create(name='groupB', system=True)
             self.roleA = Role.objects.create(name='roleA')
             self.roleB = Role.objects.create(name='roleB')
             self.policy = Policy(name='policyA', group=self.group)
@@ -58,3 +59,9 @@ class GroupModelTests(IdentityRequest):
         """Test the role count for a group."""
         with tenant_context(self.tenant):
             self.assertEqual(self.group.role_count(), 1)
+
+    def test_platform_default_set(self):
+        """Test the platform default queryset only returns system groups."""
+        with tenant_context(self.tenant):
+            platform_default_groups = Group.platform_default_set()
+            self.assertEqual(list(platform_default_groups), [self.group, self.groupB])


### PR DESCRIPTION
If the default group has been modified, meaning it's no longer a `platform_default`
group, the roles associated with the default group aren't included in the filtered
results from `/roles/?username=<someuser>`

This issue is due to the fact that when a default group is updated and thus is no
longer managed by the platform, we flip the `platform_default` flag on the group
to `False`. The `system` flag is still `True`, which is how we know which group
for a tenant is that "default" group that all principals inherit roles from. The
platform_default informs us of whether or not it's been updated and is managed by
the platform.

Currently, our query on the group model to retrieve the platform default queryset [1]
filters based on the `platform_default` flag. This means that after a default group
has been modified, that query will no longer return the roles for that group when
used to retrieve a user's roles.

The fix for this should just be to change the query flag to use `system`.

You should be able to exploit this locally on `master` by having a default group
with roles, and flipping the `platform_default` flag to `False`. You should no
longer see the roles from that group on `/roles/?username=<someuser>`.

Then, on this feature branch do the same. You should now see the roles from the
default group be included, as expected.

[1] https://github.com/RedHatInsights/insights-rbac/blob/master/rbac/management/group/model.py#L55