### PR TITLE
Remove start date not past restriction

### DIFF
--- a/rbac/api/cross_access/model.py
+++ b/rbac/api/cross_access/model.py
@@ -42,9 +42,9 @@ class CrossAccountRequest(models.Model):
     roles = models.ManyToManyField("management.Role", through="RequestsRoles")
 
     def validate_date(self, date):
-        """Validate that start and end dates are not in the past."""
+        """Validate that end dates are not in the past."""
         if isinstance(date, datetime.datetime) and date.date() < timezone.now().date():
-            raise ValidationError("Please verify the start and end dates are not in the past.")
+            raise ValidationError("Please verify the end dates are not in the past.")
 
     def validate_input_value(self):
         """Validate status is valid, and date is valid."""
@@ -52,7 +52,7 @@ class CrossAccountRequest(models.Model):
             raise ValidationError(f'Unknown status "{self.status}" specified, {STATUS_LIST} are valid inputs.')
 
         if self.status != "expired":
-            [self.validate_date(date) for date in [self.start_date, self.end_date]]
+            self.validate_date(self.end_date)
 
         if isinstance(self.end_date, datetime.datetime) and isinstance(self.start_date, datetime.datetime):
             if self.start_date.date() > (datetime.datetime.now() + datetime.timedelta(60)).date():

--- a/tests/api/cross_access/test_view.py
+++ b/tests/api/cross_access/test_view.py
@@ -354,20 +354,7 @@ class CrossAccountRequestViewTests(IdentityRequest):
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(
-            response.data.get("errors")[0].get("detail"), "Please verify the start and end dates are not in the past."
-        )
-
-    def test_create_requests_fail_for_start_date_being_past_value(self):
-        """Test the creation of cross account request fail for start_date being past value."""
-        self.data4create["start_date"] = self.format_date(self.ref_time + timedelta(-1))
-        client = APIClient()
-        response = client.post(
-            f"{URL_LIST}?", self.data4create, format="json", **self.associate_non_admin_request.META
-        )
-
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEqual(
-            response.data.get("errors")[0].get("detail"), "Please verify the start and end dates are not in the past."
+            response.data.get("errors")[0].get("detail"), "Please verify the end dates are not in the past."
         )
 
     def test_create_requests_fail_for_not_exist_role(self):


### PR DESCRIPTION
## Description of Intent of Change(s)
When the approver try to approve the request, the start date maybe
several days past. This is too strict, as long as we restrict that
the start date is before end date, we are ok to remove this start
date restriction.

## Local Testing
Unit test still pass

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  -  if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
