### PR TITLE
Add tenant counts to internal tenant api

### DIFF
--- a/rbac/internal/views.py
+++ b/rbac/internal/views.py
@@ -59,7 +59,12 @@ def list_unmodified_tenants(request):
         with tenant_context(tenant_obj):
             if tenant_is_unmodified():
                 to_return.append(tenant_obj.schema_name)
-    return HttpResponse(json.dumps(to_return), content_type="application/json")
+    payload = {
+        "unmodified_tenants": to_return,
+        "unmodified_tenants_count": len(to_return),
+        "total_tenants_count": tenant_qs.count(),
+    }
+    return HttpResponse(json.dumps(payload), content_type="application/json")
 
 
 def tenant_view(request, tenant_schema_name):

--- a/tests/internal/test_views.py
+++ b/tests/internal/test_views.py
@@ -151,5 +151,9 @@ class InternalViewsetTests(IdentityRequest):
 
         response = self.client.get(f"/_private/api/tenant/unmodified/", **self.request.META)
         response_data = json.loads(response.content)
-        self.assertCountEqual(response_data, [self.tenant.schema_name, unmodified_tenant_2.schema_name])
+        self.assertCountEqual(
+            response_data["unmodified_tenants"], [self.tenant.schema_name, unmodified_tenant_2.schema_name]
+        )
+        self.assertEqual(response_data["unmodified_tenants_count"], 2)
+        self.assertEqual(response_data["total_tenants_count"], 4)
         self.assertEqual(Tenant.objects.count(), 4)


### PR DESCRIPTION
## Description of Intent of Change(s)
This will update the `/_private/api/tenant/unmodified/` payload to return some additional data:
```json
{
  "unmodified_tenants": [
    "acct3",
    "acct4",
    "acct100013"
  ],
  "unmodified_tenants_count": 3,
  "total_tenants_count": 5
}
```

## Local Testing
View the output of `/_private/api/tenant/unmodified/`

## Checklist
- [ ] if API spec changes are required, is the spec updated?

- [ ] are there any pre/post merge actions required? if so, document here.

- [ ] are theses changes covered by unit tests?

- [ ] if warranted, are documentation changes accounted for?

- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?

- [ ] is there known, direct impact to dependent teams/components?
  -  if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/xxlhacker/secure-code-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation

- [ ] Output Encoding

- [ ] Authentication and Password Management

- [ ] Session Management

- [ ] Access Control

- [ ] Cryptographic Practices

- [ ] Error Handling and Logging

- [ ] Data Protection

- [ ] Communication Security

- [ ] System Configuration

- [ ] Database Security

- [ ] File Management

- [ ] Memory Management

- [ ] General Coding Practices
