### PR TITLE
Tune migrations and seeds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,8 +86,8 @@ html:
 lint:
 	tox -elint
 
-reinitdb: 
-	make stop-compose 
+reinitdb:
+	make stop-compose
 	make remove-db
 	make start-db
 	sleep 5
@@ -100,7 +100,7 @@ make-migrations:
 	DJANGO_READ_DOT_ENV_FILE=True $(PYTHON) $(PYDIR)/manage.py makemigrations api management
 
 run-migrations:
-	DJANGO_READ_DOT_ENV_FILE=True $(PYTHON) $(PYDIR)/manage.py migrate_schemas
+	DJANGO_READ_DOT_ENV_FILE=True $(PYTHON) $(PYDIR)/manage.py migrate_schemas --executor=parallel
 
 create-test-db-file: run-migrations
 	sleep 1

--- a/openshift/s2i/bin/run
+++ b/openshift/s2i/bin/run
@@ -75,7 +75,7 @@ manage_file=$APP_HOME/manage.py
 if should_migrate; then
   if [[ -f "$manage_file" ]]; then
     echo "---> Migrating database ..."
-    python "$manage_file" migrate_schemas --noinput
+    python "$manage_file" migrate_schemas --noinput --executor=parallel
   else
     echo "WARNING: seems that you're using Django, but we could not find a 'manage.py' file."
     echo "Skipped 'python manage.py migrate'."

--- a/rbac/rbac/settings.py
+++ b/rbac/rbac/settings.py
@@ -348,6 +348,7 @@ ACCESS_CACHE_ENABLED = ENVIRONMENT.bool('ACCESS_CACHE_ENABLED', default=True)
 # Seeding Setup
 ROLE_SEEDING_ENABLED = ENVIRONMENT.bool('ROLE_SEEDING_ENABLED', default=True)
 GROUP_SEEDING_ENABLED = ENVIRONMENT.bool('GROUP_SEEDING_ENABLED', default=True)
+MAX_SEED_THREADS = ENVIRONMENT.int('MAX_SEED_THREADS', default=None)
 
 # disable log messages less than CRITICAL when running unit tests.
 if len(sys.argv) > 1 and sys.argv[1] == 'test':

--- a/run_server.sh
+++ b/run_server.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 sleep 15
-python rbac/manage.py migrate_schemas
+python rbac/manage.py migrate_schemas --executor=parallel
 DJANGO_READ_DOT_ENV_FILE=True python rbac/manage.py runserver 0.0.0.0:8000


### PR DESCRIPTION
**Run migrations in parallel**
---
2169573
By default, this will enable our migrations to run in 2 parallel processes, which
will help speed up our database seeding process as more tenants are created.

https://django-tenant-schemas.readthedocs.io/en/latest/use.html?highlight=connection%20pool#migrate-schemas-in-parallel

**Ensure we close thread connections while seeding**
---
9748494
We need to ensure we close the DB connection(s) which end up being opened with
`ThreadPoolExecutor()` explicitly, otherwise they are not released, and we end
up hitting our PostgreSQL limit in environments where this is set to the default (100).

What happens is that when we run seeds, each tenant/thread opens a new database
connection. When the number of tenants exceeds the number of connections, the async
processing can quickly exhaust all available database connections, since they
are not immediately released.

We need to ensure that after each thread is completed, we close the connections for
that thread. This should resolve the issue, but we can also limit this further
by setting an explicit `max_workers` value to limit the concurrent threads being
run for seeding. When this is _not_ supplied, it will use the default value for
the concurrent threads [1].

[1] https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.ThreadPoolExecutor

**Testing Locally**
---
You can test these changes the following ways:

Migrations:
- Run `make run-migrations` or the migrate command manually, with `--executor=parallel`
appended, and see that the output should reflect two schemas being migrated at once.


Seeding:
- You will want to create multiple tenants in order to see the full effect of the
before/after. 
- If you have ~ 100 tenants, you'll be able to reproduce the connection failure 
by just starting the server and watching the seeds run. It should run out of connections.
You should do this on `master`.
- You can monitor your connections in `psql` with the query: `SELECT sum(numbackends) FROM pg_stat_database;`
while seeds are running, to see the connections open and eventually become orphaned.
- Once you checkout this feature branch, start the server again, running seeds,
and again monitor your local database connections. They should remain low, and constant
regardless of the number of tenants you have.
- You may also optionally set `MAX_SEED_THREADS` in your `.env` file, to see how
that affects concurrency.
