### PR TITLE
Add a check to enable/disable group seeding on app init

### DIFF
--- a/rbac/management/apps.py
+++ b/rbac/management/apps.py
@@ -72,6 +72,10 @@ class ManagementConfig(AppConfig):
         # noqa: E402 pylint: disable=C0413
         from api.models import Tenant
         from management.group.definer import seed_group
+        from rbac.settings import GROUP_SEEDING_ENABLED
+
+        if not GROUP_SEEDING_ENABLED:
+            return
 
         logger.info('Start goup seed changes check.')
         try:

--- a/rbac/rbac/settings.py
+++ b/rbac/rbac/settings.py
@@ -328,8 +328,9 @@ DEFAULT_REDIS_URL = f'redis://{REDIS_HOST}:{REDIS_PORT}/0'
 CELERY_BROKER_URL = ENVIRONMENT.get_value('CELERY_BROKER_URL',
                                           default=DEFAULT_REDIS_URL)
 
-# Role Seeding Setup
+# Seeding Setup
 ROLE_SEEDING_ENABLED = ENVIRONMENT.bool('ROLE_SEEDING_ENABLED', default=True)
+GROUP_SEEDING_ENABLED = ENVIRONMENT.bool('GROUP_SEEDING_ENABLED', default=True)
 
 # disable log messages less than CRITICAL when running unit tests.
 if len(sys.argv) > 1 and sys.argv[1] == 'test':


### PR DESCRIPTION
Context from: https://github.com/RedHatInsights/e2e-deploy/pull/1498

> As the number of tenants grows for RBAC, we've run into an issue where we cannot
> run migrations and seeds when the app boots in enough time to allow for the health
> checks to succeed.
>
> We've bumped the probes, but hit a timeout in OpenShift over 10 minutes in, where
> pods and the deployment end up getting killed.
>
> We really shouldn't have this initial seeding coupled to the app startup anyway,
> but rather the config sync job we now have setup. This way, when we update the config
> and sync it, updating the config maps in the project, that is what should trigger
> the seeds to run.
>
> As an interim solution, if any config changes need to go up, we can manually
> run the seeding task in the environment.
>
> For now this is priority, as the issue prevents us from successfully deploying
> RBAC in production as is.
>
> This will only change the behavior for prod, currently.

The change in this repo is to support the new `GROUP_SEEDING_ENABLED` variable
introduced in the e2e PR above.