### PR TITLE
Add templates from saas-templates here

### DIFF
--- a/templates/_imagestreams.yaml
+++ b/templates/_imagestreams.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+items:
+- apiVersion: image.openshift.io/v1
+  kind: ImageStream
+  metadata:
+    name: postgresql-96
+  spec:
+    lookupPolicy:
+      local: false
+    tags:
+    - from:
+        kind: DockerImage
+        name: registry.redhat.io/rhel8/postgresql-96
+      importPolicy:
+        scheduled: false
+      name: latest
+      referencePolicy:
+        type: Source
+- apiVersion: image.openshift.io/v1
+  kind: ImageStream
+  metadata:
+    name: redis
+  spec:
+    lookupPolicy:
+      local: false
+    tags:
+    - from:
+        kind: DockerImage
+        name: quay.io/cloudservices/redis
+      importPolicy:
+        scheduled: false
+      name: latest
+      referencePolicy:
+        type: Source
+kind: List

--- a/templates/config-sync.yaml
+++ b/templates/config-sync.yaml
@@ -1,0 +1,174 @@
+apiVersion: v1
+kind: Template
+labels:
+  app: rbac
+  template: rbac-config-sync
+metadata:
+  annotations:
+    description: Component to sync from config repo and create config map for service
+      to consume
+    iconClass: icon-python
+    openshift.io/display-name: RBAC
+    openshift.io/documentation-url: https://insight-rbac.readthedocs.io/en/latest/
+    openshift.io/long-description: This template defines resources needed to run the
+      RBAC application, including a build configuration, application deployment configuration,
+      and database deployment configuration.
+    openshift.io/provider-display-name: Red Hat, Inc.
+    tags: python,flask
+  name: rbac-config-sync
+objects:
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    labels:
+      app: ${NAME}
+    name: ${JOB_NAME}
+  spec:
+    minReadySeconds: 15
+    progressDeadlineSeconds: 600
+    replicas: ${{REPLICAS}}
+    revisionHistoryLimit: 9
+    selector:
+      matchLabels:
+        name: ${JOB_NAME}
+    strategy:
+      type: Recreate
+    template:
+      metadata:
+        labels:
+          app: ${NAME}
+          name: ${JOB_NAME}
+        name: ${JOB_NAME}
+      spec:
+        affinity:
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                    - ${NAME}
+                topologyKey: failure-domain.beta.kubernetes.io/zone
+              weight: 100
+            - podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                    - ${NAME}
+                topologyKey: kubernetes.io/hostname
+              weight: 99
+        containers:
+        - command:
+          - /bin/bash
+          - -c
+          - "while [ true ] ; do\n  repo_changes=false\n  cd /data\n  if [ ! -d config_repo\
+            \ ]; then \n    git clone -b ${CONFIG_SOURCE_REPOSITORY_REF} --single-branch\
+            \ ${CONFIG_SOURCE_REPOSITORY_URL} config_repo\n    repo_changes=true\n\
+            \  fi\n\n  cd config_repo\n  git fetch > change_log.txt 2>&1\n  git reset\
+            \ --hard FETCH_HEAD\n  if [ -s change_log.txt ]; then\n    repo_changes=true\n\
+            \  fi\n\n  if $repo_changes; then\n    oc create configmap ${CONFIG_MAP_NAME}\
+            \ --from-file=configs/roles --dry-run -o json | oc apply -f -\n    oc\
+            \ create configmap ${MODEL_ACCESS_PERMISSIONS} --from-file=configs/permissions\
+            \ --dry-run -o json | oc apply -f -\n    oc rollout latest dc/${NAME}\n\
+            \  fi\n  sleep 1d\ndone\n"
+          env:
+          - name: GIT_COMMITTER_NAME
+            value: rbac
+          - name: GIT_COMMITTER_EMAIL
+            value: nobody@redhat.com
+          - name: NAME
+            value: ${NAME}
+          - name: CONFIG_SOURCE_REPOSITORY_REF
+            value: ${CONFIG_SOURCE_REPOSITORY_REF}
+          - name: CONFIG_SOURCE_REPOSITORY_URL
+            value: ${CONFIG_SOURCE_REPOSITORY_URL}
+          - name: CONFIG_MAP_NAME
+            value: ${CONFIG_MAP_NAME}
+          image: quay.io/cloudservices/rbac-config-cronjob:${IMAGE_TAG}
+          name: ${JOB_NAME}
+          resources:
+            limits:
+              cpu: 200m
+              memory: 200Mi
+            requests:
+              cpu: 100m
+              memory: 100Mi
+          volumeMounts:
+          - mountPath: /data
+            name: config-repo
+        imagePullSecrets:
+        - name: quay-cloudservices-pull
+        - name: rh-registry-pull
+        serviceAccountName: ${JOB_NAME}
+        volumes:
+        - name: config-repo
+          persistentVolumeClaim:
+            claimName: ${CLAIM_NAME}
+- apiVersion: v1
+  kind: PersistentVolumeClaim
+  metadata:
+    name: ${CLAIM_NAME}
+  spec:
+    accessModes:
+    - ReadWriteOnce
+    resources:
+      requests:
+        storage: 20Mi
+- apiVersion: v1
+  imagePullSecrets:
+  - name: quay-cloudservices-pull
+  kind: ServiceAccount
+  metadata:
+    name: ${JOB_NAME}
+  secrets:
+  - name: quay-cloudservices-pull
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: RoleBinding
+  metadata:
+    name: ${JOB_NAME}
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: edit
+  subjects:
+  - kind: ServiceAccount
+    name: ${JOB_NAME}
+parameters:
+- description: The name assigned to all frontend objects defined in this template.
+  displayName: Name
+  name: NAME
+  required: true
+  value: rbac
+- description: The URL of the repository for rbac config
+  displayName: Git Repository URL
+  name: CONFIG_SOURCE_REPOSITORY_URL
+  required: true
+  value: https://github.com/RedHatInsights/rbac-config.git
+- description: Set this to a branch name, tag or other ref of your repository if you
+    are not using the default branch.
+  displayName: Git Reference
+  name: CONFIG_SOURCE_REPOSITORY_REF
+  value: master
+- description: Name of the Scheduled Job to sync from rbac-config repo. A service
+    account is created specifically for this job
+  displayName: Job Name
+  name: JOB_NAME
+  value: rbac-config-sync
+- description: Name of the rbac-config config map
+  name: CONFIG_MAP_NAME
+  value: rbac-config
+- description: Name of the predefined access permissions config map
+  name: MODEL_ACCESS_PERMISSIONS
+  value: model-access-permissions
+- name: CLAIM_NAME
+  value: config-repo-pv-claim
+- description: The number of replicas to use for the prometheus deployment
+  name: REPLICAS
+  value: '1'
+- description: Image tag
+  name: IMAGE_TAG
+  required: true

--- a/templates/rbac-pgsql.yaml
+++ b/templates/rbac-pgsql.yaml
@@ -1,0 +1,196 @@
+apiVersion: v1
+kind: Template
+labels:
+  app: rbac
+  template: rbac
+metadata:
+  annotations:
+    description: Role Based Access Control powered by Django+PostgreSQL
+    iconClass: icon-python
+    openshift.io/display-name: rbac-pgsql
+    openshift.io/documentation-url: https://insight-rbac.readthedocs.io/en/latest/
+    openshift.io/long-description: This template defines resources needed to run the
+      RBAC application database
+    openshift.io/provider-display-name: Red Hat, Inc.
+    tags: quickstart,python,django,postgresql
+  name: rbac
+objects:
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    labels:
+      app: rbac
+      template: rbac
+    name: rbac-pgsql
+  spec:
+    minReadySeconds: 15
+    progressDeadlineSeconds: 600
+    replicas: ${{DB_REPLICAS}}
+    revisionHistoryLimit: 9
+    selector:
+      matchLabels:
+        name: rbac-pgsql
+    strategy:
+      type: Recreate
+    template:
+      metadata:
+        labels:
+          app: rbac
+          name: rbac-pgsql
+          template: rbac
+        name: rbac-pgsql
+      spec:
+        affinity:
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                    - rbac
+                  - key: template
+                    operator: In
+                    values:
+                    - rbac
+                topologyKey: failure-domain.beta.kubernetes.io/zone
+              weight: 100
+            - podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                    - rbac
+                  - key: template
+                    operator: In
+                    values:
+                    - rbac
+                topologyKey: kubernetes.io/hostname
+              weight: 99
+        containers:
+        - env:
+          - name: POSTGRESQL_USER
+            valueFrom:
+              secretKeyRef:
+                key: db.user
+                name: ${DB_SECRET_NAME}
+          - name: POSTGRESQL_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                key: db.password
+                name: ${DB_SECRET_NAME}
+          - name: POSTGRESQL_DATABASE
+            valueFrom:
+              secretKeyRef:
+                key: db.name
+                name: ${DB_SECRET_NAME}
+          image: registry.redhat.io/rhel8/postgresql-96
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            exec:
+              command:
+              - /usr/libexec/check-container
+              - --live
+            failureThreshold: 3
+            initialDelaySeconds: 120
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 10
+          name: rbac-pgsql
+          ports:
+          - containerPort: 5432
+            protocol: TCP
+          readinessProbe:
+            exec:
+              command:
+              - /usr/libexec/check-container
+            failureThreshold: 3
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: ${CPU_LIMIT}
+              memory: ${MEMORY_LIMIT}
+            requests:
+              cpu: ${CPU_REQUEST}
+              memory: ${MEMORY_REQUEST}
+          volumeMounts:
+          - mountPath: /var/lib/pgsql/data
+            name: rbac-pgsql-data
+        imagePullSecrets:
+        - name: quay-cloudservices-pull
+        - name: rh-registry-pull
+        volumes:
+        - name: rbac-pgsql-data
+          persistentVolumeClaim:
+            claimName: rbac-pgsql
+- apiVersion: v1
+  kind: PersistentVolumeClaim
+  metadata:
+    labels:
+      app: rbac
+      template: rbac
+    name: rbac-pgsql
+  spec:
+    accessModes:
+    - ReadWriteOnce
+    resources:
+      requests:
+        storage: ${VOLUME_CAPACITY}
+- apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+      description: Exposes the database server
+    labels:
+      app: rbac
+      template: rbac
+    name: rbac-pgsql
+  spec:
+    ports:
+    - name: rbac-pgsql
+      port: 5432
+      protocol: TCP
+      targetPort: 5432
+    selector:
+      name: ${SERVICE_DEPENDENCY_NAME}
+parameters:
+- description: Initial amount of memory
+  displayName: Memory Request
+  name: MEMORY_REQUEST
+  required: true
+  value: 512Mi
+- description: Maximum amount of memory
+  displayName: Memory Limit
+  name: MEMORY_LIMIT
+  required: true
+  value: 1Gi
+- description: Initial amount of cpu
+  displayName: CPU Request
+  name: CPU_REQUEST
+  required: true
+  value: 300m
+- description: Maximum amount of cpu
+  displayName: CPU Limit
+  name: CPU_LIMIT
+  required: true
+  value: '1'
+- description: Volume space available for data, e.g. 512Mi, 2Gi
+  displayName: Volume Capacity
+  name: VOLUME_CAPACITY
+  required: true
+  value: 1Gi
+- displayName: Service Dependency Name
+  name: SERVICE_DEPENDENCY_NAME
+  value: rbac-pgsql
+- description: The number of replicas to be used by the DB
+  displayName: DB Replicas
+  name: DB_REPLICAS
+  value: '0'
+- description: Name of DB secret
+  name: DB_SECRET_NAME
+  value: rbac-db

--- a/templates/rbac.yaml
+++ b/templates/rbac.yaml
@@ -1,0 +1,441 @@
+apiVersion: v1
+kind: Template
+labels:
+  app: rbac
+  template: rbac
+metadata:
+  annotations:
+    description: Role Based Access Control powered by Django+PostgreSQL
+    iconClass: icon-python
+    openshift.io/display-name: RBAC
+    openshift.io/documentation-url: https://insight-rbac.readthedocs.io/en/latest/
+    openshift.io/long-description: This template defines resources needed to run the
+      RBAC application
+    openshift.io/provider-display-name: Red Hat, Inc.
+    tags: quickstart,python,django,postgresql
+  name: rbac
+objects:
+- apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+      description: Exposes and load balances the application pods
+      prometheus.io/path: /metrics
+      prometheus.io/port: '8080'
+      prometheus.io/scrape: 'true'
+      service.alpha.openshift.io/dependencies: '[{"name": "${SERVICE_DEPENDENCY_NAME}",
+        "kind": "Service"}]'
+    name: rbac
+  spec:
+    ports:
+    - name: 8080-tcp
+      port: 8080
+      protocol: TCP
+      targetPort: 8080
+    selector:
+      name: rbac
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    labels: {}
+    name: rbac
+  spec:
+    minReadySeconds: 15
+    progressDeadlineSeconds: 600
+    replicas: ${{MIN_REPLICAS}}
+    revisionHistoryLimit: 9
+    selector:
+      matchLabels:
+        name: rbac
+    strategy:
+      rollingUpdate:
+        maxSurge: 25%
+        maxUnavailable: 25%
+      type: RollingUpdate
+    template:
+      metadata:
+        labels:
+          name: rbac
+        name: rbac
+      spec:
+        affinity:
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                  - key: name
+                    operator: In
+                    values:
+                    - rbac
+                topologyKey: failure-domain.beta.kubernetes.io/zone
+              weight: 100
+            - podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                  - key: name
+                    operator: In
+                    values:
+                    - rbac
+                topologyKey: kubernetes.io/hostname
+              weight: 99
+        containers:
+        - env:
+          - name: REDIS_HOST
+            valueFrom:
+              configMapKeyRef:
+                key: redis-service-host
+                name: redis-config
+          - name: REDIS_PORT
+            valueFrom:
+              configMapKeyRef:
+                key: redis-service-port
+                name: redis-config
+          - name: SERVICE_PSKS
+            valueFrom:
+              secretKeyRef:
+                key: psks.json
+                name: ${RBAC_PSKS}
+                optional: false
+          - name: DATABASE_HOST
+            valueFrom:
+              secretKeyRef:
+                key: db.host
+                name: ${DB_SECRET_NAME}
+                optional: false
+          - name: DATABASE_PORT
+            valueFrom:
+              secretKeyRef:
+                key: db.port
+                name: ${DB_SECRET_NAME}
+          - name: DATABASE_NAME
+            valueFrom:
+              secretKeyRef:
+                key: db.name
+                name: ${DB_SECRET_NAME}
+                optional: false
+          - name: DATABASE_USER
+            valueFrom:
+              secretKeyRef:
+                key: db.user
+                name: ${DB_SECRET_NAME}
+                optional: false
+          - name: DATABASE_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                key: db.password
+                name: ${DB_SECRET_NAME}
+                optional: false
+          - name: PGSSLMODE
+            value: ${PGSSLMODE}
+          - name: PGSSLROOTCERT
+            value: /etc/rds-certs/rds-cacert
+          - name: DJANGO_SECRET_KEY
+            valueFrom:
+              secretKeyRef:
+                key: django-secret-key
+                name: rbac-secret
+                optional: false
+          - name: PRINCIPAL_PROXY_SERVICE_PROTOCOL
+            valueFrom:
+              secretKeyRef:
+                key: principal-proxy-protocol
+                name: rbac-secret
+                optional: false
+          - name: PRINCIPAL_PROXY_SERVICE_HOST
+            valueFrom:
+              secretKeyRef:
+                key: principal-proxy-host
+                name: rbac-secret
+                optional: false
+          - name: PRINCIPAL_PROXY_SERVICE_PORT
+            valueFrom:
+              secretKeyRef:
+                key: principal-proxy-port
+                name: rbac-secret
+                optional: false
+          - name: PRINCIPAL_PROXY_SERVICE_PATH
+            value: ''
+          - name: PRINCIPAL_PROXY_USER_ENV
+            valueFrom:
+              secretKeyRef:
+                key: principal-proxy-env
+                name: rbac-secret
+                optional: false
+          - name: PRINCIPAL_PROXY_CLIENT_ID
+            valueFrom:
+              secretKeyRef:
+                key: principal-proxy-client-id
+                name: rbac-secret
+                optional: false
+          - name: PRINCIPAL_PROXY_API_TOKEN
+            valueFrom:
+              secretKeyRef:
+                key: principal-proxy-api-token
+                name: rbac-secret
+                optional: false
+          - name: PRINCIPAL_PROXY_SERVICE_SSL_VERIFY
+            valueFrom:
+              secretKeyRef:
+                key: principal-proxy-ssl-verify
+                name: rbac-secret
+                optional: true
+          - name: PRINCIPAL_PROXY_SERVICE_SOURCE_CERT
+            valueFrom:
+              secretKeyRef:
+                key: principal-proxy-source-cert
+                name: rbac-secret
+                optional: true
+          - name: POD_CPU_LIMIT
+            valueFrom:
+              resourceFieldRef:
+                containerName: rbac
+                resource: limits.cpu
+          - name: ACCESS_CACHE_ENABLED
+            value: ${ACCESS_CACHE_ENABLED}
+          - name: APP_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: DJANGO_DEBUG
+            value: ${DJANGO_DEBUG}
+          - name: API_PATH_PREFIX
+            value: ${API_PATH_PREFIX}
+          - name: DEVELOPMENT
+            value: ${DEVELOPMENT}
+          - name: RBAC_LOG_LEVEL
+            value: ${RBAC_LOG_LEVEL}
+          - name: DJANGO_LOG_LEVEL
+            value: ${DJANGO_LOG_LEVEL}
+          - name: DJANGO_LOG_FORMATTER
+            value: ${DJANGO_LOG_FORMATTER}
+          - name: DJANGO_LOG_HANDLERS
+            value: ${DJANGO_LOG_HANDLERS}
+          - name: DJANGO_LOG_DIRECTORY
+            value: ${DJANGO_LOG_DIRECTORY}
+          - name: DJANGO_LOGGING_FILE
+            value: ${DJANGO_LOGGING_FILE}
+          - name: PERMISSION_SEEDING_ENABLED
+            value: ${PERMISSION_SEEDING_ENABLED}
+          - name: ROLE_SEEDING_ENABLED
+            value: ${ROLE_SEEDING_ENABLED}
+          - name: GROUP_SEEDING_ENABLED
+            value: ${GROUP_SEEDING_ENABLED}
+          - name: DISABLE_MIGRATE
+            value: ${DISABLE_MIGRATE}
+          - name: BYPASS_BOP_VERIFICATION
+            value: ${BYPASS_BOP_VERIFICATION}
+          - name: ROLE_CREATE_ALLOW_LIST
+            value: ${ROLE_CREATE_ALLOW_LIST}
+          - name: RBAC_DESTRUCTIVE_ENABLED_UNTIL
+            value: ${RBAC_DESTRUCTIVE_ENABLED_UNTIL}
+          - name: TESTING_APPLICATION
+            value: ${TESTING_APPLICATION}
+          - name: HABERDASHER_EMITTER
+            value: ${HABERDASHER_EMITTER}
+          - name: HABERDASHER_KAFKA_BOOTSTRAP
+            value: ${HABERDASHER_KAFKA_BOOTSTRAP}
+          - name: HABERDASHER_KAFKA_TOPIC
+            value: ${HABERDASHER_KAFKA_TOPIC}
+          - name: HABERDASHER_LABELS
+            value: ${HABERDASHER_LABELS}
+          - name: HABERDASHER_TAGS
+            value: ${HABERDASHER_TAGS}
+          - name: CLOWDER_ENABLED
+            value: ${CLOWDER_ENABLED}
+          - name: APP_CONFIG
+            value: /opt/app-root/src/rbac/gunicorn.py
+          - name: APP_HOME
+            value: /opt/app-root/src/rbac
+          - name: APP_MODULE
+            value: rbac.wsgi
+          image: quay.io/cloudservices/rbac:${IMAGE_TAG}
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: ${API_PATH_PREFIX}/v1/status/
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 3
+          name: rbac
+          ports:
+          - containerPort: 8080
+            protocol: TCP
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: ${API_PATH_PREFIX}/v1/status/
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 40
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 3
+          resources:
+            limits:
+              cpu: ${CPU_LIMIT}
+              memory: ${MEMORY_LIMIT}
+            requests:
+              cpu: ${CPU_REQUEST}
+              memory: ${MEMORY_REQUEST}
+          volumeMounts:
+          - mountPath: /opt/app-root/src/rbac/management/role/definitions
+            name: default-role-config
+          - mountPath: /opt/app-root/src/rbac/management/role/permissions
+            name: model-access-permissions
+          - mountPath: /etc/rds-certs
+            name: rds-client-ca
+            readOnly: true
+        imagePullSecrets:
+        - name: quay-cloudservices-pull
+        - name: rh-registry-pull
+        volumes:
+        - configMap:
+            name: ${CONFIG_MAP_NAME}
+          name: default-role-config
+        - configMap:
+            name: ${MODEL_ACCESS_PERMISSIONS}
+          name: model-access-permissions
+        - name: rds-client-ca
+          secret:
+            secretName: rds-client-ca
+- apiVersion: autoscaling/v1
+  kind: HorizontalPodAutoscaler
+  metadata:
+    name: rbac
+  spec:
+    maxReplicas: ${{MAX_REPLICAS}}
+    minReplicas: ${{MIN_REPLICAS}}
+    scaleTargetRef:
+      apiVersion: apps/v1
+      kind: Deployment
+      name: rbac
+    targetCPUUtilizationPercentage: ${{TARGET_CPU_UTILIZATION}}
+parameters:
+- description: Initial amount of memory the Django container will request.
+  displayName: Memory Request
+  name: MEMORY_REQUEST
+  required: true
+  value: 1Gi
+- description: Maximum amount of memory the Django container can use.
+  displayName: Memory Limit
+  name: MEMORY_LIMIT
+  required: true
+  value: 1Gi
+- description: Initial amount of cpu the Django container will request.
+  displayName: CPU Request
+  name: CPU_REQUEST
+  required: true
+  value: 250m
+- description: Maximum amount of cpu the Django container can use.
+  displayName: CPU Limit
+  name: CPU_LIMIT
+  required: true
+  value: 700m
+- displayName: Django debug flag
+  name: DJANGO_DEBUG
+  value: 'False'
+- displayName: RBAC PSKs
+  name: RBAC_PSKS
+  value: rbac-psks
+- displayName: Service Dependency Name
+  name: SERVICE_DEPENDENCY_NAME
+  value: rbac-pgsql
+- displayName: API Prefix Path
+  name: API_PATH_PREFIX
+  value: /api/rbac
+- displayName: Development
+  name: DEVELOPMENT
+  value: 'false'
+- displayName: Rbac log level
+  name: RBAC_LOG_LEVEL
+  value: INFO
+- displayName: Django log level
+  name: DJANGO_LOG_LEVEL
+  value: INFO
+- displayName: Django log formatter
+  name: DJANGO_LOG_FORMATTER
+  value: simple
+- displayName: Django log handlers
+  name: DJANGO_LOG_HANDLERS
+  value: console
+- displayName: Django log directory
+  name: DJANGO_LOG_DIRECTORY
+  required: false
+- displayName: Django logging file
+  name: DJANGO_LOGGING_FILE
+  required: false
+- description: Name of the rbac-config config map
+  name: CONFIG_MAP_NAME
+  value: rbac-config
+- description: Name of the predefined access permissions config map
+  name: MODEL_ACCESS_PERMISSIONS
+  value: model-access-permissions
+- description: minimum number of pods to use when autoscaling is enabled
+  name: MIN_REPLICAS
+  value: '1'
+- description: maximum number of pods to use when autoscaling is enabled
+  name: MAX_REPLICAS
+  value: '1'
+- description: target CPU utilization for the service
+  name: TARGET_CPU_UTILIZATION
+  value: '90'
+- description: 'Options can be found in the doc: https://www.postgresql.org/docs/current/libpq-ssl.html#LIBPQ-SSL-SSLMODE-STATEMENTS'
+  displayName: Postgres SSL mode
+  name: PGSSLMODE
+  value: prefer
+- description: Python boolean value to enable/disable permission seeding on app boot
+  name: PERMISSION_SEEDING_ENABLED
+  value: 'True'
+- description: Python boolean value to enable/disable role seeding on app boot
+  name: ROLE_SEEDING_ENABLED
+  value: 'True'
+- description: Python boolean value to enable/disable group seeding on app boot
+  name: GROUP_SEEDING_ENABLED
+  value: 'True'
+- description: Flag to disable migrations
+  name: DISABLE_MIGRATE
+  value: 'True'
+- description: Enable the RBAC access cache
+  name: ACCESS_CACHE_ENABLED
+  value: 'True'
+- description: Bypass interaction with the BOP service
+  name: BYPASS_BOP_VERIFICATION
+  value: 'False'
+- description: Application allow list for role creation in RBAC
+  name: ROLE_CREATE_ALLOW_LIST
+  value: cost-management,remediations,inventory,drift,policies,advisor,catalog,approval,vulnerability,compliance,automation-analytics,notifications
+- description: Timestamp expiration allowance on destructive actions through the internal
+    RBAC API
+  name: RBAC_DESTRUCTIVE_ENABLED_UNTIL
+  value: ''
+- description: Application name for testing purposes for creating roles
+  name: TESTING_APPLICATION
+  value: ''
+- description: Emitter for haberdasher logs [stderr|kafka]
+  name: HABERDASHER_EMITTER
+  value: stderr
+- description: Bootstrap server for haberdasher kafka emitter
+  name: HABERDASHER_KAFKA_BOOTSTRAP
+  value: ''
+- description: Kafka topic for haberdasher kafka emitter
+  name: HABERDASHER_KAFKA_TOPIC
+  value: ''
+- description: Haberdasher tags for unstrutured logs
+  name: HABERDASHER_TAGS
+  value: '[]'
+- description: Haberdasher labels for unstructured logs
+  name: HABERDASHER_LABELS
+  value: '{}'
+- description: Determines Clowder deployment
+  name: CLOWDER_ENABLED
+  value: 'false'
+- description: Image tag
+  name: IMAGE_TAG
+  required: true
+- description: Name of DB secret
+  name: DB_SECRET_NAME
+  value: rbac-db

--- a/templates/redis.yaml
+++ b/templates/redis.yaml
@@ -1,0 +1,202 @@
+apiVersion: v1
+kind: Template
+labels:
+  app: ${NAME}
+  template: ${NAME}-redis
+metadata:
+  annotations:
+    description: Redis for Role Based Access Control powered by Django+PostgreSQL+Celery
+    iconClass: icon-python
+    openshift.io/display-name: RBAC
+    openshift.io/documentation-url: https://insight-rbac.readthedocs.io/en/latest/
+    openshift.io/long-description: This template defines resources needed to run the
+      RBAC application, including a build configuration, application deployment configuration,
+      and database deployment configuration.
+    openshift.io/provider-display-name: Red Hat, Inc.
+    tags: python,flask
+  name: rbac-redis
+objects:
+- apiVersion: v1
+  data:
+    redis-service-host: ${NAME}-redis
+    redis-service-port: '6379'
+    redis.conf: 'dir /var/lib/redis/data
+
+      '
+  kind: ConfigMap
+  metadata:
+    name: redis-config
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    labels:
+      app: rbac
+      template: rbac
+    name: ${NAME}-redis
+  spec:
+    minReadySeconds: 15
+    progressDeadlineSeconds: 600
+    replicas: ${{REPLICAS}}
+    revisionHistoryLimit: 9
+    selector:
+      matchLabels:
+        name: ${NAME}-redis
+    strategy:
+      type: Recreate
+    template:
+      metadata:
+        labels:
+          app: rbac
+          name: ${NAME}-redis
+          template: rbac-template
+        name: ${NAME}-redis
+      spec:
+        affinity:
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                    - rbac
+                  - key: template
+                    operator: In
+                    values:
+                    - rbac-template
+                topologyKey: failure-domain.beta.kubernetes.io/zone
+              weight: 100
+            - podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                    - rbac
+                  - key: template
+                    operator: In
+                    values:
+                    - rbac-template
+                topologyKey: kubernetes.io/hostname
+              weight: 99
+        containers:
+        - args:
+          - /etc/redis/redis.conf
+          command:
+          - redis-server
+          env: null
+          image: ${IMAGE}:${IMAGE_TAG}
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            exec:
+              command:
+              - redis-cli
+              - ping
+            failureThreshold: 3
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 3
+          name: ${NAME}-redis
+          ports:
+          - containerPort: 6379
+            protocol: TCP
+          readinessProbe:
+            exec:
+              command:
+              - redis-cli
+              - ping
+            failureThreshold: 3
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 3
+          resources:
+            limits:
+              cpu: ${CPU_LIMIT}
+              memory: ${MEMORY_LIMIT}
+            requests:
+              cpu: ${CPU_REQUEST}
+              memory: ${MEMORY_REQUEST}
+          volumeMounts:
+          - mountPath: /var/lib/redis/data
+            name: ${NAME}-redis-data
+          - mountPath: /etc/redis/
+            name: ${NAME}-redis-config
+        imagePullSecrets:
+        - name: quay-cloudservices-pull
+        - name: rh-registry-pull
+        volumes:
+        - name: ${NAME}-redis-data
+          persistentVolumeClaim:
+            claimName: ${NAME}-redis
+        - configMap:
+            name: redis-config
+          name: ${NAME}-redis-config
+- apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+      description: Exposes the redis service
+    labels:
+      app: rbac
+      template: rbac
+    name: ${NAME}-redis
+  spec:
+    ports:
+    - name: ${NAME}-redis
+      port: 6379
+      protocol: TCP
+      targetPort: 6379
+    selector:
+      name: ${NAME}-redis
+- apiVersion: v1
+  kind: PersistentVolumeClaim
+  metadata:
+    name: ${NAME}-redis
+  spec:
+    accessModes:
+    - ReadWriteOnce
+    resources:
+      requests:
+        storage: ${VOLUME_CAPACITY}
+parameters:
+- description: The name assigned to all frontend objects defined in this template.
+  displayName: Name
+  name: NAME
+  required: true
+  value: rbac
+- description: Initial amount of memory the container will request.
+  displayName: Memory Request
+  name: MEMORY_REQUEST
+  required: true
+  value: 1Gi
+- description: Maximum amount of memory the container can use.
+  displayName: Memory Limit
+  name: MEMORY_LIMIT
+  required: true
+  value: 1Gi
+- description: Initial amount of cpu the container will request.
+  displayName: CPU Request
+  name: CPU_REQUEST
+  required: true
+  value: 100m
+- description: Maximum amount of cpu the container can use.
+  displayName: CPU Limit
+  name: CPU_LIMIT
+  required: true
+  value: 200m
+- description: Volume space available for data, e.g. 512Mi, 2Gi
+  displayName: Volume Capacity
+  name: VOLUME_CAPACITY
+  required: true
+  value: 1Gi
+- name: IMAGE
+  value: redis
+- description: The number of replicas to use for the prometheus deployment
+  name: REPLICAS
+  value: '1'
+- description: Image tag
+  name: IMAGE_TAG
+  required: true

--- a/templates/scheduler.yaml
+++ b/templates/scheduler.yaml
@@ -1,0 +1,173 @@
+apiVersion: v1
+kind: Template
+labels:
+  app: ${NAME}
+  template: ${NAME}-scheduler
+metadata:
+  annotations:
+    description: Scheduler for Role Based Access Control powered by Django+PostgreSQL+Celery
+    iconClass: icon-python
+    openshift.io/display-name: RBAC
+    openshift.io/documentation-url: https://insight-rbac.readthedocs.io/en/latest/
+    openshift.io/long-description: This template defines resources needed to run the
+      RBAC application, including a build configuration, application deployment configuration,
+      and database deployment configuration.
+    openshift.io/provider-display-name: Red Hat, Inc.
+    tags: python,flask
+  name: rbac-scheduler
+objects:
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    labels:
+      app: ${NAME}
+    name: ${NAME}-scheduler
+  spec:
+    minReadySeconds: 15
+    progressDeadlineSeconds: 600
+    replicas: ${{REPLICAS}}
+    revisionHistoryLimit: 9
+    selector:
+      matchLabels:
+        name: ${NAME}-scheduler
+    strategy:
+      type: Recreate
+    template:
+      metadata:
+        labels:
+          name: ${NAME}-scheduler
+        name: ${NAME}-scheduler
+      spec:
+        affinity:
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                  - key: name
+                    operator: In
+                    values:
+                    - ${NAME}-scheduler
+                topologyKey: failure-domain.beta.kubernetes.io/zone
+              weight: 100
+            - podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                  - key: name
+                    operator: In
+                    values:
+                    - ${NAME}-scheduler
+                topologyKey: kubernetes.io/hostname
+              weight: 99
+        containers:
+        - command:
+          - /bin/bash
+          - -c
+          - 'PYTHONPATH=${PWD}/rbac/ celery -A rbac.celery beat -l $DJANGO_LOG_LEVEL
+
+            '
+          env:
+          - name: REDIS_HOST
+            valueFrom:
+              configMapKeyRef:
+                key: redis-service-host
+                name: redis-config
+          - name: REDIS_PORT
+            valueFrom:
+              configMapKeyRef:
+                key: redis-service-port
+                name: redis-config
+          - name: DJANGO_LOG_LEVEL
+            value: ${DJANGO_LOG_LEVEL}
+          - name: DJANGO_DEBUG
+            value: ${DJANGO_DEBUG}
+          - name: APP_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: PERMISSION_SEEDING_ENABLED
+            value: 'False'
+          - name: ROLE_SEEDING_ENABLED
+            value: 'False'
+          - name: GROUP_SEEDING_ENABLED
+            value: 'False'
+          - name: CLOWDER_ENABLED
+            value: ${CLOWDER_ENABLED}
+          image: quay.io/cloudservices/rbac:${IMAGE_TAG}
+          livenessProbe:
+            exec:
+              command:
+              - /bin/bash
+              - -c
+              - 'PYTHONPATH=${PWD}/rbac/ celery inspect ping -A rbac.celery
+
+                '
+            failureThreshold: 3
+            initialDelaySeconds: 30
+            periodSeconds: 300
+            successThreshold: 1
+            timeoutSeconds: 10
+          name: ${NAME}-scheduler
+          readinessProbe:
+            exec:
+              command:
+              - /bin/bash
+              - -c
+              - 'PYTHONPATH=${PWD}/rbac/ celery inspect ping -A rbac.celery
+
+                '
+            failureThreshold: 3
+            periodSeconds: 300
+            successThreshold: 1
+            timeoutSeconds: 10
+          resources:
+            limits:
+              cpu: ${CELERY_SCHEDULER_CPU_LIMIT}
+              memory: ${CELERY_SCHEDULER_MEMORY_LIMIT}
+            requests:
+              cpu: ${CELERY_SCHEDULER_CPU_REQUEST}
+              memory: ${CELERY_SCHEDULER_MEMORY_REQUEST}
+        imagePullSecrets:
+        - name: quay-cloudservices-pull
+        - name: rh-registry-pull
+parameters:
+- description: The name assigned to all frontend objects defined in this template.
+  displayName: Name
+  name: NAME
+  required: true
+  value: rbac
+- description: Initial amount of CPU the Flower container will request.
+  displayName: Celery scheduler CPU Resource Request
+  name: CELERY_SCHEDULER_CPU_REQUEST
+  required: true
+  value: 100m
+- description: Maximum amount of CPU the scheduler container can use.
+  displayName: CPU Limit
+  name: CELERY_SCHEDULER_CPU_LIMIT
+  required: true
+  value: 300m
+- description: Initial amount of memory the scheduler container will request.
+  displayName: Celery scheduler Memory Resource Request
+  name: CELERY_SCHEDULER_MEMORY_REQUEST
+  required: true
+  value: 256Mi
+- description: Maximum amount of memory the scheduler container can use.
+  displayName: Memory Limit
+  name: CELERY_SCHEDULER_MEMORY_LIMIT
+  required: true
+  value: 512Mi
+- displayName: Django Debug
+  name: DJANGO_DEBUG
+  value: 'false'
+- displayName: Django log level
+  name: DJANGO_LOG_LEVEL
+  value: INFO
+- description: The number of replicas to use for the prometheus deployment
+  name: REPLICAS
+  value: '1'
+- description: Determines Clowder deployment
+  name: CLOWDER_ENABLED
+  value: 'false'
+- description: Image tag
+  name: IMAGE_TAG
+  required: true

--- a/templates/worker.yaml
+++ b/templates/worker.yaml
@@ -1,0 +1,305 @@
+apiVersion: v1
+kind: Template
+labels:
+  app: ${NAME}
+  template: ${NAME}-worker
+metadata:
+  annotations:
+    description: Celery worker for Role Based Access Control powered by Django+PostgreSQL+Celery
+    iconClass: icon-python
+    openshift.io/display-name: RBAC
+    openshift.io/documentation-url: https://insight-rbac.readthedocs.io/en/latest/
+    openshift.io/long-description: This template defines resources needed to run the
+      RBAC application, including a build configuration, application deployment configuration,
+      and database deployment configuration.
+    openshift.io/provider-display-name: Red Hat, Inc.
+    tags: python,flask
+  name: rbac-worker
+objects:
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    labels:
+      app: ${NAME}
+    name: ${NAME}-worker
+  spec:
+    minReadySeconds: 15
+    progressDeadlineSeconds: 600
+    replicas: ${{REPLICAS}}
+    revisionHistoryLimit: 9
+    selector:
+      matchLabels:
+        name: ${NAME}-worker
+    strategy:
+      type: Recreate
+    template:
+      metadata:
+        labels:
+          name: ${NAME}-worker
+        name: ${NAME}-worker
+      spec:
+        affinity:
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                  - key: name
+                    operator: In
+                    values:
+                    - ${NAME}-worker
+                topologyKey: failure-domain.beta.kubernetes.io/zone
+              weight: 100
+            - podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                  - key: name
+                    operator: In
+                    values:
+                    - ${NAME}-worker
+                topologyKey: kubernetes.io/hostname
+              weight: 99
+        containers:
+        - command:
+          - /bin/bash
+          - -c
+          - 'PYTHONPATH=${PWD}/rbac/ celery -A rbac.celery worker -l $DJANGO_LOG_LEVEL
+
+            '
+          env:
+          - name: REDIS_HOST
+            valueFrom:
+              configMapKeyRef:
+                key: redis-service-host
+                name: redis-config
+          - name: REDIS_PORT
+            valueFrom:
+              configMapKeyRef:
+                key: redis-service-port
+                name: redis-config
+          - name: DJANGO_LOG_LEVEL
+            value: ${DJANGO_LOG_LEVEL}
+          - name: DJANGO_DEBUG
+            value: ${DJANGO_DEBUG}
+          - name: PERMISSION_SEEDING_ENABLED
+            value: 'False'
+          - name: ROLE_SEEDING_ENABLED
+            value: 'False'
+          - name: GROUP_SEEDING_ENABLED
+            value: 'False'
+          - name: DATABASE_SERVICE_CERT
+            valueFrom:
+              secretKeyRef:
+                key: rds-cacert
+                name: rds-client-ca
+                optional: true
+          - name: DJANGO_SECRET_KEY
+            valueFrom:
+              secretKeyRef:
+                key: django-secret-key
+                name: ${NAME}-secret
+                optional: false
+          - name: PRINCIPAL_PROXY_SERVICE_PROTOCOL
+            valueFrom:
+              secretKeyRef:
+                key: principal-proxy-protocol
+                name: ${NAME}-secret
+                optional: false
+          - name: PRINCIPAL_PROXY_SERVICE_HOST
+            valueFrom:
+              secretKeyRef:
+                key: principal-proxy-host
+                name: ${NAME}-secret
+                optional: false
+          - name: PRINCIPAL_PROXY_SERVICE_PORT
+            valueFrom:
+              secretKeyRef:
+                key: principal-proxy-port
+                name: ${NAME}-secret
+                optional: false
+          - name: PRINCIPAL_PROXY_SERVICE_PATH
+            value: ''
+          - name: PRINCIPAL_PROXY_USER_ENV
+            valueFrom:
+              secretKeyRef:
+                key: principal-proxy-env
+                name: ${NAME}-secret
+                optional: false
+          - name: PRINCIPAL_PROXY_CLIENT_ID
+            valueFrom:
+              secretKeyRef:
+                key: principal-proxy-client-id
+                name: ${NAME}-secret
+                optional: false
+          - name: PRINCIPAL_PROXY_API_TOKEN
+            valueFrom:
+              secretKeyRef:
+                key: principal-proxy-api-token
+                name: ${NAME}-secret
+                optional: false
+          - name: PRINCIPAL_PROXY_SERVICE_SSL_VERIFY
+            valueFrom:
+              secretKeyRef:
+                key: principal-proxy-ssl-verify
+                name: ${NAME}-secret
+                optional: true
+          - name: PRINCIPAL_PROXY_SERVICE_SOURCE_CERT
+            valueFrom:
+              secretKeyRef:
+                key: principal-proxy-source-cert
+                name: ${NAME}-secret
+                optional: true
+          - name: APP_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: DATABASE_HOST
+            valueFrom:
+              secretKeyRef:
+                key: db.host
+                name: ${DB_SECRET_NAME}
+                optional: false
+          - name: DATABASE_PORT
+            valueFrom:
+              secretKeyRef:
+                key: db.port
+                name: ${DB_SECRET_NAME}
+                optional: false
+          - name: DATABASE_NAME
+            valueFrom:
+              secretKeyRef:
+                key: db.name
+                name: ${DB_SECRET_NAME}
+                optional: false
+          - name: DATABASE_USER
+            valueFrom:
+              secretKeyRef:
+                key: db.user
+                name: ${DB_SECRET_NAME}
+                optional: false
+          - name: DATABASE_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                key: db.password
+                name: ${DB_SECRET_NAME}
+                optional: false
+          - name: PGSSLMODE
+            value: ${PGSSLMODE}
+          - name: PGSSLROOTCERT
+            value: /etc/rds-certs/rds-cacert
+          - name: ACCESS_CACHE_CONNECT_SIGNALS
+            value: ${ACCESS_CACHE_CONNECT_SIGNALS}
+          - name: CLOWDER_ENABLED
+            value: ${CLOWDER_ENABLED}
+          image: quay.io/cloudservices/rbac:${IMAGE_TAG}
+          livenessProbe:
+            exec:
+              command:
+              - /bin/bash
+              - -c
+              - 'PYTHONPATH=${PWD}/rbac/ celery inspect ping -A rbac.celery
+
+                '
+            failureThreshold: 3
+            initialDelaySeconds: 30
+            periodSeconds: 300
+            successThreshold: 1
+            timeoutSeconds: 10
+          name: ${NAME}-worker
+          readinessProbe:
+            exec:
+              command:
+              - /bin/bash
+              - -c
+              - 'PYTHONPATH=${PWD}/rbac/ celery inspect ping -A rbac.celery
+
+                '
+            failureThreshold: 3
+            periodSeconds: 300
+            successThreshold: 1
+            timeoutSeconds: 10
+          resources:
+            limits:
+              cpu: ${CELERY_WORKER_CPU_LIMIT}
+              memory: ${CELERY_WORKER_MEMORY_LIMIT}
+            requests:
+              cpu: ${CELERY_WORKER_CPU_REQUEST}
+              memory: ${CELERY_WORKER_MEMORY_REQUEST}
+          volumeMounts:
+          - mountPath: /etc/rds-certs
+            name: rds-client-ca
+            readOnly: true
+          - mountPath: /opt/app-root/src/rbac/management/role/definitions
+            name: default-role-config
+          - mountPath: /opt/app-root/src/rbac/management/role/permissions
+            name: model-access-permissions
+        imagePullSecrets:
+        - name: quay-cloudservices-pull
+        - name: rh-registry-pull
+        volumes:
+        - name: rds-client-ca
+          secret:
+            secretName: rds-client-ca
+        - configMap:
+            name: ${CONFIG_MAP_NAME}
+          name: default-role-config
+        - configMap:
+            name: ${MODEL_ACCESS_PERMISSIONS}
+          name: model-access-permissions
+parameters:
+- description: The name assigned to all frontend objects defined in this template.
+  displayName: Name
+  name: NAME
+  required: true
+  value: rbac
+- description: Initial amount of CPU the worker container will request.
+  displayName: Celery worker CPU Resource Request
+  name: CELERY_WORKER_CPU_REQUEST
+  required: true
+  value: 100m
+- description: Maximum amount of CPU the worker container can use.
+  displayName: CPU Limit
+  name: CELERY_WORKER_CPU_LIMIT
+  required: true
+  value: 300m
+- description: Initial amount of memory the worker container will request.
+  displayName: Celery worker Memory Resource Request
+  name: CELERY_WORKER_MEMORY_REQUEST
+  required: true
+  value: 256Mi
+- description: Maximum amount of memory the worker container can use.
+  displayName: Memory Limit
+  name: CELERY_WORKER_MEMORY_LIMIT
+  required: true
+  value: 512Mi
+- displayName: Django Debug
+  name: DJANGO_DEBUG
+  value: 'false'
+- displayName: Django log level
+  name: DJANGO_LOG_LEVEL
+  value: INFO
+- description: 'Options can be found in the doc: https://www.postgresql.org/docs/current/libpq-ssl.html#LIBPQ-SSL-SSLMODE-STATEMENTS'
+  displayName: Postgres SSL mode
+  name: PGSSLMODE
+  value: prefer
+- description: The number of replicas to use for the prometheus deployment
+  name: REPLICAS
+  value: '1'
+- description: Name of the rbac-config config map
+  name: CONFIG_MAP_NAME
+  value: rbac-config
+- description: Name of the predefined access permissions config map
+  name: MODEL_ACCESS_PERMISSIONS
+  value: model-access-permissions
+- description: Boolean for controlling access cache invalidation signals
+  name: ACCESS_CACHE_CONNECT_SIGNALS
+  value: 'False'
+- description: Determines Clowder deployment
+  name: CLOWDER_ENABLED
+  value: 'false'
+- description: Image tag
+  name: IMAGE_TAG
+  required: true
+- description: Name of DB secret
+  name: DB_SECRET_NAME
+  value: rbac-db


### PR DESCRIPTION
Not yet overwriting template instances in /openshift, there are some
differences and I'm not sure if anything is using those still. Follow up
MR to external deploy file will reference these new templates

Signed-off-by: Chris Mitchell <cmitchel@redhat.com>

## Link(s) to Jira
- https://issues.redhat.com/browse/RHCLOUD-11996

## Description of Intent of Change(s)
The what, why and how.

## Local Testing
How can the feature be exercised? 
How can the bug be exploited and fix confirmed?
Is any special local setup required?

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  -  if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
