### PR TITLE
Revert "Ensure the default group query for a tenant returns the system groups"

### DIFF
--- a/rbac/management/group/model.py
+++ b/rbac/management/group/model.py
@@ -52,7 +52,7 @@ class Group(models.Model):
 
     def platform_default_set():
         """Queryset for platform default group."""
-        return Group.objects.filter(system=True)
+        return Group.objects.filter(platform_default=True)
 
     def __policy_ids(self):
         """Policy IDs for a group."""

--- a/tests/management/group/test_model.py
+++ b/tests/management/group/test_model.py
@@ -31,8 +31,7 @@ class GroupModelTests(IdentityRequest):
         super().setUp()
 
         with tenant_context(self.tenant):
-            self.group = Group.objects.create(name='groupA', platform_default=True, system=True)
-            self.groupB = Group.objects.create(name='groupB', system=True)
+            self.group = Group.objects.create(name='groupA')
             self.roleA = Role.objects.create(name='roleA')
             self.roleB = Role.objects.create(name='roleB')
             self.policy = Policy(name='policyA', group=self.group)
@@ -59,9 +58,3 @@ class GroupModelTests(IdentityRequest):
         """Test the role count for a group."""
         with tenant_context(self.tenant):
             self.assertEqual(self.group.role_count(), 1)
-
-    def test_platform_default_set(self):
-        """Test the platform default queryset only returns system groups."""
-        with tenant_context(self.tenant):
-            platform_default_groups = Group.platform_default_set()
-            self.assertEqual(list(platform_default_groups), [self.group, self.groupB])


### PR DESCRIPTION
Reverts RedHatInsights/insights-rbac#255