### PR TITLE
Add group description to /roles/?add_field=groups_in

### DIFF
--- a/docs/source/specs/openapi.json
+++ b/docs/source/specs/openapi.json
@@ -2038,6 +2038,10 @@
             "type": "string",
             "example": "GroupA"
           },
+          "description": {
+            "type": "string",
+            "example": "GroupA Description"
+          },
           "uuid": {
             "type": "string",
             "example": "234df936-abb4-4238-a1c9-d91fc540c702"

--- a/rbac/management/role/serializer.py
+++ b/rbac/management/role/serializer.py
@@ -212,7 +212,7 @@ class RoleDynamicSerializer(DynamicFieldsModelSerializer):
 
     def get_groups_in(self, obj):
         """Get the groups where the role is in."""
-        return obtain_groups_in(obj).values('name', 'uuid')
+        return obtain_groups_in(obj).values('name', 'uuid', 'description')
 
 
 def obtain_applications(obj):


### PR DESCRIPTION
This adds the group `description` field to the nested `groups_in` collection
returned from `/roles/?add_field=groups_in` when the `add_fields=groups_in` param
and value are supplied.

```
{
  "data": [
    {
      "uuid": "6c8c2901-58d1-4175-a09f-164e5a48b5a0",
      "name": "Ansible Automation Access",
      "description": "An all access role which grants read and write permissions.",
      "created": "2020-03-26T16:16:29.695894Z",
      "modified": "2020-03-26T16:16:29.698012Z",
      "policyCount": 2,
      "groups_in": [
        {
          "name": "Custom default user access",
          "uuid": "82c6a6c8-bf7b-4665-a690-db21a0533c5d",
          "description": "This group contains the roles that all users inherit by default. Adding or removing roles in this group will affect permissions for all users in your organization."
        },
        {
          "name": "Test Group",
          "uuid": "5a0f198c-7dfb-41a1-bca5-9862a3789d1d",
          "description": "This is a test"
        }
      ],
      "accessCount": 2,
      "applications": [
        "ansible-automation",
        "inventory"
      ],
      "system": true,
      "platform_default": true
    }
  ]
}
```

I've also updated the associated spec to validate the fields, and remove assertions unrelated
to the test.