### PR TITLE
RedisIntegration needs to be imported from sentry_sdk.integrations.redis

### DIFF
--- a/rbac/rbac/settings.py
+++ b/rbac/rbac/settings.py
@@ -52,7 +52,8 @@ from .env import ENVIRONMENT
 SENTRY_DSN = os.getenv("SENTRY_DSN", "")
 if SENTRY_DSN:
     import sentry_sdk
-    from sentry_sdk.integrations.django import DjangoIntegration, RedisIntegration
+    from sentry_sdk.integrations.django import DjangoIntegration
+    from sentry_sdk.integrations.redis import RedisIntegration
 
     sentry_sdk.init(dsn=SENTRY_DSN, integrations=[DjangoIntegration(), RedisIntegration()])
 else:


### PR DESCRIPTION
## Description of Intent of Change(s)
Since merging #440, the [service pod in stage has failed to rollout](https://console-openshift-console.apps.crcs02ue1.urby.p1.openshiftapps.com/k8s/ns/rbac-stage/pods). CI/QA are fine because we don't have Sentry enabled there. In stage, the import was failing:

```
---> Serving application with gunicorn (rbac.wsgi) ...
Traceback (most recent call last):
  File "/opt/app-root/bin/gunicorn", line 8, in <module>
    sys.exit(run())
  File "/opt/app-root/lib/python3.6/site-packages/gunicorn/app/wsgiapp.py", line 58, in run
    WSGIApplication("%(prog)s [OPTIONS] [APP_MODULE]").run()
  File "/opt/app-root/lib/python3.6/site-packages/gunicorn/app/base.py", line 228, in run
    super().run()
  File "/opt/app-root/lib/python3.6/site-packages/gunicorn/app/base.py", line 72, in run
    Arbiter(self).run()
  File "/opt/app-root/lib/python3.6/site-packages/gunicorn/arbiter.py", line 58, in __init__
    self.setup(app)
  File "/opt/app-root/lib/python3.6/site-packages/gunicorn/arbiter.py", line 118, in setup
    self.app.wsgi()
  File "/opt/app-root/lib/python3.6/site-packages/gunicorn/app/base.py", line 67, in wsgi
    self.callable = self.load()
  File "/opt/app-root/lib/python3.6/site-packages/gunicorn/app/wsgiapp.py", line 49, in load
    return self.load_wsgiapp()
  File "/opt/app-root/lib/python3.6/site-packages/gunicorn/app/wsgiapp.py", line 39, in load_wsgiapp
    return util.import_app(self.app_uri)
  File "/opt/app-root/lib/python3.6/site-packages/gunicorn/util.py", line 358, in import_app
    mod = importlib.import_module(module)
  File "/opt/app-root/lib64/python3.6/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 994, in _gcd_import
  File "<frozen importlib._bootstrap>", line 971, in _find_and_load
  File "<frozen importlib._bootstrap>", line 955, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 665, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 678, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/opt/app-root/src/rbac/rbac/wsgi.py", line 33, in <module>
    application = get_wsgi_application()
  File "/opt/app-root/lib/python3.6/site-packages/django/core/wsgi.py", line 12, in get_wsgi_application
    django.setup(set_prefix=False)
  File "/opt/app-root/lib/python3.6/site-packages/django/__init__.py", line 19, in setup
    configure_logging(settings.LOGGING_CONFIG, settings.LOGGING)
  File "/opt/app-root/lib/python3.6/site-packages/django/conf/__init__.py", line 79, in __getattr__
    self._setup(name)
  File "/opt/app-root/lib/python3.6/site-packages/django/conf/__init__.py", line 66, in _setup
    self._wrapped = Settings(settings_module)
  File "/opt/app-root/lib/python3.6/site-packages/django/conf/__init__.py", line 157, in __init__
    mod = importlib.import_module(self.SETTINGS_MODULE)
  File "/opt/app-root/lib64/python3.6/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 994, in _gcd_import
  File "<frozen importlib._bootstrap>", line 971, in _find_and_load
  File "<frozen importlib._bootstrap>", line 955, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 665, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 678, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/opt/app-root/src/rbac/rbac/settings.py", line 55, in <module>
    from sentry_sdk.integrations.django import DjangoIntegration, RedisIntegration
ImportError: cannot import name 'RedisIntegration'
```

## Local Testing
Set `SENTRY_DSN` locally in your `.env` and ensure the app starts. It won't on master, currently with Sentry enabled.
