### PR TITLE
Add internal endpoint for triggering seeds

### DIFF
--- a/rbac/internal/urls.py
+++ b/rbac/internal/urls.py
@@ -25,4 +25,5 @@ urlpatterns = [
     path("api/tenant/<str:tenant_schema_name>/", views.tenant_view),
     path("api/migrations/run/", views.run_migrations),
     path("api/migrations/progress/", views.migration_progress),
+    path("api/seeds/run/", views.run_seeds),
 ]

--- a/rbac/management/tasks.py
+++ b/rbac/management/tasks.py
@@ -32,3 +32,9 @@ def principal_cleanup():
 def run_migrations_in_worker():
     """Celery task to run migrations."""
     call_command("migrate_schemas")
+
+
+@shared_task
+def run_seeds_in_worker(kwargs):
+    """Celery task to run seeds."""
+    call_command("seeds", **kwargs)


### PR DESCRIPTION
## Link(s) to Jira
- https://issues.redhat.com/browse/RHCLOUD-8965

## Description of Intent of Change(s)
Adds a `POST` endpoint at `/_private/api/seeds/run/` with optional params for
specifying which seeds to run with `?seed_types=roles,permissions,groups`.

When this is not specified, it will default to all, similar to the underlying
Django command.

If an unsupported seed type is presented, it will 400 the request in order to
help prevent seeds from failing silently in a background process.

## Local Testing
Ensure you have a celery worker running locally, and run a `POST` request
against `/_private/api/seeds/run/` with/without `?seed_types=` populated.

## Checklist
- [ ] if API spec changes are required, is the spec updated?

- [ ] are there any pre/post merge actions required? if so, document here.

- [x] are theses changes covered by unit tests?

- [ ] if warranted, are documentation changes accounted for?

- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?

- [ ] is there known, direct impact to dependent teams/components?
  -  if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [x] Input Validation

- [x] Output Encoding

- [ ] Authentication and Password Management

- [ ] Session Management

- [ ] Access Control

- [ ] Cryptographic Practices

- [x] Error Handling and Logging

- [ ] Data Protection

- [ ] Communication Security

- [ ] System Configuration

- [ ] Database Security

- [ ] File Management

- [ ] Memory Management

- [x] General Coding Practices
