### PR TITLE
Associate with tenant on create

### DIFF
--- a/rbac/management/group/serializer.py
+++ b/rbac/management/group/serializer.py
@@ -20,11 +20,12 @@ from management.group.model import Group
 from management.principal.proxy import PrincipalProxy
 from management.principal.serializer import PrincipalInputSerializer, PrincipalSerializer
 from management.role.serializer import RoleMinimumSerializer
+from management.serializer_override_mixin import SerializerCreateOverrideMixin
 from rest_framework import serializers, status
 from rest_framework.validators import UniqueValidator
 
 
-class GroupInputSerializer(serializers.ModelSerializer):
+class GroupInputSerializer(SerializerCreateOverrideMixin, serializers.ModelSerializer):
     """Serializer for Group input model."""
 
     uuid = serializers.UUIDField(read_only=True)
@@ -60,7 +61,7 @@ class GroupInputSerializer(serializers.ModelSerializer):
         )
 
 
-class GroupSerializer(serializers.ModelSerializer):
+class GroupSerializer(SerializerCreateOverrideMixin, serializers.ModelSerializer):
     """Serializer for the Group model."""
 
     uuid = serializers.UUIDField(read_only=True)

--- a/rbac/management/group/view.py
+++ b/rbac/management/group/view.py
@@ -321,7 +321,7 @@ class GroupViewSet(
             try:
                 principal = Principal.objects.get(username__iexact=username)
             except Principal.DoesNotExist:
-                principal = Principal.objects.create(username=username)
+                principal = Principal.objects.create(username=username, tenant=self.request.tenant)
                 logger.info("Created new principal %s for account_id %s.", username, account)
             group.principals.add(principal)
         group.save()
@@ -551,7 +551,7 @@ class GroupViewSet(
             serializer = GroupRoleSerializerIn(data=request.data)
             if serializer.is_valid(raise_exception=True):
                 roles = request.data.pop(ROLES_KEY, [])
-            add_roles(group, roles)
+            add_roles(group, roles, request.tenant)
             set_system_flag_post_update(group)
             response_data = GroupRoleSerializerIn(group)
         elif request.method == "GET":

--- a/rbac/management/management/commands/reconcile_tenant_relations.py
+++ b/rbac/management/management/commands/reconcile_tenant_relations.py
@@ -17,9 +17,10 @@
 """Reconcile tenant relations command."""
 import logging
 
-from django.core.management.base import BaseCommand
 from django.apps import apps
+from django.core.management.base import BaseCommand
 from tenant_schemas.utils import tenant_context
+
 from api.models import Tenant
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
@@ -35,6 +36,7 @@ class Command(BaseCommand):
         parser.add_argument("--readonly", action="store_true")
 
     def models_with_tenant_relations(self):
+        """Return models with tenant relations."""
         return ["ResourceDefinition", "Access", "Role", "Principal", "Policy", "Group", "Permission"]
 
     def handle(self, *args, **options):

--- a/rbac/management/management/commands/reconcile_tenant_relations.py
+++ b/rbac/management/management/commands/reconcile_tenant_relations.py
@@ -1,0 +1,80 @@
+#
+# Copyright 2021 Red Hat, Inc.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""Reconcile tenant relations command."""
+import logging
+
+from django.core.management.base import BaseCommand
+from django.apps import apps
+from tenant_schemas.utils import tenant_context
+from api.models import Tenant
+
+logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
+
+
+class Command(BaseCommand):
+    """Command class for reconciling/querying tenant_ids on objects."""
+
+    help = "Reconciles the tenant_id relations on RBAC objects"
+
+    def add_arguments(self, parser):
+        """Add arguments to command."""
+        parser.add_argument("--readonly", action="store_true")
+
+    def models_with_tenant_relations(self):
+        return ["ResourceDefinition", "Access", "Role", "Principal", "Policy", "Group", "Permission"]
+
+    def handle(self, *args, **options):
+        """Handle method for command."""
+        read_only = options["readonly"]
+        tenants = Tenant.objects.all()
+        tenants_missing_releations = set()
+
+        try:
+            for idx, tenant in enumerate(list(tenants)):
+                with tenant_context(tenant):
+                    tenant_id = tenant.id
+                    tenant_name = tenant.schema_name
+                    logger.info(
+                        f"*** Syncing Tenant '{tenant_id}' - '{tenant_name}' ({idx + 1} of {len(tenants)}) ***"
+                    )
+                    for model in self.models_with_tenant_relations():
+                        tenant_misses = 0
+                        klass = apps.get_model("management", model)
+                        records = klass.objects.filter(tenant__isnull=True)
+                        for record in records:
+                            if not read_only:
+                                try:
+                                    logger.info(
+                                        f"Setting tenant '{tenant_id}' - '{tenant_name}' on {model} '{record.id}'"
+                                    )
+                                    record.tenant = tenant
+                                    record.save()
+                                except Exception as e:
+                                    logger.error(f"Failed to update record: {str(e)}")
+                            else:
+                                tenant_misses += 1
+                        if tenant_misses > 0:
+                            tenants_missing_releations.add(f"{tenant_name}:{tenant_id}")
+                            logger.info(f"{tenant_misses} {model} objects without a tenant")
+
+            logger.info("--- SUMMARY ---")
+            if len(tenants_missing_releations) > 0:
+                logger.info(f"Tenants with records needing a tenant_id: {list(tenants_missing_releations)}")
+            else:
+                logger.info("All tenant relations are set!")
+        except Exception as e:
+            logger.error(f"Failure: {str(e)}")

--- a/rbac/management/permission/serializer.py
+++ b/rbac/management/permission/serializer.py
@@ -17,10 +17,11 @@
 
 """Serializer for permission management."""
 from management.models import Permission
+from management.serializer_override_mixin import SerializerCreateOverrideMixin
 from rest_framework import serializers
 
 
-class PermissionSerializer(serializers.ModelSerializer):
+class PermissionSerializer(SerializerCreateOverrideMixin, serializers.ModelSerializer):
     """Serializer for the Permission model."""
 
     class Meta:

--- a/rbac/management/policy/serializer.py
+++ b/rbac/management/policy/serializer.py
@@ -21,6 +21,7 @@ from management.group.serializer import GroupInputSerializer
 from management.policy.model import Policy
 from management.role.model import Role
 from management.role.serializer import RoleMinimumSerializer
+from management.serializer_override_mixin import SerializerCreateOverrideMixin
 from rest_framework import serializers
 from rest_framework.validators import UniqueValidator
 
@@ -31,7 +32,7 @@ class UUIDListField(serializers.ListField):
     child = serializers.UUIDField()
 
 
-class PolicyInputSerializer(serializers.ModelSerializer):
+class PolicyInputSerializer(SerializerCreateOverrideMixin, serializers.ModelSerializer):
     """Serializer for the policy model."""
 
     uuid = serializers.UUIDField(read_only=True)
@@ -53,6 +54,7 @@ class PolicyInputSerializer(serializers.ModelSerializer):
     def create(self, validated_data):
         """Create the policy object in the database."""
         name = validated_data.pop("name")
+        tenant = self.context["request"].tenant
         description = validated_data.pop("description", None)
         group_uuid = validated_data.pop("group")
         role_uuids = validated_data.pop("roles")
@@ -63,7 +65,7 @@ class PolicyInputSerializer(serializers.ModelSerializer):
             error = {"detail": msg.format(group_uuid)}
             raise serializers.ValidationError(error)
 
-        policy = Policy(name=name, description=description, group=group)
+        policy = Policy(name=name, description=description, group=group, tenant=tenant)
         roles = []
         for role_uuid in role_uuids:
             try:
@@ -138,7 +140,7 @@ class PolicyInputSerializer(serializers.ModelSerializer):
         }
 
 
-class PolicySerializer(serializers.ModelSerializer):
+class PolicySerializer(SerializerCreateOverrideMixin, serializers.ModelSerializer):
     """Serializer for the policy model."""
 
     uuid = serializers.UUIDField(read_only=True)

--- a/rbac/management/principal/serializer.py
+++ b/rbac/management/principal/serializer.py
@@ -16,12 +16,13 @@
 #
 
 """Serializer for principal management."""
+from management.serializer_override_mixin import SerializerCreateOverrideMixin
 from rest_framework import serializers
 
 from .model import Principal
 
 
-class PrincipalSerializer(serializers.ModelSerializer):
+class PrincipalSerializer(SerializerCreateOverrideMixin, serializers.ModelSerializer):
     """Serializer for the Principal model."""
 
     class Meta:

--- a/rbac/management/querysets.py
+++ b/rbac/management/querysets.py
@@ -71,7 +71,7 @@ def get_group_queryset(request):
 
     username = request.query_params.get("username")
     if username:
-        principal = get_principal(username, request.user.account)
+        principal = get_principal(username, request)
         if principal.cross_account:
             return Group.objects.none()
         return Group.objects.filter(principals__username__iexact=username) | Group.platform_default_set()

--- a/rbac/management/role/definer.py
+++ b/rbac/management/role/definer.py
@@ -42,6 +42,15 @@ def _make_role(tenant, data):
         platform_default=data.get("platform_default", False),
     )
     role, created = Role.objects.get_or_create(name=name, defaults=defaults)
+
+    # NOTE: after we ensure/enforce all object have a tenant_id FK, we can add tenant=tenant
+    # to the get_or_create. We cannot currently, because records without would fail the GET
+    # and would create duplicate records. This ensures we temporarily do an update if
+    # obj.tenant_id is NULL
+    if not role.tenant:
+        role.tenant = tenant
+        role.save()
+
     if created:
         if role.display_name != display_name:
             role.display_name = display_name
@@ -57,10 +66,19 @@ def _make_role(tenant, data):
             return role
     for access_item in access_list:
         resource_def_list = access_item.pop("resourceDefinitions", [])
-        permission, created = Permission.objects.get_or_create(**access_item)
-        access_obj = Access.objects.create(permission=permission, role=role)
+        permission, created = Permission.objects.get_or_create(**access_item, tenant=tenant)
+
+        # NOTE: after we ensure/enforce all object have a tenant_id FK, we can add tenant=tenant
+        # to the get_or_create. We cannot currently, because records without would fail the GET
+        # and would create duplicate records. This ensures we temporarily do an update if
+        # obj.tenant_id is NULL
+        if not permission.tenant:
+            permission.tenant = tenant
+            permission.save()
+
+        access_obj = Access.objects.create(permission=permission, role=role, tenant=tenant)
         for resource_def_item in resource_def_list:
-            ResourceDefinition.objects.create(**resource_def_item, access=access_obj)
+            ResourceDefinition.objects.create(**resource_def_item, access=access_obj, tenant=tenant)
     return role
 
 
@@ -139,6 +157,13 @@ def seed_permissions(tenant):
                                     permission, created = Permission.objects.update_or_create(
                                         permission=f"{app_name}:{resource}:{operation_object}"
                                     )
+                                # NOTE: after we ensure/enforce all object have a tenant_id FK, we can add tenant=tenant
+                                # to the get_or_create. We cannot currently, because records without would fail the GET
+                                # and would create duplicate records. This ensures we temporarily do an update if
+                                # obj.tenant_id is NULL
+                                if not permission.tenant:
+                                    permission.tenant = tenant
+                                    permission.save()
                                 if created:
                                     logger.info(
                                         f"Created permission {permission.permission} "

--- a/rbac/management/role/serializer.py
+++ b/rbac/management/role/serializer.py
@@ -81,7 +81,7 @@ class AccessSerializer(SerializerCreateOverrideMixin, serializers.ModelSerialize
         fields = ("resourceDefinitions", "permission")
 
 
-class RoleSerializer(SerializerCreateOverrideMixin, serializers.ModelSerializer):
+class RoleSerializer(serializers.ModelSerializer):
     """Serializer for the Role model."""
 
     uuid = serializers.UUIDField(read_only=True)

--- a/rbac/management/role/serializer.py
+++ b/rbac/management/role/serializer.py
@@ -18,6 +18,7 @@
 """Serializer for role management."""
 from django.utils.translation import gettext as _
 from management.group.model import Group
+from management.serializer_override_mixin import SerializerCreateOverrideMixin
 from management.utils import get_principal_from_request
 from rest_framework import serializers
 from rest_framework.validators import UniqueValidator
@@ -28,7 +29,7 @@ ALLOWED_OPERATIONS = ["in", "equal"]
 FILTER_FIELDS = set(["key", "value", "operation"])
 
 
-class ResourceDefinitionSerializer(serializers.ModelSerializer):
+class ResourceDefinitionSerializer(SerializerCreateOverrideMixin, serializers.ModelSerializer):
     """Serializer for the ResourceDefinition model."""
 
     attributeFilter = serializers.JSONField()
@@ -56,7 +57,7 @@ class ResourceDefinitionSerializer(serializers.ModelSerializer):
         fields = ("attributeFilter",)
 
 
-class AccessSerializer(serializers.ModelSerializer):
+class AccessSerializer(SerializerCreateOverrideMixin, serializers.ModelSerializer):
     """Serializer for the Access model."""
 
     resourceDefinitions = ResourceDefinitionSerializer(many=True)
@@ -80,7 +81,7 @@ class AccessSerializer(serializers.ModelSerializer):
         fields = ("resourceDefinitions", "permission")
 
 
-class RoleSerializer(serializers.ModelSerializer):
+class RoleSerializer(SerializerCreateOverrideMixin, serializers.ModelSerializer):
     """Serializer for the Role model."""
 
     uuid = serializers.UUIDField(read_only=True)
@@ -129,15 +130,25 @@ class RoleSerializer(serializers.ModelSerializer):
         display_name = validated_data.pop("display_name", name)
         description = validated_data.pop("description", None)
         access_list = validated_data.pop("access")
-        role = Role.objects.create(name=name, description=description, display_name=display_name)
+        tenant = self.context["request"].tenant
+        role = Role.objects.create(name=name, description=description, display_name=display_name, tenant=tenant)
         role.save()
         for access_item in access_list:
             resource_def_list = access_item.pop("resourceDefinitions")
             access_permission = access_item.pop("permission")
             permission, created = Permission.objects.get_or_create(**access_permission)
-            access_obj = Access.objects.create(permission=permission, role=role)
+
+            # NOTE: after we ensure/enforce all object have a tenant_id FK, we can add tenant=tenant
+            # to the get_or_create. We cannot currently, because records without would fail the GET
+            # and would create duplicate records. This ensures we temporarily do an update if
+            # obj.tenant_id is NULL
+            if not permission.tenant:
+                permission.tenant = tenant
+                permission.save()
+
+            access_obj = Access.objects.create(permission=permission, role=role, tenant=tenant)
             for resource_def_item in resource_def_list:
-                ResourceDefinition.objects.create(**resource_def_item, access=access_obj)
+                ResourceDefinition.objects.create(**resource_def_item, access=access_obj, tenant=tenant)
         return role
 
     def update(self, instance, validated_data):
@@ -151,6 +162,7 @@ class RoleSerializer(serializers.ModelSerializer):
         instance.name = validated_data.get("name", instance.name)
         instance.display_name = validated_data.get("display_name", instance.display_name)
         instance.description = validated_data.get("description", instance.description)
+        tenant = self.context["request"].tenant
         instance.save()
         instance.access.all().delete()
 
@@ -158,15 +170,24 @@ class RoleSerializer(serializers.ModelSerializer):
             resource_def_list = access_item.pop("resourceDefinitions")
             access_permission = access_item.pop("permission")
             permission, created = Permission.objects.get_or_create(**access_permission)
-            access_obj = Access.objects.create(permission=permission, role=instance)
+
+            # NOTE: after we ensure/enforce all object have a tenant_id FK, we can add tenant=tenant
+            # to the get_or_create. We cannot currently, because records without would fail the GET
+            # and would create duplicate records. This ensures we temporarily do an update if
+            # obj.tenant_id is NULL
+            if not permission.tenant:
+                permission.tenant = tenant
+                permission.save()
+
+            access_obj = Access.objects.create(permission=permission, role=instance, tenant=tenant)
             for resource_def_item in resource_def_list:
-                ResourceDefinition.objects.create(**resource_def_item, access=access_obj)
+                ResourceDefinition.objects.create(**resource_def_item, access=access_obj, tenant=tenant)
 
         instance.save()
         return instance
 
 
-class RoleMinimumSerializer(serializers.ModelSerializer):
+class RoleMinimumSerializer(SerializerCreateOverrideMixin, serializers.ModelSerializer):
     """Serializer for the Role model that doesn't return access info."""
 
     uuid = serializers.UUIDField(read_only=True)
@@ -204,7 +225,7 @@ class RoleMinimumSerializer(serializers.ModelSerializer):
         return obtain_applications(obj)
 
 
-class DynamicFieldsModelSerializer(serializers.ModelSerializer):
+class DynamicFieldsModelSerializer(SerializerCreateOverrideMixin, serializers.ModelSerializer):
     """A ModelSerializer that controls which fields should be displayed."""
 
     def __init__(self, *args, **kwargs):

--- a/rbac/management/serializer_override_mixin.py
+++ b/rbac/management/serializer_override_mixin.py
@@ -45,8 +45,7 @@ class SerializerCreateOverrideMixin:
                 many_to_many[field_name] = validated_data.pop(field_name)
 
         try:
-            tenant_id = self.context["request"].tenant.id
-            validated_data["tenant_id"] = tenant_id
+            validated_data["tenant"] = self.context["request"].tenant
             instance = ModelClass._default_manager.create(**validated_data)
         except TypeError:
             tb = traceback.format_exc()

--- a/rbac/management/serializer_override_mixin.py
+++ b/rbac/management/serializer_override_mixin.py
@@ -1,0 +1,77 @@
+"""Mixin to override ModelSerializer."""
+
+import traceback
+
+from rest_framework.serializers import raise_errors_on_nested_writes
+from rest_framework.utils import model_meta
+
+
+class SerializerCreateOverrideMixin:
+    """Mixin to override ModelSerializer."""
+
+    # Overrides the `create` method in `ModelSerializer` for DRF 3.12.2:
+    # https://github.com/encode/django-rest-framework/blob/3.12.2/rest_framework/serializers.py#L904
+    #
+    # Existing behavior, plus appending the `tenant_id` to all creates
+    def create(self, validated_data):
+        """Override of create method."""
+        """
+        We have a bit of extra checking around this in order to provide
+        descriptive messages when something goes wrong, but this method is
+        essentially just:
+            return ExampleModel.objects.create(**validated_data)
+        If there are many to many fields present on the instance then they
+        cannot be set until the model is instantiated, in which case the
+        implementation is like so:
+            example_relationship = validated_data.pop('example_relationship')
+            instance = ExampleModel.objects.create(**validated_data)
+            instance.example_relationship = example_relationship
+            return instance
+        The default implementation also does not handle nested relationships.
+        If you want to support writable nested relationships you'll need
+        to write an explicit `.create()` method.
+        """
+        raise_errors_on_nested_writes("create", self, validated_data)
+
+        ModelClass = self.Meta.model
+
+        # Remove many-to-many relationships from validated_data.
+        # They are not valid arguments to the default `.create()` method,
+        # as they require that the instance has already been saved.
+        info = model_meta.get_field_info(ModelClass)
+        many_to_many = {}
+        for field_name, relation_info in info.relations.items():
+            if relation_info.to_many and (field_name in validated_data):
+                many_to_many[field_name] = validated_data.pop(field_name)
+
+        try:
+            tenant_id = self.context["request"].tenant.id
+            validated_data["tenant_id"] = tenant_id
+            instance = ModelClass._default_manager.create(**validated_data)
+        except TypeError:
+            tb = traceback.format_exc()
+            msg = (
+                "Got a `TypeError` when calling `%s.%s.create()`. "
+                "This may be because you have a writable field on the "
+                "serializer class that is not a valid argument to "
+                "`%s.%s.create()`. You may need to make the field "
+                "read-only, or override the %s.create() method to handle "
+                "this correctly.\nOriginal exception was:\n %s"
+                % (
+                    ModelClass.__name__,
+                    ModelClass._default_manager.name,
+                    ModelClass.__name__,
+                    ModelClass._default_manager.name,
+                    self.__class__.__name__,
+                    tb,
+                )
+            )
+            raise TypeError(msg)
+
+        # Save many-to-many relationships after the instance is created.
+        if many_to_many:
+            for field_name, value in many_to_many.items():
+                field = getattr(instance, field_name)
+                field.set(value)
+
+        return instance

--- a/tests/api/cross_access/test_view.py
+++ b/tests/api/cross_access/test_view.py
@@ -588,6 +588,7 @@ class CrossAccountRequestViewTests(IdentityRequest):
         principal_name = get_cross_principal_name(self.request_4.target_account, self.request_4.user_id)
         car_uuid = self.request_4.request_id
         url = reverse("cross-detail", kwargs={"pk": str(car_uuid)})
+        tenant = Tenant.objects.get(schema_name=tenant_schema)
 
         client = APIClient()
         response = client.patch(url, update_data, format="json", **self.associate_admin_request.META)
@@ -595,9 +596,10 @@ class CrossAccountRequestViewTests(IdentityRequest):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get("status"), update_data.get("status"))
 
-        with tenant_context(Tenant.objects.get(schema_name=tenant_schema)):
+        with tenant_context(tenant):
             princ = Principal.objects.get(username__iexact=principal_name)
         self.assertEqual(princ.username, principal_name)
+        self.assertEqual(princ.tenant, tenant)
         self.assertTrue(princ.cross_account)
 
     def test_cross_account_request_ordering_filter(self):

--- a/tests/management/group/test_definer.py
+++ b/tests/management/group/test_definer.py
@@ -36,13 +36,17 @@ class GroupDefinerTests(IdentityRequest):
         """Test that default group are seeded properly."""
         with tenant_context(self.tenant):
             group = Group.objects.get(platform_default=True)
+            system_policy = group.policies.get(name="System Policy for Group {}".format(group.uuid))
             self.assertEqual(group.platform_default, True)
             self.assertEqual(group.system, True)
             self.assertEqual(group.name, "Default access")
-            self.assertEqual(group.policies.get(name="System Policy for Group {}".format(group.uuid)).system, True)
+            self.assertEqual(group.tenant, self.tenant)
+            self.assertEqual(system_policy.system, True)
+            self.assertEqual(system_policy.tenant, self.tenant)
             # only platform_default roles would be assigned to the default group
             for role in group.roles():
                 self.assertTrue(role.platform_default)
+                self.assertEqual(role.tenant, self.tenant)
 
     def test_default_group_seeding_skips(self):
         """Test that default groups with system flag false will be skipped during seeding"""
@@ -57,6 +61,7 @@ class GroupDefinerTests(IdentityRequest):
         with tenant_context(self.tenant):
             group = Group.objects.get(platform_default=True)
             self.assertEqual(group.system, False)
+            self.assertEqual(group.tenant, self.tenant)
             group.roles().get(name="Ansible Automation Access Local Test")
 
     def test_default_group_seeding_reassign_roles(self):

--- a/tests/management/group/test_definer.py
+++ b/tests/management/group/test_definer.py
@@ -80,7 +80,7 @@ class GroupDefinerTests(IdentityRequest):
         with tenant_context(self.tenant):
             group = Group.objects.get(platform_default=True)
             roles = Role.objects.filter(name="RBAC Administrator").values_list("uuid", flat=True)
-            add_roles(group, roles)
+            add_roles(group, roles, self.tenant)
 
             group.system = system
             group.save()

--- a/tests/management/policy/test_view.py
+++ b/tests/management/policy/test_view.py
@@ -99,10 +99,13 @@ class PolicyViewsetTests(IdentityRequest):
         url = reverse("policy-detail", kwargs={"uuid": response.data.get("uuid")})
         client = APIClient()
         response = client.get(url, **self.headers)
+        uuid = response.data.get("uuid")
+        policy = Policy.objects.get(uuid=uuid)
 
-        self.assertIsNotNone(response.data.get("uuid"))
+        self.assertIsNotNone(uuid)
         self.assertIsNotNone(response.data.get("name"))
         self.assertEqual(policy_name, response.data.get("name"))
+        self.assertEqual(policy.tenant, self.tenant)
         self.assertEqual(str(self.group.uuid), response.data.get("group").get("uuid"))
 
     def test_delete_policy_success(self):

--- a/tox.ini
+++ b/tox.ini
@@ -32,7 +32,7 @@ deps =
 commands =
   pipenv run pip install -U pip
   pipenv install --dev --ignore-pipfile
-  coverage run {toxinidir}/rbac/manage.py test -v 2 {posargs: tests/}
+  coverage run {toxinidir}/rbac/manage.py test --failfast -v 2 {posargs: tests/}
   coverage report --show-missing
 
 [testenv:lint]


### PR DESCRIPTION
_**NOTE:** Relies on #464 being merged before review! Drafting until then._

## Link(s) to Jira
- https://issues.redhat.com/browse/RHCLOUD-11196

## Description of Intent of Change(s)

This is a follow-up to #464

**Override `create` method in `ModelSerializer`** - f02f35a
This overrides the `create` method in the `ModelSerializer` to ensure that we are
able to set the `tenant_id` for any object created in the API.

We'll still need to handle seeds by passing in the tenant, and any other object
creation that happens outside of views. In the future, we'll want to enforce this
via RLS.

We cannot add the `tenant_id` in a signal, because we don't have access to the
request, where the tenant exists. We also cannot do this directly in the views,
since it would require we expose the `tenant_id` field in the serializers which
we don't want to do.

Instead, this provides us the opportunity to add the `tenant_id` after serialization
has succeeded, but before the object is saved. This is abstracted out so we can
include it as a mixin to the serializer classes which inherit from `ModelSerializer`.

The existing behavior is copied directly from our current version 3.12.2 https://github.com/encode/django-rest-framework/blob/3.12.2/rest_framework/serializers.py#L904
and injects the `tenant_id` in the `try` block.

**Ensure `tenant_id` is saved on all creates** - e36b34a
This makes use of the `SerializerCreateOverrideMixin` in order to add the behavior
of saving the `tenant_id` from the request object on creates.

There are also some instances where serializers implement their own create, or
are not model serializers. In these cases, and other cases where we're doing an
explicit `create()` or `save()` we also need to ensure the `tenant_id` is set.

For `get_or_create()` calls, currently we don't have `tenant_id` set on all objects.
If we add `tenant=tenant` directly into these calls, we'd create duplicate records
since the `get` would not match on the tenant identifier. To get around this, we'll
need to update the object after `get_or_create()` to add the `tenant_id` value if
it does not yet exist.

We should be able to pull these noted references out after we're strictly enforcing
the FK constraints and have confirmed all records have `tenant_id` values. At that
point we should be able to add `tenant=tenant` to the `get_or_create()` directly.

One other consideration is that this commit may be something we'll want to revert
if/when we have RLS (row-level security) in place. If we do it correctly, we would
ideally have RLS policies setup for all operations (SELECT, INSERT, etc), which would
mean we'd no longer need to update all queries directly with the tenant, as the
policy would set the `tenant_id` in the middleware.

**Post-deploy**
After this is merged/deployed, we'll need to run the following script to populate `tenant_id` 
on historical data. After a a period of time we should verify that all records in all
schemas (including public) have `tenant_id`s populated.

## Local Testing
1) To first test the post-deploy script, run it against an existing dataset. If you have data
in your local db already, you can do it on this branch. Otherwise, reinit the db on `master`
and run the following:

Usage:
```
-- to run reconciliation as read-only:
./rbac/manage.py reconcile_tenant_relations --readonly

-- to run reconciliation and apply updates for missing `tenant_id` relations:
./rbac/manage.py reconcile_tenant_relations
```

You should see output about setting the `tenant_id`. If the script runs, you can flip
`READ_ONLY = False` and run it again. This will actually make the update. Running
it again should confirm that you have no records without a `tenant_id` (you can also check
the db directly).

2) To confirm that creating new and nested resources associates `tenant` objects,
you can exercise `POST`/create requests  on the API:

```
- curl http://localhost:8000/api/rbac/v1/groups/ -H 'Content-Type: application/json' -d '{"name": "test group"}'
- curl http://localhost:8000/api/rbac/v1/groups/<UUID>/principals/ -H 'Content-Type: application/json' -d '{"principals": [{"username": "test principal in group"}]}'
- curl http://localhost:8000/api/rbac/v1/groups/<UUID>/roles/ -H 'Content-Type: application/json' -d '{"roles": ["<UUID>"]}'
- curl http://localhost:8000/api/rbac/v1/roles/ -H 'Content-Type: application/json' -d '{"name": "test role", "access": [{"permission": "sources:*:*", "resourceDefinitions": [{"attributeFilter": {"key": "foo-key", "operation": "equal", "value": "1234"}}]}]}'
- curl http://localhost:8000/api/rbac/v1/policies/ -H 'Content-Type: application/json' -d '{"name": "test policy", "group": "<UUID>", "roles": ["<UUID>"]}'

```

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [x] are there any pre/post merge actions required? if so, document here.
    - [ ] the documented script above needs to be run
- [x] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  -  if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
