### PR TITLE
RHCLOUD-7071: Simplify sentry initialization

### DIFF
--- a/rbac/rbac/settings.py
+++ b/rbac/rbac/settings.py
@@ -45,24 +45,16 @@ from . import database
 from .env import ENVIRONMENT
 
 # Sentry monitoring configuration
-# Note: Sentry is disabled unless it is explicitly turned on
+# Note: Sentry is disabled unless it is explicitly turned on by setting DSN
 
-
-class SentryMisconfigurationError(Exception):
-    """
-    Raise this if sentry is enabled but the DSN is not set
-    """
-
-
-SENTRY_ENABLED = os.getenv("SENTRY_ENABLED", "false")
 SENTRY_DSN = os.getenv("SENTRY_DSN", "")
-if SENTRY_ENABLED.lower() == "true":
+if SENTRY_DSN:
     import sentry_sdk
     from sentry_sdk.integrations.django import DjangoIntegration
 
-    if SENTRY_DSN == "":
-        raise SentryMisconfigurationError
     sentry_sdk.init(dsn=SENTRY_DSN, integrations=[DjangoIntegration()])
+else:
+    print("SENTRY_DSN was not set, skipping Sentry initialization.")
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))


### PR DESCRIPTION
## Link(s) to Jira
- RHCLOUD-7071

## Description of Intent of Change(s)
In the previous scheme, if SENTRY_ENABLED was set to True and SENTRY_DSN was not set, this would raise an error resulting in the termination of the container. This simplified process removes the SENTRY_ENABLED environment variable. It only checks if SENTRY_DSN is non-empty before attempting initialization.

Benefits:
- Only one config value needed
- Container does not terminate unless SENTRY_DSN is invalid and initialization fails
- IF SENTRY_DSN is not set, the rbac service operates as normal.

## Local Testing
How can the feature be exercised?  Set SENTRY_DSN (or don't) and start the service.
How can the bug be exploited and fix confirmed? N/A
Is any special local setup required? N/A

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  -  if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
