### PR TITLE
Exclude the public schema from the Tenant query on internal endpoint

### DIFF
--- a/rbac/internal/views.py
+++ b/rbac/internal/views.py
@@ -53,7 +53,7 @@ def tenant_is_unmodified():
 def list_unmodified_tenants(request):
     """List unmodified tenants."""
     logger.info(f"Unmodified tenants requested by: {request.user.username}")
-    tenant_qs = Tenant.objects.all()
+    tenant_qs = Tenant.objects.exclude(schema_name="public")
     to_return = []
     for tenant_obj in tenant_qs:
         with tenant_context(tenant_obj):


### PR DESCRIPTION
Locally, the code works as is. Deployed however, the `public` schema is returned
in `Tenant.objects.all()`, which causes subsequent queries using `management` models
to fail.

I'm not entirely sure why the `public` schema isn't returned locally as it is deployed,
but we should be excluding this anyway.
