### PR TITLE
Ensure the "applications" field is set on /api/rbac/v1/roles/<uuid>/

### DIFF
--- a/rbac/management/role/serializer.py
+++ b/rbac/management/role/serializer.py
@@ -99,7 +99,7 @@ class RoleSerializer(serializers.ModelSerializer):
 
     def get_applications(self, obj):
         """Get the list of applications in the role."""
-        obtain_applications(obj)
+        return obtain_applications(obj)
 
     def create(self, validated_data):
         """Create the role object in the database."""

--- a/tests/management/role/test_view.py
+++ b/tests/management/role/test_view.py
@@ -230,6 +230,22 @@ class RoleViewsetTests(IdentityRequest):
         response = client.get(url, **self.headers)
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
+    def test_read_role_valid(self):
+        """Test that reading a valid role returns expected fields/values."""
+        url = reverse("role-detail", kwargs={"uuid": self.defRole.uuid})
+        client = APIClient()
+        response = client.get(url, **self.headers)
+        response_data = response.data
+        expected_fields = self.display_fields
+        expected_fields.add("access")
+        self.assertEqual(expected_fields, set(response_data.keys()))
+        self.assertEqual(response_data.get("uuid"), str(self.defRole.uuid))
+        self.assertEqual(response_data.get("name"), self.defRole.name)
+        self.assertEqual(response_data.get("display_name"), self.defRole.display_name)
+        self.assertEqual(response_data.get("description"), self.defRole.description)
+        self.assertEqual(response_data.get("applications"), ["app"])
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
     def test_read_role_access_success(self):
         """Test that reading a valid role returns access."""
         url = reverse("role-access", kwargs={"uuid": self.defRole.uuid})


### PR DESCRIPTION
## Link(s) to Jira
[RBAC GET /roles/<uuid>/ does not set "applications" field](https://projects.engineering.redhat.com/browse/RHCLOUD-8801) 

## Description of Intent of Change(s)
If I visit `/api/rbac/v1/roles/<uuid>/` I should see the `applications` field
populated with the same value(s) as I see for the role when viewed at `/api/rbac/v1/roles/`.

Currently it is set as `null` because we don't return the value.

## Local Testing
If I see the following for role `1234` on `/api/rbac/v1/roles/`:
```
{
  "data": [
    {
      "uuid": "1234",
      "name": "test role",
      "display_name": "test role",
      "description": "A description of test role",
      "created": "2020-08-26T01:33:19.639405Z",
      "modified": "2020-08-26T01:33:19.647813Z",
      "policyCount": 0,
      "accessCount": 1,
      "applications": [
        "cost-management"
      ],
      "system": false,
      "platform_default": false
    }
  ]
}
```

I should see the following on `/api/rbac/v1/roles/1234/` (note the `applications` field):
```
{
  "uuid": "1234",
  "name": "test role",
  "display_name": "test role",
  "description": "A description of test role",
  "access": [
    {
      "resourceDefinitions": [],
      "permission": "cost-management:*:read"
    }
  ],
  "policyCount": 0,
  "accessCount": 1,
  "applications": [
    "cost-management"
  ],
  "system": false,
  "platform_default": false,
  "created": "2020-08-26T01:33:19.639405Z",
  "modified": "2020-08-26T01:33:19.647813Z"
}
```

## Checklist
- [ ] if API spec changes are required, is the spec updated?

- [ ] are there any pre/post merge actions required? if so, document here.

- [x] are theses changes covered by unit tests?

- [ ] if warranted, are documentation changes accounted for?

- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?

- [ ] is there known, direct impact to dependent teams/components?
  -  if yes, how will this be handled?
