### PR TITLE
Pin the version of flake8 in our tox.ini to 3.7

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -38,7 +38,7 @@ commands =
 
 [testenv:lint]
 deps =
-  flake8
+  flake8==3.7
   flake8-docstrings
   flake8-import-order
   flake8-quotes


### PR DESCRIPTION
It seems that 3.8 introduced a dependency on `importlib-metadata` 2.0.0 which is
killing our CI and local runs of `tox -e lint`: https://github.com/PyCQA/flake8/blob/b4d285019210ccdb5d526e64c281db64e5316d6c/docs/source/release-notes/3.8.0.rst#new-dependency-information

If this passes Travis (currently busted), it worked. 😄 