### PR TITLE
Add is org admin flag

### DIFF
--- a/docs/source/specs/openapi.json
+++ b/docs/source/specs/openapi.json
@@ -2098,6 +2098,9 @@
           },
           "is_active": {
             "type": "boolean"
+          },
+          "is_org_admin": {
+            "type": "boolean"
           }
         }
       },

--- a/rbac/management/principal/proxy.py
+++ b/rbac/management/principal/proxy.py
@@ -95,6 +95,7 @@ class PrincipalProxy:  # pylint: disable=too-few-public-methods
             "first_name": item.get("first_name"),
             "last_name": item.get("last_name"),
             "is_active": item.get("is_active"),
+            "is_org_admin": item.get("is_org_admin"),
         }
         return processed_item
 

--- a/tests/management/principal/test_proxy.py
+++ b/tests/management/principal/test_proxy.py
@@ -64,6 +64,7 @@ def mocked_requests_get_200_json(*args, **kwargs):  # pylint: disable=unused-arg
         "first_name": "test",
         "last_name": "user1",
         "is_active": "true",
+        "is_org_admin": "true",
     }
     json_response = [user]
     return MockResponse(json_response, status.HTTP_200_OK)
@@ -77,6 +78,7 @@ def mocked_requests_get_200_json_count(*args, **kwargs):  # pylint: disable=unus
         "first_name": "test",
         "last_name": "user1",
         "is_active": "true",
+        "is_org_admin": "true",
     }
     user2 = {
         "username": "test_user2",
@@ -84,6 +86,7 @@ def mocked_requests_get_200_json_count(*args, **kwargs):  # pylint: disable=unus
         "first_name": "test",
         "last_name": "user2",
         "is_active": "true",
+        "is_org_admin": "false",
     }
     json_response = {"userCount": 2, "users": [user1, user2]}
     return MockResponse(json_response, status.HTTP_200_OK)
@@ -164,6 +167,7 @@ class PrincipalProxyTest(TestCase):
             "first_name": "test",
             "last_name": "user1",
             "is_active": "true",
+            "is_org_admin": "true",
         }
         expected = {"data": [user], "status_code": 200}
         self.assertEqual(expected, result)
@@ -180,6 +184,7 @@ class PrincipalProxyTest(TestCase):
             "first_name": "test",
             "last_name": "user1",
             "is_active": "true",
+            "is_org_admin": "true",
         }
         user2 = {
             "username": "test_user2",
@@ -187,6 +192,7 @@ class PrincipalProxyTest(TestCase):
             "first_name": "test",
             "last_name": "user2",
             "is_active": "true",
+            "is_org_admin": "false",
         }
         expected = {"data": {"userCount": 2, "users": [user1, user2]}, "status_code": 200}
         self.assertEqual(expected, result)


### PR DESCRIPTION
## Link(s) to Jira
- https://projects.engineering.redhat.com/browse/RHCLOUD-6153

## Description of Intent of Change(s)
Need to pass along the is_org_admin flag from BOP with our principal returns.

## Local Testing
Local testing will require either a mocked BOP running or local certs for accessing CI/QA BOP. With one of these mechanisms in place and returning the is_org_admin flag properly, hits to any of the /principals/  or /group/uuid/principals/ endpoints should return the principal's org_admin status

## Checklist
- [x] if API spec changes are required, is the spec updated?

- [ ] are there any pre/post merge actions required? if so, document here.

- [x] are theses changes covered by unit tests?

- [x] if warranted, are documentation changes accounted for?

- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?

- [ ] is there known, direct impact to dependent teams/components?
  -  if yes, how will this be handled?
