### PR TITLE
Ensure the /access/?application= check is on permission name only

### DIFF
--- a/rbac/management/role/model.py
+++ b/rbac/management/role/model.py
@@ -47,6 +47,14 @@ class Access(models.Model):
     permission = models.TextField(null=False)
     role = models.ForeignKey(Role, null=True, on_delete=models.CASCADE, related_name='access')
 
+    def permission_application(self):
+        """Return the application name from the permission."""
+        return next(iter(self.split_permission()))
+
+    def split_permission(self):
+        """Split the permission."""
+        return self.permission.split(':')
+
 
 class ResourceDefinition(models.Model):
     """A resource definition."""

--- a/rbac/management/utils.py
+++ b/rbac/management/utils.py
@@ -83,9 +83,7 @@ def access_for_roles(roles, param_application):
     for role in set(roles):
         role_access = set(role.access.all())
         for access_item in role_access:
-            split_permission = access_item.permission.split(':')
-            permission_application = next(iter(split_permission))
-            if param_application == permission_application:
+            if param_application == access_item.permission_application():
                 access.append(access_item)
     return access
 

--- a/rbac/management/utils.py
+++ b/rbac/management/utils.py
@@ -77,13 +77,15 @@ def roles_for_policies(policies):
     return roles
 
 
-def access_for_roles(roles, application):
+def access_for_roles(roles, param_application):
     """Gathers all access for the given roles and application."""
     access = []
     for role in set(roles):
         role_access = set(role.access.all())
         for access_item in role_access:
-            if application in access_item.permission:
+            split_permission = access_item.permission.split(':')
+            permission_application = next(iter(split_permission))
+            if param_application == permission_application:
                 access.append(access_item)
     return access
 

--- a/tests/management/access/test_model.py
+++ b/tests/management/access/test_model.py
@@ -1,0 +1,49 @@
+#
+# Copyright 2019 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""Test the group model."""
+from django.test import TestCase
+from tenant_schemas.utils import tenant_context
+# from unittest.mock import Mock
+
+from management.models import Access
+from tests.identity_request import IdentityRequest
+
+
+class AccessModelTests(IdentityRequest):
+    """Test the access model."""
+
+    def setUp(self):
+        """Set up the access model tests."""
+        super().setUp()
+
+        with tenant_context(self.tenant):
+            self.access = Access.objects.create(permission='app:*:*')
+
+    def tearDown(self):
+        """Tear down access model tests."""
+        with tenant_context(self.tenant):
+            Access.objects.all().delete()
+
+    def test_permission_application(self):
+        """Test we get back the application name of the permission."""
+        with tenant_context(self.tenant):
+            self.assertEqual(self.access.permission_application(), 'app')
+
+    def test_split_permission(self):
+        """Test we split the permission."""
+        with tenant_context(self.tenant):
+            self.assertEqual(self.access.split_permission(), ['app', '*', '*'])

--- a/tests/management/access/test_view.py
+++ b/tests/management/access/test_view.py
@@ -87,8 +87,6 @@ class AccessViewTests(IdentityRequest):
         url = reverse('role-list')
         client = APIClient()
         response = client.post(url, test_data, format='json', **self.headers)
-        print("RESPONSE: ")
-        print(response.data)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         return response
 


### PR DESCRIPTION
There's currently a bug where the `/?application=` param value is being compared
against the entire permission string. This is causing scenarios where resource types
or actions in the permission can cause it to match on the application name since
it's a partial match on the entire permission.

Here is [an issue](https://github.com/RedHatInsights/insights-rbac/issues/264) that was logged against this as well.

For instance, a permission `catalog:*:foobar` would be returned with a query:
`/access/?application=foo` when it should only respect the `catalog` substring
as the partial being matched against.

Also, the same permission would return for a query: `/access/?application=cat`.

This does two things:
- restricts the matching to the application name of the permission only
- requires an exact match, to align with the spec.

**Testing Locally**
- checkout master
- modify a permission on a role that would normally return on a given ?application=
  query so that the it looks something like `app-name:foo:bar`
- query `/access/?application=foo` and see that the permission returns
- query `/access/?application=app` and see that the permission returns
- now checkout this feature branch and run the same query against `foo` and `app`.
  you should not see the permission returned, but `/access/?application=app-name`
  should work.