### PR TITLE
Add Inventory to custom role creation whitelist

### DIFF
--- a/rbac/management/role/view.py
+++ b/rbac/management/role/view.py
@@ -36,7 +36,11 @@ from .model import Role
 from .serializer import RoleSerializer
 
 TESTING_APP = os.getenv("TESTING_APPLICATION")
-APP_WHITELIST = ["cost-management", "remediations"]
+APP_WHITELIST = [
+    "cost-management",
+    "remediations",
+    "inventory",
+]
 ADDITIONAL_FIELDS_KEY = "add_fields"
 VALID_FIELD_VALUES = ["groups_in_count", "groups_in"]
 LIST_ROLE_FIELDS = [


### PR DESCRIPTION
This is blocking Inventory testing, adding this as a quick fix until we
can parameterize it/move the whitelist to a config

Signed-off-by: Chris Mitchell <cmitchel@redhat.com>

## Link(s) to Jira
- No Jira, directly requested through Slack

## Description of Intent of Change(s)
As we haven't gotten the APP_WHITELIST for custom role creation parameterized yet, we need to manually add in inventory to allow for their testing

## Local Testing
Create/POST a custom role with a permission including 'inventory:<someresource>:<someverb>

## Checklist
- [ ] if API spec changes are required, is the spec updated?

- [ ] are there any pre/post merge actions required? if so, document here.

- [x] are theses changes covered by unit tests?

- [ ] if warranted, are documentation changes accounted for?

- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?

- [ ] is there known, direct impact to dependent teams/components?
  -  if yes, how will this be handled?
