### PR TITLE
Fix platform_default group cache invalidation

### DIFF
--- a/rbac/management/cache.py
+++ b/rbac/management/cache.py
@@ -1,5 +1,6 @@
 """Redis-based caching of per-Principal per-app access policy."""
 
+import contextlib
 import json
 import logging
 
@@ -49,15 +50,31 @@ class AccessCache:
             logger.exception("Error querying policy for uuid %s", uuid)
         return None
 
-    def delete_policy(self, uuid):
-        """Purge the given user's policy from the cache."""
+    @contextlib.contextmanager
+    def delete_handler(self, err_msg):
+        """Handle policy delete events."""
         if not settings.ACCESS_CACHE_ENABLED:
             return
         try:
+            yield
+        except exceptions.RedisError:
+            logger.exception(err_msg)
+
+    def delete_policy(self, uuid):
+        """Purge the given user's policy from the cache."""
+        err_msg = "Error deleting policy for uuid %s", uuid
+        with self.delete_handler(err_msg):
             logger.info("Deleting policy cache for uuid %s", uuid)
             self.connection.delete(self.key_for(uuid))
-        except exceptions.RedisError:
-            logger.exception("Error deleting policy for uuid %s", uuid)
+
+    def delete_all_policies_for_tenant(self):
+        """Purge users' policies for a given tenant from the cache."""
+        err_msg = "Error deleting all policies for tenant %s", self.tenant
+        with self.delete_handler(err_msg):
+            logger.info("Deleting entire policy cache for tenant %s", self.tenant)
+            keys = self.connection.keys(self.key_for("*"))
+            if keys:
+                self.connection.delete(*keys)
 
     def save_policy(self, uuid, application, policy):
         """Write the policy for a given user for a given app to Redis."""

--- a/rbac/management/cache.py
+++ b/rbac/management/cache.py
@@ -62,14 +62,14 @@ class AccessCache:
 
     def delete_policy(self, uuid):
         """Purge the given user's policy from the cache."""
-        err_msg = "Error deleting policy for uuid %s", uuid
+        err_msg = f"Error deleting policy for uuid {uuid}"
         with self.delete_handler(err_msg):
             logger.info("Deleting policy cache for uuid %s", uuid)
             self.connection.delete(self.key_for(uuid))
 
     def delete_all_policies_for_tenant(self):
         """Purge users' policies for a given tenant from the cache."""
-        err_msg = "Error deleting all policies for tenant %s", self.tenant
+        err_msg = f"Error deleting all policies for tenant {self.tenant}"
         with self.delete_handler(err_msg):
             logger.info("Deleting entire policy cache for tenant %s", self.tenant)
             keys = self.connection.keys(self.key_for("*"))

--- a/rbac/management/policy/model.py
+++ b/rbac/management/policy/model.py
@@ -55,7 +55,7 @@ def policy_changed_cache_handler(sender=None, instance=None, using=None, **kwarg
     if instance.group:
         principals = instance.group.principals.all()
         if instance.group.platform_default:
-            principals = Principal.objects.all()
+            cache.delete_all_policies_for_tenant()
         for principal in principals:
             cache.delete_policy(principal.uuid)
 

--- a/rbac/management/policy/model.py
+++ b/rbac/management/policy/model.py
@@ -53,7 +53,10 @@ def policy_changed_cache_handler(sender=None, instance=None, using=None, **kwarg
     logger.info("Handling signal for deleted policy %s - invalidating associated user cache keys", instance)
     cache = AccessCache(connections[using].schema_name)
     if instance.group:
-        for principal in instance.group.principals.all():
+        principals = instance.group.principals.all()
+        if instance.group.platform_default:
+            principals = Principal.objects.all()
+        for principal in principals:
             cache.delete_policy(principal.uuid)
 
 

--- a/tests/rbac/test_cache.py
+++ b/tests/rbac/test_cache.py
@@ -95,75 +95,71 @@ class AccessCacheTest(TestCase):
         cache.assert_called_once()
         cache.assert_called_once_with(self.principal_a.uuid)
 
+    @patch("management.policy.model.AccessCache.delete_all_policies_for_tenant")
     @patch("management.policy.model.AccessCache.delete_policy")
-    def test_policy_cache_group_signals(self, cache):
+    def test_policy_cache_group_signals(self, cache_delete, cache_delete_all):
         """Test signals attached to Groups"""
         self.group_a.principals.add(self.principal_a)
         self.group_b.principals.add(self.principal_b)
-        cache.reset_mock()
+        cache_delete.reset_mock()
 
         # If a policy has its group set
         self.policy_a.group = self.group_a
         self.policy_a.save()
-        cache.assert_any_call(self.principal_a.uuid)
-        cache.assert_any_call(self.principal_b.uuid)
-        self.assertEqual(cache.call_count, 2)
+        cache_delete_all.asset_called_once()
 
-        cache.reset_mock()
+        cache_delete.reset_mock()
         # If a policy has its group changed
         self.policy_a.group = self.group_b
         self.policy_a.save()
-        cache.asset_called_once()
-        cache.asset_called_once_with(self.principal_b.uuid)
+        cache_delete.asset_called_once()
+        cache_delete.asset_called_once_with(self.principal_b.uuid)
 
-        cache.reset_mock()
+        cache_delete.reset_mock()
         # If a policy is deleted
         self.policy_a.delete()
-        cache.assert_called_once()
-        cache.assert_called_once_with(self.principal_b.uuid)
+        cache_delete.assert_called_once()
+        cache_delete.assert_called_once_with(self.principal_b.uuid)
 
+    @patch("management.policy.model.AccessCache.delete_all_policies_for_tenant")
     @patch("management.policy.model.AccessCache.delete_policy")
-    def test_policy_cache_add_remove_roles_signals(self, cache):
+    def test_policy_cache_add_remove_roles_signals(self, cache_delete, cache_delete_all):
         """Test signals attached to Policy/Roles"""
         self.group_b.principals.add(self.principal_b)
         self.policy_a.group = self.group_a
         self.policy_a.save()
         self.policy_b.group = self.group_b
         self.policy_b.save()
-        cache.reset_mock()
+        cache_delete.reset_mock()
 
         # If a Role is added to a platform default group's Policy
         self.policy_a.roles.add(self.role_a)
         self.policy_a.save()
-        cache.assert_any_call(self.principal_a.uuid)
-        cache.assert_any_call(self.principal_b.uuid)
-        self.assertEqual(cache.call_count, 2)
+        cache_delete_all.asset_called_once()
 
-        cache.reset_mock()
+        cache_delete.reset_mock()
         # If a Policy is added to a Role
         self.role_b.policies.add(self.policy_a)
-        cache.asset_called_once()
-        cache.asset_called_once_with(self.principal_b.uuid)
+        cache_delete.asset_called_once()
+        cache_delete.asset_called_once_with(self.principal_b.uuid)
 
-        cache.reset_mock()
+        cache_delete.reset_mock()
         # If a Role is removed from a platform default group's Policy
         self.policy_a.roles.remove(self.role_a)
         self.policy_a.save()
-        cache.assert_any_call(self.principal_a.uuid)
-        cache.assert_any_call(self.principal_b.uuid)
-        self.assertEqual(cache.call_count, 2)
+        cache_delete_all.asset_called_once()
 
-        cache.reset_mock()
+        cache_delete.reset_mock()
         # If a Role is removed from a Policy
         self.policy_b.roles.remove(self.role_b)
-        cache.assert_called_once()
-        cache.assert_called_once_with(self.principal_b.uuid)
+        cache_delete.assert_called_once()
+        cache_delete.assert_called_once_with(self.principal_b.uuid)
 
-        cache.reset_mock()
+        cache_delete.reset_mock()
         # If a Policy is removed from a Role
         self.role_b.policies.remove(self.policy_b)
-        cache.asset_called_once()
-        cache.asset_called_once_with(self.principal_b.uuid)
+        cache_delete.asset_called_once()
+        cache_delete.asset_called_once_with(self.principal_b.uuid)
 
     @patch("management.policy.model.AccessCache.delete_policy")
     def test_policy_cache_clear_signals(self, cache):


### PR DESCRIPTION
Jira: https://projects.engineering.redhat.com/browse/RHCLOUD-6522

There are triggers on all data relations which would affect a user's permissions,
to invalidate the user's policy cache. This includes adding/removing roles to/from 
a group. When this happens, the cache for all users in a group's policy is invalidated.

The problem is that for `platform_default` groups, there is no actual relation
between users and the group/policy/roles for that group. This means it effectively
bypasses the cache invalidation logic [1].

The fix for this is to conditionally invalidate all users' cache when the
`platform_default` group is updated.

[1] https://github.com/RedHatInsights/insights-rbac/blob/master/rbac/management/policy/model.py#L56