### PR TITLE
Associate models with tenant

### DIFF
--- a/rbac/api/models.py
+++ b/rbac/api/models.py
@@ -19,6 +19,7 @@ from tenant_schemas.models import TenantMixin
 
 from api.cross_access.model import CrossAccountRequest  # noqa: F401
 from api.status.model import Status  # noqa: F401
+from django.db import models
 
 
 class Tenant(TenantMixin):
@@ -33,6 +34,15 @@ class Tenant(TenantMixin):
     def __str__(self):
         """Get string representation of Tenant."""
         return f"Tenant ({self.schema_name})"
+
+
+class TenantAwareModel(models.Model):
+    """Abstract model for inheriting `Tenant`."""
+
+    tenant = models.ForeignKey(Tenant, blank=True, null=True, on_delete=models.CASCADE)
+
+    class Meta:
+        abstract = True
 
 
 class User:

--- a/rbac/api/models.py
+++ b/rbac/api/models.py
@@ -15,11 +15,11 @@
 #    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 """API models for import organization."""
+from django.db import models
 from tenant_schemas.models import TenantMixin
 
 from api.cross_access.model import CrossAccountRequest  # noqa: F401
 from api.status.model import Status  # noqa: F401
-from django.db import models
 
 
 class Tenant(TenantMixin):

--- a/rbac/management/group/model.py
+++ b/rbac/management/group/model.py
@@ -28,11 +28,13 @@ from management.principal.model import Principal
 from management.rbac_fields import AutoDateTimeField
 from management.role.model import Role
 
+from api.models import TenantAwareModel
+
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
 
-class Group(models.Model):
+class Group(TenantAwareModel):
     """A group."""
 
     uuid = models.UUIDField(default=uuid4, editable=False, unique=True, null=False)

--- a/rbac/management/permission/model.py
+++ b/rbac/management/permission/model.py
@@ -18,8 +18,10 @@
 """Model for permission management."""
 from django.db import models
 
+from api.models import TenantAwareModel
 
-class Permission(models.Model):
+
+class Permission(TenantAwareModel):
     """A Permission."""
 
     application = models.TextField(null=False)

--- a/rbac/management/policy/model.py
+++ b/rbac/management/policy/model.py
@@ -29,11 +29,13 @@ from management.principal.model import Principal
 from management.rbac_fields import AutoDateTimeField
 from management.role.model import Role
 
+from api.models import TenantAwareModel
+
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
 
-class Policy(models.Model):
+class Policy(TenantAwareModel):
     """A policy."""
 
     uuid = models.UUIDField(default=uuid4, editable=False, unique=True, null=False)

--- a/rbac/management/principal/model.py
+++ b/rbac/management/principal/model.py
@@ -20,8 +20,10 @@ from uuid import uuid4
 
 from django.db import models
 
+from api.models import TenantAwareModel
 
-class Principal(models.Model):
+
+class Principal(TenantAwareModel):
     """A principal."""
 
     uuid = models.UUIDField(default=uuid4, editable=False, unique=True, null=False)

--- a/rbac/management/role/model.py
+++ b/rbac/management/role/model.py
@@ -28,11 +28,13 @@ from management.cache import AccessCache
 from management.models import Permission, Principal
 from management.rbac_fields import AutoDateTimeField
 
+from api.models import TenantAwareModel
+
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
 
-class Role(models.Model):
+class Role(TenantAwareModel):
     """A role."""
 
     uuid = models.UUIDField(default=uuid4, editable=False, unique=True, null=False)
@@ -60,7 +62,7 @@ class Role(models.Model):
         super(Role, self).save(*args, **kwargs)
 
 
-class Access(models.Model):
+class Access(TenantAwareModel):
     """An access object."""
 
     permission = models.ForeignKey(Permission, null=True, on_delete=models.CASCADE, related_name="accesses")
@@ -71,7 +73,7 @@ class Access(models.Model):
         return self.permission.application
 
 
-class ResourceDefinition(models.Model):
+class ResourceDefinition(TenantAwareModel):
     """A resource definition."""
 
     attributeFilter = JSONField(default=dict)

--- a/tests/management/permission/test_model.py
+++ b/tests/management/permission/test_model.py
@@ -47,4 +47,3 @@ class PermissionModelTests(IdentityRequest):
             self.assertEqual(self.permission.resource_type, "roles")
             self.assertEqual(self.permission.verb, "read")
             self.assertEqual(self.permission.permission, "rbac:roles:read")
-            self.assertEqual(len(Permission._meta.fields), 6)


### PR DESCRIPTION
## Link(s) to Jira
- https://issues.redhat.com/browse/RHCLOUD-11196

## Description of Intent of Change(s)
This adds a `TenantAwareModel` class, which inherits from `model.Model`. This allows
us to reuse this class on all models which will have a relation to the `Tenant`
model, meaning we will just need to have those models inherit from `TenantAwareModel`
to pick up any behavior related to the tenant relation.

The following models will now inherit from `TenantAwareModel`:

- access
- group
- permission
- policy
- principal
- resourcedefinition
- role

## Local Testing
Functionally, there should be no change. This is strictly the model code for #430

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  -  if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
