### PR TITLE
Add update endpoints and tests for cross-account API

### DIFF
--- a/docs/source/specs/openapi.json
+++ b/docs/source/specs/openapi.json
@@ -283,6 +283,178 @@
             }
           }
         }
+      },
+      "put": {
+        "tags": [
+          "CrossAccountRequest"
+        ],
+        "summary": "Update a cross account request",
+        "operationId": "putCrossAccountRequest",
+        "description":"Update a cross account request",
+        "parameters": [
+          {
+            "name": "uuid",
+            "in": "path",
+            "description": "ID of cross account request to get",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CrossAccountRequestUpdateIn"
+              }
+            }
+          },
+          "description": "Updates to CrossAccountRequest",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "A cross account request object",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CrossAccountRequestDetail"
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "An object describing the cross account request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CrossAccountRequestOut"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Insufficient permissions to get group",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error403"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "CrossAccountRequest"
+        ],
+        "summary": "Update a cross account request",
+        "operationId": "patchCrossAccountRequest",
+        "description":"Update a cross account request",
+        "parameters": [
+          {
+            "name": "uuid",
+            "in": "path",
+            "description": "ID of cross account request to get",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CrossAccountRequestPatch"
+              }
+            }
+          },
+          "description": "Updates to CrossAccountRequest",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "A cross account request object",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CrossAccountRequestDetail"
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "An object describing the cross account request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CrossAccountRequestOut"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Insufficient permissions to get group",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error403"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
       }
     },
     "/status/": {
@@ -3049,6 +3221,69 @@
               "example": "Role Name"
             }
           }
+        }
+      },
+      "CrossAccountRequestUpdateIn": {
+        "required": [
+          "start_date",
+          "end_date",
+          "roles"
+        ],
+        "properties": {
+          "start_date": {
+            "type": "string",
+            "example": "01/01/2021"
+          },
+          "end_date": {
+            "type": "string",
+            "example": "01/01/2021"
+          },
+          "roles": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "example": "Role Name"
+            }
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "pending",
+              "approved",
+              "expired",
+              "cancelled",
+              "denied"
+            ]
+          }  
+        }
+      },
+      "CrossAccountRequestPatch": {
+        "properties": {
+          "start_date": {
+            "type": "string",
+            "example": "01/01/2021"
+          },
+          "end_date": {
+            "type": "string",
+            "example": "01/01/2021"
+          },
+          "roles": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "example": "Role Name"
+            }
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "pending",
+              "approved",
+              "expired",
+              "cancelled",
+              "denied"
+            ]
+          }  
         }
       },
       "CrossAccountRequestByAccount": {

--- a/rbac/api/cross_access/model.py
+++ b/rbac/api/cross_access/model.py
@@ -53,10 +53,7 @@ class CrossAccountRequest(models.Model):
 
         [self.validate_date(date) for date in [self.start_date, self.end_date]]
 
-        if (
-            isinstance(self.end_date, datetime.datetime)
-            and isinstance(self.start_date, datetime.datetime)
-        ):
+        if isinstance(self.end_date, datetime.datetime) and isinstance(self.start_date, datetime.datetime):
             if self.start_date.date() > (datetime.datetime.now() + datetime.timedelta(60)).date():
                 raise ValidationError("Start date must be within 60 days of today.")
 

--- a/rbac/api/cross_access/model.py
+++ b/rbac/api/cross_access/model.py
@@ -56,9 +56,15 @@ class CrossAccountRequest(models.Model):
         if (
             isinstance(self.end_date, datetime.datetime)
             and isinstance(self.start_date, datetime.datetime)
-            and self.start_date.date() > self.end_date.date()
         ):
-            raise ValidationError("Start date must be earlier than end date.")
+            if self.start_date.date() > (datetime.datetime.now() + datetime.timedelta(60)).date():
+                raise ValidationError("Start date must be within 60 days of today.")
+
+            if self.start_date > self.end_date:
+                raise ValidationError("Start date must be earlier than end date.")
+
+            if self.end_date - self.start_date > datetime.timedelta(365):
+                raise ValidationError("Access duration may not be longer than one year.")
 
     def save(self, *args, **kwargs):
         """Override save method to validate some input."""

--- a/rbac/api/cross_access/serializer.py
+++ b/rbac/api/cross_access/serializer.py
@@ -95,3 +95,16 @@ class CrossAccountRequestDetailSerializer(serializers.ModelSerializer):
         for role in roles:
             request.roles.add(role)
         return request
+
+    def update(self, instance, validated_data):
+        """Override the update method to associate the roles to cross account request after it is updated."""
+        role_data = validated_data.pop("roles")
+        display_names = [role["display_name"] for role in role_data]
+        for field in validated_data:
+            setattr(instance, field, validated_data.get(field))
+
+        roles = Role.objects.filter(display_name__in=display_names)
+        for role in roles:
+            instance.roles.add(role)
+        instance.save()
+        return instance

--- a/rbac/api/cross_access/serializer.py
+++ b/rbac/api/cross_access/serializer.py
@@ -16,6 +16,7 @@
 #
 
 """Serializer for CrossAccountRequest."""
+from django.db import transaction
 from management.models import Role
 from management.permission.serializer import PermissionSerializer
 from rest_framework import serializers
@@ -96,6 +97,7 @@ class CrossAccountRequestDetailSerializer(serializers.ModelSerializer):
             request.roles.add(role)
         return request
 
+    @transaction.atomic
     def update(self, instance, validated_data):
         """Override the update method to associate the roles to cross account request after it is updated."""
         if "roles" in validated_data:

--- a/rbac/api/cross_access/view.py
+++ b/rbac/api/cross_access/view.py
@@ -72,7 +72,7 @@ class CrossAccountRequestViewSet(
     mixins.ListModelMixin,
     mixins.RetrieveModelMixin,
     mixins.UpdateModelMixin,
-    viewsets.GenericViewSet
+    viewsets.GenericViewSet,
 ):
     """Cross Account Request view set.
 
@@ -119,7 +119,7 @@ class CrossAccountRequestViewSet(
             if field not in VALID_PATCH_FIELDS:
                 self.throw_validation_error(
                     "cross-accont partial update",
-                    f"Field '{field}' is not supported. Please use one or more of: {VALID_PATCH_FIELDS}"
+                    f"Field '{field}' is not supported. Please use one or more of: {VALID_PATCH_FIELDS}",
                 )
 
         with tenant_context(Tenant.objects.get(schema_name="public")):
@@ -220,8 +220,7 @@ class CrossAccountRequestViewSet(
                 Tenant.objects.get(schema_name=tenant_schema_name)
             except Tenant.DoesNotExist:
                 raise self.throw_validation_error(
-                    "cross-account-request",
-                    f"Account '{target_account}' does not exist."
+                    "cross-account-request", f"Account '{target_account}' does not exist."
                 )
 
         request_data["user_id"] = self.request.user.user_id
@@ -246,8 +245,7 @@ class CrossAccountRequestViewSet(
                 role = Role.objects.get(display_name=role_name)
                 if not role.system:
                     self.throw_validation_error(
-                        "cross-account-request",
-                        "Only system roles may be assigned to a cross-account-request."
+                        "cross-account-request", "Only system roles may be assigned to a cross-account-request."
                     )
             except Role.DoesNotExist:
                 raise self.throw_validation_error("cross-account-request", f"Role '{role_name}' does not exist.")

--- a/rbac/api/cross_access/view.py
+++ b/rbac/api/cross_access/view.py
@@ -16,17 +16,14 @@
 #
 
 """View for cross access request."""
-from datetime import datetime, timedelta
 
-import pytz
-from django.db.models.query import QuerySet
 from django.utils import timezone
-from django.utils.translation import gettext as _
 from django_filters import rest_framework as filters
 from management.models import Principal, Role
 from management.principal.proxy import PrincipalProxy
 from management.utils import validate_and_get_key, validate_limit_and_offset, validate_uuid
-from rest_framework import mixins, serializers, viewsets
+from rest_framework import mixins, viewsets
+from rest_framework import status as http_status
 from rest_framework.response import Response
 from rest_framework.serializers import ValidationError
 from tenant_schemas.utils import tenant_context
@@ -101,9 +98,8 @@ class CrossAccountRequestViewSet(
 
     def create(self, request, *args, **kwargs):
         """Create cross account requests for associate."""
-        self.validate_and_get_input_for_creation(request.data)
-
         with tenant_context(Tenant.objects.get(schema_name="public")):
+            self.validate_and_format_input(request.data)
             return super().create(request=request, args=args, kwargs=kwargs)
 
     def list(self, request, *args, **kwargs):
@@ -119,35 +115,28 @@ class CrossAccountRequestViewSet(
     def partial_update(self, request, *args, **kwargs):
         """Patch a cross-account request."""
         validate_uuid(kwargs.get("pk"), "cross-account request uuid validation")
-        payload = request.data
-        for field in payload:
+        for field in request.data:
             if field not in VALID_PATCH_FIELDS:
-                key = "cross-account request"
-                message = f"Field '{field}' is not supported. Please use one or more of: {VALID_PATCH_FIELDS}."
-                error = {key: [_(message)]}
-                raise serializers.ValidationError(error)
+                self.throw_validation_error(
+                    "cross-accont partial update",
+                    f"Field '{field}' is not supported. Please use one or more of: {VALID_PATCH_FIELDS}"
+                )
 
         with tenant_context(Tenant.objects.get(schema_name="public")):
             current = self.get_object()
-            update_data = {
-                "start_date": request.data.get("start_date", current.start_date),
-                "end_date": request.data.get("end_date", current.end_date),
-                "roles": request.data.get("roles", current.roles.all()),
-                "status": request.data.get("status", current.status),
-            }
-            # Todo: This function is pretty messy, and basically just a rehash of the create version,
-            #       can likely clean it up and maybe provide a partial flag
-            self.validate_and_get_input_for_update(update_data)
 
-            if current.status == "expired":
-                update_data["target_account"] = current.target_account
-                if isinstance(update_data.get("roles"), QuerySet):
-                    update_data["roles"] = [role.display_name for role in update_data.get("roles")]
-                request.data.update(update_data)
-                return super().create(request=request, args=args, kwargs=kwargs)
+            if current.status != "pending":
+                self.throw_validation_error("cross-account partial update", "Only pending requests may be updated.")
 
-            self.update_cross_account_request(current, update_data)
-            return Response(CrossAccountRequestDetailSerializer(current).data)
+            self.validate_and_format_input(request.data)
+
+            kwargs["partial"] = True
+            response = super().update(request=request, *args, **kwargs)
+            if response.status_code and response.status_code is http_status.HTTP_200_OK:
+                if request.data.get("status"):
+                    self.update_status(current, request.data.get("status"))
+                    return Response(CrossAccountRequestDetailSerializer(current).data)
+            return response
 
     def update(self, request, *args, **kwargs):
         """Update a cross-account request."""
@@ -155,14 +144,19 @@ class CrossAccountRequestViewSet(
 
         with tenant_context(Tenant.objects.get(schema_name="public")):
             current = self.get_object()
+            if current.status != "pending":
+                self.throw_validation_error("cross-account update", "Only pending requests may be updated.")
+            if "target_account" in request.data and str(request.data.get("target_account")) != current.target_account:
+                self.throw_validation_error("cross-account-update", "Target account may not be updated.")
 
-            self.validate_and_get_input_for_creation(request.data)
+            self.validate_and_format_input(request.data)
 
-            if current.status == "expired":
-                return super().create(request=request, args=args, kwargs=kwargs)
-
-            self.update_cross_account_request(current, request.data)
-            return Response(CrossAccountRequestDetailSerializer(current).data)
+            response = super().update(request=request, args=args, kwargs=kwargs)
+            if response.status_code and response.status_code is http_status.HTTP_200_OK:
+                if request.data.get("status"):
+                    self.update_status(current, request.data.get("status"))
+                    return Response(CrossAccountRequestDetailSerializer(current).data)
+            return response
 
     def retrieve(self, request, *args, **kwargs):
         """Retrive cross account requests by request_id."""
@@ -216,63 +210,24 @@ class CrossAccountRequestViewSet(
         error = {source: [message]}
         raise ValidationError(error)
 
-    def update_cross_account_request(self, car, update_data):
-        """Update cross-account-request with list of role names."""
-        if car.status == "pending" and update_data.get("status").lower() == "approved":
-            # create_principal_for_approved_request()
-            pass
-        for field in update_data:
-            if field == "roles":
-                car.roles.clear()
-                for role in update_data.get("roles"):
-                    car.roles.add(Role.objects.get(display_name=role.get("display_name")))
-                car.save()
-                continue
-            setattr(car, field, update_data.get(field))
-        car.save()
-
-    def validate_and_get_input_for_creation(self, request_data):
+    def validate_and_format_input(self, request_data, partial=False):
         """Validate the create api input."""
         target_account = request_data.get("target_account")
-        start_date = request_data.get("start_date")
-        end_date = request_data.get("end_date")
-        roles = request_data.get("roles")
-        if None in [target_account, start_date, end_date, roles]:
-            self.throw_validation_error("cross-account-create", f"{PARAMS_FOR_CREATION} must be all specified.")
 
-        try:
-            start_date = datetime.strptime(start_date, "%m/%d/%Y")
-            end_date = datetime.strptime(end_date, "%m/%d/%Y")
-        except ValueError:
-            raise self.throw_validation_error(
-                "cross-account-create", "start_date or end_date does not match format: '%m/%d/%Y'."
-            )
+        if target_account:
+            try:
+                tenant_schema_name = create_schema_name(target_account)
+                Tenant.objects.get(schema_name=tenant_schema_name)
+            except Tenant.DoesNotExist:
+                raise self.throw_validation_error(
+                    "cross-account-request",
+                    f"Account '{target_account}' does not exist."
+                )
 
-        if start_date > (datetime.now() + timedelta(60)):
-            raise self.throw_validation_error("cross-account-create", "Start date must be within 60 days of today.")
-
-        if end_date - start_date > timedelta(365):
-            raise self.throw_validation_error(
-                "cross-account-create", "Access duration may not be longer than one year."
-            )
-
-        with tenant_context(Tenant.objects.get(schema_name="public")):
-            for role in roles:
-                try:
-                    Role.objects.get(display_name=role)
-                except Role.DoesNotExist:
-                    raise self.throw_validation_error("cross-account-create", f"Role '{role}' does not exist.")
-
-        try:
-            tenant_schema_name = create_schema_name(target_account)
-            Tenant.objects.get(schema_name=tenant_schema_name)
-        except Tenant.DoesNotExist:
-            raise self.throw_validation_error("cross-account-create", f"Account '{target_account}' does not exist.")
-
-        request_data["start_date"] = start_date
-        request_data["end_date"] = end_date
         request_data["user_id"] = self.request.user.user_id
-        request_data["roles"] = [{"display_name": role} for role in roles]
+        if "roles" in request_data:
+            with tenant_context(Tenant.objects.get(schema_name="public")):
+                request_data["roles"] = self.format_roles(request_data.get("roles"))
 
     def create_principal(self, target_account, user_id):
         """Create a cross account principal in the target account."""
@@ -284,51 +239,24 @@ class CrossAccountRequestViewSet(
 
         return cross_account_principal
 
-    def validate_and_get_input_for_update(self, request_data):
-        """Validate the update api input."""
-        target_account = request_data.get("target_account")
-        start_date = request_data.get("start_date")
-        end_date = request_data.get("end_date")
-        roles = request_data.get("roles")
-
-        try:
-            if start_date and isinstance(start_date, str):
-                start_date = pytz.utc.localize(datetime.strptime(start_date, "%m/%d/%Y"))
-            if end_date and isinstance(end_date, str):
-                end_date = pytz.utc.localize(datetime.strptime(end_date, "%m/%d/%Y"))
-        except ValueError:
-            raise self.throw_validation_error(
-                "cross-account-update", "start_date or end_date does not match format: '%m/%d/%Y'."
-            )
-
-        if start_date and start_date > pytz.utc.localize(datetime.now() + timedelta(60)):
-            raise self.throw_validation_error("cross-account-update", "Start date must be within 60 days of today.")
-
-        if end_date and start_date and (end_date - start_date) > timedelta(365):
-            raise self.throw_validation_error(
-                "cross-account-update", "Access duration may not be longer than one year."
-            )
-
-        if isinstance(roles, QuerySet):
-            roles = [role.display_name for role in roles]
-
-        if roles:
-            with tenant_context(Tenant.objects.get(schema_name="public")):
-                for role in roles:
-                    try:
-                        Role.objects.get(display_name=role)
-                    except Role.DoesNotExist:
-                        raise self.throw_validation_error("cross-account-update", f"Role '{role}' does not exist.")
-
-        if target_account:
+    def format_roles(self, roles):
+        """Format role list as expected for cross-account-request."""
+        for role_name in roles:
             try:
-                tenant_schema_name = create_schema_name(target_account)
-                Tenant.objects.get(schema_name=tenant_schema_name)
-            except Tenant.DoesNotExist:
-                raise self.throw_validation_error("cross-account-update", f"Account '{target_account}' does not exist.")
+                role = Role.objects.get(display_name=role_name)
+                if not role.system:
+                    self.throw_validation_error(
+                        "cross-account-request",
+                        "Only system roles may be assigned to a cross-account-request."
+                    )
+            except Role.DoesNotExist:
+                raise self.throw_validation_error("cross-account-request", f"Role '{role_name}' does not exist.")
 
-        request_data["start_date"] = start_date
-        request_data["end_date"] = end_date
-        request_data["user_id"] = self.request.user.user_id
-        if roles:
-            request_data["roles"] = [{"display_name": role} for role in roles]
+        return [{"display_name": role} for role in roles]
+
+    def update_status(self, car, status):
+        """Update the status of a cross-account-request."""
+        car.status = status
+        if status == "approved":
+            self.create_principal(car.target_account, car.user_id)
+        car.save()

--- a/tests/api/cross_access/test_view.py
+++ b/tests/api/cross_access/test_view.py
@@ -392,7 +392,8 @@ class CrossAccountRequestViewTests(IdentityRequest):
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(
-            response.data.get("errors")[0].get("detail"), "Role 'role_2' is not canned role and could not be assigned."
+            response.data.get("errors")[0].get("detail"),
+            "Only system roles may be assigned to a cross-account-request.",
         )
 
     def test_create_requests_fail_for_over_60_day_start_date(self):

--- a/tests/api/cross_access/test_view.py
+++ b/tests/api/cross_access/test_view.py
@@ -31,6 +31,7 @@ from tests.identity_request import IdentityRequest
 
 URL_LIST = reverse("cross-list")
 
+
 class CrossAccountRequestViewTests(IdentityRequest):
     """Test the cross account request view."""
 
@@ -98,7 +99,7 @@ class CrossAccountRequestViewTests(IdentityRequest):
                 target_account=self.another_account,
                 user_id="2222222",
                 end_date=self.ref_time + timedelta(10),
-                status="pending"
+                status="pending",
             )
             self.request_5 = CrossAccountRequest.objects.create(
                 target_account=self.account,
@@ -399,12 +400,7 @@ class CrossAccountRequestViewTests(IdentityRequest):
         url = reverse("cross-detail", kwargs={"pk": str(car_uuid)})
 
         client = APIClient()
-        response = client.put(
-            url,
-            self.data4create,
-            format="json",
-            **self.associate_admin_request.META
-        )
+        response = client.put(url, self.data4create, format="json", **self.associate_admin_request.META)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         for field in self.data4create:
@@ -422,13 +418,8 @@ class CrossAccountRequestViewTests(IdentityRequest):
         url = reverse("cross-detail", kwargs={"pk": car_uuid})
 
         client = APIClient()
-        response = client.put(
-            url,
-            self.data4create,
-            format="json",
-            **self.associate_admin_request.META
-        )
-        
+        response = client.put(url, self.data4create, format="json", **self.associate_admin_request.META)
+
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_update_request_expired(self):
@@ -439,70 +430,44 @@ class CrossAccountRequestViewTests(IdentityRequest):
         url = reverse("cross-detail", kwargs={"pk": car_uuid})
 
         client = APIClient()
-        response = client.put(
-            url,
-            self.data4create,
-            format="json",
-            **self.associate_admin_request.META
-        )
-        
+        response = client.put(url, self.data4create, format="json", **self.associate_admin_request.META)
+
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-    
+
     def test_partial_update_success(self):
         """Test updating part of a CAR."""
-        update_data = {
-            "start_date": self.format_date(self.ref_time + timedelta(2))
-        }
+        update_data = {"start_date": self.format_date(self.ref_time + timedelta(2))}
 
         car_uuid = self.request_2.request_id
         url = reverse("cross-detail", kwargs={"pk": str(car_uuid)})
 
         client = APIClient()
-        response = client.patch(
-            url,
-            update_data,
-            format="json",
-            **self.associate_admin_request.META
-        )
+        response = client.patch(url, update_data, format="json", **self.associate_admin_request.META)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get("start_date"), update_data.get("start_date"))
 
     def test_partial_update_fail_invalid_field(self):
         """Test that updating protected fields of a CAR fails."""
-        update_data = {
-            "target_account": "123456"
-        }
+        update_data = {"target_account": "123456"}
 
         car_uuid = self.request_1.request_id
         url = reverse("cross-detail", kwargs={"pk": str(car_uuid)})
 
         client = APIClient()
-        response = client.patch(
-            url,
-            update_data,
-            format="json",
-            **self.associate_admin_request.META
-        )
+        response = client.patch(url, update_data, format="json", **self.associate_admin_request.META)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_partial_update_expired(self):
         """Test that PATCHing an expired CAR fails."""
-        update_data = {
-            "end_date": self.format_date(self.ref_time + timedelta(18))
-        }
+        update_data = {"end_date": self.format_date(self.ref_time + timedelta(18))}
 
         car_uuid = self.request_5.request_id
         url = reverse("cross-detail", kwargs={"pk": car_uuid})
 
         client = APIClient()
-        response = client.patch(
-            url,
-            update_data,
-            format="json",
-            **self.associate_admin_request.META
-        )
-        
+        response = client.patch(url, update_data, format="json", **self.associate_admin_request.META)
+
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_update_bmi(self):
@@ -513,32 +478,19 @@ class CrossAccountRequestViewTests(IdentityRequest):
         url = reverse("cross-detail", kwargs={"pk": car_uuid})
 
         client = APIClient()
-        response = client.put(
-            url,
-            self.data4create,
-            format="json",
-            **self.associate_admin_request.META
-        )
-        
+        response = client.put(url, self.data4create, format="json", **self.associate_admin_request.META)
+
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_partial_update_bmi(self):
         """Test that PATCH with extra fields in body fails."""
-        update_data = {
-            "start_date": self.format_date(self.ref_time + timedelta(2)),
-            "cup": "cake"
-        }
+        update_data = {"start_date": self.format_date(self.ref_time + timedelta(2)), "cup": "cake"}
 
         car_uuid = self.request_1.request_id
         url = reverse("cross-detail", kwargs={"pk": str(car_uuid)})
 
         client = APIClient()
-        response = client.patch(
-            url,
-            update_data,
-            format="json",
-            **self.associate_admin_request.META
-        )
+        response = client.patch(url, update_data, format="json", **self.associate_admin_request.META)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_update_bad_date_spec(self):
@@ -549,56 +501,34 @@ class CrossAccountRequestViewTests(IdentityRequest):
         url = reverse("cross-detail", kwargs={"pk": car_uuid})
 
         client = APIClient()
-        response = client.put(
-            url,
-            self.data4create,
-            format="json",
-            **self.associate_admin_request.META
-        )
-        
+        response = client.put(url, self.data4create, format="json", **self.associate_admin_request.META)
+
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_partial_update_bad_date_spec(self):
         """Test that PATCH with body fields not matching spec fails."""
-        update_data = {
-            "start_date": 12252021
-        }
+        update_data = {"start_date": 12252021}
 
         car_uuid = self.request_1.request_id
         url = reverse("cross-detail", kwargs={"pk": str(car_uuid)})
 
         client = APIClient()
-        response = client.patch(
-            url,
-            update_data,
-            format="json",
-            **self.associate_admin_request.META
-        )
+        response = client.patch(url, update_data, format="json", **self.associate_admin_request.META)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_update_bad_uuid(self):
         """Test that update endpoints reject invalid UUIDs."""
         bad_uuids = [
-            "imateapot!", # Not even close
-            str(self.request_5.request_id).replace("-", ""), # Malformed but valid UUID
-            "7g895hq3-6204-43e6-9g4c-20de5f61e021", # Non-hex values in UUID
-            None
+            "imateapot!",  # Not even close
+            str(self.request_5.request_id).replace("-", ""),  # Malformed but valid UUID
+            "7g895hq3-6204-43e6-9g4c-20de5f61e021",  # Non-hex values in UUID
+            None,
         ]
 
         client = APIClient()
         for bad_uuid in bad_uuids:
             url = reverse("cross-detail", kwargs={"pk": bad_uuid})
-            response = client.put(
-                url,
-                self.data4create,
-                format="json",
-                **self.associate_admin_request.META
-            )
+            response = client.put(url, self.data4create, format="json", **self.associate_admin_request.META)
             self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-            response = client.patch(
-                url,
-                self.data4create,
-                format="json",
-                **self.associate_admin_request.META
-            )
+            response = client.patch(url, self.data4create, format="json", **self.associate_admin_request.META)
             self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
Signed-off-by: Chris Mitchell <cmitchel@redhat.com>

## Link(s) to Jira
- https://issues.redhat.com/browse/RHCLOUD-8882

## Description of Intent of Change(s)
Adds PUT and PATCH handlers for updating cross-account requests

## Local Testing
tox will run the unit tests written to try the new endpoints

Outside of that, pulling down the branch and running `make serve` as usual should allow for creation and updating of cross account requests. PUT or PATCH requests to [...]/rbac/v1/cross-account-requests/[uuid]/ will update allowed fields.

NB: Updating an expired request will instead create a new request for the requested account/roles/timeline


## Checklist
- [ ] if API spec changes are required, is the spec updated?
- Spec update to come
- [ ] are there any pre/post merge actions required? if so, document here.
- [x] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  -  if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [x] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [x] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
