### PR TITLE
Exact match filters

### DIFF
--- a/docs/source/specs/openapi.json
+++ b/docs/source/specs/openapi.json
@@ -228,6 +228,9 @@
             "$ref": "#/components/parameters/ScopeFilter"
           },
           {
+            "$ref": "#/components/parameters/NameMatchCriteria"
+          },
+          {
             "name": "username",
             "in": "query",
             "description": "A username for a principal to filter for groups",
@@ -1817,6 +1820,16 @@
             "principal"
           ],
           "default": "account"
+        }
+      },
+      "NameMatchCriteria": {
+        "in": "query",
+        "name": "name_match",
+        "required": false,
+        "description": "Parameter for specifying the matching criteria for an object's name.",
+        "schema": {
+          "type": "string",
+          "enum": ["partial", "exact"]
         }
       }
     },

--- a/docs/source/specs/openapi.json
+++ b/docs/source/specs/openapi.json
@@ -225,10 +225,10 @@
             "$ref": "#/components/parameters/NameFilter"
           },
           {
-            "$ref": "#/components/parameters/ScopeFilter"
+            "$ref": "#/components/parameters/NameMatchCriteria"
           },
           {
-            "$ref": "#/components/parameters/NameMatchCriteria"
+            "$ref": "#/components/parameters/ScopeFilter"
           },
           {
             "name": "username",
@@ -1065,6 +1065,9 @@
           },
           {
             "$ref": "#/components/parameters/NameFilter"
+          },
+          {
+            "$ref": "#/components/parameters/NameMatchCriteria"
           },
           {
             "$ref": "#/components/parameters/ScopeFilter"

--- a/rbac/management/filters.py
+++ b/rbac/management/filters.py
@@ -1,0 +1,16 @@
+from django_filters import rest_framework as filters
+from management.utils import validate_and_get_key
+
+NAME_MATCH_KEY = "name_match"
+VALID_NAME_MATCHES = ["partial", "exact"]
+
+
+class CommonFilters(filters.FilterSet):
+    def name_filter(self, queryset, field, value):
+        """Filter to lookup name, partial or exact."""
+        match_criteria = validate_and_get_key(self.request.query_params, NAME_MATCH_KEY, VALID_NAME_MATCHES, "partial")
+
+        if match_criteria == "partial":
+            return queryset.filter(name__icontains=value)
+        elif match_criteria == "exact":
+            return queryset.filter(name__iexact=value)

--- a/rbac/management/filters.py
+++ b/rbac/management/filters.py
@@ -1,3 +1,21 @@
+#
+# Copyright 2019 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+"""Filters for RBAC."""
 from django_filters import rest_framework as filters
 from management.utils import validate_and_get_key
 
@@ -6,6 +24,8 @@ VALID_NAME_MATCHES = ["partial", "exact"]
 
 
 class CommonFilters(filters.FilterSet):
+    """Common filters."""
+
     def name_filter(self, queryset, field, value):
         """Filter to lookup name, partial or exact."""
         match_criteria = validate_and_get_key(self.request.query_params, NAME_MATCH_KEY, VALID_NAME_MATCHES, "partial")

--- a/rbac/management/group/view.py
+++ b/rbac/management/group/view.py
@@ -52,11 +52,13 @@ EXCLUDE_KEY = "exclude"
 ORDERING_PARAM = "order_by"
 VALID_ROLE_ORDER_FIELDS = list(RoleViewSet.ordering_fields)
 ROLE_DISCRIMINATOR_KEY = "role_discriminator"
+NAME_MATCH_KEY = "name_match"
 VALID_EXCLUDE_VALUES = ["true", "false"]
 VALID_GROUP_ROLE_FILTERS = ["role_name", "role_description"]
 VALID_GROUP_PRINCIPAL_FILTERS = ["principal_username"]
 VALID_PRINCIPAL_ORDER_FIELDS = ["username"]
 VALID_ROLE_ROLE_DISCRIMINATOR = ["all", "any"]
+VALID_NAME_MATCHES = ["partial", "exact"]
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
 
@@ -97,7 +99,16 @@ class GroupFilter(filters.FilterSet):
             queryset = queryset.filter(policies__roles__name__icontains=role_name)
         return queryset
 
-    name = filters.CharFilter(field_name="name", lookup_expr="icontains")
+    def name_filter(self, queryset, field, value):
+        """Filter for group to lookup name, partial or exact."""
+        match_criteria = validate_and_get_key(self.request.query_params, NAME_MATCH_KEY, VALID_NAME_MATCHES, "partial")
+
+        if match_criteria == "partial":
+            return queryset.filter(name__icontains=value)
+        elif match_criteria == "exact":
+            return queryset.filter(name__iexact=value)
+
+    name = filters.CharFilter(field_name="name", method="name_filter")
     role_names = filters.CharFilter(field_name="role_names", method="roles_filter")
     uuid = filters.CharFilter(field_name="uuid", method="uuid_filter")
 

--- a/rbac/management/group/view.py
+++ b/rbac/management/group/view.py
@@ -22,6 +22,7 @@ from uuid import UUID
 from django.db.models.aggregates import Count
 from django.utils.translation import gettext as _
 from django_filters import rest_framework as filters
+from management.filters import CommonFilters
 from management.group.definer import add_roles, remove_roles, set_system_flag_post_update
 from management.group.model import Group
 from management.group.serializer import (
@@ -32,7 +33,6 @@ from management.group.serializer import (
     GroupSerializer,
     RoleMinimumSerializer,
 )
-from management.filters import CommonFilters
 from management.permissions import GroupAccessPermission
 from management.principal.model import Principal
 from management.principal.proxy import PrincipalProxy

--- a/rbac/management/group/view.py
+++ b/rbac/management/group/view.py
@@ -32,6 +32,7 @@ from management.group.serializer import (
     GroupSerializer,
     RoleMinimumSerializer,
 )
+from management.filters import CommonFilters
 from management.permissions import GroupAccessPermission
 from management.principal.model import Principal
 from management.principal.proxy import PrincipalProxy
@@ -52,17 +53,15 @@ EXCLUDE_KEY = "exclude"
 ORDERING_PARAM = "order_by"
 VALID_ROLE_ORDER_FIELDS = list(RoleViewSet.ordering_fields)
 ROLE_DISCRIMINATOR_KEY = "role_discriminator"
-NAME_MATCH_KEY = "name_match"
 VALID_EXCLUDE_VALUES = ["true", "false"]
 VALID_GROUP_ROLE_FILTERS = ["role_name", "role_description"]
 VALID_GROUP_PRINCIPAL_FILTERS = ["principal_username"]
 VALID_PRINCIPAL_ORDER_FIELDS = ["username"]
 VALID_ROLE_ROLE_DISCRIMINATOR = ["all", "any"]
-VALID_NAME_MATCHES = ["partial", "exact"]
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
 
-class GroupFilter(filters.FilterSet):
+class GroupFilter(CommonFilters):
     """Filter for group."""
 
     def uuid_filter(self, queryset, field, values):
@@ -98,15 +97,6 @@ class GroupFilter(filters.FilterSet):
         for role_name in roles_list:
             queryset = queryset.filter(policies__roles__name__icontains=role_name)
         return queryset
-
-    def name_filter(self, queryset, field, value):
-        """Filter for group to lookup name, partial or exact."""
-        match_criteria = validate_and_get_key(self.request.query_params, NAME_MATCH_KEY, VALID_NAME_MATCHES, "partial")
-
-        if match_criteria == "partial":
-            return queryset.filter(name__icontains=value)
-        elif match_criteria == "exact":
-            return queryset.filter(name__iexact=value)
 
     name = filters.CharFilter(field_name="name", method="name_filter")
     role_names = filters.CharFilter(field_name="role_names", method="roles_filter")

--- a/rbac/management/role/view.py
+++ b/rbac/management/role/view.py
@@ -24,10 +24,10 @@ from django.db.models.aggregates import Count
 from django.http import Http404
 from django.utils.translation import gettext as _
 from django_filters import rest_framework as filters
+from management.filters import CommonFilters
 from management.permissions import RoleAccessPermission
 from management.querysets import get_role_queryset
 from management.role.serializer import AccessSerializer, RoleDynamicSerializer
-from management.utils import validate_and_get_key
 from rest_framework import mixins, serializers, viewsets
 from rest_framework.decorators import action
 from rest_framework.filters import OrderingFilter
@@ -38,8 +38,6 @@ from .serializer import RoleSerializer
 TESTING_APP = os.getenv("TESTING_APPLICATION")
 APP_WHITELIST = ["cost-management", "remediations"]
 ADDITIONAL_FIELDS_KEY = "add_fields"
-NAME_MATCH_KEY = "name_match"
-VALID_NAME_MATCHES = ["partial", "exact"]
 VALID_FIELD_VALUES = ["groups_in_count", "groups_in"]
 LIST_ROLE_FIELDS = [
     "uuid",
@@ -58,17 +56,8 @@ if TESTING_APP:
     APP_WHITELIST.append(TESTING_APP)
 
 
-class RoleFilter(filters.FilterSet):
+class RoleFilter(CommonFilters):
     """Filter for role."""
-
-    def name_filter(self, queryset, field, value):
-        """Filter for role to lookup name, partial or exact."""
-        match_criteria = validate_and_get_key(self.request.query_params, NAME_MATCH_KEY, VALID_NAME_MATCHES, "partial")
-
-        if match_criteria == "partial":
-            return queryset.filter(name__icontains=value)
-        elif match_criteria == "exact":
-            return queryset.filter(name__iexact=value)
 
     name = filters.CharFilter(field_name="name", method="name_filter")
 

--- a/tests/management/role/test_view.py
+++ b/tests/management/role/test_view.py
@@ -257,6 +257,48 @@ class RoleViewsetTests(IdentityRequest):
                 role = iterRole
         self.assertEqual(role.get("name"), role_name)
 
+    def test_get_role_by_partial_name_by_default(self):
+        """Test that getting roles by name returns partial match by default."""
+        url = reverse("role-list")
+        url = "{}?name={}".format(url, "role")
+        client = APIClient()
+        response = client.get(url, **self.headers)
+        self.assertEqual(response.data.get("meta").get("count"), 2)
+
+    def test_get_role_by_partial_name_explicit(self):
+        """Test that getting roles by name returns partial match when specified."""
+        url = reverse("role-list")
+        url = "{}?name={}&name_match={}".format(url, "role", "partial")
+        client = APIClient()
+        response = client.get(url, **self.headers)
+        self.assertEqual(response.data.get("meta").get("count"), 2)
+
+    def test_get_role_by_name_invalid_criteria(self):
+        """Test that getting roles by name fails with invalid name_match."""
+        url = reverse("role-list")
+        url = "{}?name={}&name_match={}".format(url, "role", "bad_criteria")
+        client = APIClient()
+        response = client.get(url, **self.headers)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_get_role_by_exact_name_match(self):
+        """Test that getting roles by name returns exact match."""
+        url = reverse("role-list")
+        url = "{}?name={}&name_match={}".format(url, self.sysRole.name, "exact")
+        client = APIClient()
+        response = client.get(url, **self.headers)
+        self.assertEqual(response.data.get("meta").get("count"), 1)
+        role = response.data.get("data")[0]
+        self.assertEqual(role.get("name"), self.sysRole.name)
+
+    def test_get_role_by_exact_name_no_match(self):
+        """Test that getting roles by name returns no results with exact match."""
+        url = reverse("role-list")
+        url = "{}?name={}&name_match={}".format(url, "role", "exact")
+        client = APIClient()
+        response = client.get(url, **self.headers)
+        self.assertEqual(response.data.get("meta").get("count"), 0)
+
     def test_list_role_with_additional_fields_success(self):
         """Test that we can read a list of roles and add fields."""
         role_name = "roleA"


### PR DESCRIPTION
## Link(s) to Jira
- [Add option to verify that group or role with certain name exists](https://projects.engineering.redhat.com/browse/RHCLOUD-7404)

## Description of Intent of Change(s)
UX has requested a way to determine if a role or group name has been taken, before the resource is created. Since `/roles/?name=` and `/groups/?name=` are both partial matches by default, we wanted to extend the behavior to include a new parameter, `?name_match=` with two valid option values, `partial|exact`. 

By default, `partial` will be applied to preserve existing behavior when not explicitly set. 

## Local Testing
**Criteria below assumes I have two groups, with the following names: GroupA, GroupB**
 - I should be able to query /groups/?name=group and have GroupA and GroupB returned, as is the behavior today.
 - I should be able to query /groups/?name=group&name_match=partial with the new name_match parameter, and have GroupA and GroupB returned.
 - I should be able to query /groups/?name=group&name_match=exact with the new name_match parameter, and have no groups returned.
 - I should be able to query /groups/?name=groupa&name_match=exact with the new name_match parameter, and have GroupA returned.
 - I should be able to query /groups/?name=group&name_match=invalid_match with the new name_match parameter, and have a 400 returned.

**Criteria below assumes I have two roles, with the following names: RoleA, RoleB**
 - I should be able to query /roles/?name=role and have RoleA and RoleB returned, as is the behavior today.
 - I should be able to query /roles/?name=group&name_match=partial with the new name_match parameter, and have RoleA and RoleB returned.
 - I should be able to query /roles/?name=group&name_match=exact with the new name_match parameter, and have no roles returned.
 - I should be able to query /roles/?name=rolea&name_match=exact with the new name_match parameter, and have RoleA returned.
 - I should be able to query /roles/?name=role&name_match=invalid_match with the new name_match parameter, and have a 400 returned.

## Checklist
- [x] if API spec changes are required, is the spec updated?

~- [ ] are there any pre/post merge actions required? if so, document here.~

- [x] are theses changes covered by unit tests?

~- [ ] if warranted, are documentation changes accounted for?~

~- [ ] does this require migration changes?~
~- [ ] if yes, are they backwards compatible?~

~- [ ] is there known, direct impact to dependent teams/components?~
~-  if yes, how will this be handled?~
