### PR TITLE
Fix group filter with invalid username

### DIFF
--- a/rbac/management/group/view.py
+++ b/rbac/management/group/view.py
@@ -61,12 +61,6 @@ logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 class GroupFilter(filters.FilterSet):
     """Filter for group."""
 
-    def username_filter(self, queryset, field, value):
-        """Filter for group username lookup."""
-        filters = {'{}__username__icontains'.format(field): value}
-        filtered_set = queryset.filter(**filters)
-        return filtered_set | Group.platform_default_set()
-
     def uuid_filter(self, queryset, field, values):
         """Filter for group uuid lookup."""
         uuids = values.split(',')
@@ -106,13 +100,12 @@ class GroupFilter(filters.FilterSet):
         return queryset
 
     name = filters.CharFilter(field_name='name', lookup_expr='icontains')
-    username = filters.CharFilter(field_name='principals', method='username_filter')
     role_names = filters.CharFilter(field_name='role_names', method='roles_filter')
     uuid = filters.CharFilter(field_name='uuid', method='uuid_filter')
 
     class Meta:
         model = Group
-        fields = ['name', 'principals', 'role_names', 'uuid']
+        fields = ['name', 'role_names', 'uuid']
 
 
 class GroupViewSet(mixins.CreateModelMixin,

--- a/rbac/management/utils.py
+++ b/rbac/management/utils.py
@@ -21,6 +21,7 @@ import os
 from django.core.exceptions import PermissionDenied
 from django.utils.translation import gettext as _
 from management.models import Group, Principal
+from management.principal.proxy import PrincipalProxy
 from rest_framework import serializers
 
 USERNAME_KEY = 'username'
@@ -50,12 +51,28 @@ def get_principal_from_request(request):
     if not username:
         username = current_user
 
+    return get_principal(username, request.user.account)
+
+
+def get_principal(username, account):
+    """Get principals from username."""
+    # First check if principal exist on our side,
+    # if not call BOP to check if user exist in the account.
     try:
         principal = Principal.objects.get(username__iexact=username)
     except Principal.DoesNotExist:
-        key = 'detail'
-        message = 'No data found for principal with username {}.'.format(username)
-        raise serializers.ValidationError({key: _(message)})
+        proxy = PrincipalProxy()
+        resp = proxy.request_filtered_principals([username], account)
+        if isinstance(resp, dict) and 'errors' in resp:
+            raise Exception('Dependency error: request to get users from dependent service failed.')
+
+        if resp.get('data') == []:
+            key = 'detail'
+            message = 'No data found for principal with username {}.'.format(username)
+            raise serializers.ValidationError({key: _(message)})
+
+        return Principal.objects.create(username=username)
+
     return principal
 
 

--- a/tests/management/access/test_view.py
+++ b/tests/management/access/test_view.py
@@ -19,6 +19,7 @@
 import random
 from decimal import Decimal
 from uuid import uuid4
+from unittest.mock import patch
 
 from django.urls import reverse
 from rest_framework import status
@@ -156,7 +157,9 @@ class AccessViewTests(IdentityRequest):
         response = client.get(url, **self.headers)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
-    def test_missing_invalid_username(self):
+    @patch('management.principal.proxy.PrincipalProxy.request_filtered_principals',
+           return_value={'status_code': 200, 'data': []})
+    def test_missing_invalid_username(self, mock_request):
         """Test that we get expected failure when missing required query params."""
         url = '{}?application={}&username={}'.format(reverse('access'),
                                                      'app',

--- a/tests/management/test_querysets.py
+++ b/tests/management/test_querysets.py
@@ -102,7 +102,7 @@ class QuerySetTest(TestCase):
             }
         }
 
-        user = Mock(spec=User, admin=True, identity_header=identity_header)
+        user = Mock(spec=User, admin=True, account='00001', identity_header=identity_header)
         req = Mock(user=user, query_params={'username': 'test_user'})
         queryset = get_group_queryset(req)
         self.assertEquals(queryset.count(), 1)
@@ -122,7 +122,7 @@ class QuerySetTest(TestCase):
                 }
             }
         }
-        user = Mock(spec=User, admin=False, identity_header=identity_header)
+        user = Mock(spec=User, admin=False, account='00001', identity_header=identity_header)
         req = Mock(user=user, method='GET', query_params={'username': 'test_user'}, path=reverse('group-list'))
         queryset = get_group_queryset(req)
         self.assertEquals(queryset.count(), 1)
@@ -131,6 +131,7 @@ class QuerySetTest(TestCase):
         """Test get_group_queryset to get a users other users groups."""
         self._create_groups()
         principal = Principal.objects.create(username='test_user')
+        principal2 = Principal.objects.create(username='test_user2')
         group = Group.objects.first()
         group.principals.add(principal)
         identity_header = {
@@ -142,7 +143,7 @@ class QuerySetTest(TestCase):
                 }
             }
         }
-        user = Mock(spec=User, admin=False, identity_header=identity_header)
+        user = Mock(spec=User, admin=False, account='00001', identity_header=identity_header)
         req = Mock(user=user, method='GET', query_params={'username': 'test_user2'})
         queryset = get_group_queryset(req)
         self.assertEquals(queryset.count(), 0)
@@ -206,7 +207,7 @@ class QuerySetTest(TestCase):
             }
         }
 
-        user = Mock(spec=User, admin=True, identity_header=identity_header)
+        user = Mock(spec=User, admin=True, account='00001', identity_header=identity_header)
         req = Mock(user=user, method='GET', query_params={'username': 'test_user2'})
         queryset = get_role_queryset(req)
         role = queryset.last()
@@ -228,7 +229,7 @@ class QuerySetTest(TestCase):
             }
         }
 
-        user = Mock(spec=User, admin=True, identity_header=identity_header)
+        user = Mock(spec=User, admin=True, account='00001', identity_header=identity_header)
         req = Mock(user=user, method='GET', query_params={SCOPE_KEY: PRINCIPAL_SCOPE, 'username': 'test_user2'})
         queryset = get_role_queryset(req)
         role = queryset.last()
@@ -250,7 +251,7 @@ class QuerySetTest(TestCase):
             }
         }
 
-        user = Mock(spec=User, admin=True, identity_header=identity_header)
+        user = Mock(spec=User, admin=True, account='00001', identity_header=identity_header)
         req = Mock(user=user, method='GET', query_params={'username': 'test_user2'})
         queryset = get_role_queryset(req)
         self.assertEquals(list(queryset), [roles.first()])


### PR DESCRIPTION
When invalid username is given, default group will still be returned,
which should be fixed. The username have to be validated.