### PR TITLE
Add ability to search for principal by exact e-mail

### DIFF
--- a/docs/source/specs/openapi.json
+++ b/docs/source/specs/openapi.json
@@ -105,6 +105,15 @@
               "type": "string",
               "enum": ["asc", "desc"]
             }
+          },
+          {
+            "name": "email",
+            "in": "query",
+            "description": "Exact e-mail address of principal to search for",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {

--- a/rbac/management/principal/proxy.py
+++ b/rbac/management/principal/proxy.py
@@ -174,9 +174,18 @@ class PrincipalProxy:  # pylint: disable=too-few-public-methods
             resp['errors'] = [error]
         return resp
 
-    def request_principals(self, account, limit=None, offset=None, sort_order=None):
+    def request_principals(self, account, email=None, limit=None, offset=None, sort_order=None):
         """Request principals for an account."""
-        account_principals_path = '/v2/accounts/{}/users'.format(account)
+        if email:
+            account_principals_path = f'/v1/accounts/{account}/usersBy'
+            payload = {
+                'primaryEmail': email
+            }
+            method = requests.post
+        else:
+            account_principals_path = f'/v2/accounts/{account}/users'
+            method = requests.get
+            payload = None
 
         params = self._create_params(limit=limit, offset=offset, sort_order=sort_order)
         url = '{}://{}:{}{}{}'.format(self.protocol,
@@ -186,7 +195,7 @@ class PrincipalProxy:  # pylint: disable=too-few-public-methods
                                       account_principals_path)
 
         # For v2 account users endpoints are already filtered by account
-        return self._request_principals(url, params=params, account_filter=False)
+        return self._request_principals(url, params=params, account_filter=False, method=method, data=payload)
 
     def request_filtered_principals(self, principals, account=None, limit=None, offset=None, sort_order=None):
         """Request specific principals for an account."""

--- a/rbac/management/principal/view.py
+++ b/rbac/management/principal/view.py
@@ -137,6 +137,8 @@ class PrincipalView(APIView):
             if isinstance(data, dict):
                 count = data.get('userCount')
                 data = data.get('users')
+            elif isinstance(data, list):
+                count = len(data)
             else:
                 count = None
             response_data['meta'] = {

--- a/rbac/management/principal/view.py
+++ b/rbac/management/principal/view.py
@@ -26,6 +26,7 @@ from .proxy import PrincipalProxy
 from ..permissions.admin_access import AdminAccessPermission
 
 USERNAMES_KEY = 'usernames'
+EMAIL_KEY = 'email'
 SORTORDER_KEY = 'sort_order'
 VALID_SORTORDER_VALUE = ['asc', 'desc']
 
@@ -90,6 +91,7 @@ class PrincipalView(APIView):
             limit = int(query_params.get('limit', default_limit))
             offset = int(query_params.get('offset', 0))
             usernames = query_params.get(USERNAMES_KEY)
+            email = query_params.get(EMAIL_KEY)
             sort_order = validate_and_get_key(
                 query_params,
                 SORTORDER_KEY,
@@ -112,11 +114,17 @@ class PrincipalView(APIView):
         if usernames:
             principals = usernames.split(',')
             resp = proxy.request_filtered_principals(principals,
-                                                     user.account,
+                                                     account=user.account,
                                                      limit=limit,
                                                      offset=offset,
                                                      sort_order=sort_order)
             usernames_filter = f'&usernames={usernames}'
+        elif email:
+            resp = proxy.request_principals(user.account,
+                                            email=email,
+                                            limit=limit,
+                                            offset=offset,
+                                            sort_order=sort_order)
         else:
             resp = proxy.request_principals(user.account,
                                             limit=limit,

--- a/tests/management/principal/test_view.py
+++ b/tests/management/principal/test_view.py
@@ -82,7 +82,7 @@ class PrincipalViewsetTests(IdentityRequest):
         client = APIClient()
         response = client.get(url, **self.headers)
 
-        mock_request.assert_called_once_with(['test_user'], ANY, limit=10, offset=30, sort_order='asc')
+        mock_request.assert_called_once_with(['test_user'], account=ANY, limit=10, offset=30, sort_order='asc')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         for keyname in ['meta', 'links', 'data']:
             self.assertIn(keyname, response.data)
@@ -132,7 +132,7 @@ class PrincipalViewsetTests(IdentityRequest):
         proxy = PrincipalProxy()
         response = client.get(url, **self.headers)
 
-        mock_request.assert_called_once_with(['test_user'], ANY, limit=10, offset=30, sort_order='desc')
+        mock_request.assert_called_once_with(['test_user'], account=ANY, limit=10, offset=30, sort_order='desc')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         for keyname in ['meta', 'links', 'data']:
             self.assertIn(keyname, response.data)
@@ -177,5 +177,25 @@ class PrincipalViewsetTests(IdentityRequest):
         self.assertEqual(response.data.get('meta').get('count'), None)
         resp = proxy._process_data(response.data.get('data'), account='1234', account_filter=False)
         self.assertEqual(len(resp), 1)
+
+        self.assertEqual(resp[0]['username'], 'test_user')
+
+    @patch('management.principal.proxy.PrincipalProxy.request_principals',
+           return_value={'status_code': 200, 'data': [{'username': 'test_user', 'account_number': '54321'}]})
+    def test_read_principal_list_by_email(self, mock_request):
+        """Test that we can handle a request with an email address"""
+        url = f'{reverse("principals")}?email=test_user@example.com'
+        client = APIClient()
+        proxy = PrincipalProxy()
+        response = client.get(url, **self.headers)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        for keyname in ['meta', 'links', 'data']:
+            self.assertIn(keyname, response.data)
+        self.assertIsInstance(response.data.get('data'), list)
+        self.assertEqual(response.data.get('meta').get('count'), None)
+        resp = proxy._process_data(response.data.get('data'), account='1234', account_filter=False)
+        self.assertEqual(len(resp), 1)
+
+        mock_request.assert_called_once_with(ANY, email='test_user@example.com', limit=10, offset=0, sort_order='asc')
 
         self.assertEqual(resp[0]['username'], 'test_user')

--- a/tests/management/principal/test_view.py
+++ b/tests/management/principal/test_view.py
@@ -88,7 +88,7 @@ class PrincipalViewsetTests(IdentityRequest):
             self.assertIn(keyname, response.data)
         self.assertIsInstance(response.data.get('data'), list)
         self.assertEqual(len(response.data.get('data')), 1)
-        self.assertEqual(response.data.get('meta').get('count'), None)
+        self.assertEqual(response.data.get('meta').get('count'), 1)
 
         principal = response.data.get('data')[0]
         self.assertIsNotNone(principal.get('username'))
@@ -137,7 +137,7 @@ class PrincipalViewsetTests(IdentityRequest):
         for keyname in ['meta', 'links', 'data']:
             self.assertIn(keyname, response.data)
         self.assertIsInstance(response.data.get('data'), list)
-        self.assertEqual(response.data.get('meta').get('count'), None)
+        self.assertEqual(response.data.get('meta').get('count'), 1)
         resp = proxy._process_data(response.data.get('data'), account='1234', account_filter=True)
         self.assertEqual(len(resp), 1)
 
@@ -174,7 +174,7 @@ class PrincipalViewsetTests(IdentityRequest):
         for keyname in ['meta', 'links', 'data']:
             self.assertIn(keyname, response.data)
         self.assertIsInstance(response.data.get('data'), list)
-        self.assertEqual(response.data.get('meta').get('count'), None)
+        self.assertEqual(response.data.get('meta').get('count'), 1)
         resp = proxy._process_data(response.data.get('data'), account='1234', account_filter=False)
         self.assertEqual(len(resp), 1)
 
@@ -192,8 +192,8 @@ class PrincipalViewsetTests(IdentityRequest):
         for keyname in ['meta', 'links', 'data']:
             self.assertIn(keyname, response.data)
         self.assertIsInstance(response.data.get('data'), list)
-        self.assertEqual(response.data.get('meta').get('count'), None)
-        resp = proxy._process_data(response.data.get('data'), account='1234', account_filter=False)
+        self.assertEqual(response.data.get('meta').get('count'), 1)
+        resp = proxy._process_data(response.data.get('data'), account='54321', account_filter=False)
         self.assertEqual(len(resp), 1)
 
         mock_request.assert_called_once_with(ANY, email='test_user@example.com', limit=10, offset=0, sort_order='asc')


### PR DESCRIPTION
I managed to test this locally using a dev_user with the insights-qa account number and valid client-id and token as env vars.

Signed-off-by: Chris Mitchell <cmitchel@redhat.com>