### PR TITLE
Capitalization does matter for principal name

### DIFF
--- a/rbac/management/querysets.py
+++ b/rbac/management/querysets.py
@@ -67,7 +67,7 @@ def get_group_queryset(request):
     username = request.query_params.get('username')
     if username:
         get_principal(username, request.user.account)
-        return Group.objects.filter(principals__username=username) | Group.platform_default_set()
+        return Group.objects.filter(principals__username__iexact=username) | Group.platform_default_set()
 
     if has_group_all_access(request):
         return get_annotated_groups() | Group.platform_default_set()

--- a/tests/management/group/test_view.py
+++ b/tests/management/group/test_view.py
@@ -429,6 +429,15 @@ class GroupViewsetTests(IdentityRequest):
         response = client.get(url, **self.headers)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
+    def test_get_group_by_username_with_capitalization(self):
+        """Test that getting groups for a user name with capitalization returns successfully."""
+        url = reverse('group-list')
+        username = "".join(random.choice([k.upper(), k]) for k in self.principal.username)
+        url = '{}?username={}'.format(url, username)
+        client = APIClient()
+        response = client.get(url, **self.headers)
+        self.assertEqual(response.data.get('meta').get('count'), 3)
+
     def test_get_group_roles_success(self):
         """Test that getting roles for a group returns successfully."""
         url = reverse('group-roles', kwargs={'uuid': self.group.uuid})


### PR DESCRIPTION
For RBAC principals, capitalization for name does not matter. They should refer to
the same principal.