### PR TITLE
Ensure /roles/?add_fields=groups_in is scoped correctly

### DIFF
--- a/tests/management/role/test_view.py
+++ b/tests/management/role/test_view.py
@@ -74,9 +74,6 @@ class RoleViewsetTests(IdentityRequest):
             self.defRole.save()
 
             self.policy.roles.add(self.defRole, self.sysRole)
-
-            self.policy = Policy.objects.create(name='policyA', group=self.group)
-            self.policy.roles.add(self.sysRole)
             self.policy.save()
 
             self.access = Access.objects.create(permission='app:*:*', role=self.defRole)
@@ -338,7 +335,7 @@ class RoleViewsetTests(IdentityRequest):
         client = APIClient()
         response = client.get(url, **self.headers)
 
-        self.assertEqual(len(response.data.get('data')), 1)
+        self.assertEqual(len(response.data.get('data')), 2)
 
         role = response.data.get('data')[0]
         self.assertEqual(new_diaplay_fields, set(role.keys()))
@@ -356,7 +353,7 @@ class RoleViewsetTests(IdentityRequest):
         client = APIClient()
         response = client.get(url, **self.headers)
 
-        self.assertEqual(len(response.data.get('data')), 1)
+        self.assertEqual(len(response.data.get('data')), 2)
 
         role = response.data.get('data')[0]
         self.assertEqual(new_diaplay_fields, set(role.keys()))

--- a/tests/management/role/test_view.py
+++ b/tests/management/role/test_view.py
@@ -65,6 +65,7 @@ class RoleViewsetTests(IdentityRequest):
             self.group.policies.add(self.policy)
             self.group.save()
 
+
             self.sysRole = Role(**sys_role_config)
             self.sysRole.save()
 
@@ -73,6 +74,10 @@ class RoleViewsetTests(IdentityRequest):
             self.defRole.save()
 
             self.policy.roles.add(self.defRole, self.sysRole)
+
+            self.policy = Policy.objects.create(name='policyA', group=self.group)
+            self.policy.roles.add(self.sysRole)
+            self.policy.save()
 
             self.access = Access.objects.create(permission='app:*:*', role=self.defRole)
 
@@ -320,6 +325,42 @@ class RoleViewsetTests(IdentityRequest):
             self.assertIsNotNone(iterRole.get('groups_in')[0]['name'])
             self.assertIsNotNone(iterRole.get('groups_in')[0]['uuid'])
             self.assertIsNotNone(iterRole.get('groups_in')[0]['description'])
+
+    def test_list_role_with_additional_fields_username_success(self):
+        """Test that we can read a list of roles and add fields for username."""
+        field_1 = 'groups_in_count'
+        field_2 = 'groups_in'
+        new_diaplay_fields = self.display_fields
+        new_diaplay_fields.add(field_1)
+        new_diaplay_fields.add(field_2)
+
+        url = '{}?add_fields={},{}&username={}'.format(reverse('role-list'), field_1, field_2, self.user_data['username'])
+        client = APIClient()
+        response = client.get(url, **self.headers)
+
+        self.assertEqual(len(response.data.get('data')), 1)
+
+        role = response.data.get('data')[0]
+        self.assertEqual(new_diaplay_fields, set(role.keys()))
+        self.assertEqual(role['groups_in_count'], 1)
+
+    def test_list_role_with_additional_fields_principal_success(self):
+        """Test that we can read a list of roles and add fields for principal."""
+        field_1 = 'groups_in_count'
+        field_2 = 'groups_in'
+        new_diaplay_fields = self.display_fields
+        new_diaplay_fields.add(field_1)
+        new_diaplay_fields.add(field_2)
+
+        url = '{}?add_fields={},{}&scope=principal'.format(reverse('role-list'), field_1, field_2)
+        client = APIClient()
+        response = client.get(url, **self.headers)
+
+        self.assertEqual(len(response.data.get('data')), 1)
+
+        role = response.data.get('data')[0]
+        self.assertEqual(new_diaplay_fields, set(role.keys()))
+        self.assertEqual(role['groups_in_count'], 1)
 
     def test_list_role_with_invalid_additional_fields(self):
         """Test that invalid additional fields will raise exception."""


### PR DESCRIPTION
When `/roles/?add_fields=groups_in` or `/roles/?add_fields=groups_incount` is accessed
with `?username=` or `?scope=principal`, we should ensure that the data in the
`groups_incount` and `groups_in` payload is scoped to the user, either by username
or the principal making the request, depending on which parameter is passed in.

This does that by grabbing the principal from the request (username or scope) if
either of those params exist, and filtering the group query to the principal in
question.

TODO:
- [x] add specs to exploit this
~- update the openapi.json spec with a note about the behavior~