### PR TITLE
Add /roles/?application=app1,app2 filter to /roles/

### DIFF
--- a/docs/source/specs/openapi.json
+++ b/docs/source/specs/openapi.json
@@ -1101,6 +1101,15 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "application",
+            "in": "query",
+            "description": "The application name(s) to filter roles by, from permissions. This is an exact match. You may also use a comma-separated list to match on multiple applications.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {


### PR DESCRIPTION
## Link(s) to Jira
- https://projects.engineering.redhat.com/browse/RHCLOUD-8917

## Description of Intent of Change(s)
The front-end needs a way to filter roles by application(s). Given one or many
application names, we need to find the permissions which are associated with roles
which match that application name, and return the role it belongs to in the set.

These should be "OR" queries, where any permission with any application in the
list would be returned in the result set.

## Local Testing
- If I query `/roles/?application=app1` I should get back all roles which contain
  at least one permission with "app1" as the application, regardless of other
  permissions in the role.

- If I query `/roles/?application=app1,app2` I should get back all roles which
  contain at least one permission with either "app1" or "app2" as the application,
  regardless of the other permissions in the role.

## Checklist
- [x] if API spec changes are required, is the spec updated?

- [x] are theses changes covered by unit tests?
