### PR TITLE
Remove `update` flag in role seeds to simplify logic and fix bug

### DIFF
--- a/rbac/management/role/definer.py
+++ b/rbac/management/role/definer.py
@@ -28,10 +28,9 @@ from tenant_schemas.utils import tenant_context
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
 
-def _make_role(tenant, data, update=False):
+def _make_role(tenant, data):
     """Create the role object in the database."""
     name = data.pop("name")
-    version_diff = False
     access_list = data.get("access")
     defaults = dict(
         description=data.get("description", None),
@@ -40,34 +39,31 @@ def _make_role(tenant, data, update=False):
         platform_default=data.get("platform_default", False),
     )
     role, created = Role.objects.get_or_create(name=name, defaults=defaults)
-    version_diff = defaults["version"] != role.version
     if created:
         logger.info("Created role %s for tenant %s.", name, tenant.schema_name)
-    elif version_diff:
-        logger.info("Updated role %s for tenant %s.", name, tenant.schema_name)
     else:
-        logger.info("No change in role %s for tenant %s", name, tenant.schema_name)
-    if created or (not created and version_diff):
-        for attr, value in defaults.items():
-            setattr(role, attr, value)
-        role.save(force_update=True)
-        role.access.all().delete()
-    if not update or (update and version_diff):
-        for access_item in access_list:
-            resource_def_list = access_item.pop("resourceDefinitions", [])
-            access_obj = Access.objects.create(**access_item, role=role)
-            for resource_def_item in resource_def_list:
-                ResourceDefinition.objects.create(**resource_def_item, access=access_obj)
+        if role.version != defaults["version"]:
+            Role.objects.filter(name=name).update(**defaults)
+            logger.info("Updated role %s for tenant %s.", name, tenant.schema_name)
+            role.access.all().delete()
+        else:
+            logger.info("No change in role %s for tenant %s", name, tenant.schema_name)
+            return role
+    for access_item in access_list:
+        resource_def_list = access_item.pop("resourceDefinitions", [])
+        access_obj = Access.objects.create(**access_item, role=role)
+        for resource_def_item in resource_def_list:
+            ResourceDefinition.objects.create(**resource_def_item, access=access_obj)
     return role
 
 
-def _update_or_create_roles(tenant, roles, update=False):
+def _update_or_create_roles(tenant, roles):
     """Update or create roles from list."""
     for role_json in roles:
-        _make_role(tenant, role_json, update)
+        _make_role(tenant, role_json)
 
 
-def seed_roles(tenant, update=False):
+def seed_roles(tenant):
     """For a tenant update or create system defined roles."""
     roles_directory = os.path.join(settings.BASE_DIR, "management", "role", "definitions")
     role_files = [
@@ -82,7 +78,7 @@ def seed_roles(tenant, update=False):
                 with open(role_file_path) as json_file:
                     data = json.load(json_file)
                     role_list = data.get("roles")
-                    _update_or_create_roles(tenant, role_list, update)
+                    _update_or_create_roles(tenant, role_list)
     return tenant
 
 

--- a/rbac/management/seeds.py
+++ b/rbac/management/seeds.py
@@ -57,7 +57,7 @@ def run_seeds(seed_type):
     from management.role.definer import seed_roles, seed_permissions
     from rbac.settings import MAX_SEED_THREADS
 
-    seed_functions = {"role": partial(seed_roles, update=True), "group": seed_group, "permission": seed_permissions}
+    seed_functions = {"role": seed_roles, "group": seed_group, "permission": seed_permissions}
 
     try:
         with concurrent.futures.ThreadPoolExecutor(max_workers=MAX_SEED_THREADS) as executor:

--- a/rbac/rbac/middleware.py
+++ b/rbac/rbac/middleware.py
@@ -80,7 +80,7 @@ class IdentityHeaderMiddleware(BaseTenantMiddleware):
                     )
                     if created:
                         seed_permissions(tenant=tenant)
-                        seed_roles(tenant=tenant, update=False)
+                        seed_roles(tenant=tenant)
                         seed_group(tenant=tenant)
             TENANTS[request.user.account] = tenant
         return TENANTS[request.user.account]

--- a/tests/management/group/test_definer.py
+++ b/tests/management/group/test_definer.py
@@ -29,7 +29,7 @@ class GroupDefinerTests(IdentityRequest):
     def setUp(self):
         """Set up the group definer tests."""
         super().setUp()
-        seed_roles(self.tenant, update=True)
+        seed_roles(self.tenant)
         seed_group(self.tenant)
 
     def test_default_group_seeding_properly(self):

--- a/tests/management/role/test_definer.py
+++ b/tests/management/role/test_definer.py
@@ -49,7 +49,7 @@ class RoleDefinerTests(IdentityRequest):
             roles = Role.objects.filter(platform_default=True)
             self.assertFalse(len(roles))
 
-            seed_roles(self.tenant, update=True)
+            seed_roles(self.tenant)
             roles = Role.objects.filter(platform_default=True)
             self.assertTrue(len(roles))
 
@@ -62,14 +62,14 @@ class RoleDefinerTests(IdentityRequest):
             roles = Role.objects.filter(platform_default=True).update(version=0, platform_default=False)
             self.assertFalse(len(Role.objects.filter(platform_default=True)))
 
-            seed_roles(self.tenant, update=True)
+            seed_roles(self.tenant)
             roles = Role.objects.filter(platform_default=True)
             self.assertTrue(len(roles))
 
     def try_seed_roles(self):
         """ Try to seed roles """
         try:
-            seed_roles(self.tenant, update=False)
+            seed_roles(self.tenant)
         except Exception:
             self.fail(msg="seed_roles encountered an exception")
 


### PR DESCRIPTION
## Description of Intent of Change(s)
Submitting this in favor of #312 in order to simplify the logic around role
seeding when we're updating vs creating.

This will ensure that when we're creating a new role, we are creating access
records from permissions. When we're updating and the version differs, we'll
remove the access records and recreate them. When we're updating and the version
is _not_ different, we'll update the role, but return early and not do anything
with the access records.

This also fixes the original bug in #312 while reducing complexity.

## Local Testing
> How can the bug be exploited and fix confirmed?

To exploit the issue on the `master` branch, create a _new_ role in an existing or new config file in `/rbac/management/role/definitions/*.json`, after you've created a tenant and the migrations and seeds have run. This only affects new roles being added during explicit seeding, where `update=True`, not during new tenant creation where `update=False`.

Run seeds as you normally would, and note in the database that `Access` records were not created for the new role. Subsequent runs of seeding, if you bump the version for that role, _will_ create the `Access` records.

Now checkout this PR's feature branch. Do the same as above where you create a net-new role in your config, and run the seeds manually. Now for that new role you should see the `Access` records.
