### PR TITLE
Add DB lock during tenant creation

### DIFF
--- a/rbac/rbac/middleware.py
+++ b/rbac/rbac/middleware.py
@@ -77,6 +77,8 @@ class IdentityHeaderMiddleware(BaseTenantMiddleware):
                     raise Http404()
             else:
                 with transaction.atomic():
+                    cursor = transaction.get_connection().cursor()
+                    cursor.execute("LOCK TABLE public.api_tenant in SHARE ROW EXCLUSIVE MODE")
                     tenant, created = Tenant.objects.get_or_create(schema_name=tenant_schema)
                     if created:
                         seed_permissions(tenant=tenant)

--- a/rbac/rbac/middleware.py
+++ b/rbac/rbac/middleware.py
@@ -77,13 +77,16 @@ class IdentityHeaderMiddleware(BaseTenantMiddleware):
                     raise Http404()
             else:
                 with transaction.atomic():
-                    cursor = transaction.get_connection().cursor()
-                    cursor.execute("LOCK TABLE public.api_tenant in SHARE ROW EXCLUSIVE MODE")
-                    tenant, created = Tenant.objects.get_or_create(schema_name=tenant_schema)
-                    if created:
-                        seed_permissions(tenant=tenant)
-                        seed_roles(tenant=tenant)
-                        seed_group(tenant=tenant)
+                    try:
+                        tenant = Tenant.objects.get(schema_name=tenant_schema)
+                    except Tenant.DoesNotExist:
+                        cursor = transaction.get_connection().cursor()
+                        cursor.execute("LOCK TABLE public.api_tenant in SHARE ROW EXCLUSIVE MODE")
+                        tenant, created = Tenant.objects.get_or_create(schema_name=tenant_schema)
+                        if created:
+                            seed_permissions(tenant=tenant)
+                            seed_roles(tenant=tenant)
+                            seed_group(tenant=tenant)
             TENANTS.save_tenant(tenant)
         return tenant
 


### PR DESCRIPTION
Add explicit DB locks for tenant creation

Signed-off-by: Chris Mitchell <cmitchel@redhat.com>

## Link(s) to Jira
- 

## Description of Intent of Change(s)
Two requests occurring close enough together in this codebase can cause DB deadlocks due to how our migrations are set up. This PR will set up a table lock during creation to prevent that occurrence

## Local Testing
1. Pull down branch
2. make reinitdb
3. make serve
4. In another shell run `curl localhost:8000/api/rbac/v1/roles/ & curl localhost:8000/api/rbac/v1/roles/` to cause a double access
5. Ensure that no 500s are returned and no deadlocks reported

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  -  if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
