### PR TITLE
Add missing query limit and offset

### DIFF
--- a/docs/source/specs/openapi.json
+++ b/docs/source/specs/openapi.json
@@ -603,6 +603,12 @@
             }
           },
           {
+            "$ref": "#/components/parameters/QueryLimit"
+          },
+          {
+            "$ref": "#/components/parameters/QueryOffset"
+          },
+          {
             "in": "query",
             "name": "order_by",
             "required": false,


### PR DESCRIPTION
Pagination requires limit and offset, which are missing.