### PR TITLE
Add support for multiple applications on /access/?application=

### DIFF
--- a/docs/source/specs/openapi.json
+++ b/docs/source/specs/openapi.json
@@ -1663,7 +1663,7 @@
           {
             "name": "application",
             "in": "query",
-            "description": "The application name to obtain access for the principal. This is an exact match. When no application is supplied, all permissions for the principal are returned.",
+            "description": "The application name(s) to obtain access for the principal. This is an exact match. When no application is supplied, all permissions for the principal are returned. You may also use a comma-separated list to match on multiple applications.",
             "required": true,
             "schema": {
               "type": "string"

--- a/rbac/management/utils.py
+++ b/rbac/management/utils.py
@@ -77,13 +77,13 @@ def roles_for_policies(policies):
     return roles
 
 
-def access_for_roles(roles, param_application):
-    """Gathers all access for the given roles and application."""
+def access_for_roles(roles, param_applications):
+    """Gathers all access for the given roles and application(s)."""
     access = []
     for role in set(roles):
         role_access = set(role.access.all())
         for access_item in role_access:
-            if param_application == access_item.permission_application() or param_application == '':
+            if (not param_applications) or (access_item.permission_application() in param_applications):
                 access.append(access_item)
     return access
 


### PR DESCRIPTION
This adds support for optionally supplying a comma-separated list of application
values to `/access/?application=app1,app2` in order to return the policy/policies
for a principal and application(s) combination.