### PR TITLE
Skip principal cleanup for cross account principals

### DIFF
--- a/rbac/management/principal/cleaner.py
+++ b/rbac/management/principal/cleaner.py
@@ -37,6 +37,8 @@ def clean_tenant_principals(tenant):
         principals = list(Principal.objects.all())
         logger.info("Running clean up on %d principals for tenant %s.", len(principals), tenant.schema_name)
         for principal in principals:
+            if principal.cross_account:
+                continue
             logger.debug("Checking for username %s for tenant %s.", principal.username, tenant.schema_name)
             resp = proxy.request_filtered_principals([principal.username])
             status_code = resp.get("status_code")

--- a/rbac/management/utils.py
+++ b/rbac/management/utils.py
@@ -202,8 +202,10 @@ def roles_for_cross_account_principal(principal):
     """Return roles for cross account principals."""
     target_account, user_id = principal.username.split("-")
     with tenant_context(Tenant.objects.get(schema_name="public")):
-        cross_account_request = CrossAccountRequest.objects.filter(
+        cross_account_requests = CrossAccountRequest.objects.filter(
             target_account=target_account, user_id=user_id, status="approved"
-        ).first()
-        role_names = list(cross_account_request.roles.all().values_list("name", flat=True))
+        )
+        role_names = []
+        for car in cross_account_requests:
+            role_names.extend(list(car.roles.all().values_list("name", flat=True)))
     return Role.objects.filter(name__in=role_names)

--- a/rbac/management/utils.py
+++ b/rbac/management/utils.py
@@ -202,10 +202,10 @@ def roles_for_cross_account_principal(principal):
     """Return roles for cross account principals."""
     target_account, user_id = principal.username.split("-")
     with tenant_context(Tenant.objects.get(schema_name="public")):
-        cross_account_requests = CrossAccountRequest.objects.filter(
-            target_account=target_account, user_id=user_id, status="approved"
+        role_names = (
+            CrossAccountRequest.objects.filter(target_account=target_account, user_id=user_id, status="approved")
+            .values_list("roles__name", flat=True)
+            .distinct()
         )
-        role_names = []
-        for car in cross_account_requests:
-            role_names.extend(list(car.roles.all().values_list("name", flat=True)))
-    return Role.objects.filter(name__in=role_names)
+        role_names_list = list(role_names)
+    return Role.objects.filter(name__in=role_names_list)


### PR DESCRIPTION
For cross account principals, they are only stored in RBAC,
Therefore, the cleaner would clean those principals since they could not
be found against IT.

## Link(s) to Jira
- 

## Description of Intent of Change(s)
For cross account principals, they are only stored in RBAC,
Therefore, the cleaner would clean those principals since they could not
be found against IT.

## Local Testing
Unit tests covers the case.

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [x] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  -  if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
