### PR TITLE
Cloudwatch logs as json

### DIFF
--- a/rbac/rbac/middleware.py
+++ b/rbac/rbac/middleware.py
@@ -277,7 +277,6 @@ class IdentityHeaderMiddleware(MiddlewareMixin):  # pylint: disable=R0903
             request (object): The request object
             response (object): The response object
         """
-        context = ''
         query_string = ''
         is_admin = False
         account = None
@@ -293,15 +292,20 @@ class IdentityHeaderMiddleware(MiddlewareMixin):  # pylint: disable=R0903
             is_system = f'System: {request.user.system}'
             req_id = request.user.req_id
 
-            logger.info(dict(request_id=req_id,
-                             account=account,
-                             username=username,
-                             is_admin=request.user.admin,
-                             is_system=request.user.system))
+        log_object = {
+            'method': request.method,
+            'path': request.path + query_string,
+            'status': response.status_code,
+        }
+
         if account:
-            context = f' -- {req_id} {account} {username} {is_admin} {is_system}'
-        logger.info(f'{request.method} {request.path}{query_string}'  # pylint: disable=W1203
-                    f' {response.status_code}{context}')
+            log_object['req_id'] = req_id
+            log_object['account'] = account
+            log_object['username'] = username
+            log_object['is_admin'] = request.user.admin
+            log_object['is_system'] = request.user.system
+
+        logger.info(log_object)
         return response
 
 

--- a/rbac/rbac/middleware.py
+++ b/rbac/rbac/middleware.py
@@ -292,6 +292,12 @@ class IdentityHeaderMiddleware(MiddlewareMixin):  # pylint: disable=R0903
             username = request.user.username
             is_system = f'System: {request.user.system}'
             req_id = request.user.req_id
+
+            logger.info(dict(request_id=req_id,
+                             account=account,
+                             username=username,
+                             is_admin=request.user.admin,
+                             is_system=request.user.system))
         if account:
             context = f' -- {req_id} {account} {username} {is_admin} {is_system}'
         logger.info(f'{request.method} {request.path}{query_string}'  # pylint: disable=W1203

--- a/rbac/rbac/middleware.py
+++ b/rbac/rbac/middleware.py
@@ -279,6 +279,7 @@ class IdentityHeaderMiddleware(MiddlewareMixin):  # pylint: disable=R0903
         """
         query_string = ''
         is_admin = False
+        is_system = False
         account = None
         username = None
         req_id = None
@@ -286,24 +287,22 @@ class IdentityHeaderMiddleware(MiddlewareMixin):  # pylint: disable=R0903
             query_string = '?{}'.format(request.META['QUERY_STRING'])
 
         if hasattr(request, 'user') and request.user:
-            is_admin = f'Admin: {request.user.admin}'
+            is_admin = request.user.admin
             account = request.user.account
             username = request.user.username
-            is_system = f'System: {request.user.system}'
+            is_system = request.user.system
             req_id = request.user.req_id
 
         log_object = {
             'method': request.method,
             'path': request.path + query_string,
             'status': response.status_code,
+            'req_id': req_id,
+            'account': account,
+            'username': username,
+            'is_admin': is_admin,
+            'is_system': is_system,
         }
-
-        if account:
-            log_object['req_id'] = req_id
-            log_object['account'] = account
-            log_object['username'] = username
-            log_object['is_admin'] = request.user.admin
-            log_object['is_system'] = request.user.system
 
         logger.info(log_object)
         return response

--- a/rbac/rbac/settings.py
+++ b/rbac/rbac/settings.py
@@ -287,16 +287,10 @@ LOGGING = {
             'handlers': LOGGING_HANDLERS,
             'level': RBAC_LOGGING_LEVEL,
         },
-        'gunicorn.access': {
-            'handlers': ['console'],
-            'level': RBAC_LOGGING_LEVEL,
-            'propagate': False,
-        },
     },
 }
 
 if CW_AWS_ACCESS_KEY_ID:
-    print('setting up CW handler')
     NAMESPACE = ENVIRONMENT.get_value('APP_NAMESPACE', default='unknown')
     BOTO3_SESSION = Session(aws_access_key_id=CW_AWS_ACCESS_KEY_ID,
                             aws_secret_access_key=CW_AWS_SECRET_ACCESS_KEY,
@@ -306,8 +300,9 @@ if CW_AWS_ACCESS_KEY_ID:
         'class': 'watchtower.CloudWatchLogHandler',
         'boto3_session': BOTO3_SESSION,
         'log_group': CW_LOG_GROUP,
-        'stream_name': 'rbac-test',
+        'stream_name': NAMESPACE,
         'formatter': LOGGING_FORMATTER,
+        'use_queues': False,
     }
     LOGGING['handlers']['watchtower'] = WATCHTOWER_HANDLER
 
@@ -335,7 +330,6 @@ CELERY_BROKER_URL = ENVIRONMENT.get_value('CELERY_BROKER_URL',
 
 # Role Seeding Setup
 ROLE_SEEDING_ENABLED = ENVIRONMENT.bool('ROLE_SEEDING_ENABLED', default=True)
-logconfig_dict = LOGGING
 
 # disable log messages less than CRITICAL when running unit tests.
 if len(sys.argv) > 1 and sys.argv[1] == 'test':

--- a/rbac/rbac/settings.py
+++ b/rbac/rbac/settings.py
@@ -287,10 +287,16 @@ LOGGING = {
             'handlers': LOGGING_HANDLERS,
             'level': RBAC_LOGGING_LEVEL,
         },
+        'gunicorn.access': {
+            'handlers': ['console'],
+            'level': RBAC_LOGGING_LEVEL,
+            'propagate': False,
+        },
     },
 }
 
 if CW_AWS_ACCESS_KEY_ID:
+    print('setting up CW handler')
     NAMESPACE = ENVIRONMENT.get_value('APP_NAMESPACE', default='unknown')
     BOTO3_SESSION = Session(aws_access_key_id=CW_AWS_ACCESS_KEY_ID,
                             aws_secret_access_key=CW_AWS_SECRET_ACCESS_KEY,
@@ -300,7 +306,7 @@ if CW_AWS_ACCESS_KEY_ID:
         'class': 'watchtower.CloudWatchLogHandler',
         'boto3_session': BOTO3_SESSION,
         'log_group': CW_LOG_GROUP,
-        'stream_name': NAMESPACE,
+        'stream_name': 'rbac-test',
         'formatter': LOGGING_FORMATTER,
     }
     LOGGING['handlers']['watchtower'] = WATCHTOWER_HANDLER
@@ -329,6 +335,7 @@ CELERY_BROKER_URL = ENVIRONMENT.get_value('CELERY_BROKER_URL',
 
 # Role Seeding Setup
 ROLE_SEEDING_ENABLED = ENVIRONMENT.bool('ROLE_SEEDING_ENABLED', default=True)
+logconfig_dict = LOGGING
 
 # disable log messages less than CRITICAL when running unit tests.
 if len(sys.argv) > 1 and sys.argv[1] == 'test':


### PR DESCRIPTION
There's currently an issue where logs in the gunicorn app server process don't
get pushed to CW. This resolves that, in order to make way for formatting RBAC
logs as JSON.

This sets up the request logging to be a dictionary, which CW will be able to
consume and push to Kibana in order for us to easily index and filter on the
fields in our log messages.

----

**Testing Locally:**
Since the issue with not logging too CloudWatch is specific to the handler with gunicorn, you'll need to fire up the server locally with gunicorn if you want to test all the way through to CloudWatch/Kibana:

```
$ make gunicorn-serve
```

Note that the seeding/migration logs output as normal:
```
[2020-04-03 14:48:29,354] INFO: Start role seed changes check.
...
...
```

Send a request to the API (note the port for gunicorn is `8080`), and notice there is a JSON log entry:
```
[2020-04-03 14:48:57,226] INFO: {'method': 'GET', 'path': '/api/rbac/v1/groups/', 'status': 200, 'req_id': None, 'account': '10001', 'username': 'user_dev', 'is_admin': True, 'is_system': False}
```

If you want to test all the way through CloudWatch, you can add the correct CW config values in [settings.py](https://github.com/RedHatInsights/insights-rbac/blob/master/rbac/rbac/settings.py#L293-L306)