### PR TITLE
Ensure we adjust the schemas to support both options of query_by=account|user_id

### DIFF
--- a/docs/source/specs/openapi.json
+++ b/docs/source/specs/openapi.json
@@ -355,7 +355,6 @@
               "example": "userA,userB"
             }
           },
-
           {
             "name": "sort_order",
             "in": "query",
@@ -363,7 +362,10 @@
             "required": false,
             "schema": {
               "type": "string",
-              "enum": ["asc", "desc"]
+              "enum": [
+                "asc",
+                "desc"
+              ]
             }
           },
           {
@@ -411,7 +413,9 @@
             "description": "Parameter for ordering principals by value. For inverse ordering, supply '-' before the param value, such as: ?order_by=-username",
             "schema": {
               "type": "string",
-              "enum": ["username"]
+              "enum": [
+                "username"
+              ]
             }
           }
         ],
@@ -573,7 +577,10 @@
             "required": false,
             "schema": {
               "type": "string",
-              "enum": ["all", "any"]
+              "enum": [
+                "all",
+                "any"
+              ]
             }
           },
           {
@@ -938,7 +945,9 @@
             "description": "Parameter for ordering principals by value. For inverse ordering, supply '-' before the param value, such as: ?order_by=-username",
             "schema": {
               "type": "string",
-              "enum": ["username"]
+              "enum": [
+                "username"
+              ]
             }
           }
         ],
@@ -2482,7 +2491,10 @@
         "description": "Parameter for specifying the matching criteria for an object's name or display_name.",
         "schema": {
           "type": "string",
-          "enum": ["partial", "exact"]
+          "enum": [
+            "partial",
+            "exact"
+          ]
         }
       }
     },
@@ -2912,6 +2924,16 @@
         ]
       },
       "CrossAccountRequestDetail": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/CrossAccountRequestDetailByAccount"
+          },
+          {
+            "$ref": "#/components/schemas/CrossAccountRequestDetailByUseId"
+          }
+        ]
+      },
+      "CrossAccountRequestDetailByAccount": {
         "allOf": [
           {
             "$ref": "#/components/schemas/CrossAccountRequestWithRoles"
@@ -2935,21 +2957,17 @@
           }
         ]
       },
-      "CrossAccountRequestWithDates": {
+      "CrossAccountRequestDetailByUseId": {
         "allOf": [
           {
-            "$ref": "#/components/schemas/CrossAccountRequest"
+            "$ref": "#/components/schemas/CrossAccountRequestWithRoles"
           },
           {
             "type": "object",
             "properties": {
-              "start_date": {
-                "format": "date-time",
-                "example": "2019-01-21T17:32:28Z"
-              },
-              "end_date": {
-                "format": "date-time",
-                "example": "2019-01-21T17:32:28Z"
+              "user_id": {
+                "format": "string",
+                "example": "1234"
               }
             }
           }
@@ -2969,7 +2987,14 @@
               "data": {
                 "type": "array",
                 "items": {
-                  "$ref": "#/components/schemas/CrossAccountRequestWithDates"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/CrossAccountRequestByAccount"
+                    },
+                    {
+                      "$ref": "#/components/schemas/CrossAccountRequestByUserId"
+                    }
+                  ]
                 }
               }
             }
@@ -3005,6 +3030,46 @@
           }
         }
       },
+      "CrossAccountRequestByAccount": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/CrossAccountRequest"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "first_name": {
+                "type": "string",
+                "example": "Jane"
+              },
+              "last_name": {
+                "type": "string",
+                "example": "Doe"
+              },
+              "email": {
+                "type": "string",
+                "example": "test@redhat.com"
+              }
+            }
+          }
+        ]
+      },
+      "CrossAccountRequestByUserId": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/CrossAccountRequest"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "user_id": {
+                "type": "string",
+                "example": "1234"
+              }
+            }
+          }
+        ]
+      },
       "CrossAccountRequest": {
         "properties": {
           "request_id": {
@@ -3020,20 +3085,16 @@
             "type": "string",
             "example": "pending"
           },
-          "first_name": {
-            "type": "string",
-            "example": "Jane"
-          },
-          "last_name": {
-            "type": "string",
-            "example": "Doe"
-          },
-          "email": {
-            "type": "string",
-            "example": "test@redhat.com"
-          },
           "created": {
             "type": "string",
+            "format": "date-time",
+            "example": "2019-01-21T17:32:28Z"
+          },
+          "start_date": {
+            "format": "date-time",
+            "example": "2019-01-21T17:32:28Z"
+          },
+          "end_date": {
             "format": "date-time",
             "example": "2019-01-21T17:32:28Z"
           }


### PR DESCRIPTION
## Link(s) to Jira
- Fix for: https://issues.redhat.com/browse/RHCLOUD-9472?focusedCommentId=15707380&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-15707380

## Description of Intent of Change(s)
The payload will change based on whether the response is for `user_id` scope, or `account` scope.

## Local Testing
Build a new API client and test the `/cross-account-requests/` endpoint for both `?query_by=user_id|account`

## Checklist
- [x] if API spec changes are required, is the spec updated?

- [ ] are there any pre/post merge actions required? if so, document here.

- [ ] are theses changes covered by unit tests?

- [ ] if warranted, are documentation changes accounted for?

- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?

- [ ] is there known, direct impact to dependent teams/components?
  -  if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation

- [ ] Output Encoding

- [ ] Authentication and Password Management

- [ ] Session Management

- [ ] Access Control

- [ ] Cryptographic Practices

- [ ] Error Handling and Logging

- [ ] Data Protection

- [ ] Communication Security

- [ ] System Configuration

- [ ] Database Security

- [ ] File Management

- [ ] Memory Management

- [ ] General Coding Practices
