### PR TITLE
Return users with desired status

### DIFF
--- a/docs/source/specs/openapi.json
+++ b/docs/source/specs/openapi.json
@@ -114,6 +114,21 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "description": "Set the status of users to get back. Could not be used with: usernames, email, admin_only",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "enabled",
+                "disabled",
+                "all"
+              ],
+              "default": "enabled"
+            }
           }
         ],
         "responses": {

--- a/rbac/management/principal/proxy.py
+++ b/rbac/management/principal/proxy.py
@@ -59,7 +59,7 @@ class PrincipalProxy:  # pylint: disable=too-few-public-methods
         self.client_cert = os.path.join(settings.BASE_DIR, "management", "principal", "certs", "client.pem")
 
     @staticmethod
-    def _create_params(limit=None, offset=None, sort_order=None):
+    def _create_params(limit=None, offset=None, sort_order=None, status=None):
         """Create query parameters."""
         params = {}
         if limit:
@@ -71,6 +71,8 @@ class PrincipalProxy:  # pylint: disable=too-few-public-methods
             if sort_order == "desc":
                 sort_order = "des"
             params["sortOrder"] = sort_order
+        if status:
+            params["status"] = status
 
         return params
 
@@ -170,7 +172,7 @@ class PrincipalProxy:  # pylint: disable=too-few-public-methods
             resp["errors"] = [error]
         return resp
 
-    def request_principals(self, account, email=None, limit=None, offset=None, sort_order=None):
+    def request_principals(self, account, email=None, limit=None, offset=None, sort_order=None, status=None):
         """Request principals for an account."""
         if email:
             account_principals_path = f"/v1/accounts/{account}/usersBy"
@@ -181,7 +183,7 @@ class PrincipalProxy:  # pylint: disable=too-few-public-methods
             method = requests.get
             payload = None
 
-        params = self._create_params(limit=limit, offset=offset, sort_order=sort_order)
+        params = self._create_params(limit=limit, offset=offset, sort_order=sort_order, status=status)
         url = "{}://{}:{}{}{}".format(self.protocol, self.host, self.port, self.path, account_principals_path)
 
         # For v2 account users endpoints are already filtered by account

--- a/rbac/management/principal/view.py
+++ b/rbac/management/principal/view.py
@@ -29,6 +29,8 @@ USERNAMES_KEY = "usernames"
 EMAIL_KEY = "email"
 SORTORDER_KEY = "sort_order"
 VALID_SORTORDER_VALUE = ["asc", "desc"]
+STATUS_KEY = "status"
+VALID_STATUS_VALUE = ["enabled", "disabled", "all"]
 
 
 class PrincipalView(APIView):
@@ -93,6 +95,7 @@ class PrincipalView(APIView):
             usernames = query_params.get(USERNAMES_KEY)
             email = query_params.get(EMAIL_KEY)
             sort_order = validate_and_get_key(query_params, SORTORDER_KEY, VALID_SORTORDER_VALUE, "asc")
+            principal_status = validate_and_get_key(query_params, STATUS_KEY, VALID_STATUS_VALUE, "enabled")
         except ValueError:
             error = {
                 "detail": "Values for limit and offset must be positive numbers.",
@@ -116,7 +119,9 @@ class PrincipalView(APIView):
                 user.account, email=email, limit=limit, offset=offset, sort_order=sort_order
             )
         else:
-            resp = proxy.request_principals(user.account, limit=limit, offset=offset, sort_order=sort_order)
+            resp = proxy.request_principals(
+                user.account, limit=limit, offset=offset, sort_order=sort_order, status=principal_status
+            )
         status_code = resp.get("status_code")
         response_data = {}
         if status_code == status.HTTP_200_OK:


### PR DESCRIPTION
This is to support returning users with desired status. Default is to return
only active users.


## Link(s) to Jira
- JIRA: https://issues.redhat.com/browse/RHCLOUD-8989

## Description of Intent of Change(s)
Provide FE options to return users with desired status

## Local Testing
Unit test available

Set up against local BOP which works

## Checklist
- [x] if API spec changes are required, is the spec updated?

- [ ] are there any pre/post merge actions required? if so, document here.

- [x] are theses changes covered by unit tests?

- [ ] if warranted, are documentation changes accounted for?

- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?

- [ ] is there known, direct impact to dependent teams/components?
  -  if yes, how will this be handled?
