### PR TITLE
Check permissions against whitelist on role update

### DIFF
--- a/rbac/management/role/view.py
+++ b/rbac/management/role/view.py
@@ -357,6 +357,15 @@ class RoleViewSet(
             }
         """
         validate_uuid(kwargs.get("uuid"), "role uuid validation")
+        access_list = self.validate_and_get_access_list(request.data)
+        if access_list:
+            for perm in access_list:
+                app = perm.get("permission").split(":")[0]
+                if app not in APP_WHITELIST:
+                    key = "role"
+                    message = "Custom roles cannot be created for {}".format(app)
+                    error = {key: [_(message)]}
+                    raise serializers.ValidationError(error)
         return super().update(request=request, args=args, kwargs=kwargs)
 
     @action(detail=True, methods=["get"])

--- a/tests/management/role/test_view.py
+++ b/tests/management/role/test_view.py
@@ -450,7 +450,30 @@ class RoleViewsetTests(IdentityRequest):
         url = reverse("role-detail", kwargs={"uuid": uuid4()})
         client = APIClient()
         response = client.put(url, {}, format="json", **self.headers)
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_update_role_invalid_permission(self):
+        """Test that updating a role with an invalid permission returns an error."""
+        # Set up
+        role_name = "permRole"
+        access_data = [
+            {
+                "permission": "cost-management:*:*",
+                "resourceDefinitions": [{"attributeFilter": {"key": "keyA", "operation": "equal", "value": "valueA"}}],
+            }
+        ]
+        response = self.create_role(role_name, in_access_data=access_data)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        role_uuid = response.data.get("uuid")
+        test_data = response.data
+        test_data.get("access")[0]["permission"] = "foo:*:read"
+        test_data["applications"] = ["foo"]
+
+        # Test update failure
+        url = reverse("role-detail", kwargs={"uuid": role_uuid})
+        client = APIClient()
+        response = client.put(url, test_data, format="json", **self.headers)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_delete_role_success(self):
         """Test that we can delete an existing role."""


### PR DESCRIPTION
Signed-off-by: Chris Mitchell <cmitchel@redhat.com>

## Link(s) to Jira
- https://projects.engineering.redhat.com/browse/RHCLOUD-8803

## Description of Intent of Change(s)
Roles for non-whitelisted applications could not be created, but non-whitelisted permissions could be added to existing roles through updates. This resolves that loophole.

## Local Testing
- Pull down branch
- Make serve
- Create a new role with a whitelisted permission
- Update that role through a PUT to the /role/uuid/ endpoint with a non-whitelisted application
- Verify failure/400 status

## Checklist
- [ ] if API spec changes are required, is the spec updated?

- [ ] are there any pre/post merge actions required? if so, document here.

- [x] are theses changes covered by unit tests?

- [ ] if warranted, are documentation changes accounted for?

- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?

- [ ] is there known, direct impact to dependent teams/components?
  -  if yes, how will this be handled?
