### PR TITLE
Add Django command for running seeds and abstract seed logic

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -83,6 +83,20 @@ If a docker container running Postgres is not feasible, it is possible to run Po
 
     make run-migrations
 
+Seeds
+^^^^^
+
+Default roles and groups are automatically seeded when the application starts by default unless either of the following environment variables are set to 'False' respectively: ::
+
+  ROLE_SEEDING_ENABLED
+  GROUP_SEEDING_ENABLED
+
+Locally these are sourced from `/rbac/management/role/definitions/*.json`, while the config maps in deployed instances are source from our `RBAC config repo`_. **If any changes to default roles/groups are required, they should be make there.**
+
+You can also execute the following Django command to run seeds manually: ::
+
+  rbac/manage.py seeds
+
 Server
 ^^^^^^
 
@@ -115,22 +129,19 @@ RBAC also allows for service-to-service requests. These requests require a PSK, 
 
 First disable the local setting of the identity header in `dev_middleware.py` by [commenting this line out](https://github.com/RedHatInsights/insights-rbac/blob/master/rbac/rbac/dev_middleware.py#L53)
 
-Next, start the server with:
-```
-make serve SERVICE_PSKS='{"catalog": {"secret": "abc123"}}'
-```
+Next, start the server with: ::
 
-Verify that you cannot access any endpoints requiring auth:
-```
-curl http://localhost:8000/api/rbac/v1/roles/ -v
-```
+  make serve SERVICE_PSKS='{"catalog": {"secret": "abc123"}}'
 
-Verify that if you pass in the correct headers/values, you _can_ access the endpoint:
-```
-curl http://localhost:8000/api/rbac/v1/roles/ -v -H 'x-rh-rbac-psk: abc123' -H 'x-rh-rbac-account: 10001' -H 'x-rh-rbac-client-id: catalog'
-```
+Verify that you cannot access any endpoints requiring auth: ::
 
-Change the `x-rh-rbac-client-id`, `x-rh-rbac-psk` and `x-rh-rbac-account` header values to see that you should get back a 401 (or 400 with an account that doesn't exist).
+  curl http://localhost:8000/api/rbac/v1/roles/ -v
+
+Verify that if you pass in the correct headers/values, you _can_ access the endpoint: ::
+
+  curl http://localhost:8000/api/rbac/v1/roles/ -v -H 'x-rh-rbac-psk: abc123' -H 'x-rh-rbac-account: 10001' -H 'x-rh-rbac-client-id: catalog'
+
+Change the 'x-rh-rbac-client-id', 'x-rh-rbac-psk' and 'x-rh-rbac-account' header values to see that you should get back a 401 (or 400 with an account that doesn't exist).
 
 You can also send a request _with_ the identity header explicitly in the curl command along with the service-to-service headers to verify that the identity header will take precedence.
 
@@ -195,9 +206,7 @@ afterwards. Other formats and text files are linted as well.
 
 Install pre-commit hooks to your local repository by running:
 
-```bash
-$ pre-commit install
-```
+  $ pre-commit install
 
 After that, all your commited files will be linted. If the checks don’t succeed, the commit will be rejected. Please
 make sure all checks pass before submitting a pull request. Thanks!
@@ -205,7 +214,7 @@ make sure all checks pass before submitting a pull request. Thanks!
 Repositories of the roles to be seeded
 --------------------------------------
 
-Default roles: https://github.com/RedHatInsights/rbac-config.git
+Default roles can be found in the `RBAC config repo`_.
 
 For additional information please refer to Contributing_.
 
@@ -228,3 +237,4 @@ For additional information please refer to Contributing_.
    :target: https://pyup.io/repos/github/RedHatInsights/insights-rbac/
 .. |Docs| image:: https://readthedocs.org/projects/insights-rbac/badge/
    :target: https://insights-rbac.readthedocs.io/en/latest/
+.. _`RBAC config repo`: https://github.com/RedHatInsights/rbac-config.git

--- a/README.rst
+++ b/README.rst
@@ -95,7 +95,7 @@ Locally these are sourced from `/rbac/management/role/definitions/*.json`, while
 
 You can also execute the following Django command to run seeds manually: ::
 
-  rbac/manage.py seeds
+  rbac/manage.py seeds [--roles-only|--groups-only]
 
 Server
 ^^^^^^

--- a/rbac/management/apps.py
+++ b/rbac/management/apps.py
@@ -15,13 +15,14 @@
 #    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 """Management application configuration module."""
-import concurrent.futures
 import logging
 import sys
 
 from django.apps import AppConfig
-from django.db import connections
 from django.db.utils import OperationalError, ProgrammingError
+from management.seeds import group_seeding, role_seeding
+
+from rbac.settings import GROUP_SEEDING_ENABLED, ROLE_SEEDING_ENABLED
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
@@ -37,59 +38,13 @@ class ManagementConfig(AppConfig):
         if "manage.py" in sys.argv[0] and "runserver" not in sys.argv:
             return
         try:
-            self.role_seeding()
-            self.group_seeding()
+            if ROLE_SEEDING_ENABLED:
+                role_seeding()
+            if GROUP_SEEDING_ENABLED:
+                group_seeding()
         except (OperationalError, ProgrammingError) as op_error:
             if "no such table" in str(op_error) or "does not exist" in str(op_error):
                 # skip this if we haven't created tables yet.
                 return
             else:
-                logger.error("Error: %s.", op_error)
-
-    def on_complete(self, future):
-        """Explicitly close the connection for the thread."""
-        connections.close_all()
-
-    def role_seeding(self):  # pylint: disable=R0201
-        """Update any roles at startup."""
-        # noqa: E402 pylint: disable=C0413
-        from api.models import Tenant
-        from management.role.definer import seed_roles
-        from rbac.settings import ROLE_SEEDING_ENABLED, MAX_SEED_THREADS
-
-        if not ROLE_SEEDING_ENABLED:
-            return
-
-        logger.info("Start role seed changes check.")
-        try:
-            with concurrent.futures.ThreadPoolExecutor(max_workers=MAX_SEED_THREADS) as executor:
-                for tenant in list(Tenant.objects.all()):
-                    if tenant.schema_name != "public":
-                        logger.info("Checking for role seed changes for tenant %s.", tenant.schema_name)
-                        future = executor.submit(seed_roles, tenant, update=True)
-                        future.add_done_callback(self.on_complete)
-                        logger.info("Completed role seed changes for tenant %s.", future.result().schema_name)
-        except Exception as exc:
-            logger.error("Error encountered during role seeding %s.", exc)
-
-    def group_seeding(self):  # pylint: disable=R0201
-        """Update platform group at startup."""
-        # noqa: E402 pylint: disable=C0413
-        from api.models import Tenant
-        from management.group.definer import seed_group
-        from rbac.settings import GROUP_SEEDING_ENABLED, MAX_SEED_THREADS
-
-        if not GROUP_SEEDING_ENABLED:
-            return
-
-        logger.info("Start goup seed changes check.")
-        try:
-            with concurrent.futures.ThreadPoolExecutor(max_workers=MAX_SEED_THREADS) as executor:
-                for tenant in list(Tenant.objects.all()):
-                    if tenant.schema_name != "public":
-                        logger.info("Checking for group seed changes for tenant %s.", tenant.schema_name)
-                        future = executor.submit(seed_group, tenant)
-                        future.add_done_callback(self.on_complete)
-                        logger.info("Completed group seed changes for tenant %s.", future.result().schema_name)
-        except Exception as exc:
-            logger.error("Error encountered during group seeding %s.", exc)
+                logger.error('Error: %s.', op_error)

--- a/rbac/management/apps.py
+++ b/rbac/management/apps.py
@@ -47,4 +47,4 @@ class ManagementConfig(AppConfig):
                 # skip this if we haven't created tables yet.
                 return
             else:
-                logger.error('Error: %s.', op_error)
+                logger.error("Error: %s.", op_error)

--- a/rbac/management/management/commands/seeds.py
+++ b/rbac/management/management/commands/seeds.py
@@ -28,12 +28,19 @@ class Command(BaseCommand):
 
     help = 'Runs the seeding for roles and groups'
 
+    def add_arguments(self, parser):
+        """Add arguments to command."""
+        parser.add_argument('--roles-only', action='store_true')
+        parser.add_argument('--groups-only', action='store_true')
+
     def handle(self, *args, **options):
         """Handle method for command."""
-        logger.info('*** Seeding roles... ***')
-        role_seeding()
-        logger.info('*** Role seeding completed. ***\n')
+        if not options['groups_only']:
+            logger.info('*** Seeding roles... ***')
+            role_seeding()
+            logger.info('*** Role seeding completed. ***\n')
 
-        logger.info('*** Seeding groups... ***')
-        group_seeding()
-        logger.info('*** Group seeding completed. ***\n')
+        if not options['roles_only']:
+            logger.info('*** Seeding groups... ***')
+            group_seeding()
+            logger.info('*** Group seeding completed. ***\n')

--- a/rbac/management/management/commands/seeds.py
+++ b/rbac/management/management/commands/seeds.py
@@ -1,0 +1,34 @@
+#
+# Copyright 2019 Red Hat, Inc.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""Seeds command."""
+import logging
+
+from django.core.management.base import BaseCommand
+from management.seeds import group_seeding, role_seeding
+
+logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
+
+
+class Command(BaseCommand):
+    """Command class for running seeds."""
+
+    help = 'Runs the seeding for roles and groups'
+
+    def handle(self, *args, **options):
+        """Handle method for command."""
+        role_seeding()
+        group_seeding()

--- a/rbac/management/management/commands/seeds.py
+++ b/rbac/management/management/commands/seeds.py
@@ -30,5 +30,10 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         """Handle method for command."""
+        logger.info('*** Seeding roles... ***')
         role_seeding()
+        logger.info('*** Role seeding completed. ***\n')
+
+        logger.info('*** Seeding groups... ***')
         group_seeding()
+        logger.info('*** Group seeding completed. ***\n')

--- a/rbac/management/management/commands/seeds.py
+++ b/rbac/management/management/commands/seeds.py
@@ -26,21 +26,21 @@ logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 class Command(BaseCommand):
     """Command class for running seeds."""
 
-    help = 'Runs the seeding for roles and groups'
+    help = "Runs the seeding for roles and groups"
 
     def add_arguments(self, parser):
         """Add arguments to command."""
-        parser.add_argument('--roles-only', action='store_true')
-        parser.add_argument('--groups-only', action='store_true')
+        parser.add_argument("--roles-only", action="store_true")
+        parser.add_argument("--groups-only", action="store_true")
 
     def handle(self, *args, **options):
         """Handle method for command."""
-        if not options['groups_only']:
-            logger.info('*** Seeding roles... ***')
+        if not options["groups_only"]:
+            logger.info("*** Seeding roles... ***")
             role_seeding()
-            logger.info('*** Role seeding completed. ***\n')
+            logger.info("*** Role seeding completed. ***\n")
 
-        if not options['roles_only']:
-            logger.info('*** Seeding groups... ***')
+        if not options["roles_only"]:
+            logger.info("*** Seeding groups... ***")
             group_seeding()
-            logger.info('*** Group seeding completed. ***\n')
+            logger.info("*** Group seeding completed. ***\n")

--- a/rbac/management/seeds.py
+++ b/rbac/management/seeds.py
@@ -1,0 +1,69 @@
+#
+# Copyright 2019 Red Hat, Inc.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""Seeds module."""
+import concurrent.futures
+import logging
+
+from django.db import connections
+
+logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
+
+
+def on_complete(future):
+    """Explicitly close the connection for the thread."""
+    connections.close_all()
+
+
+def role_seeding():
+    """Update any roles at startup."""
+    # noqa: E402 pylint: disable=C0413
+    from api.models import Tenant
+    from management.role.definer import seed_roles
+    from rbac.settings import MAX_SEED_THREADS
+
+    logger.info('Start role seed changes check.')
+    try:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=MAX_SEED_THREADS) as executor:
+            for tenant in list(Tenant.objects.all()):
+                if tenant.schema_name != 'public':
+                    logger.info('Checking for role seed changes for tenant %s.', tenant.schema_name)
+                    future = executor.submit(seed_roles, tenant, update=True)
+                    future.add_done_callback(on_complete)
+                    logger.info('Completed role seed changes for tenant %s.', future.result().schema_name)
+    except Exception as exc:
+        print('bam!!!')
+        logger.error('Error encountered during role seeding %s.', exc)
+
+
+def group_seeding():
+    """Update platform group at startup."""
+    # noqa: E402 pylint: disable=C0413
+    from api.models import Tenant
+    from management.group.definer import seed_group
+    from rbac.settings import MAX_SEED_THREADS
+
+    logger.info('Start group seed changes check.')
+    try:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=MAX_SEED_THREADS) as executor:
+            for tenant in list(Tenant.objects.all()):
+                if tenant.schema_name != 'public':
+                    logger.info('Checking for group seed changes for tenant %s.', tenant.schema_name)
+                    future = executor.submit(seed_group, tenant)
+                    future.add_done_callback(on_complete)
+                    logger.info('Completed group seed changes for tenant %s.', future.result().schema_name)
+    except Exception as exc:
+        logger.error('Error encountered during group seeding %s.', exc)

--- a/rbac/management/seeds.py
+++ b/rbac/management/seeds.py
@@ -42,14 +42,16 @@ def role_seeding():
             tenants = Tenant.objects.all()
             tenant_count = tenants.count()
             for idx, tenant in enumerate(list(tenants)):
-                if tenant.schema_name != 'public':
-                    logger.info(f'Seeding role changes for tenant {tenant.schema_name} [{idx + 1} of {tenant_count}].')
+                if tenant.schema_name != "public":
+                    logger.info(f"Seeding role changes for tenant {tenant.schema_name} [{idx + 1} of {tenant_count}].")
                     future = executor.submit(seed_roles, tenant, update=True)
-                    completed_log_message = 'Finished seeding role changes for tenant '\
-                                            f'{tenant.schema_name} [{idx + 1} of {tenant_count}].'
+                    completed_log_message = (
+                        "Finished seeding role changes for tenant "
+                        f"{tenant.schema_name} [{idx + 1} of {tenant_count}]."
+                    )
                     future.add_done_callback(partial(on_complete, completed_log_message))
     except Exception as exc:
-        logger.error(f'Error encountered during role seeding {exc}.')
+        logger.error(f"Error encountered during role seeding {exc}.")
 
 
 def group_seeding():
@@ -64,11 +66,15 @@ def group_seeding():
             tenants = Tenant.objects.all()
             tenant_count = tenants.count()
             for idx, tenant in enumerate(list(tenants)):
-                if tenant.schema_name != 'public':
-                    logger.info(f'Seeding group changes for tenant {tenant.schema_name} [{idx + 1} of {tenant_count}].')
+                if tenant.schema_name != "public":
+                    logger.info(
+                        f"Seeding group changes for tenant {tenant.schema_name} [{idx + 1} of {tenant_count}]."
+                    )
                     future = executor.submit(seed_group, tenant)
-                    completed_log_message = 'Finished seeding group changes for tenant '\
-                                            f'{tenant.schema_name} [{idx + 1} of {tenant_count}].'
+                    completed_log_message = (
+                        "Finished seeding group changes for tenant "
+                        f"{tenant.schema_name} [{idx + 1} of {tenant_count}]."
+                    )
                     future.add_done_callback(partial(on_complete, completed_log_message))
     except Exception as exc:
-        logger.error(f'Error encountered during group seeding {exc}.')
+        logger.error(f"Error encountered during group seeding {exc}.")

--- a/tests/tests_apps.py
+++ b/tests/tests_apps.py
@@ -48,9 +48,9 @@ class AppsModelTest(TestCase):
         mock_role_seeding.assert_not_called()
         mock_group_seeding.assert_not_called()
 
-    @patch('management.apps.sys.argv', ['manage.py', 'runserver'])
-    @patch('management.apps.role_seeding')
-    @patch('management.apps.group_seeding')
+    @patch("management.apps.sys.argv", ["manage.py", "runserver"])
+    @patch("management.apps.role_seeding")
+    @patch("management.apps.group_seeding")
     def test_role_seeding(self, mock_role_seeding, mock_group_seeding):
         """Test the server role seeding startup."""
         mgmt_config = apps.get_app_config("management")

--- a/tests/tests_apps.py
+++ b/tests/tests_apps.py
@@ -41,29 +41,27 @@ class AppsModelTest(TestCase):
         logging.disable(logging.CRITICAL)
 
     @patch("management.apps.sys.argv", ["manage.py", "test"])
-    @patch("management.apps.ManagementConfig.role_seeding")
-    def test_ready_silent_run(self, mock_status):
+    @patch("management.apps.role_seeding")
+    @patch("management.apps.group_seeding")
+    def test_ready_silent_run(self, mock_role_seeding, mock_group_seeding):
         """Test that ready functions are not called."""
-        mock_status.assert_not_called()
+        mock_role_seeding.assert_not_called()
+        mock_group_seeding.assert_not_called()
 
-    def test_role_seeding(self):
+    @patch('management.apps.sys.argv', ['manage.py', 'runserver'])
+    @patch('management.apps.role_seeding')
+    @patch('management.apps.group_seeding')
+    def test_role_seeding(self, mock_role_seeding, mock_group_seeding):
         """Test the server role seeding startup."""
-        with self.assertLogs("management.apps", level="INFO") as logger:
-            mgmt_config = apps.get_app_config("management")
-            mgmt_config.role_seeding()
-            self.assertNotEqual(logger.output, [])
+        mgmt_config = apps.get_app_config("management")
 
-    # patching a method called by ManagementConfig.ready()
-    @patch.object(
-        ManagementConfig, "role_seeding", lambda x: exec('raise OperationalError("This is a Test Exception")')
-    )
+        mgmt_config.ready()
+        mock_role_seeding.assert_called()
+        mock_group_seeding.assert_called()
+
     def test_catch_operational_error(self):
         """Test that we handle exceptions thrown when tables are missing."""
         mgmt_config = apps.get_app_config("management")
 
         # the real test
         mgmt_config.ready()
-
-        # sanity-checking that the mocked object is raising the expected error
-        with self.assertRaises(OperationalError):
-            mgmt_config.role_seeding()


### PR DESCRIPTION
In order to reuse the seeding logic to execute a full seeding run outside the
context of the app starting (in this case a Django command), this abstracts the
seeding for all tenants into a separate module.

We need to eventually decouple this from the app, so it can be run when our `rbac-config-sync`
job runs: https://github.com/RedHatInsights/e2e-deploy/blob/master/templates/rbac/config-sync.yaml
in order to not have seeding run for every deployment and pod. This is the first
step in getting to that point.

**Local Testing**

- to test that the current behavior is unchanged, ensure both `ROLE_SEEDING_ENABLED`
and `GROUP_SEEDING_ENABLED` are unset locally. in this case, seeds should run
when you start your local server. you should see seeds run in your console.

- to test that seeding can be disabled by default, set `ROLE_SEEDING_ENABLED`
and `GROUP_SEEDING_ENABLED` both to False and restart your local server. you
should not see seeds run in the console.

- to test the seeds can be triggered manually, from the command like run:
`./rbac/manage.py seeds` and you should see seeds run in the console.