### PR TITLE
List cross request

### DIFF
--- a/rbac/api/cross_access/access_control.py
+++ b/rbac/api/cross_access/access_control.py
@@ -30,7 +30,7 @@ class CrossAccountRequestAccessPermission(permissions.BasePermission):
 
     def has_permission(self, request, view):
         """Check permission based on identity and query by."""
-        if request._request.path == reverse("cross-list"):
+        if request._request.path.startswith(reverse("cross-list")):
             query_by = validate_and_get_key(request.query_params, QUERY_BY_KEY, VALID_QUERY_BY_KEY, ACCOUNT)
             if query_by == ACCOUNT:
                 return request.user.admin

--- a/rbac/api/cross_access/access_control.py
+++ b/rbac/api/cross_access/access_control.py
@@ -1,0 +1,44 @@
+#
+# Copyright 2019 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""Defines the Admin Access Permissions class."""
+from django.urls import reverse
+from management.utils import validate_and_get_key
+from rest_framework import permissions
+
+QUERY_BY_KEY = "query_by"
+USER_ID = "user_id"
+ACCOUNT = "target_account"
+VALID_QUERY_BY_KEY = [ACCOUNT, USER_ID]
+
+
+class CrossAccountRequestAccessPermission(permissions.BasePermission):
+    """Determines if a user is an Account Admin."""
+
+    def has_permission(self, request, view):
+        """Check permission based on identity and query by."""
+        if request._request.path == reverse("cross-list"):
+            query_by = validate_and_get_key(request.query_params, QUERY_BY_KEY, VALID_QUERY_BY_KEY, ACCOUNT)
+            if query_by == ACCOUNT:
+                return request.user.admin
+            elif query_by == USER_ID:
+                return request.user.internal
+            return False
+
+        if request.method not in permissions.SAFE_METHODS:
+            return False
+
+        return True

--- a/rbac/api/cross_access/serializer.py
+++ b/rbac/api/cross_access/serializer.py
@@ -16,9 +16,12 @@
 #
 
 """Serializer for CrossAccountRequest."""
+from management.models import Role
+from management.permission.serializer import PermissionSerializer
 from rest_framework import serializers
+from tenant_schemas.utils import tenant_context
 
-from .model import CrossAccountRequest
+from api.models import CrossAccountRequest, Tenant
 
 
 class CrossAccountRequestSerializer(serializers.ModelSerializer):
@@ -37,3 +40,47 @@ class CrossAccountRequestSerializer(serializers.ModelSerializer):
 
         model = CrossAccountRequest
         fields = ("request_id", "target_account", "user_id", "start_date", "end_date", "created", "status")
+
+
+class RoleSerializer(serializers.ModelSerializer):
+    """Serializer for the roles of cross access request model."""
+
+    display_name = serializers.CharField(read_only=True)
+    description = serializers.CharField(read_only=True)
+    permissions = serializers.SerializerMethodField()
+
+    class Meta:
+        """Metadata for the serializer."""
+
+        model = Role
+        fields = ("display_name", "description", "permissions")
+
+    def get_permissions(self, obj):
+        """Permissions constructor for the serializer."""
+        serialized_permissions = [PermissionSerializer(access.permission).data for access in obj.access.all()]
+        return serialized_permissions
+
+
+class CrossAccountRequestDetailSerializer(serializers.ModelSerializer):
+    """Serializer for the cross access request model with details."""
+
+    request_id = serializers.UUIDField(read_only=True)
+    target_account = serializers.CharField(max_length=15)
+    user_id = serializers.CharField(max_length=15)
+    start_date = serializers.DateTimeField(format="%m/%d/%Y")
+    end_date = serializers.DateTimeField(format="%m/%d/%Y")
+    created = serializers.DateTimeField(format="%m/%d/%Y")
+    status = serializers.CharField(max_length=10)
+    roles = serializers.SerializerMethodField()
+
+    class Meta:
+        """Metadata for the serializer."""
+
+        model = CrossAccountRequest
+        fields = ("request_id", "target_account", "user_id", "start_date", "end_date", "created", "status", "roles")
+
+    def get_roles(self, obj):
+        """Roles constructor for the serializer."""
+        with tenant_context(Tenant.objects.get(schema_name="public")):
+            serialized_roles = [RoleSerializer(role).data for role in obj.roles.all()]
+        return serialized_roles

--- a/rbac/api/cross_access/serializer.py
+++ b/rbac/api/cross_access/serializer.py
@@ -1,0 +1,39 @@
+#
+# Copyright 2020 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+"""Serializer for CrossAccountRequest."""
+from rest_framework import serializers
+
+from .model import CrossAccountRequest
+
+
+class CrossAccountRequestSerializer(serializers.ModelSerializer):
+    """Serializer for the cross access request model."""
+
+    request_id = serializers.UUIDField(read_only=True)
+    target_account = serializers.CharField(max_length=15)
+    user_id = serializers.CharField(max_length=15)
+    start_date = serializers.DateTimeField(format="%d %b %Y")
+    end_date = serializers.DateTimeField(format="%d %b %Y")
+    created = serializers.DateTimeField(format="%d %b %Y, %H:%M UTC")
+    status = serializers.CharField(max_length=10)
+
+    class Meta:
+        """Metadata for the serializer."""
+
+        model = CrossAccountRequest
+        fields = ("request_id", "target_account", "user_id", "start_date", "end_date", "created", "status")

--- a/rbac/api/cross_access/view.py
+++ b/rbac/api/cross_access/view.py
@@ -1,0 +1,119 @@
+#
+# Copyright 2019 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+"""View for cross access request."""
+from django.utils import timezone
+from django_filters import rest_framework as filters
+from management.principal.proxy import PrincipalProxy
+from management.utils import validate_and_get_key, validate_limit_and_offset
+from rest_framework import mixins, status, viewsets
+from rest_framework.response import Response
+
+from api.cross_access.access_control import CrossAccountRequestAccessPermission
+from api.cross_access.model import CrossAccountRequest
+from api.cross_access.serializer import CrossAccountRequestSerializer
+
+
+QUERY_BY_KEY = "query_by"
+ACCOUNT = "target_account"
+USER_ID = "user_id"
+VALID_QUERY_BY_KEY = [ACCOUNT, USER_ID]
+PROXY = PrincipalProxy()
+
+
+class CrossAccountRequestFilter(filters.FilterSet):
+    """Filter for cross account request."""
+
+    def account_filter(self, queryset, field, values):
+        """Filter to lookup requests by target_account."""
+        accounts = values.split(",")
+        return queryset.filter(target_account__in=accounts)
+
+    def approved_filter(self, queryset, field, value):
+        """Filter to lookup requests by status of approved."""
+        if value:
+            return queryset.filter(status="approved").filter(end_date__gt=timezone.now())
+        return queryset
+
+    account = filters.CharFilter(field_name="target_account", method="account_filter")
+    approved_only = filters.BooleanFilter(field_name="end_date", method="approved_filter")
+
+    class Meta:
+        model = CrossAccountRequest
+        fields = ["account", "approved_only"]
+
+
+class CrossAccountRequestViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
+    """Cross Account Request view set.
+
+    A viewset that provides default `list()` actions.
+
+    """
+
+    queryset = CrossAccountRequest.objects.all()
+    permission_classes = (CrossAccountRequestAccessPermission,)
+    filter_backends = (filters.DjangoFilterBackend,)
+    filterset_class = CrossAccountRequestFilter
+
+    def get_queryset(self):
+        """Get query set based on the queryBy key word."""
+        if validate_and_get_key(self.request.query_params, QUERY_BY_KEY, VALID_QUERY_BY_KEY, ACCOUNT) == ACCOUNT:
+            return CrossAccountRequest.objects.filter(target_account=self.request.user.account)
+        return CrossAccountRequest.objects.filter(user_id=self.request.user.user_id)
+
+    def get_serializer_class(self):
+        """Get serializer based on route."""
+        if self.request.path.endswith("cross-account-requests/") and self.request.method == "GET":
+            return CrossAccountRequestSerializer
+
+    def list(self, request, *args, **kwargs):
+        """List cross account requests for account/user_id."""
+        errors = validate_limit_and_offset(self.request.query_params)
+        if errors:
+            return Response(status=status.HTTP_400_BAD_REQUEST, data=errors)
+
+        result = super().list(request=request, args=args, kwargs=kwargs)
+        # The approver's view requires requester's info such as first name, last name, email address.
+        if validate_and_get_key(self.request.query_params, QUERY_BY_KEY, VALID_QUERY_BY_KEY, ACCOUNT) == ACCOUNT:
+            return self.replace_user_id_with_info(result)
+        return result
+
+    def replace_user_id_with_info(self, result):
+        """Replace user id with user's info."""
+        # Get principals through user_ids from BOP
+        user_ids = [element["user_id"] for element in result.data["data"]]
+        bop_resp = PROXY.request_filtered_principals(
+            user_ids, account=None, options={"query_by": "user_id", "return_id": True}
+        )
+
+        # Make a mapping: user_id => principal
+        principals = {
+            str(principal["user_id"]): {
+                "first_name": principal["first_name"],
+                "last_name": principal["last_name"],
+                "email": principal["email"],
+            }
+            for principal in bop_resp["data"]
+        }
+
+        # Replace the user_id with user's info
+        for element in result.data["data"]:
+            user_id = element.pop("user_id")
+            requestor_info = principals[user_id]
+            element.update(requestor_info)
+
+        return result

--- a/rbac/api/urls.py
+++ b/rbac/api/urls.py
@@ -17,9 +17,10 @@
 from django.conf.urls import include, url
 from rest_framework.routers import DefaultRouter
 
-from api.views import openapi, status
+from api.views import CrossAccountRequestViewSet, openapi, status
 
 ROUTER = DefaultRouter()
+ROUTER.register(r"cross-account-requests", CrossAccountRequestViewSet, basename="cross")
 
 # pylint: disable=invalid-name
 urlpatterns = [

--- a/rbac/api/views.py
+++ b/rbac/api/views.py
@@ -20,3 +20,4 @@
 # pylint: disable=unused-import
 from api.status.view import status
 from api.openapi.view import openapi
+from api.cross_access.view import CrossAccountRequestViewSet

--- a/rbac/management/group/view.py
+++ b/rbac/management/group/view.py
@@ -446,7 +446,7 @@ class GroupViewSet(
                 sort_order = "des" if sort_field == "-username" else "asc"
             else:
                 sort_order = None
-            resp = proxy.request_filtered_principals(username_list, account, sort_order=sort_order)
+            resp = proxy.request_filtered_principals(username_list, account, options={"sort_order": sort_order})
             if isinstance(resp, dict) and "errors" in resp:
                 return Response(status=resp.get("status_code"), data=resp.get("errors"))
             response = self.get_paginated_response(resp.get("data"))

--- a/rbac/management/principal/proxy.py
+++ b/rbac/management/principal/proxy.py
@@ -76,6 +76,11 @@ class PrincipalProxy:  # pylint: disable=too-few-public-methods
             params["status"] = options["status"]
         if "admin_only" in options:
             params["admin_only"] = options["admin_only"]
+        if "query_by" in options:
+            if options["query_by"] == "user_id":
+                params["queryBy"] = "userId"
+            else:
+                params["queryBy"] = options["query_by"]
 
         return params
 
@@ -197,7 +202,7 @@ class PrincipalProxy:  # pylint: disable=too-few-public-methods
         # For v2 account users endpoints are already filtered by account
         return self._request_principals(url, params=params, account_filter=False, method=method, data=payload)
 
-    def request_filtered_principals(self, principals, account=None, limit=None, offset=None, sort_order=None):
+    def request_filtered_principals(self, principals, account=None, limit=None, offset=None, options={}):
         """Request specific principals for an account."""
         if account is None:
             account_filter = False
@@ -206,7 +211,7 @@ class PrincipalProxy:  # pylint: disable=too-few-public-methods
         if not principals:
             return {"status_code": status.HTTP_200_OK, "data": []}
         filtered_principals_path = "/v1/users"
-        params = self._create_params(limit, offset, {"sort_order": sort_order})
+        params = self._create_params(limit, offset, options)
         payload = {"users": principals, "include_permissions": False}
         url = "{}://{}:{}{}{}".format(self.protocol, self.host, self.port, self.path, filtered_principals_path)
         return self._request_principals(

--- a/rbac/management/principal/proxy.py
+++ b/rbac/management/principal/proxy.py
@@ -84,20 +84,20 @@ class PrincipalProxy:  # pylint: disable=too-few-public-methods
 
         return params
 
-    def _process_data(self, data, account, account_filter):
+    def _process_data(self, data, account, account_filter, return_id=False):
         """Process data for uniform output."""
         processed_data = []
         for item in data:
             if account_filter:
                 if account == item.get("account_number"):
-                    processed_data.append(self._call_item(item))
+                    processed_data.append(self._call_item(item, return_id))
             else:
-                processed_data.append(self._call_item(item))
+                processed_data.append(self._call_item(item, return_id))
 
         return processed_data
 
     @staticmethod
-    def _call_item(item):
+    def _call_item(item, return_id=False):
         processed_item = {
             "username": item.get("username"),
             "email": item.get("email"),
@@ -106,6 +106,9 @@ class PrincipalProxy:  # pylint: disable=too-few-public-methods
             "is_active": item.get("is_active"),
             "is_org_admin": item.get("is_org_admin"),
         }
+
+        if return_id:
+            processed_item["user_id"] = item.get("id")
         return processed_item
 
     def _get_proxy_service(self):  # pylint: disable=no-self-use
@@ -124,7 +127,14 @@ class PrincipalProxy:  # pylint: disable=too-few-public-methods
         return proxy_conn_info
 
     def _request_principals(
-        self, url, account=None, account_filter=False, method=requests.get, params=None, data=None  # noqa: C901
+        self,
+        url,
+        account=None,
+        account_filter=False,
+        method=requests.get,
+        params=None,
+        data=None,
+        return_id=False,  # noqa: C901
     ):
         """Send request to proxy service."""
         if settings.BYPASS_BOP_VERIFICATION:
@@ -162,10 +172,10 @@ class PrincipalProxy:  # pylint: disable=too-few-public-methods
             try:
                 data = response.json()
                 if isinstance(data, dict):
-                    userList = self._process_data(data.get("users"), account, account_filter)
+                    userList = self._process_data(data.get("users"), account, account_filter, return_id)
                     resp["data"] = {"userCount": data.get("userCount"), "users": userList}
                 else:
-                    userList = self._process_data(data, account, account_filter)
+                    userList = self._process_data(data, account, account_filter, return_id)
                     resp["data"] = userList
             except ValueError:
                 resp["status_code"] = status.HTTP_500_INTERNAL_SERVER_ERROR
@@ -214,6 +224,14 @@ class PrincipalProxy:  # pylint: disable=too-few-public-methods
         params = self._create_params(limit, offset, options)
         payload = {"users": principals, "include_permissions": False}
         url = "{}://{}:{}{}{}".format(self.protocol, self.host, self.port, self.path, filtered_principals_path)
+
+        return_id = False if options.get("return_id") is None else True
         return self._request_principals(
-            url, account=account, account_filter=account_filter, method=requests.post, params=params, data=payload
+            url,
+            account=account,
+            account_filter=account_filter,
+            method=requests.post,
+            params=params,
+            data=payload,
+            return_id=return_id,
         )

--- a/rbac/management/principal/view.py
+++ b/rbac/management/principal/view.py
@@ -123,7 +123,11 @@ class PrincipalView(APIView):
                 )
             else:
                 resp = proxy.request_filtered_principals(
-                    principals, account=user.account, limit=limit, offset=offset, sort_order=options["sort_order"]
+                    principals,
+                    account=user.account,
+                    limit=limit,
+                    offset=offset,
+                    options={"sort_order": options["sort_order"]},
                 )
                 usernames_filter = f"&usernames={usernames}"
         elif email:

--- a/rbac/management/utils.py
+++ b/rbac/management/utils.py
@@ -23,7 +23,8 @@ from django.core.exceptions import PermissionDenied
 from django.utils.translation import gettext as _
 from management.models import Group, Principal
 from management.principal.proxy import PrincipalProxy
-from rest_framework import serializers
+from rest_framework import serializers, status
+
 
 USERNAME_KEY = "username"
 APPLICATION_KEY = "application"
@@ -177,3 +178,14 @@ def validate_uuid(uuid, key="UUID Validation"):
         key = key
         message = f"{uuid} is not a valid UUID."
         raise serializers.ValidationError({key: _(message)})
+
+
+def validate_limit_and_offset(query_params):
+    """Limit and offset should not be negative number."""
+    if (int(query_params.get("limit", 10)) < 0) | (int(query_params.get("offset", 0)) < 0):
+        error = {
+            "detail": "Values for limit and offset must be positive numbers.",
+            "source": "CrossAccountRequest",
+            "status": str(status.HTTP_400_BAD_REQUEST),
+        }
+        return {"errors": [error]}

--- a/rbac/rbac/dev_middleware.py
+++ b/rbac/rbac/dev_middleware.py
@@ -41,7 +41,13 @@ class DevelopmentIdentityHeaderMiddleware(MiddlewareMixin):  # pylint: disable=t
                 "identity": {
                     "account_number": "10001",
                     "type": "User",
-                    "user": {"username": "user_dev", "email": "user_dev@foo.com", "is_org_admin": True},
+                    "user": {
+                        "username": "user_dev",
+                        "email": "user_dev@foo.com",
+                        "is_org_admin": True,
+                        "is_internal": True,
+                        "user_id": "51736777",
+                    },
                 }
             }
             json_identity = json_dumps(identity_header)

--- a/rbac/rbac/middleware.py
+++ b/rbac/rbac/middleware.py
@@ -125,6 +125,8 @@ class IdentityHeaderMiddleware(BaseTenantMiddleware):
             user.username = json_rh_auth.get("identity", {}).get("user", {})["username"]
             user.account = json_rh_auth.get("identity", {})["account_number"]
             user.admin = json_rh_auth.get("identity", {}).get("user", {}).get("is_org_admin")
+            user.internal = json_rh_auth.get("identity", {}).get("user", {}).get("is_internal")
+            user.user_id = json_rh_auth.get("identity", {}).get("user", {}).get("user_id")
             user.system = False
             if not user.admin:
                 user.access = IdentityHeaderMiddleware._get_access_for_user()

--- a/tests/api/cross_access/test_model.py
+++ b/tests/api/cross_access/test_model.py
@@ -25,10 +25,9 @@ from tenant_schemas.utils import tenant_context
 
 from datetime import timedelta
 from unittest.mock import Mock
-from tests.identity_request import IdentityRequest
 
 
-class CrossAccountRequestModelTests(IdentityRequest):
+class CrossAccountRequestModelTests(TestCase):
     """Test the cross account request model."""
 
     def setUp(self):
@@ -135,5 +134,5 @@ class CrossAccountRequestModelTests(IdentityRequest):
 
         # Add role
         self.request.roles.add(role)
-        self.assertEqual(self.requests.roles.first(), role)
-        self.assertEqual(role.cross_account_requests.first(), self.request)
+        self.assertEqual(self.request.roles.count(), 1)
+        self.assertEqual(self.request.roles.filter(name="Test Role").first(), role)

--- a/tests/api/cross_access/test_view.py
+++ b/tests/api/cross_access/test_view.py
@@ -1,0 +1,176 @@
+#
+# Copyright 2020 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""Test the cross account request model."""
+from api.models import CrossAccountRequest
+from django.urls import reverse
+from django.utils import timezone
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from datetime import timedelta
+from unittest.mock import patch
+from tests.identity_request import IdentityRequest
+
+
+URL_LIST = reverse("cross-list")
+
+
+class CrossAccountRequestViewTests(IdentityRequest):
+    """Test the cross account request view."""
+
+    def setUp(self):
+        """Set up the cross account request for tests."""
+        super().setUp()
+
+        self.ref_time = timezone.now()
+        self.account = self.customer_data["account_id"]
+        self.associate_non_admin_request_context = self._create_request_context(
+            self.customer_data, self.user_data, create_customer=False, is_org_admin=False, is_internal=True
+        )
+        self.associate_non_admin_request = self.associate_non_admin_request_context["request"]
+
+        self.another_account = "123456"
+        self.request_1 = CrossAccountRequest.objects.create(
+            target_account=self.account, user_id="1111111", end_date=self.ref_time + timedelta(10), status="approved"
+        )
+        self.request_2 = CrossAccountRequest.objects.create(
+            target_account=self.account, user_id="2222222", end_date=self.ref_time + timedelta(10)
+        )
+        self.request_3 = CrossAccountRequest.objects.create(
+            target_account=self.another_account,
+            user_id="1111111",
+            end_date=self.ref_time + timedelta(10),
+            status="approved",
+        )
+        self.request_4 = CrossAccountRequest.objects.create(
+            target_account=self.another_account, user_id="2222222", end_date=self.ref_time + timedelta(10)
+        )
+
+    def tearDown(self):
+        """Tear down cross account request model tests."""
+        CrossAccountRequest.objects.all().delete()
+
+    @patch(
+        "management.principal.proxy.PrincipalProxy.request_filtered_principals",
+        return_value={
+            "status_code": 200,
+            "data": [
+                {
+                    "username": "test_user",
+                    "email": "test_user@email.com",
+                    "first_name": "user",
+                    "last_name": "test",
+                    "account_number": "567890",
+                    "user_id": "1111111",
+                },
+                {
+                    "username": "test_user_2",
+                    "email": "test_user_2@email.com",
+                    "first_name": "user_2",
+                    "last_name": "test",
+                    "account_number": "123456",
+                    "user_id": "2222222",
+                },
+            ],
+        },
+    )
+    def test_list_requests_query_by_account_success(self, mock_request):
+        """Test listing of cross account request based on account number of identity."""
+        client = APIClient()
+        response = client.get(URL_LIST, **self.headers)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data["data"]), 2)
+        self.assertEqual(response.data["data"][0].get("email"), "test_user@email.com")
+        self.assertEqual(response.data["data"][1].get("email"), "test_user_2@email.com")
+
+    def test_list_requests_query_by_account_fail_if_not_admin(self):
+        """Test listing cross account request based on account number of identity would fail for non org admin."""
+        client = APIClient()
+        response = client.get(URL_LIST, **self.associate_non_admin_request.META)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.data["errors"][0]["detail"].code, "permission_denied")
+
+    def test_list_requests_query_by_user_id_success(self):
+        """Test listing cross account request based on user id of identity."""
+        client = APIClient()
+        response = client.get(f"{URL_LIST}?query_by=user_id", **self.associate_non_admin_request.META)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data["data"]), 2)
+        self.assertEqual(response.data["data"][0].get("email"), None)
+        self.assertEqual(response.data["data"][0].get("user_id"), "1111111")
+        self.assertEqual(response.data["data"][0].get("target_account"), self.account)
+        self.assertEqual(response.data["data"][1].get("email"), None)
+        self.assertEqual(response.data["data"][0].get("user_id"), "1111111")
+        self.assertEqual(response.data["data"][1].get("target_account"), self.another_account)
+
+    def test_list_requests_query_by_user_id_filter_by_account_success(self):
+        """Test listing cross account request based on user id of identity."""
+        client = APIClient()
+        response = client.get(
+            f"{URL_LIST}?query_by=user_id&account={self.account}", **self.associate_non_admin_request.META
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data["data"]), 1)
+        self.assertEqual(response.data["data"][0].get("user_id"), "1111111")
+        self.assertEqual(response.data["data"][0].get("target_account"), self.account)
+        self.assertEqual(response.data["data"][0].get("status"), "approved")
+
+        response = client.get(
+            f"{URL_LIST}?query_by=user_id&account={self.account},{self.another_account}",
+            **self.associate_non_admin_request.META,
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data["data"]), 2)
+
+    def test_list_requests_query_by_user_id_with_combined_filters_success(self):
+        """Test listing cross account request based on user id of identity."""
+        expired_request = CrossAccountRequest.objects.create(
+            target_account="098765", user_id="1111111", end_date=self.ref_time + timedelta(10), status="approved"
+        )
+        CrossAccountRequest.objects.filter(request_id=expired_request.request_id).update(end_date=timezone.now())
+
+        client = APIClient()
+        response = client.get(
+            f"{URL_LIST}?query_by=user_id&account=098765&approved_only=True", **self.associate_non_admin_request.META
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data["data"]), 0)
+
+        response = client.get(
+            f"{URL_LIST}?query_by=user_id&account={self.another_account}&approved_only=True",
+            **self.associate_non_admin_request.META,
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data["data"]), 1)
+        self.assertEqual(response.data["data"][0].get("user_id"), "1111111")
+        self.assertEqual(response.data["data"][0].get("target_account"), self.another_account)
+        self.assertEqual(response.data["data"][0].get("status"), "approved")
+
+    def test_list_requests_query_by_user_id_fail_if_not_associate(self):
+        """Test listing cross account request based on user id of identity would fail for non associate."""
+        client = APIClient()
+        response = client.get(f"{URL_LIST}?query_by=user_id", **self.headers)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.data["errors"][0]["detail"].code, "permission_denied")

--- a/tests/api/cross_access/test_view.py
+++ b/tests/api/cross_access/test_view.py
@@ -15,11 +15,13 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 """Test the cross account request model."""
-from api.models import CrossAccountRequest
+from api.models import CrossAccountRequest, Tenant
 from django.urls import reverse
 from django.utils import timezone
+from management.models import Role
 from rest_framework import status
 from rest_framework.test import APIClient
+from tenant_schemas.utils import tenant_context
 
 from datetime import timedelta
 from unittest.mock import patch
@@ -43,22 +45,38 @@ class CrossAccountRequestViewTests(IdentityRequest):
         )
         self.associate_non_admin_request = self.associate_non_admin_request_context["request"]
 
+        """
+            Create cross account requests
+            | target_account | user_id | start_date | end_date  |  status  | roles |
+            |     xxxxxx     | 1111111 |    now     | now+10day | approved |
+            |     xxxxxx     | 2222222 |    now     | now+10day | pending  |
+            |     123456     | 1111111 |    now     | now+10day | approved |
+            |     123456     | 2222222 |    now     | now+10day | pending  |
+        """
         self.another_account = "123456"
-        self.request_1 = CrossAccountRequest.objects.create(
-            target_account=self.account, user_id="1111111", end_date=self.ref_time + timedelta(10), status="approved"
-        )
-        self.request_2 = CrossAccountRequest.objects.create(
-            target_account=self.account, user_id="2222222", end_date=self.ref_time + timedelta(10)
-        )
-        self.request_3 = CrossAccountRequest.objects.create(
-            target_account=self.another_account,
-            user_id="1111111",
-            end_date=self.ref_time + timedelta(10),
-            status="approved",
-        )
-        self.request_4 = CrossAccountRequest.objects.create(
-            target_account=self.another_account, user_id="2222222", end_date=self.ref_time + timedelta(10)
-        )
+        with tenant_context(Tenant.objects.get(schema_name="public")):
+            self.role_1 = Role.objects.create(name="role_1")
+            self.role_2 = Role.objects.create(name="role_2")
+            self.request_1 = CrossAccountRequest.objects.create(
+                target_account=self.account,
+                user_id="1111111",
+                end_date=self.ref_time + timedelta(10),
+                status="approved",
+            )
+            self.request_1.roles.add(*(self.role_1, self.role_2))
+            self.request_2 = CrossAccountRequest.objects.create(
+                target_account=self.account, user_id="2222222", end_date=self.ref_time + timedelta(10)
+            )
+            self.request_2.roles.add(*(self.role_1, self.role_2))
+            self.request_3 = CrossAccountRequest.objects.create(
+                target_account=self.another_account,
+                user_id="1111111",
+                end_date=self.ref_time + timedelta(10),
+                status="approved",
+            )
+            self.request_4 = CrossAccountRequest.objects.create(
+                target_account=self.another_account, user_id="2222222", end_date=self.ref_time + timedelta(10)
+            )
 
     def tearDown(self):
         """Tear down cross account request model tests."""
@@ -171,6 +189,77 @@ class CrossAccountRequestViewTests(IdentityRequest):
         """Test listing cross account request based on user id of identity would fail for non associate."""
         client = APIClient()
         response = client.get(f"{URL_LIST}?query_by=user_id", **self.headers)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.data["errors"][0]["detail"].code, "permission_denied")
+
+    @patch(
+        "management.principal.proxy.PrincipalProxy.request_filtered_principals",
+        return_value={
+            "status_code": 200,
+            "data": [
+                {
+                    "username": "test_user",
+                    "email": "test_user@email.com",
+                    "first_name": "user",
+                    "last_name": "test",
+                    "account_number": "567890",
+                    "user_id": "1111111",
+                }
+            ],
+        },
+    )
+    def test_retrieve_request_query_by_account_success(self, mock_request):
+        """Test retrieve of cross account request based on account number of identity."""
+        client = APIClient()
+        response = client.get(f"{URL_LIST}{self.request_1.request_id}/", **self.headers)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data.get("email"), "test_user@email.com")
+        self.assertEqual(response.data.get("target_account"), self.account)
+        self.assertEqual(len(response.data.get("roles")), 2)
+
+    def test_retrieve_request_query_by_account_fail_if_request_in_another_account(self):
+        """Test retrieve cross account request based on account number of identity would fail for non org admin."""
+        client = APIClient()
+        response = client.get(f"{URL_LIST}{self.request_3.request_id}/", **self.headers)
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_retrieve_request_query_by_account_fail_if_not_admin(self):
+        """Test retrieve cross account request based on account number of identity would fail for non org admin."""
+        client = APIClient()
+        response = client.get(f"{URL_LIST}{self.request_1.request_id}/", **self.associate_non_admin_request.META)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.data["errors"][0]["detail"].code, "permission_denied")
+
+    def test_retrieve_request_query_by_user_id_success(self):
+        """Test retrieve cross account request based on user id of identity."""
+        client = APIClient()
+        response = client.get(
+            f"{URL_LIST}{self.request_1.request_id}/?query_by=user_id", **self.associate_non_admin_request.META
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data.get("email"), None)
+        self.assertEqual(response.data.get("user_id"), "1111111")
+        self.assertEqual(response.data.get("target_account"), self.account)
+        self.assertEqual(len(response.data.get("roles")), 2)
+
+    def test_retrieve_request_query_by_user_id_fail_if_request_by_another_associate(self):
+        """Test retrieve cross account request based on user id of identity would fail for non associate."""
+        client = APIClient()
+        response = client.get(
+            f"{URL_LIST}{self.request_2.request_id}/?query_by=user_id", **self.associate_non_admin_request.META
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_retrieve_request_query_by_user_id_fail_if_not_associate(self):
+        """Test retrieve cross account request based on user id of identity would fail for non associate."""
+        client = APIClient()
+        response = client.get(f"{URL_LIST}{self.request_1.request_id}/?query_by=user_id", **self.headers)
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
         self.assertEqual(response.data["errors"][0]["detail"].code, "permission_denied")

--- a/tests/identity_request.py
+++ b/tests/identity_request.py
@@ -111,11 +111,13 @@ class IdentityRequest(TestCase):
                 "username": user_data.get("username"),
                 "email": user_data.get("email"),
                 "is_org_admin": is_org_admin,
+                "user_id": "1111111",
             }
 
         if is_internal:
             identity["identity"]["type"] = "Associate"
-            identity["identity"]["associate"] = {"email": user_data.get("email")}
+            identity["identity"]["associate"] = {"email": user_data["email"]}
+            identity["identity"]["user"]["is_internal"] = True
         else:
             identity["identity"]["type"] = "User"
 

--- a/tests/management/group/test_view.py
+++ b/tests/management/group/test_view.py
@@ -682,7 +682,7 @@ class GroupViewsetTests(IdentityRequest):
         response = client.get(url, **self.headers)
         principals = response.data.get("data")
 
-        mock_request.assert_called_with([], ANY, sort_order=None)
+        mock_request.assert_called_with([], ANY, options={"sort_order": None})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(principals), 0)
 
@@ -698,7 +698,7 @@ class GroupViewsetTests(IdentityRequest):
         response = client.get(url, **self.headers)
         principals = response.data.get("data")
 
-        mock_request.assert_called_with([self.principal.username], ANY, sort_order=None)
+        mock_request.assert_called_with([self.principal.username], ANY, options={"sort_order": None})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(principals), 1)
 
@@ -713,7 +713,7 @@ class GroupViewsetTests(IdentityRequest):
         response = client.get(url, **self.headers)
         principals = response.data.get("data")
         expected_principals = sorted([self.principal.username, self.principalB.username])
-        mock_request.assert_called_with(expected_principals, ANY, sort_order="asc")
+        mock_request.assert_called_with(expected_principals, ANY, options={"sort_order": "asc"})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(principals), 1)
 

--- a/tests/management/principal/test_view.py
+++ b/tests/management/principal/test_view.py
@@ -196,7 +196,7 @@ class PrincipalViewsetTests(IdentityRequest):
 
     @patch(
         "management.principal.proxy.PrincipalProxy.request_filtered_principals",
-        return_value={"status_code": 200, "data": [{"username": "test_user", "account_number": "1234"}]},
+        return_value={"status_code": 200, "data": [{"username": "test_user", "account_number": "1234", "id": "5678"}]},
     )
     def test_read_principal_list_account(self, mock_request):
         """Test that we can handle a request with matching accounts"""
@@ -213,10 +213,11 @@ class PrincipalViewsetTests(IdentityRequest):
             self.assertIn(keyname, response.data)
         self.assertIsInstance(response.data.get("data"), list)
         self.assertEqual(response.data.get("meta").get("count"), 1)
-        resp = proxy._process_data(response.data.get("data"), account="1234", account_filter=True)
+        resp = proxy._process_data(response.data.get("data"), account="1234", account_filter=True, return_id=True)
         self.assertEqual(len(resp), 1)
 
         self.assertEqual(resp[0]["username"], "test_user")
+        self.assertEqual(resp[0]["user_id"], "5678")
 
     @patch(
         "management.principal.proxy.PrincipalProxy.request_filtered_principals",

--- a/tests/management/principal/test_view.py
+++ b/tests/management/principal/test_view.py
@@ -122,7 +122,9 @@ class PrincipalViewsetTests(IdentityRequest):
         client = APIClient()
         response = client.get(url, **self.headers)
 
-        mock_request.assert_called_once_with(["test_user"], account=ANY, limit=10, offset=30, sort_order="asc")
+        mock_request.assert_called_once_with(
+            ["test_user"], account=ANY, limit=10, offset=30, options={"sort_order": "asc"}
+        )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         for keyname in ["meta", "links", "data"]:
             self.assertIn(keyname, response.data)
@@ -203,7 +205,9 @@ class PrincipalViewsetTests(IdentityRequest):
         proxy = PrincipalProxy()
         response = client.get(url, **self.headers)
 
-        mock_request.assert_called_once_with(["test_user"], account=ANY, limit=10, offset=30, sort_order="desc")
+        mock_request.assert_called_once_with(
+            ["test_user"], account=ANY, limit=10, offset=30, options={"sort_order": "desc"}
+        )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         for keyname in ["meta", "links", "data"]:
             self.assertIn(keyname, response.data)


### PR DESCRIPTION
## Link(s) to Jira
JIRA: https://issues.redhat.com/browse/RHCLOUD-8880

## Description of Intent of Change(s)
This is for adding list API for both target_account and associate requestor, distinguished by the queryBy parameter. The info of user id and account number will be determined by the identity header.

Add user id in the response so the principal could be mapped to the user id it belongs to.

Now BOP supports search users by username/user_id which requires queryBy parameter. This is to support calling with that parameter.


## Local Testing
Unit test
After setting up local envs:
curl -v GET "http://0.0.0.0:8080/r/insights/platform/rbac/v1/cross-account-requests/" | python -m json.tool
curl -v GET "http://0.0.0.0:8080/r/insights/platform/rbac/v1/cross-account-requests/?query_by=user_id" | python -m json.tool

## Checklist
- [ ] if API spec changes are required, is the spec updated?
       Not yet, maybe don't wanna expose the api yet?
- [ ] are there any pre/post merge actions required? if so, document here.

- [ ] are theses changes covered by unit tests?

- [ ] if warranted, are documentation changes accounted for?

- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?

- [ ] is there known, direct impact to dependent teams/components?
  -  if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation

- [ ] Output Encoding

- [ ] Authentication and Password Management

- [ ] Session Management

- [ ] Access Control

- [ ] Cryptographic Practices

- [ ] Error Handling and Logging

- [ ] Data Protection

- [ ] Communication Security

- [ ] System Configuration

- [ ] Database Security

- [ ] File Management

- [ ] Memory Management

- [ ] General Coding Practices
