### PR TITLE
Ensure `DJANGO_DEBUG` is set to "False" by default

### DIFF
--- a/deploy/rbac-clowdapp.yml
+++ b/deploy/rbac-clowdapp.yml
@@ -1740,7 +1740,7 @@ parameters:
   value: 512Mi
 - displayName: Django Debug
   name: DJANGO_DEBUG
-  value: 'false'
+  value: 'False'
 - displayName: Django log level
   name: DJANGO_LOG_LEVEL
   value: INFO


### PR DESCRIPTION
We have an explicit check on `DJANGO_DEBUG` being set to "False" [1]. I noticed
the way the Clowder config is setup has enabled debug in ci/qa/stage. We need
to ensure this goes in before we release the Clowder version or RBAC into prod.

[1] https://github.com/RedHatInsights/insights-rbac/blob/49909263a7aecf86313c87d3fc035acae1d953d7/rbac/rbac/settings.py#L76
