### PR TITLE
Enable policies and drift for role creation

### DIFF
--- a/rbac/management/role/view.py
+++ b/rbac/management/role/view.py
@@ -38,7 +38,7 @@ from .model import Role
 from .serializer import RoleSerializer
 
 TESTING_APP = os.getenv("TESTING_APPLICATION")
-APP_WHITELIST = ["cost-management", "remediations", "inventory"]
+APP_WHITELIST = ["cost-management", "remediations", "inventory", "drift", "policies"]
 ADDITIONAL_FIELDS_KEY = "add_fields"
 VALID_FIELD_VALUES = ["groups_in_count", "groups_in"]
 LIST_ROLE_FIELDS = [

--- a/rbac/management/role/view.py
+++ b/rbac/management/role/view.py
@@ -38,7 +38,7 @@ from .model import Role
 from .serializer import RoleSerializer
 
 TESTING_APP = os.getenv("TESTING_APPLICATION")
-APP_WHITELIST = ["cost-management", "remediations", "inventory", "drift", "policies"]
+APP_ALLOW_LIST = ["cost-management", "remediations", "inventory", "drift", "policies"]
 ADDITIONAL_FIELDS_KEY = "add_fields"
 VALID_FIELD_VALUES = ["groups_in_count", "groups_in"]
 LIST_ROLE_FIELDS = [
@@ -56,7 +56,7 @@ LIST_ROLE_FIELDS = [
 ]
 
 if TESTING_APP:
-    APP_WHITELIST.append(TESTING_APP)
+    APP_ALLOW_LIST.append(TESTING_APP)
 
 
 class RoleFilter(CommonFilters):
@@ -181,7 +181,7 @@ class RoleViewSet(
         access_list = self.validate_and_get_access_list(request.data)
         for perm in access_list:
             app = perm.get("permission").split(":")[0]
-            if app not in APP_WHITELIST:
+            if app not in APP_ALLOW_LIST:
                 key = "role"
                 message = "Custom roles cannot be created for {}".format(app)
                 error = {key: [_(message)]}
@@ -367,7 +367,7 @@ class RoleViewSet(
         if access_list:
             for perm in access_list:
                 app = perm.get("permission").split(":")[0]
-                if app not in APP_WHITELIST:
+                if app not in APP_ALLOW_LIST:
                     key = "role"
                     message = "Custom roles cannot be created for {}".format(app)
                     error = {key: [_(message)]}

--- a/tests/management/role/test_view.py
+++ b/tests/management/role/test_view.py
@@ -177,8 +177,8 @@ class RoleViewsetTests(IdentityRequest):
         response = client.post(url, test_data, format="json", **self.headers)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
-    def test_create_role_whitelist(self):
-        """Test that we can create a role in a whitelisted application via API."""
+    def test_create_role_allow_list(self):
+        """Test that we can create a role in an allow_listed application via API."""
         role_name = "C-MRole"
         access_data = [
             {
@@ -200,8 +200,8 @@ class RoleViewsetTests(IdentityRequest):
         self.assertIsInstance(response.data.get("access"), list)
         self.assertEqual(access_data, response.data.get("access"))
 
-    def test_create_role_whitelist_fail(self):
-        """Test that we cannot create a role for a non-whitelisted app."""
+    def test_create_role_allow_list_fail(self):
+        """Test that we cannot create a role for a non-allow_listed app."""
         role_name = "roleFail"
         access_data = [
             {
@@ -213,7 +213,7 @@ class RoleViewsetTests(IdentityRequest):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_create_role_fail_with_access_not_list(self):
-        """Test that we cannot create a role for a non-whitelisted app."""
+        """Test that we cannot create a role for a non-allow_listed app."""
         role_name = "AccessNotList"
         access_data = "some data"
         response = self.create_role(role_name, in_access_data=access_data)


### PR DESCRIPTION
## Link(s) to Jira
- https://issues.redhat.com/browse/RHCLOUD-8416

## Description of Intent of Change(s)
Update the allow list to include drift and policies as allowable permissions 
for custom role creation in the API.

## Local Testing
Create a role with drift and policies permissions.

## Checklist
- [ ] if API spec changes are required, is the spec updated?

- [ ] are there any pre/post merge actions required? if so, document here.

- [ ] are theses changes covered by unit tests?

- [ ] if warranted, are documentation changes accounted for?

- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?

- [ ] is there known, direct impact to dependent teams/components?
  -  if yes, how will this be handled?
