### PR TITLE
Add checks for GUIDs to group requests

### DIFF
--- a/rbac/management/group/view.py
+++ b/rbac/management/group/view.py
@@ -267,7 +267,7 @@ class GroupViewSet(
                 ]
             }
         """
-        self.validate_guid(request.path.split("/")[4])
+        self.validate_guid(kwargs.get("uuid"))
         return super().retrieve(request=request, args=args, kwargs=kwargs)
 
     def destroy(self, request, *args, **kwargs):
@@ -286,7 +286,7 @@ class GroupViewSet(
         @apiSuccessExample {json} Success-Response:
             HTTP/1.1 204 NO CONTENT
         """
-        self.validate_guid(request.path.split("/")[4])
+        self.validate_guid(kwargs.get("uuid"))
         self.protect_default_groups("delete")
         return super().destroy(request=request, args=args, kwargs=kwargs)
 
@@ -312,7 +312,7 @@ class GroupViewSet(
                 "name": "GroupA"
             }
         """
-        self.validate_guid(request.path.split("/")[4])
+        self.validate_guid(kwargs.get("uuid"))
         self.protect_default_groups("update")
         return super().update(request=request, args=args, kwargs=kwargs)
 
@@ -424,7 +424,7 @@ class GroupViewSet(
             HTTP/1.1 204 NO CONTENT
         """
         principals = []
-        self.validate_guid(request.path.split("/")[4])
+        self.validate_guid(uuid)
         group = self.get_object()
         account = self.request.user.account
         if request.method == "POST":
@@ -551,7 +551,7 @@ class GroupViewSet(
             HTTP/1.1 204 NO CONTENT
         """
         roles = []
-        self.validate_guid(request.path.split("/")[4])
+        self.validate_guid(uuid)
         group = self.get_object()
         if request.method == "POST":
             serializer = GroupRoleSerializerIn(data=request.data)

--- a/rbac/management/group/view.py
+++ b/rbac/management/group/view.py
@@ -267,6 +267,7 @@ class GroupViewSet(
                 ]
             }
         """
+        self.validate_guid(request.path.split("/")[4])
         return super().retrieve(request=request, args=args, kwargs=kwargs)
 
     def destroy(self, request, *args, **kwargs):
@@ -285,6 +286,7 @@ class GroupViewSet(
         @apiSuccessExample {json} Success-Response:
             HTTP/1.1 204 NO CONTENT
         """
+        self.validate_guid(request.path.split("/")[4])
         self.protect_default_groups("delete")
         return super().destroy(request=request, args=args, kwargs=kwargs)
 
@@ -310,6 +312,7 @@ class GroupViewSet(
                 "name": "GroupA"
             }
         """
+        self.validate_guid(request.path.split("/")[4])
         self.protect_default_groups("update")
         return super().update(request=request, args=args, kwargs=kwargs)
 
@@ -421,6 +424,7 @@ class GroupViewSet(
             HTTP/1.1 204 NO CONTENT
         """
         principals = []
+        self.validate_guid(request.path.split("/")[4])
         group = self.get_object()
         account = self.request.user.account
         if request.method == "POST":
@@ -547,6 +551,7 @@ class GroupViewSet(
             HTTP/1.1 204 NO CONTENT
         """
         roles = []
+        self.validate_guid(request.path.split("/")[4])
         group = self.get_object()
         if request.method == "POST":
             serializer = GroupRoleSerializerIn(data=request.data)
@@ -604,6 +609,16 @@ class GroupViewSet(
                 attr_filter_name = param_name.replace(f"{model_name}_", "")
                 filters[f"{attr_filter_name}__icontains"] = param_value
         return filters
+
+    def validate_guid(self, uuid):
+        """Verify GUID provided is valid before attempting to retrieve it."""
+        try:
+            UUID(uuid)
+        except ValueError:
+            key = "groups uuid validation"
+            message = f"{uuid} is not a valid UUID."
+            raise serializers.ValidationError({key: _(message)})
+        return
 
     def obtain_roles(self, request, group):
         """Obtain roles based on request, supports exclusion."""

--- a/rbac/management/group/view.py
+++ b/rbac/management/group/view.py
@@ -17,7 +17,6 @@
 
 """View for group management."""
 import logging
-from uuid import UUID
 
 from django.db.models.aggregates import Count
 from django.utils.translation import gettext as _
@@ -40,7 +39,7 @@ from management.principal.serializer import PrincipalSerializer
 from management.querysets import get_group_queryset, get_object_principal_queryset
 from management.role.model import Role
 from management.role.view import RoleViewSet
-from management.utils import validate_and_get_key
+from management.utils import validate_and_get_key, validate_uuid
 from rest_framework import mixins, serializers, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.filters import OrderingFilter
@@ -68,12 +67,7 @@ class GroupFilter(CommonFilters):
         """Filter for group uuid lookup."""
         uuids = values.split(",")
         for uuid in uuids:
-            try:
-                UUID(uuid)
-            except ValueError:
-                key = "groups uuid filter"
-                message = f"{uuid} is not a valid UUID."
-                raise serializers.ValidationError({key: _(message)})
+            validate_uuid(uuid, "groups uuid filter")
         return CommonFilters.multiple_values_in(self, queryset, field, values)
 
     def roles_filter(self, queryset, field, values):
@@ -267,7 +261,7 @@ class GroupViewSet(
                 ]
             }
         """
-        self.validate_guid(kwargs.get("uuid"))
+        validate_uuid(kwargs.get("uuid"), "group uuid validation")
         return super().retrieve(request=request, args=args, kwargs=kwargs)
 
     def destroy(self, request, *args, **kwargs):
@@ -286,7 +280,7 @@ class GroupViewSet(
         @apiSuccessExample {json} Success-Response:
             HTTP/1.1 204 NO CONTENT
         """
-        self.validate_guid(kwargs.get("uuid"))
+        validate_uuid(kwargs.get("uuid"), "group uuid validation")
         self.protect_default_groups("delete")
         return super().destroy(request=request, args=args, kwargs=kwargs)
 
@@ -312,7 +306,7 @@ class GroupViewSet(
                 "name": "GroupA"
             }
         """
-        self.validate_guid(kwargs.get("uuid"))
+        validate_uuid(kwargs.get("uuid"), "group uuid validation")
         self.protect_default_groups("update")
         return super().update(request=request, args=args, kwargs=kwargs)
 
@@ -424,7 +418,7 @@ class GroupViewSet(
             HTTP/1.1 204 NO CONTENT
         """
         principals = []
-        self.validate_guid(uuid)
+        validate_uuid(uuid, "group uuid validation")
         group = self.get_object()
         account = self.request.user.account
         if request.method == "POST":
@@ -551,7 +545,7 @@ class GroupViewSet(
             HTTP/1.1 204 NO CONTENT
         """
         roles = []
-        self.validate_guid(uuid)
+        validate_uuid(uuid, "group uuid validation")
         group = self.get_object()
         if request.method == "POST":
             serializer = GroupRoleSerializerIn(data=request.data)
@@ -609,16 +603,6 @@ class GroupViewSet(
                 attr_filter_name = param_name.replace(f"{model_name}_", "")
                 filters[f"{attr_filter_name}__icontains"] = param_value
         return filters
-
-    def validate_guid(self, uuid):
-        """Verify GUID provided is valid before attempting to retrieve it."""
-        try:
-            UUID(uuid)
-        except ValueError:
-            key = "groups uuid validation"
-            message = f"{uuid} is not a valid UUID."
-            raise serializers.ValidationError({key: _(message)})
-        return
 
     def obtain_roles(self, request, group):
         """Obtain roles based on request, supports exclusion."""

--- a/rbac/management/role/view.py
+++ b/rbac/management/role/view.py
@@ -28,6 +28,7 @@ from management.filters import CommonFilters
 from management.permissions import RoleAccessPermission
 from management.querysets import get_role_queryset
 from management.role.serializer import AccessSerializer, RoleDynamicSerializer
+from management.utils import validate_uuid
 from rest_framework import mixins, serializers, viewsets
 from rest_framework.decorators import action
 from rest_framework.filters import OrderingFilter
@@ -264,6 +265,7 @@ class RoleViewSet(
                 ]
             }
         """
+        validate_uuid(kwargs.get("uuid"), "role uuid validation")
         return super().retrieve(request=request, args=args, kwargs=kwargs)
 
     def destroy(self, request, *args, **kwargs):
@@ -282,6 +284,7 @@ class RoleViewSet(
         @apiSuccessExample {json} Success-Response:
             HTTP/1.1 204 NO CONTENT
         """
+        validate_uuid(kwargs.get("uuid"), "role uuid validation")
         role = self.get_object()
         if role.system or role.platform_default:
             key = "role"
@@ -353,11 +356,13 @@ class RoleViewSet(
                 ]
             }
         """
+        validate_uuid(kwargs.get("uuid"), "role uuid validation")
         return super().update(request=request, args=args, kwargs=kwargs)
 
     @action(detail=True, methods=["get"])
     def access(self, request, uuid=None):
         """Return access objects for specified role."""
+        validate_uuid(uuid, "role uuid validation")
         try:
             role = Role.objects.get(uuid=uuid)
         except (Role.DoesNotExist, ValidationError):

--- a/rbac/management/utils.py
+++ b/rbac/management/utils.py
@@ -17,6 +17,7 @@
 """Helper utilities for management module."""
 import json
 import os
+from uuid import UUID
 
 from django.core.exceptions import PermissionDenied
 from django.utils.translation import gettext as _
@@ -159,3 +160,13 @@ def validate_and_get_key(params, query_key, valid_values, default_value):
         message = "{} query parameter value {} is invalid. {} are valid inputs.".format(query_key, value, valid_values)
         raise serializers.ValidationError({key: _(message)})
     return value
+
+
+def validate_uuid(uuid, key="UUID Validation"):
+    """Verify UUID provided is valid."""
+    try:
+        UUID(uuid)
+    except ValueError:
+        key = key
+        message = f"{uuid} is not a valid UUID."
+        raise serializers.ValidationError({key: _(message)})

--- a/tests/management/group/test_view.py
+++ b/tests/management/group/test_view.py
@@ -192,6 +192,13 @@ class GroupViewsetTests(IdentityRequest):
         response = client.get(url, **self.headers)
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
+    def test_read_group_nonguid(self):
+        """Test that reading a group with an invalid UUID returns an error."""
+        url = reverse("group-detail", kwargs={"uuid": "potato"})
+        client = APIClient()
+        response = client.get(url, **self.headers)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
     def test_read_group_list_success(self):
         """Test that we can read a list of groups."""
         url = reverse("group-list")

--- a/tests/management/role/test_view.py
+++ b/tests/management/role/test_view.py
@@ -263,7 +263,7 @@ class RoleViewsetTests(IdentityRequest):
         url = reverse("role-access", kwargs={"uuid": "abc-123"})
         client = APIClient()
         response = client.get(url, **self.headers)
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_read_role_access_not_found_uuid(self):
         """Test that reading an invalid role uuid returns an error."""


### PR DESCRIPTION
Signed-off-by: Chris Mitchell <cmitchel@redhat.com>

## Link(s) to Jira
- https://projects.engineering.redhat.com/browse/RHCLOUD-3699

## Description of Intent of Change(s)
Previously we didn't validate GUIDs before attempting to get the objects, leading to misleading 404s. This adds checks

## Local Testing
Pull down branch
make serve
Try to grab a /group/uuid/ endpoint with 'potato' or 'danceparty' as the uuid

## Checklist
- [ ] if API spec changes are required, is the spec updated?

- [ ] are there any pre/post merge actions required? if so, document here.

- [x] are theses changes covered by unit tests?

- [ ] if warranted, are documentation changes accounted for?

- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?

- [ ] is there known, direct impact to dependent teams/components?
  -  if yes, how will this be handled?
