### PR TITLE
Return options for permission fields

### DIFF
--- a/docs/source/specs/openapi.json
+++ b/docs/source/specs/openapi.json
@@ -1846,6 +1846,100 @@
           }
         }
       }
+    },
+    "/permissions/options/": {
+      "get": {
+        "tags": [
+          "Permission"
+        ],
+        "summary": "List the available options for fields of permissions for a tenant",
+        "description": "By default, options of application is returned. And could be resource_type or verb on demand.",
+        "operationId": "listPermissionOptions",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/QueryLimit"
+          },
+          {
+            "$ref": "#/components/parameters/QueryOffset"
+          },
+          {
+            "name": "field",
+            "in": "query",
+            "description": "specify which fields of permission to display",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "application",
+                "resource_type",
+                "verb"
+              ]
+            }
+          },
+          {
+            "name": "application",
+            "in": "query",
+            "description": "Filter returned options based on application. You may also use a comma-separated list to filter on multiple applications.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "resource_type",
+            "in": "query",
+            "description": "Filter returned options based on resource_type. You may also use a comma-separated list to filter on multiple resource_types.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "verb",
+            "in": "query",
+            "description": "Filter returned options based on verb. You may also use a comma-separated list to filter on multiple verbs.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A list of options for field of permission",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PermissionOptionsPagination"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Insufficient permissions to list permissions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error403"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "servers": [
@@ -2821,6 +2915,27 @@
                 "type": "array",
                 "items": {
                   "$ref": "#/components/schemas/Permission"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "PermissionOptionsPagination": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ListPagination"
+          },
+          {
+            "type": "object",
+            "required": [
+              "data"
+            ],
+            "properties": {
+              "data": {
+                "type": "array",
+                "items": {
+                  "type": "string"
                 }
               }
             }

--- a/rbac/management/utils.py
+++ b/rbac/management/utils.py
@@ -154,12 +154,19 @@ def queryset_by_id(objects, clazz, **kwargs):
 
 def validate_and_get_key(params, query_key, valid_values, default_value):
     """Validate the key."""
-    value = params.get(query_key, default_value).lower()
-    if value not in valid_values:
+    value = params.get(query_key, default_value)
+    if not value:
         key = "detail"
-        message = "{} query parameter value {} is invalid. {} are valid inputs.".format(query_key, value, valid_values)
+        message = "Query parameter '{}' is required.".format(query_key)
         raise serializers.ValidationError({key: _(message)})
-    return value
+
+    if value.lower() not in valid_values:
+        key = "detail"
+        message = "{} query parameter value '{}' is invalid. {} are valid inputs.".format(
+            query_key, value, valid_values
+        )
+        raise serializers.ValidationError({key: _(message)})
+    return value.lower()
 
 
 def validate_uuid(uuid, key="UUID Validation"):


### PR DESCRIPTION
Return available options for permission fields so UI could call this api
to return lists to customer.

Also provide filters for the returned list.

## Link(s) to Jira
- https://projects.engineering.redhat.com/browse/RHCLOUD-8472

## Description of Intent of Change(s)
UI team wants to be able to list available options for fields of permission. 

## Local Testing
How can the feature be exercised? 
Setup local server and use curl:
e.g. curl -v GET "http://0.0.0.0:8080/r/insights/platform/rbac/v1/permissions/get_options/?field=application&verb=unlink" | python -m json.tool
How can the bug be exploited and fix confirmed?
Unit tests
Is any special local setup required?
No

## Checklist
- [x] if API spec changes are required, is the spec updated?

- [ ] are there any pre/post merge actions required? if so, document here.

- [x] are theses changes covered by unit tests?

- [ ] if warranted, are documentation changes accounted for?

- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?

- [ ] is there known, direct impact to dependent teams/components?
  -  if yes, how will this be handled?
