### PR TITLE
Use field permission instead of perm

### DIFF
--- a/rbac/management/role/definer.py
+++ b/rbac/management/role/definer.py
@@ -56,8 +56,8 @@ def _make_role(tenant, data):
             return role
     for access_item in access_list:
         resource_def_list = access_item.pop("resourceDefinitions", [])
-        access_item["perm"] = access_item.pop("permission")
-        access_obj = Access.objects.create(**access_item, role=role)
+        permission, created = Permission.objects.get_or_create(**access_item)
+        access_obj = Access.objects.create(permission=permission, role=role)
         for resource_def_item in resource_def_list:
             ResourceDefinition.objects.create(**resource_def_item, access=access_obj)
     return role

--- a/rbac/management/role/model.py
+++ b/rbac/management/role/model.py
@@ -60,14 +60,6 @@ class Role(models.Model):
         super(Role, self).save(*args, **kwargs)
 
 
-class CustomManager(models.Manager):
-    """Control which fields to query."""
-
-    def get_queryset(self):
-        """Override default get_queryset to defer fields."""
-        return super(CustomManager, self).get_queryset().defer("perm")
-
-
 class Access(models.Model):
     """An access object."""
 
@@ -75,22 +67,9 @@ class Access(models.Model):
     permission = models.ForeignKey(Permission, null=True, on_delete=models.CASCADE, related_name="accesses")
     role = models.ForeignKey(Role, null=True, on_delete=models.CASCADE, related_name="access")
 
-    objects = CustomManager()
-
     def permission_application(self):
         """Return the application name from the permission."""
-        return next(iter(self.split_permission()))
-
-    def split_permission(self):
-        """Split the permission."""
-        return self.perm.split(":")
-
-    def save(self, *args, **kwargs):
-        """Save method that sync the perm field and permission."""
-        if not self.permission:
-            self.permission, created = Permission.objects.get_or_create(permission=self.perm)
-
-        super(Access, self).save(*args, **kwargs)
+        return self.permission.application
 
 
 class ResourceDefinition(models.Model):

--- a/rbac/management/role/view.py
+++ b/rbac/management/role/view.py
@@ -68,14 +68,14 @@ class RoleFilter(CommonFilters):
         applications = values.split(",")
         query = Q()
         for application in applications:
-            query = query | Q(access__perm__istartswith=f"{application}:")
+            query = query | Q(access__permission__permission__istartswith=f"{application}:")
         return queryset.distinct().filter(query)
 
     def permission_filter(self, queryset, field, values):
         """Filter to lookup role by application(s) in permissions."""
         permissions = values.split(",")
 
-        return queryset.filter(access__perm__in=permissions).distinct()
+        return queryset.filter(access__permission__permission__in=permissions).distinct()
 
     name = filters.CharFilter(field_name="name", method="name_filter")
     application = filters.CharFilter(field_name="application", method="application_filter")

--- a/tests/management/access/test_model.py
+++ b/tests/management/access/test_model.py
@@ -20,7 +20,7 @@ from tenant_schemas.utils import tenant_context
 
 # from unittest.mock import Mock
 
-from management.models import Access
+from management.models import Access, Permission
 from tests.identity_request import IdentityRequest
 
 
@@ -32,7 +32,8 @@ class AccessModelTests(IdentityRequest):
         super().setUp()
 
         with tenant_context(self.tenant):
-            self.access = Access.objects.create(perm="app:*:*")
+            self.permission = Permission.objects.create(permission="app:*:*")
+            self.access = Access.objects.create(permission=self.permission)
 
     def tearDown(self):
         """Tear down access model tests."""
@@ -43,11 +44,6 @@ class AccessModelTests(IdentityRequest):
         """Test we get back the application name of the permission."""
         with tenant_context(self.tenant):
             self.assertEqual(self.access.permission_application(), "app")
-
-    def test_split_permission(self):
-        """Test we split the permission."""
-        with tenant_context(self.tenant):
-            self.assertEqual(self.access.split_permission(), ["app", "*", "*"])
 
     def test_perm_and_permission_are_synced(self):
         """Test the permission field is populated when creating Access."""

--- a/tests/management/access/test_view.py
+++ b/tests/management/access/test_view.py
@@ -27,7 +27,7 @@ from rest_framework.test import APIClient
 from tenant_schemas.utils import tenant_context
 
 from api.models import User
-from management.models import Group, Principal, Policy, Role, Access, Permission
+from management.models import Group, Permission, Principal, Policy, Role, Access
 from tests.identity_request import IdentityRequest
 
 
@@ -56,8 +56,8 @@ class AccessViewTests(IdentityRequest):
             self.group.save()
             self.group.principals.add(self.principal)
             self.group.save()
+            self.permission = Permission.objects.create(permission="app:*:*")
             Permission.objects.create(permission="app:foo:bar")
-            Permission.objects.create(permission="app:*:*")
 
     def tearDown(self):
         """Tear down access view tests."""
@@ -98,7 +98,7 @@ class AccessViewTests(IdentityRequest):
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         role_uuid = response.data.get("uuid")
         role = Role.objects.get(uuid=role_uuid)
-        access = Access.objects.create(role=role, perm="app2:foo:bar")
+        access = Access.objects.create(role=role, permission=self.permission)
         policy_name = "policyA"
         response = self.create_policy(policy_name, self.group.uuid, [role_uuid])
 
@@ -109,7 +109,7 @@ class AccessViewTests(IdentityRequest):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIsNotNone(response.data.get("data"))
         self.assertIsInstance(response.data.get("data"), list)
-        self.assertEqual(len(response.data.get("data")), 1)
+        self.assertEqual(len(response.data.get("data")), 2)
         self.assertEqual(response.data.get("meta").get("limit"), 1000)
         self.assertEqual(self.access_data, response.data.get("data")[0])
 
@@ -124,7 +124,7 @@ class AccessViewTests(IdentityRequest):
         response = self.create_role(role_name, access_data)
         role_uuid = response.data.get("uuid")
         role = Role.objects.get(uuid=role_uuid)
-        access = Access.objects.create(role=role, perm="app2:foo:bar")
+        access = Access.objects.create(role=role, permission=self.permission)
         self.create_policy(policy_name, self.group.uuid, [role_uuid])
 
         url = "{}?application=&username={}".format(reverse("access"), self.principal.username)
@@ -147,7 +147,7 @@ class AccessViewTests(IdentityRequest):
         response = self.create_role(role_name, access_data)
         role_uuid = response.data.get("uuid")
         role = Role.objects.get(uuid=role_uuid)
-        access = Access.objects.create(role=role, perm="app2:foo:bar")
+        access = Access.objects.create(role=role, permission=self.permission)
         self.create_policy(policy_name, self.group.uuid, [role_uuid])
 
         url = "{}?application={}&username={}".format(reverse("access"), "app,app2", self.principal.username)

--- a/tests/management/role/test_view.py
+++ b/tests/management/role/test_view.py
@@ -26,7 +26,7 @@ from rest_framework.test import APIClient
 from tenant_schemas.utils import tenant_context
 
 from api.models import User
-from management.models import Group, Principal, Role, Access, Policy, Permission
+from management.models import Group, Permission, Principal, Role, Access, Policy
 from tests.identity_request import IdentityRequest
 
 
@@ -83,10 +83,12 @@ class RoleViewsetTests(IdentityRequest):
             self.policy.roles.add(self.defRole, self.sysRole)
             self.policy.save()
 
-            self.access = Access.objects.create(perm="app:*:*", role=self.defRole)
-            self.access2 = Access.objects.create(perm="app2:*:*", role=self.defRole)
+            self.permission = Permission.objects.create(permission="app:*:*")
+            self.permission2 = Permission.objects.create(permission="app2:*:*")
+            self.access = Access.objects.create(permission=self.permission, role=self.defRole)
+            self.access2 = Access.objects.create(permission=self.permission2, role=self.defRole)
 
-            self.access3 = Access.objects.create(perm="app2:*:*", role=self.sysRole)
+            self.access3 = Access.objects.create(permission=self.permission2, role=self.sysRole)
             Permission.objects.create(permission="cost-management:*:*")
 
     def tearDown(self):

--- a/tests/management/test_utils.py
+++ b/tests/management/test_utils.py
@@ -17,7 +17,7 @@
 """Test the utils module."""
 from tenant_schemas.utils import tenant_context
 
-from management.models import Group, Principal, Policy, Role, Access
+from management.models import Group, Permission, Principal, Policy, Role, Access
 from management.utils import access_for_principal, groups_for_principal, policies_for_principal, roles_for_principal
 from tests.identity_request import IdentityRequest
 
@@ -35,7 +35,8 @@ class UtilsTests(IdentityRequest):
 
             # setup data for the principal
             self.roleA = Role.objects.create(name="roleA")
-            self.accessA = Access.objects.create(perm="app:*:*", role=self.roleA)
+            self.permission = Permission.objects.create(permission="app:*:*")
+            self.accessA = Access.objects.create(permission=self.permission, role=self.roleA)
             self.policyA = Policy.objects.create(name="policyA")
             self.policyA.roles.add(self.roleA)
             self.groupA = Group.objects.create(name="groupA")
@@ -44,7 +45,7 @@ class UtilsTests(IdentityRequest):
 
             # setup data the principal does not have access to
             self.roleB = Role.objects.create(name="roleB")
-            self.accessB = Access.objects.create(perm="app:*:*", role=self.roleB)
+            self.accessB = Access.objects.create(permission=self.permission, role=self.roleB)
             self.policyB = Policy.objects.create(name="policyB")
             self.policyB.roles.add(self.roleB)
             self.groupB = Group.objects.create(name="groupB")
@@ -53,7 +54,7 @@ class UtilsTests(IdentityRequest):
             # setup default group/role which all tenant users
             # should inherit without explicit association
             self.default_role = Role.objects.create(name="default role", platform_default=True, system=True)
-            self.default_access = Access.objects.create(perm="app:*:*", role=self.default_role)
+            self.default_access = Access.objects.create(permission=self.permission, role=self.default_role)
             self.default_policy = Policy.objects.create(name="default policy", system=True)
             self.default_policy.roles.add(self.default_role)
             self.default_group = Group.objects.create(name="default group", system=True, platform_default=True)

--- a/tests/rbac/test_cache.py
+++ b/tests/rbac/test_cache.py
@@ -23,7 +23,7 @@ from rbac.settings import ACCESS_CACHE_ENABLED
 from django.db import connection
 from django.test import TestCase
 
-from management.models import Access, Group, Policy, Principal, ResourceDefinition, Role
+from management.models import Access, Group, Permission, Policy, Principal, ResourceDefinition, Role
 from api.models import Tenant
 
 
@@ -207,7 +207,8 @@ class AccessCacheTest(TestCase):
 
         cache.reset_mock()
         # If Access is added
-        self.access_a = Access.objects.create(perm="foo:*:*", role=self.role_a)
+        self.permission = Permission.objects.create(permission="foo:*:*")
+        self.access_a = Access.objects.create(permission=self.permission, role=self.role_a)
         cache.assert_called_once()
         cache.assert_called_once_with(self.principal_a.uuid)
 


### PR DESCRIPTION
Promote the changes to qa: now that the content of permission and perm fields are synced,
it is safe to switch usage of perm to permission. 