### PR TITLE
Status type

### DIFF
--- a/docs/source/specs/openapi.json
+++ b/docs/source/specs/openapi.json
@@ -1972,9 +1972,6 @@
             "type": "array",
             "items": {
               "type": "object",
-              "required": [
-                "status"
-              ],
               "properties": {
                 "detail": {
                   "type": "string",
@@ -1984,6 +1981,7 @@
                   "type": "string",
                   "example": "403"
                 }
+              }
             }
           }
         }
@@ -1997,9 +1995,6 @@
             "type": "array",
             "items": {
               "type": "object",
-              "required": [
-                "status"
-              ],
               "properties": {
                 "detail": {
                   "type": "string",

--- a/docs/source/specs/openapi.json
+++ b/docs/source/specs/openapi.json
@@ -1972,10 +1972,18 @@
             "type": "array",
             "items": {
               "type": "object",
-              "example": {
-                "detail": "Not Found.",
-                "status": 404
-              }
+              "required": [
+                "status"
+              ],
+              "properties": {
+                "detail": {
+                  "type": "string",
+                  "example": "Not found."
+                },
+                "status": {
+                  "type": "string",
+                  "example": "403"
+                }
             }
           }
         }
@@ -1989,10 +1997,22 @@
             "type": "array",
             "items": {
               "type": "object",
-              "example": {
-                "detail": "You do not have permission to perform this action.",
-                "source": "detail",
-                "status": 403
+              "required": [
+                "status"
+              ],
+              "properties": {
+                "detail": {
+                  "type": "string",
+                  "example": "You do not have permission to perform this action."
+                },
+                "source": {
+                  "type": "string",
+                  "example": "detail"
+                },
+                "status": {
+                  "type": "string",
+                  "example": "403"
+                }
               }
             }
           }

--- a/rbac/api/common/exception_handler.py
+++ b/rbac/api/common/exception_handler.py
@@ -65,9 +65,9 @@ def custom_exception_handler(exc, context):
         errors = []
         data = copy.deepcopy(response.data)
         if isinstance(data, dict):
-            errors += _generate_errors_from_dict(data, **{"status_code": response.status_code})
+            errors += _generate_errors_from_dict(data, **{"status_code": str(response.status_code)})
         elif isinstance(data, list):
-            errors += _generate_errors_from_list(data, **{"status_code": response.status_code})
+            errors += _generate_errors_from_list(data, **{"status_code": str(response.status_code)})
         error_response = {"errors": errors}
         response.data = error_response
 

--- a/rbac/management/principal/proxy.py
+++ b/rbac/management/principal/proxy.py
@@ -26,7 +26,6 @@ from rest_framework import status
 
 from rbac.env import ENVIRONMENT
 
-
 LOGGER = logging.getLogger(__name__)
 PROTOCOL = "protocol"
 HOST = "host"
@@ -132,7 +131,7 @@ class PrincipalProxy:  # pylint: disable=too-few-public-methods
         headers = {USER_ENV_HEADER: self.user_env, CLIENT_ID_HEADER: self.client_id, API_TOKEN_HEADER: self.api_token}
         unexpected_error = {
             "detail": "Unexpected error.",
-            "status": status.HTTP_500_INTERNAL_SERVER_ERROR,
+            "status": str(status.HTTP_500_INTERNAL_SERVER_ERROR),
             "source": "principals",
         }
         try:
@@ -161,11 +160,11 @@ class PrincipalProxy:  # pylint: disable=too-few-public-methods
                 resp["status_code"] = status.HTTP_500_INTERNAL_SERVER_ERROR
                 error = unexpected_error
         elif response.status_code == status.HTTP_404_NOT_FOUND:
-            error = {"detail": "Not Found.", "status": response.status_code, "source": "principals"}
+            error = {"detail": "Not Found.", "status": str(response.status_code), "source": "principals"}
         else:
             LOGGER.error("Error calling URL %s -- status=%d", url, response.status_code)
             error = unexpected_error
-            error["status"] = response.status_code
+            error["status"] = str(response.status_code)
         if error:
             resp["errors"] = [error]
         return resp

--- a/rbac/management/principal/view.py
+++ b/rbac/management/principal/view.py
@@ -79,7 +79,7 @@ class PrincipalView(APIView):
     permission_classes = (AdminAccessPermission,)
 
     def get(self, request):
-        """List prinicpals for account."""
+        """List principals for account."""
         proxy = PrincipalProxy()
         user = self.request.user
         path = self.request.path
@@ -97,7 +97,7 @@ class PrincipalView(APIView):
             error = {
                 "detail": "Values for limit and offset must be positive numbers.",
                 "source": "principals",
-                "status": status.HTTP_400_BAD_REQUEST,
+                "status": str(status.HTTP_400_BAD_REQUEST),
             }
             errors = {"errors": [error]}
             return Response(status=status.HTTP_400_BAD_REQUEST, data=errors)

--- a/tests/management/principal/test_proxy.py
+++ b/tests/management/principal/test_proxy.py
@@ -131,7 +131,7 @@ class PrincipalProxyTest(TestCase):
         """Test request with expected 404."""
         proxy = PrincipalProxy()
         result = proxy._request_principals(url="http://localhost:8080/v1/users", method=mocked_requests_get_404_json)
-        expected = {"status_code": 404, "errors": [{"detail": "Not Found.", "status": 404, "source": "principals"}]}
+        expected = {"status_code": 404, "errors": [{"detail": "Not Found.", "status": "404", "source": "principals"}]}
         self.assertEqual(expected, result)
 
     def test__request_principals_500(self):
@@ -140,7 +140,7 @@ class PrincipalProxyTest(TestCase):
         result = proxy._request_principals(url="http://localhost:8080/v1/users", method=mocked_requests_get_500_json)
         expected = {
             "status_code": 500,
-            "errors": [{"detail": "Unexpected error.", "status": 500, "source": "principals"}],
+            "errors": [{"detail": "Unexpected error.", "status": "500", "source": "principals"}],
         }
         self.assertEqual(expected, result)
 
@@ -150,7 +150,7 @@ class PrincipalProxyTest(TestCase):
         result = proxy._request_principals(url="http://localhost:8080/v1/users", method=mocked_requests_get_500_except)
         expected = {
             "status_code": 500,
-            "errors": [{"detail": "Unexpected error.", "status": 500, "source": "principals"}],
+            "errors": [{"detail": "Unexpected error.", "status": "500", "source": "principals"}],
         }
         self.assertEqual(expected, result)
 
@@ -197,6 +197,6 @@ class PrincipalProxyTest(TestCase):
         result = proxy._request_principals(url="http://localhost:8080/v1/users", method=mocked_requests_get_200_except)
         expected = {
             "status_code": 500,
-            "errors": [{"detail": "Unexpected error.", "status": 500, "source": "principals"}],
+            "errors": [{"detail": "Unexpected error.", "status": "500", "source": "principals"}],
         }
         self.assertEqual(expected, result)


### PR DESCRIPTION
## Link(s) to Jira
https://projects.engineering.redhat.com/browse/RHCLOUD-5856

## Description of Intent of Change(s)
According to this https://jsonapi.org/format/#errors, the status
within error should be string instead of integer.

## Local Testing
How can the feature be exercised? 
There are unit tests to ensure this.

How can the bug be exploited and fix confirmed?
When getting errors, the status within error should be string (quoted integer)

Is any special local setup required?
No

## Checklist
- [X] if API spec changes are required, is the spec updated?

- [ ] are there any pre/post merge actions required? if so, document here.
No
- [ ] are theses changes covered by unit tests?
Yes
- [ ] if warranted, are documentation changes accounted for?

- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
No
- [ ] is there known, direct impact to dependent teams/components?
  -  if yes, how will this be handled?
No