### PR TITLE
Upgrate node version from 8 to 10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,10 @@ FROM centos/python-36-centos7
 
 EXPOSE 8080
 
-ENV NODEJS_VERSION=8 \
-    NODEJS_SCL=rh-nodejs8 \
+ENV NODEJS_VERSION=10 \
+    NODEJS_SCL=rh-nodejs10 \
     NPM_RUN=start \
-    NODEJS_SCL=rh-nodejs8 \
+    NODEJS_SCL=rh-nodejs10 \
     NPM_CONFIG_PREFIX=$HOME/.npm-global \
     PATH=$HOME/.local/bin/:$HOME/node_modules/.bin/:$HOME/.npm-global/bin/:$PATH \
     LC_ALL=en_US.UTF-8 \
@@ -28,7 +28,7 @@ LABEL summary="$SUMMARY" \
 
 USER root
 
-# replace nodejs 6 with nodejs 8
+# replace nodejs 8 with nodejs 10
 RUN INSTALL_PKGS="${NODEJS_SCL} \
                   ${NODEJS_SCL}-npm \
                   ${NODEJS_SCL}-nodejs-nodemon \
@@ -36,7 +36,7 @@ RUN INSTALL_PKGS="${NODEJS_SCL} \
     yum-config-manager --enable centos-sclo-rh-testing && \
     yum -y --setopt=tsflags=nodocs install --enablerepo=centosplus $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
-    yum remove -y rh-nodejs6\* && \
+    yum remove -y rh-nodejs8\* && \
     ln -s /usr/lib/node_modules/nodemon/bin/nodemon.js /usr/bin/nodemon && \
     yum -y clean all --enablerepo='*'
 


### PR DESCRIPTION

## Link(s) to Jira
- 

## Description of Intent of Change(s)
The fs-extra causes failure of buiding openapi. According to this:
https://github.com/google/docsy/issues/265, node version will fix this

Failure message looks like this:
/opt/app-root/src/.npm-global/lib/node_modules/apidoc/node_modules/fs-extra/lib/mkdirs/make-dir.js:85
      } catch {
              ^

SyntaxError: Unexpected token {
    at createScript (vm.js:80:10)
    at Object.runInThisContext (vm.js:139:10)
    at Module._compile (module.js:617:28)
    at Object.Module._extensions..js (module.js:664:10)
    at Module.load (module.js:566:32)
    at tryModuleLoad (module.js:506:12)
    at Function.Module._load (module.js:498:3)
    at Module.require (module.js:597:17)
    at require (internal/module.js:11:18)
    at Object.<anonymous> (/opt/app-root/src/.npm-global/lib/node_modules/apidoc/node_modules/fs-extra/lib/mkdirs/index.js:3:44)
make: *** [gen-apidoc] Error 1

## Local Testing
How can the feature be exercised? 
How can the bug be exploited and fix confirmed?
Is any special local setup required?

## Checklist
- [ ] if API spec changes are required, is the spec updated?

- [ ] are there any pre/post merge actions required? if so, document here.

- [ ] are theses changes covered by unit tests?

- [ ] if warranted, are documentation changes accounted for?

- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
Yea, we could easily roll this back

- [ ] is there known, direct impact to dependent teams/components?
  -  if yes, how will this be handled?
