### PR TITLE
RHCLOUD-12888: unit tests from iqe-rbac-plugin

### DIFF
--- a/tests/management/policy/test_view.py
+++ b/tests/management/policy/test_view.py
@@ -112,17 +112,17 @@ class PolicyViewsetTests(IdentityRequest):
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         role_uuid = response.data.get("uuid")
         policy_name = "policyA"
-        response = self.create_policy(policy_name, uuid4(), [role_uuid], status.HTTP_400_BAD_REQUEST)
+        self.create_policy(policy_name, uuid4(), [role_uuid], status.HTTP_400_BAD_REQUEST)
 
     def test_create_policy_invalid_role(self):
         """Test that we cannot create a policy with an invalid role."""
         policy_name = "policyA"
-        response = self.create_policy(policy_name, self.group.uuid, [uuid4()], status.HTTP_400_BAD_REQUEST)
+        self.create_policy(policy_name, self.group.uuid, [uuid4()], status.HTTP_400_BAD_REQUEST)
 
     def test_create_policy_no_role(self):
         """Test that we cannot create a policy without roles."""
         policy_name = "policyA"
-        response = self.create_policy(policy_name, self.group.uuid, [], status.HTTP_400_BAD_REQUEST)
+        self.create_policy(policy_name, self.group.uuid, [], status.HTTP_400_BAD_REQUEST)
 
     def test_create_policy_invalid(self):
         """Test that creating an invalid policy returns an error."""

--- a/tests/management/policy/test_view.py
+++ b/tests/management/policy/test_view.py
@@ -118,7 +118,7 @@ class PolicyViewsetTests(IdentityRequest):
         client = APIClient()
         url = reverse("policy-detail", kwargs={"uuid": policy_uuid})
         response = client.delete(url, **self.headers)
-        self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
         url = reverse("policy-detail", kwargs={"uuid": policy_uuid})
         client = APIClient()

--- a/tests/management/policy/test_view.py
+++ b/tests/management/policy/test_view.py
@@ -132,6 +132,15 @@ class PolicyViewsetTests(IdentityRequest):
         response = client.post(url, test_data, format="json", **self.headers)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
+    def test_create_policy_no_name(self):
+        """Test that creating a policy with no name returns a 400."""
+        role_name = "roleA"
+        response = self.create_role(role_name)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        role_uuid = response.data.get("uuid")
+        policy_name = None
+        self.create_policy(policy_name, self.group.uuid, [role_uuid], status.HTTP_400_BAD_REQUEST)
+
     def test_read_policy_invalid(self):
         """Test that reading an invalid policy returns an error."""
         url = reverse("policy-detail", kwargs={"uuid": uuid4()})

--- a/tests/management/policy/test_view.py
+++ b/tests/management/policy/test_view.py
@@ -105,6 +105,26 @@ class PolicyViewsetTests(IdentityRequest):
         self.assertEqual(policy_name, response.data.get("name"))
         self.assertEqual(str(self.group.uuid), response.data.get("group").get("uuid"))
 
+    def test_delete_policy_success(self):
+        """Test that we can delete a policy."""
+        role_name = "roleA"
+        response = self.create_role(role_name)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        role_uuid = response.data.get("uuid")
+        policy_name = "policyA"
+        response = self.create_policy(policy_name, self.group.uuid, [role_uuid])
+        policy_uuid = response.data.get("uuid")
+
+        client = APIClient()
+        url = reverse("policy-detail", kwargs={"uuid": policy_uuid})
+        response = client.delete(url, **self.headers)
+        self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
+
+        url = reverse("policy-detail", kwargs={"uuid": policy_uuid})
+        client = APIClient()
+        response = client.get(url, **self.headers)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
     def test_create_policy_invalid_group(self):
         """Test that we cannot create a policy with invalid group."""
         role_name = "roleA"


### PR DESCRIPTION
## Link(s) to Jira
- [Link](https://issues.redhat.com/browse/RHCLOUD-12888)

## Description of Intent of Change(s)

Some existing tests in the IQE plug-in for RBAC really belong as unit tests in the service itself. The work here adds unit tests for the policies endpoint.

## Local Testing
How can the feature be exercised?  Run the unit tests.
How can the bug be exploited and fix confirmed? N/A
Is any special local setup required? No.

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  -  if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
