### PR TITLE
Set an optional `/?limit=` on `/_private/tenant/unmodified/`

### DIFF
--- a/rbac/internal/views.py
+++ b/rbac/internal/views.py
@@ -55,10 +55,16 @@ def tenant_is_unmodified():
 def list_unmodified_tenants(request):
     """List unmodified tenants.
 
-    GET /_private/api/tenant/unmodified/
+    GET /_private/api/tenant/unmodified/?limit=<limit>&offset=<offset>
     """
     logger.info(f"Unmodified tenants requested by: {request.user.username}")
-    tenant_qs = Tenant.objects.exclude(schema_name="public")
+    limit = int(request.GET.get("limit", 0))
+    offset = int(request.GET.get("offset", 0))
+
+    if limit:
+        tenant_qs = Tenant.objects.exclude(schema_name="public")[offset : (limit + offset)]  # noqa: E203
+    else:
+        tenant_qs = Tenant.objects.exclude(schema_name="public")
     to_return = []
     for tenant_obj in tenant_qs:
         with tenant_context(tenant_obj):

--- a/tests/internal/test_views.py
+++ b/tests/internal/test_views.py
@@ -160,6 +160,14 @@ class InternalViewsetTests(IdentityRequest):
         self.assertEqual(response_data["total_tenants_count"], 4)
         self.assertEqual(Tenant.objects.count(), 4)
 
+        response = self.client.get(f"/_private/api/tenant/unmodified/?limit=2", **self.request.META)
+        response_data = json.loads(response.content)
+        self.assertEqual(response_data["total_tenants_count"], 2)
+
+        response = self.client.get(f"/_private/api/tenant/unmodified/?limit=2&offset=3", **self.request.META)
+        response_data = json.loads(response.content)
+        self.assertEqual(response_data["total_tenants_count"], 1)
+
     @patch("management.tasks.run_migrations_in_worker.delay")
     def test_run_migrations(self, migration_mock):
         """Test that we can trigger migrations."""


### PR DESCRIPTION
## Description of Intent of Change(s)
This will limit the _initial_ queryset, so the number of Tenants in the results
will only be reflective of that limit, not the entire dataset, if `limit=` is used.
This also provides an optional `offset=` param to offset the limited query.

## Local Testing
Locally, hit `/_private/api/tenant/unmodified/` and compare the results with:
`?limit=<limit>&offset=<offset>` params supplied, which should limit and
offset your query.

## Checklist
- [ ] if API spec changes are required, is the spec updated?

- [ ] are there any pre/post merge actions required? if so, document here.

- [x] are theses changes covered by unit tests?

- [ ] if warranted, are documentation changes accounted for?

- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?

- [ ] is there known, direct impact to dependent teams/components?
  -  if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [x] Input Validation

- [ ] Output Encoding

- [ ] Authentication and Password Management

- [ ] Session Management

- [ ] Access Control

- [ ] Cryptographic Practices

- [x] Error Handling and Logging

- [ ] Data Protection

- [ ] Communication Security

- [ ] System Configuration

- [ ] Database Security

- [ ] File Management

- [ ] Memory Management

- [ ] General Coding Practices
