### PR TITLE
RHCLOUD-13834: Add unit tests to supplant iqe tests

### DIFF
--- a/tests/management/group/test_view.py
+++ b/tests/management/group/test_view.py
@@ -586,6 +586,14 @@ class GroupViewsetTests(IdentityRequest):
         self.assertEqual(roles[0].get("name"), self.roleB.name)
         self.assertEqual(roles[1].get("name"), self.role.name)
 
+    def test_get_group_roles_ordered_bad_input(self):
+        url = f"{reverse('group-roles', kwargs={'uuid': self.group.uuid})}?order_by=-themis"
+        client = APIClient()
+        response = client.get(url, **self.headers)
+        roles = response.data.get("data")
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
     def test_exclude_input_invalid(self):
         """Test that getting roles with 'exclude=' for a group returns failed validation."""
         url = "%s?exclude=sth" % (reverse("group-roles", kwargs={"uuid": self.group.uuid}))

--- a/tests/management/group/test_view.py
+++ b/tests/management/group/test_view.py
@@ -430,6 +430,14 @@ class GroupViewsetTests(IdentityRequest):
         self.assertEqual(response.data.get("meta").get("count"), 0)
         self.assertEqual(response.data.get("data"), [])
 
+    def test_get_group_principals_invalid_sort_order(self):
+        """Test that an invalid value for sort order is rejected."""
+        client = APIClient()
+        url = reverse("group-principals", kwargs={"uuid": self.emptyGroup.uuid})
+        url += "?order_by=themis"
+        response = client.get(url, **self.headers)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
     @patch(
         "management.principal.proxy.PrincipalProxy.request_filtered_principals",
         return_value={"status_code": 200, "data": []},


### PR DESCRIPTION
## Link(s) to Jira
- https://issues.redhat.com/browse/RHCLOUD-13834

## Description of Intent of Change(s)
There are two tests in iqe-rbac-plugin that are better as unit tests. This PR adds two unit tests to supplant the tests in iqe-rbac-plugin. The tests in question validate that invalid order_by values are rejected.

## Local Testing
How can the feature be exercised? 
How can the bug be exploited and fix confirmed?
Is any special local setup required?

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  -  if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
