### PR TITLE
Set optional `/?limit=&offset=` params on `/_private/tenant/unmodified/`

### DIFF
--- a/rbac/internal/views.py
+++ b/rbac/internal/views.py
@@ -51,9 +51,18 @@ def tenant_is_unmodified():
 
 
 def list_unmodified_tenants(request):
-    """List unmodified tenants."""
+    """List unmodified tenants.
+
+    GET /_private/api/tenant/unmodified/?limit=<limit>&offset=<offset>
+    """
     logger.info(f"Unmodified tenants requested by: {request.user.username}")
-    tenant_qs = Tenant.objects.exclude(schema_name="public")
+    limit = int(request.GET.get("limit", 0))
+    offset = int(request.GET.get("offset", 0))
+
+    if limit:
+        tenant_qs = Tenant.objects.exclude(schema_name="public")[offset : (limit + offset)]  # noqa: E203
+    else:
+        tenant_qs = Tenant.objects.exclude(schema_name="public")
     to_return = []
     for tenant_obj in tenant_qs:
         with tenant_context(tenant_obj):

--- a/tests/internal/test_views.py
+++ b/tests/internal/test_views.py
@@ -157,3 +157,11 @@ class InternalViewsetTests(IdentityRequest):
         self.assertEqual(response_data["unmodified_tenants_count"], 2)
         self.assertEqual(response_data["total_tenants_count"], 4)
         self.assertEqual(Tenant.objects.count(), 4)
+
+        response = self.client.get(f"/_private/api/tenant/unmodified/?limit=2", **self.request.META)
+        response_data = json.loads(response.content)
+        self.assertEqual(response_data["total_tenants_count"], 2)
+
+        response = self.client.get(f"/_private/api/tenant/unmodified/?limit=2&offset=3", **self.request.META)
+        response_data = json.loads(response.content)
+        self.assertEqual(response_data["total_tenants_count"], 1)


### PR DESCRIPTION
Moves the contents of 0657b2af9e401444987b7267a83b7539a64045da into `stable`