### PR TITLE
Update ecs formatter to deal with special request objects

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
         - POSTGRES_SQL_SERVICE_PORT=5432
         - DATABASE_USER=postgres
         - DATABASE_PASSWORD=postgres
-        - DJANGO_LOG_HANDLERS=console
+        - DJANGO_LOG_HANDLERS=console,ecs
         - DJANGO_READ_DOT_ENV_FILE=True
         - DEVELOPMENT=${DEVELOPMENT-False}
         - DJANGO_DEBUG=${DJANGO_DEBUG-True}

--- a/rbac/rbac/ECSCustom/__init__.py
+++ b/rbac/rbac/ECSCustom/__init__.py
@@ -1,0 +1,65 @@
+#
+# Copyright 2021 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""Custom ecs formatter"""
+import django
+
+from ecs_logging import StdlibFormatter
+from urllib.parse import urlparse
+
+
+class ECSCustomFormatter(StdlibFormatter):
+    def format_to_ecs(self, record):
+        request = None
+        if hasattr(record, "request"):
+            request = record.request
+            record.request = None
+
+        result = super().format_to_ecs(record)
+
+        if request is not None:
+            # Deal with socket request, example:
+            # "<socket.socket fd=9,
+            # family=AddressFamily.AF_INET,
+            # type=SocketKind.SOCK_STREAM,
+            # proto=0,
+            # laddr=('127.0.0.1', 8080), raddr=('127.0.0.1', 52219)>"
+            # Currently no valuable info to extract
+
+            if isinstance(request, django.core.handlers.wsgi.WSGIRequest):
+                result = self.add_info_from_WSGIRequest(result, request)
+
+        # Remove some field not following standard:
+        # https://www.elastic.co/guide/en/ecs/1.6/ecs-field-reference.html
+        result.pop("message", None)
+        result.pop("status_code", None)
+        result.pop("server_time", None)
+        return result
+
+    def add_info_from_WSGIRequest(self, result, request):
+        parsed_url = urlparse(request.build_absolute_uri())
+        request_body_bytes = request.headers["Content-Length"] or "0"
+
+        result["url"] = {"path": parsed_url.path, "domain": parsed_url.hostname, "port": parsed_url.port}
+        result["http"] = {
+            "request": {"body": {"bytes": int(request_body_bytes)}, "method": request.method},
+            "response": {
+                "body": {"bytes": len(result["message"]), "content": result["message"]},
+                "status_code": result["status_code"],
+            },
+        }
+
+        return result

--- a/rbac/rbac/ECSCustom/__init__.py
+++ b/rbac/rbac/ECSCustom/__init__.py
@@ -14,15 +14,18 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
-"""Custom ecs formatter"""
-import django
-
-from ecs_logging import StdlibFormatter
+"""Custom ecs formatter."""
 from urllib.parse import urlparse
+
+import django
+from ecs_logging import StdlibFormatter
 
 
 class ECSCustomFormatter(StdlibFormatter):
+    """Custom ECS formatter."""
+
     def format_to_ecs(self, record):
+        """Over write the format_to_ecs method to deal with WSGI and socket request."""
         request = None
         if hasattr(record, "request"):
             request = record.request
@@ -50,6 +53,7 @@ class ECSCustomFormatter(StdlibFormatter):
         return result
 
     def add_info_from_WSGIRequest(self, result, request):
+        """Extract info from WSGIRequest and add it to the log."""
         parsed_url = urlparse(request.build_absolute_uri())
         request_body_bytes = request.headers["Content-Length"] or "0"
 

--- a/rbac/rbac/middleware.py
+++ b/rbac/rbac/middleware.py
@@ -18,7 +18,6 @@
 """Custom RBAC Middleware."""
 import binascii
 import logging
-import sys
 from json.decoder import JSONDecodeError
 
 from django.conf import settings
@@ -201,6 +200,8 @@ class IdentityHeaderMiddleware(BaseTenantMiddleware):
                 is_admin = is_system = False
                 account = None
 
+        # Todo: add some info back to logs
+        """
         extras = {}
 
         if "ecs" in settings.LOGGING_HANDLERS:
@@ -224,6 +225,7 @@ class IdentityHeaderMiddleware(BaseTenantMiddleware):
                     "port": request.get_port(),
                 },
             }
+        """
 
         log_object = {
             "method": request.method,
@@ -236,7 +238,7 @@ class IdentityHeaderMiddleware(BaseTenantMiddleware):
             "is_system": is_system,
         }
 
-        logger.info(log_object, extra=extras)
+        logger.info(log_object)
         return response
 
 

--- a/rbac/rbac/settings.py
+++ b/rbac/rbac/settings.py
@@ -31,12 +31,13 @@ import datetime
 import sys
 import logging
 import pytz
-import ecs_logging
 
 from boto3.session import Session
 from corsheaders.defaults import default_headers
 from dateutil.parser import parse as parse_dt
 from app_common_python import LoadedConfig
+
+from . import ECSCustom
 
 # Database
 # https://docs.djangoproject.com/en/2.0/ref/settings/#databases
@@ -277,7 +278,7 @@ LOGGING = {
     "formatters": {
         "verbose": {"format": VERBOSE_FORMATTING},
         "simple": {"format": "[%(asctime)s] %(levelname)s: %(message)s"},
-        "ecs_formatter": {"()": "ecs_logging.StdlibFormatter"},
+        "ecs_formatter": {"()": "rbac.ECSCustom.ECSCustomFormatter"},
     },
     "handlers": {
         "console": {"class": "logging.StreamHandler", "formatter": LOGGING_FORMATTER},
@@ -291,8 +292,8 @@ LOGGING = {
     },
     "loggers": {
         "django": {"handlers": LOGGING_HANDLERS, "level": DJANGO_LOGGING_LEVEL},
-        "django.server": {"handlers": DEBUG_LOG_HANDLERS, "level": DJANGO_LOGGING_LEVEL},
-        "django.request": {"handlers": DEBUG_LOG_HANDLERS, "level": DJANGO_LOGGING_LEVEL},
+        "django.server": {"handlers": DEBUG_LOG_HANDLERS, "level": DJANGO_LOGGING_LEVEL, "propagate": False},
+        "django.request": {"handlers": DEBUG_LOG_HANDLERS, "level": DJANGO_LOGGING_LEVEL, "propagate": False},
         "api": {"handlers": LOGGING_HANDLERS, "level": RBAC_LOGGING_LEVEL},
         "rbac": {"handlers": LOGGING_HANDLERS, "level": RBAC_LOGGING_LEVEL},
         "management": {"handlers": LOGGING_HANDLERS, "level": RBAC_LOGGING_LEVEL},


### PR DESCRIPTION
## Link(s) to Jira
- https://issues.redhat.com/browse/RHCLOUD-11525

## Description of Intent of Change(s)
There are two request objects causing exception because they are not
json serializble: WSGIRequest and SocketRquest objects.

Extract some info from the WSGIRquest and the SocketRquest has no important
info yet, just ignore it.


## Local Testing
Setup server using docker-compose, run the following commands and check:

- curl -v GET "http://0.0.0.0:8080/r/insights/platform/rbac/v1/roles/"
- wget http://127.0.0.1:8080/invalid -O /dev//null
- Create a file test.json with only "{}" then run: `curl -X POST -H "Content-Type: application/json" -d @test.json "http://0.0.0.0:8080/r/insights/platform/rbac/v1/roles/"`


## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  -  if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
