### PR TITLE
Use cloudwatch queues

### DIFF
--- a/rbac/rbac/settings.py
+++ b/rbac/rbac/settings.py
@@ -266,7 +266,7 @@ if CW_AWS_ACCESS_KEY_ID:
         "log_group": CW_LOG_GROUP,
         "stream_name": NAMESPACE,
         "formatter": LOGGING_FORMATTER,
-        "use_queues": False,
+        "use_queues": True,
         "create_log_group": CW_CREATE_LOG_GROUP,
     }
     LOGGING["handlers"]["watchtower"] = WATCHTOWER_HANDLER


### PR DESCRIPTION
To avoid issues with cloudwatch rate limiting, `use_queues` should be set to True to batch the sending of logs.

https://github.com/kislyuk/watchtower/blob/master/watchtower/__init__.py#L55-L57