### PR TITLE
Trigger/monitor migrations from internal API endpoint

### DIFF
--- a/rbac/internal/urls.py
+++ b/rbac/internal/urls.py
@@ -23,4 +23,5 @@ from . import views
 urlpatterns = [
     path("api/tenant/unmodified/", views.list_unmodified_tenants),
     path("api/tenant/<str:tenant_schema_name>/", views.tenant_view),
+    path("api/run_migrations/", views.run_migrations),
 ]

--- a/rbac/internal/urls.py
+++ b/rbac/internal/urls.py
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-"""Describes the urls and patterns for internal routess."""
+"""Describes the urls and patterns for internal routes."""
 from django.urls import path
 
 from . import views

--- a/rbac/internal/urls.py
+++ b/rbac/internal/urls.py
@@ -23,5 +23,6 @@ from . import views
 urlpatterns = [
     path("api/tenant/unmodified/", views.list_unmodified_tenants),
     path("api/tenant/<str:tenant_schema_name>/", views.tenant_view),
-    path("api/run_migrations/", views.run_migrations),
+    path("api/migrations/run/", views.run_migrations),
+    path("api/migrations/progress/", views.migration_progress),
 ]

--- a/rbac/internal/views.py
+++ b/rbac/internal/views.py
@@ -84,7 +84,7 @@ def tenant_view(request, tenant_schema_name):
                 return HttpResponse(status=204)
             else:
                 return HttpResponse("Tenant cannot be deleted.", status=400)
-    return HttpResponse(status=405)
+    return HttpResponse(f'Method "{request.method}" not allowed.', status=405)
 
 
 def run_migrations(request):
@@ -93,7 +93,7 @@ def run_migrations(request):
         logger.info(f"Running migrations: {request.method} {request.user.username}")
         run_migrations_in_worker.delay()
         return HttpResponse("Migrations are running in a background worker.", status=202)
-    return HttpResponse(status=405)
+    return HttpResponse(f'Method "{request.method}" not allowed.', status=405)
 
 
 def migration_progress(request):
@@ -126,4 +126,4 @@ def migration_progress(request):
         }
 
         return HttpResponse(json.dumps(payload), content_type="application/json")
-    return HttpResponse(status=405)
+    return HttpResponse(f'Method "{request.method}" not allowed.', status=405)

--- a/rbac/internal/views.py
+++ b/rbac/internal/views.py
@@ -100,23 +100,30 @@ def migration_progress(request):
     """View method for checking migration progress."""
     if request.method == "GET":
         migration_name = request.GET.get("migration_name")
-        app = request.GET.get("app", "management")
+        app_name = request.GET.get("app", "management")
         if not migration_name:
             return HttpResponse("Please specify a migration name in the `?migration_name=` param.", status=400)
-        tenants_completed = 0
+        tenants_completed_count = 0
+        incomplete_tenants = []
         tenant_qs = Tenant.objects.exclude(schema_name="public")
         tenant_count = tenant_qs.count()
         for idx, tenant in enumerate(list(tenant_qs)):
             with tenant_context(tenant):
-                migrations_have_run = MigrationRecorder.Migration.objects.filter(name=migration_name, app=app).exists()
+                migrations_have_run = MigrationRecorder.Migration.objects.filter(
+                    name=migration_name, app=app_name
+                ).exists()
                 if migrations_have_run:
-                    tenants_completed += 1
+                    tenants_completed_count += 1
+                else:
+                    incomplete_tenants.append(tenant.schema_name)
         payload = {
             "migration_name": migration_name,
-            "tenants_completed": tenants_completed,
+            "app_name": app_name,
+            "tenants_completed_count": tenants_completed_count,
             "total_tenants_count": tenant_count,
-            "percent_completed": int((tenants_completed / tenant_count) * 100),
+            "incomplete_tenants": incomplete_tenants,
+            "percent_completed": int((tenants_completed_count / tenant_count) * 100),
         }
 
-        return HttpResponse(json.dumps(payload), status=200)
+        return HttpResponse(json.dumps(payload), content_type="application/json")
     return HttpResponse(status=405)

--- a/rbac/internal/views.py
+++ b/rbac/internal/views.py
@@ -25,6 +25,7 @@ from django.conf import settings
 from django.http import HttpResponse
 from django.shortcuts import get_object_or_404
 from management.models import Group, Role
+from management.tasks import run_migrations_in_worker
 from tenant_schemas.utils import tenant_context
 
 from api.models import Tenant
@@ -82,4 +83,13 @@ def tenant_view(request, tenant_schema_name):
                 return HttpResponse(status=204)
             else:
                 return HttpResponse("Tenant cannot be deleted.", status=400)
+    return HttpResponse(status=405)
+
+
+def run_migrations(request):
+    """View method for running migrations."""
+    if request.method == "POST":
+        logger.info(f"Running migrations: {request.method} {request.user.username}")
+        run_migrations_in_worker.delay()
+        return HttpResponse("Migrations are running in a background worker.", status=202)
     return HttpResponse(status=405)

--- a/rbac/management/tasks.py
+++ b/rbac/management/tasks.py
@@ -18,6 +18,7 @@
 from __future__ import absolute_import, unicode_literals
 
 from celery import shared_task
+from django.core.management import call_command
 from management.principal.cleaner import clean_tenants_principals
 
 
@@ -25,3 +26,9 @@ from management.principal.cleaner import clean_tenants_principals
 def principal_cleanup():
     """Celery task to clean up principals no longer existing."""
     clean_tenants_principals()
+
+
+@shared_task
+def run_migrations_in_worker():
+    """Celery task to run migrations."""
+    call_command("migrate_schemas")

--- a/rbac/rbac/dev_middleware.py
+++ b/rbac/rbac/dev_middleware.py
@@ -40,8 +40,8 @@ class DevelopmentIdentityHeaderMiddleware(MiddlewareMixin):  # pylint: disable=t
             identity_header = {
                 "identity": {
                     "account_number": "10001",
-                    "type": "Associate",
-                    "associate": {"username": "user_dev", "email": "user_dev@foo.com", "is_org_admin": True},
+                    "type": "User",
+                    "user": {"username": "user_dev", "email": "user_dev@foo.com", "is_org_admin": True},
                 }
             }
             json_identity = json_dumps(identity_header)

--- a/rbac/rbac/dev_middleware.py
+++ b/rbac/rbac/dev_middleware.py
@@ -40,8 +40,8 @@ class DevelopmentIdentityHeaderMiddleware(MiddlewareMixin):  # pylint: disable=t
             identity_header = {
                 "identity": {
                     "account_number": "10001",
-                    "type": "User",
-                    "user": {"username": "user_dev", "email": "user_dev@foo.com", "is_org_admin": True},
+                    "type": "Associate",
+                    "associate": {"username": "user_dev", "email": "user_dev@foo.com", "is_org_admin": True},
                 }
             }
             json_identity = json_dumps(identity_header)


### PR DESCRIPTION
## Link(s) to Jira
- https://issues.redhat.com/browse/RHCLOUD-8965

## Description of Intent of Change(s)
This sets up a `POST` endpoint on `/_private/api/migrations/run/` 
which will trigger migrations to be run in a background worker.

This will only be accessible via Turnpike/internal SSO. By default, we'll only be
able to run `migrate_schemas` without running the parallel executor, otherwise
the celery worker will complain about spawning more processes.

The output for this task will end up in the worker logs, which in a deployed environment
will help with isolated the output for migrations. 

This also sets up a `GET` endpoint on `/_private/api/migrations/progress/?migration_name=&app=`
which will allow us to get the status of a particular migration across all tenants.
By default the `?app=` will be `management`, but you can optionally supply the `app`
param for checking against `api` or other Django apps' migrations.

Given that we know what the last applied migration should be for an app during
a release, we can use this to supply that migration name to get back the completion
progress during a migration run, which will look like:

```
http://localhost:8000/_private/api/migrations/progress/?migration_name=0004_crossaccountrequest&app=api
```

```
{
  "migration_name": "0004_crossaccountrequest",
  "app_name": "api",
  "tenants_completed_count": 3,
  "total_tenants_count": 6,
  "incomplete_tenants": ["acct1", "acct2", "acct3"],
  "percent_completed": 50
}
```

## Local Testing
You'll need to ensure you have a celery process running locally to process the
queue. You can do so either with the `rbac-worker` service in the Docker
compose file if you run `docker-compose up` to run RBAC, or manually
by running similar to the following, configured to connect to your local redis:

```
$: pipenv shell
$: cd rbac/
$: celery worker -A rbac.celery --broker=redis://127.0.0.1:6379/0 --loglevel=INFO
```
Then you can trigger the process with:
```
http://localhost:8000/_private/api/migrations/run/
```

To check the progress of a migration, query a value from the `django_migrations` table
in the `name` column:

```
http://localhost:8000/_private/api/migrations/progress/?migration_name=0004_crossaccountrequest&app=api
```

TODO:
- [x] tests
- [ ] do we want migrations put behind the "destructive" gate? I lean towards no since
      it's idempotent, but maybe we should standardize on anything which alters the db
      should be, and only GETs are not?
- [x] add a monitoring endpoint to determine the progress of migrations

## Checklist
- [ ] if API spec changes are required, is the spec updated?

- [ ] are there any pre/post merge actions required? if so, document here.

- [ ] are theses changes covered by unit tests?

- [ ] if warranted, are documentation changes accounted for?

- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?

- [ ] is there known, direct impact to dependent teams/components?
  -  if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [x] Input Validation

- [x] Output Encoding

- [x] Authentication and Password Management

- [x] Session Management

- [x] Access Control

- [x] Cryptographic Practices

- [x] Error Handling and Logging

- [x] Data Protection

- [x] Communication Security

- [x] System Configuration

- [x] Database Security

- [x] File Management

- [x] Memory Management

- [x] General Coding Practices
