### PR TITLE
Allow empty ?application= param on /access/ to return all permissions

### DIFF
--- a/docs/source/specs/openapi.json
+++ b/docs/source/specs/openapi.json
@@ -105,7 +105,7 @@
               "type": "string",
               "enum": ["asc", "desc"]
             }
-          }          
+          }
         ],
         "responses": {
           "200": {
@@ -1663,7 +1663,7 @@
           {
             "name": "application",
             "in": "query",
-            "description": "The application name to obtain access for the principal",
+            "description": "The application name to obtain access for the principal. This is an exact match. When no application is supplied, all permissions for the principal are returned.",
             "required": true,
             "schema": {
               "type": "string"

--- a/rbac/management/utils.py
+++ b/rbac/management/utils.py
@@ -83,7 +83,7 @@ def access_for_roles(roles, param_application):
     for role in set(roles):
         role_access = set(role.access.all())
         for access_item in role_access:
-            if param_application == access_item.permission_application():
+            if param_application == access_item.permission_application() or param_application == '':
                 access.append(access_item)
     return access
 

--- a/tests/management/access/test_view.py
+++ b/tests/management/access/test_view.py
@@ -26,7 +26,7 @@ from rest_framework.test import APIClient
 from tenant_schemas.utils import tenant_context
 
 from api.models import User
-from management.models import Group, Principal, Policy, Role
+from management.models import Group, Principal, Policy, Role, Access
 from tests.identity_request import IdentityRequest
 
 
@@ -110,6 +110,8 @@ class AccessViewTests(IdentityRequest):
         response = self.create_role(role_name)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         role_uuid = response.data.get('uuid')
+        role = Role.objects.get(uuid=role_uuid)
+        access = Access.objects.create(role=role, permission='app2:foo:bar')
         policy_name = 'policyA'
         response = self.create_policy(policy_name, self.group.uuid, [role_uuid])
 
@@ -125,6 +127,38 @@ class AccessViewTests(IdentityRequest):
         self.assertEqual(len(response.data.get('data')), 1)
         self.assertEqual(response.data.get('meta').get('limit'), 1000)
         self.assertEqual(self.access_data, response.data.get('data')[0])
+
+    def test_get_access_no_app_supplied(self):
+        """Test that we return all permissions when no app supplied."""
+        role_name = 'roleA'
+        policy_name = 'policyA'
+        access_data = {
+            'permission': 'app:foo:bar',
+            'resourceDefinitions': [
+                {
+                    'attributeFilter': {
+                        'key': 'keyA',
+                        'operation': 'equal',
+                        'value': 'valueA'
+                    }
+                }
+            ]
+        }
+        response = self.create_role(role_name, access_data)
+        role_uuid = response.data.get('uuid')
+        role = Role.objects.get(uuid=role_uuid)
+        access = Access.objects.create(role=role, permission='app2:foo:bar')
+        self.create_policy(policy_name, self.group.uuid, [role_uuid])
+
+        url = '{}?application=&username={}'.format(reverse('access'),
+                                                     self.principal.username)
+        client = APIClient()
+        response = client.get(url, **self.headers)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIsNotNone(response.data.get('data'))
+        self.assertIsInstance(response.data.get('data'), list)
+        self.assertEqual(len(response.data.get('data')), 2)
+        self.assertEqual(response.data.get('meta').get('limit'), 1000)
 
     def test_get_access_no_partial_match(self):
         """Test that we can have a partial match on app/permission."""


### PR DESCRIPTION
The changes in #266 removed the implicit behavior allowing for no application
to be passed to `?application=` on `/access/` in order to return all permissions
for a principal.

This ensures we preserve that functionality, and documents it as expected behavior
in the spec, and with tests.