### PR TITLE
Support pagination for access with cache

### DIFF
--- a/rbac/management/access/view.py
+++ b/rbac/management/access/view.py
@@ -120,9 +120,11 @@ class AccessView(APIView):
         return self.paginator.get_paginated_response(data)
 
     def generate_sub_key(self, request):
-        """Generate the sub key to store/retrive record from redis."""
+        """Generate the sub key to store/retrieve record from redis."""
         query_params = request.query_params
-        app = query_params.get(APPLICATION_KEY, "all")
+        app = query_params.get(APPLICATION_KEY)
+        if not app:
+            app = "all"
         limit = int(query_params.get("limit", self.paginator.default_limit))
         # If there are some team setting this out of range, set it to the max support
         if limit > self.paginator.max_limit:

--- a/rbac/management/cache.py
+++ b/rbac/management/cache.py
@@ -136,11 +136,11 @@ class AccessCache(BasicCache):
         if obj:
             return json.loads(obj)
 
-    def get_policy(self, uuid, application):
-        """Get the given user's policy for the given application."""
+    def get_policy(self, uuid, sub_key):
+        """Get the given user's policy for the given sub_key (application_offset_limit)."""
         if not settings.ACCESS_CACHE_ENABLED:
             return None
-        return super().get_cached((uuid, application), f"Error querying policy for uuid {uuid}")
+        return super().get_cached((uuid, sub_key), f"Error querying policy for uuid {uuid}")
 
     def delete_policy(self, uuid):
         """Purge the given user's policy from the cache."""
@@ -157,8 +157,8 @@ class AccessCache(BasicCache):
             if keys:
                 self.connection.delete(*keys)
 
-    def save_policy(self, uuid, application, policy):
-        """Write the policy for a given user for a given app to Redis."""
+    def save_policy(self, uuid, sub_key, policy):
+        """Write the policy for a given user for a given sub_key (application_offset_limit) to Redis."""
         if not settings.ACCESS_CACHE_ENABLED:
             return
-        super().save((uuid, application), policy, "policy")
+        super().save((uuid, sub_key), policy, "policy")


### PR DESCRIPTION
## Link(s) to Jira
- https://issues.redhat.com/browse/RHCLOUD-7455

## Description of Intent of Change(s)
The limit and offset are ignored after cache is enabled. This
is to support pagination again by adding limit and offset into
the sub key.
Then the record will be saved into each entry "principal" and sub
key, e.g. "catalog_0_1000"

## Local Testing
Unit tests
Put some roles into the db, setup server locally and run each of the following twice:
curl -v GET "http://0.0.0.0:8080/r/insights/platform/rbac/v1/access/?application=&limit=20" -w '\nTotal: %{time_total}s\n'
curl -v GET "http://0.0.0.0:8080/r/insights/platform/rbac/v1/access/?application=" -w '\nTotal: %{time_total}s\n'
curl -v GET "http://0.0.0.0:8080/r/insights/platform/rbac/v1/access/?application=catalog&offset=4" -w '\nTotal: %{time_total}s\n'

You will see the total time is different for each run to make sure the caching is enabled.

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [x] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  -  if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
