### PR TITLE
Return only org admins within an account

### DIFF
--- a/docs/source/specs/openapi.json
+++ b/docs/source/specs/openapi.json
@@ -129,6 +129,20 @@
               ],
               "default": "enabled"
             }
+          },
+          {
+            "name": "admin_only",
+            "in": "query",
+            "description": "Get only admin users within an account. Setting this would ignore the parameters: usernames, email",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "true",
+                "false"
+              ],
+              "default": "false"
+            }
           }
         ],
         "responses": {

--- a/tests/management/principal/test_view.py
+++ b/tests/management/principal/test_view.py
@@ -63,7 +63,9 @@ class PrincipalViewsetTests(IdentityRequest):
         client = APIClient()
         response = client.get(url, **self.headers)
 
-        mock_request.assert_called_once_with(ANY, limit=10, offset=0, sort_order="asc", status="enabled")
+        mock_request.assert_called_once_with(
+            ANY, limit=10, offset=0, options={"sort_order": "asc", "status": "enabled", "admin_only": "false"}
+        )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         for keyname in ["meta", "links", "data"]:
             self.assertIn(keyname, response.data)
@@ -94,7 +96,9 @@ class PrincipalViewsetTests(IdentityRequest):
         client = APIClient()
         response = client.get(url, **self.headers)
 
-        mock_request.assert_called_once_with(ANY, status="enabled", limit=10, offset=0, sort_order="asc")
+        mock_request.assert_called_once_with(
+            ANY, limit=10, offset=0, options={"sort_order": "asc", "status": "enabled", "admin_only": "false"}
+        )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         for keyname in ["meta", "links", "data"]:
             self.assertIn(keyname, response.data)
@@ -241,7 +245,9 @@ class PrincipalViewsetTests(IdentityRequest):
         resp = proxy._process_data(response.data.get("data"), account="54321", account_filter=False)
         self.assertEqual(len(resp), 1)
 
-        mock_request.assert_called_once_with(ANY, email="test_user@example.com", limit=10, offset=0, sort_order="asc")
+        mock_request.assert_called_once_with(
+            ANY, email="test_user@example.com", limit=10, offset=0, options={"sort_order": "asc"}
+        )
 
         self.assertEqual(resp[0]["username"], "test_user")
 
@@ -263,12 +269,43 @@ class PrincipalViewsetTests(IdentityRequest):
             self.assertIn(keyname, response.data)
         self.assertIsInstance(response.data.get("data"), list)
         self.assertEqual(response.data.get("meta").get("count"), "1")
+        mock_request.assert_called_once_with(
+            ANY, limit=10, offset=0, options={"sort_order": "asc", "status": "disabled", "admin_only": "false"}
+        )
 
-        mock_request.assert_called_once_with(ANY, status="disabled", limit=10, offset=0, sort_order="asc")
+    @patch(
+        "management.principal.proxy.PrincipalProxy.request_principals",
+        return_value={
+            "status_code": 200,
+            "data": {"userCount": "1", "users": [{"username": "test_user", "is_org_admin": "true"}]},
+        },
+    )
+    def test_read_list_of_admins(self, mock_request):
+        """Test that we can return only org admins within an account"""
+        url = f'{reverse("principals")}?admin_only=true'
+        client = APIClient()
+        proxy = PrincipalProxy()
+        response = client.get(url, **self.headers)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        for keyname in ["meta", "links", "data"]:
+            self.assertIn(keyname, response.data)
+        self.assertIsInstance(response.data.get("data"), list)
+        self.assertEqual(response.data.get("meta").get("count"), "1")
+        mock_request.assert_called_once_with(
+            ANY, limit=10, offset=0, options={"sort_order": "asc", "status": "enabled", "admin_only": "true"}
+        )
 
     def test_read_users_with_invalid_status_value(self):
         """Test that reading user with invalid status value returns 400"""
         url = f'{reverse("principals")}?status=invalid'
+        client = APIClient()
+        proxy = PrincipalProxy()
+        response = client.get(url, **self.headers)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_read_users_with_invalid_admin_only_value(self):
+        """Test that reading user with invalid status value returns 400"""
+        url = f'{reverse("principals")}?admin_only=invalid'
         client = APIClient()
         proxy = PrincipalProxy()
         response = client.get(url, **self.headers)


### PR DESCRIPTION
This is to support return org admins only within an account.

## Link(s) to Jira
JIRA: https://issues.redhat.com/browse/RHCLOUD-8988

## Description of Intent of Change(s)
Add ability to list org admins only instead of getting a bunch of users back and then filter by org_admin flag.

## Local Testing
Unit test
Local BOP server to do the query 

## Checklist
- [x] if API spec changes are required, is the spec updated?

- [ ] are there any pre/post merge actions required? if so, document here.

- [x] are theses changes covered by unit tests?

- [ ] if warranted, are documentation changes accounted for?

- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?

- [ ] is there known, direct impact to dependent teams/components?
  -  if yes, how will this be handled?
