### PR TITLE
Control permissions for put/patch cross access requests

### DIFF
--- a/rbac/api/cross_access/access_control.py
+++ b/rbac/api/cross_access/access_control.py
@@ -35,6 +35,11 @@ class CrossAccountRequestAccessPermission(permissions.BasePermission):
                 # Only allow associates create the request
                 return request.user.internal
 
+            if request.method in ["PUT", "PATCH"]:
+                # The permission depends on the object to be updated, strict permission check in view.
+                return True
+
+            # For list
             query_by = validate_and_get_key(request.query_params, QUERY_BY_KEY, VALID_QUERY_BY_KEY, ACCOUNT)
             if query_by == ACCOUNT:
                 return request.user.admin

--- a/rbac/api/cross_access/view.py
+++ b/rbac/api/cross_access/view.py
@@ -98,6 +98,8 @@ class CrossAccountRequestViewSet(
 
     def get_queryset(self):
         """Get query set based on the queryBy key word."""
+        if self.request.method in ["PATCH", "PUT"]:
+            return CrossAccountRequest.objects.all()
         if validate_and_get_key(self.request.query_params, QUERY_BY_KEY, VALID_QUERY_BY_KEY, ACCOUNT) == ACCOUNT:
             return CrossAccountRequest.objects.filter(target_account=self.request.user.account)
         return CrossAccountRequest.objects.filter(user_id=self.request.user.user_id)
@@ -127,20 +129,12 @@ class CrossAccountRequestViewSet(
     def partial_update(self, request, *args, **kwargs):
         """Patch a cross-account request."""
         validate_uuid(kwargs.get("pk"), "cross-account request uuid validation")
-        for field in request.data:
-            if field not in VALID_PATCH_FIELDS:
-                self.throw_validation_error(
-                    "cross-accont partial update",
-                    f"Field '{field}' is not supported. Please use one or more of: {VALID_PATCH_FIELDS}",
-                )
 
         with tenant_context(Tenant.objects.get(schema_name="public")):
             current = self.get_object()
+            self.check_patch_permission(request, current)
 
-            if current.status != "pending":
-                self.throw_validation_error("cross-account partial update", "Only pending requests may be updated.")
-
-            self.validate_and_format_input(request.data)
+            self.validate_and_format_patch_input(request.data)
 
             kwargs["partial"] = True
             response = super().update(request=request, *args, **kwargs)
@@ -156,11 +150,9 @@ class CrossAccountRequestViewSet(
 
         with tenant_context(Tenant.objects.get(schema_name="public")):
             current = self.get_object()
-            if current.status != "pending":
-                self.throw_validation_error("cross-account update", "Only pending requests may be updated.")
-            if "target_account" in request.data and str(request.data.get("target_account")) != current.target_account:
-                self.throw_validation_error("cross-account-update", "Target account may not be updated.")
+            self.check_update_permission(request, current)
 
+            request.data["target_account"] = current.target_account
             self.validate_and_format_input(request.data)
 
             response = super().update(request=request, args=args, kwargs=kwargs)
@@ -222,20 +214,26 @@ class CrossAccountRequestViewSet(
         error = {source: [message]}
         raise ValidationError(error)
 
-    def validate_and_format_input(self, request_data, partial=False):
+    def validate_and_format_input(self, request_data):
         """Validate the create api input."""
-        target_account = request_data.get("target_account")
+        for field in PARAMS_FOR_CREATION:
+            if not request_data.__contains__(field):
+                self.throw_validation_error("cross-account-request", f"Field {field} must be specified.")
 
-        if target_account:
-            try:
-                tenant_schema_name = create_schema_name(target_account)
-                Tenant.objects.get(schema_name=tenant_schema_name)
-            except Tenant.DoesNotExist:
-                raise self.throw_validation_error(
-                    "cross-account-request", f"Account '{target_account}' does not exist."
-                )
+        target_account = request_data.get("target_account")
+        try:
+            tenant_schema_name = create_schema_name(target_account)
+            Tenant.objects.get(schema_name=tenant_schema_name)
+        except Tenant.DoesNotExist:
+            raise self.throw_validation_error("cross-account-request", f"Account '{target_account}' does not exist.")
+
+        with tenant_context(Tenant.objects.get(schema_name="public")):
+            request_data["roles"] = self.format_roles(request_data.get("roles"))
 
         request_data["user_id"] = self.request.user.user_id
+
+    def validate_and_format_patch_input(self, request_data):
+        """Validate the create api input."""
         if "roles" in request_data:
             with tenant_context(Tenant.objects.get(schema_name="public")):
                 request_data["roles"] = self.format_roles(request_data.get("roles"))
@@ -260,3 +258,60 @@ class CrossAccountRequestViewSet(
         if status == "approved":
             create_cross_principal(car.target_account, car.user_id)
         car.save()
+
+    def check_patch_permission(self, request, update_obj):
+        """Check if user has right to patch cross access request."""
+        if request.user.account == update_obj.target_account:
+            """ For approvers updating requests coming to them, only org admin
+                could update status from pending/approved/denied to approved/denied.
+            """
+            if not request.user.admin:
+                self.throw_validation_error("cross-account partial update", "Only org admin could update status.")
+            if update_obj.status not in ["pending", "approved", "denied"]:
+                self.throw_validation_error(
+                    "cross-account partial update", "Only pending/approved/denied requests could be updated."
+                )
+            if request.data.get("status") not in ["approved", "denied"]:
+                self.throw_validation_error(
+                    "cross-accont partial update", f"Status could only be updated to approved/denied."
+                )
+            if len(request.data.keys()) > 1 or next(iter(request.data)) != "status":
+                self.throw_validation_error("cross-accont partial update", f"Only status could be updated.")
+        elif request.user.user_id == update_obj.user_id:
+            """ For requestors updating their requests, the status update could
+                only be from pending to cancelled.
+            """
+            if update_obj.status != "pending" or request.data.get("status") != "cancelled":
+                self.throw_validation_error(
+                    "cross-accont partial update", f"Status could only be updated from pending to cancelled."
+                )
+            for field in request.data:
+                if field not in VALID_PATCH_FIELDS:
+                    self.throw_validation_error(
+                        "cross-accont partial update",
+                        f"Field '{field}' is not supported. Please use one or more of: {VALID_PATCH_FIELDS}",
+                    )
+        else:
+            self.throw_validation_error(
+                "cross-accont partial update",
+                f"User does not have permission to update the request that does not belong to them.",
+            )
+
+    def check_update_permission(self, request, update_obj):
+        """Check if user has permission to update cross access request."""
+        # Only requestors could update the cross access request.
+        if request.user.user_id != update_obj.user_id:
+            self.throw_validation_error(
+                "cross-account update", "Only requestor could update the cross access request."
+            )
+
+        # Only pending request could be updated.
+        if update_obj.status != "pending":
+            self.throw_validation_error("cross-account update", "Only pending requests could be updated.")
+
+        # Do not allow updating the status:
+        if request.data.get("status") and str(request.data.get("status")) != "pending":
+            self.throw_validation_error("cross-account update", "Please use partial update to update the status.")
+
+        if request.data.get("target_account") and str(request.data.get("target_account")) != update_obj.target_account:
+            self.throw_validation_error("cross-account-update", "Target account has to stay the same.")

--- a/tests/api/cross_access/test_view.py
+++ b/tests/api/cross_access/test_view.py
@@ -57,13 +57,17 @@ class CrossAccountRequestViewTests(IdentityRequest):
         self.associate_admin_request = self.associate_admin_request_context["request"]
 
         """
-            Create cross account requests
+            Create cross account requests 1 to 6: request_1 to request_6
+            self.associate_admin_request has user_id 1111111, and account nubmer xxxxxx
+            It would be approver for request_1, request_2, request_5;
+            It would be requestor for request_3, request_6
             | target_account | user_id | start_date | end_date  |  status  | roles |
             |     xxxxxx     | 1111111 |    now     | now+10day | approved |       |
             |     xxxxxx     | 2222222 |    now     | now+10day | pending  |       |
             |     123456     | 1111111 |    now     | now+10day | approved |       |
             |     123456     | 2222222 |    now     | now+10day | pending  |       |
             |     xxxxxx     | 2222222 |    now     | now+10day | expired  |       |
+            |     123456     | 1111111 |    now     | now_10day | pending  |       |
         """
         self.another_account = "123456"
 
@@ -109,6 +113,12 @@ class CrossAccountRequestViewTests(IdentityRequest):
                 user_id="2222222",
                 end_date=self.ref_time + timedelta(10),
                 status="expired",
+            )
+            self.request_6 = CrossAccountRequest.objects.create(
+                target_account=self.another_account,
+                user_id="1111111",
+                end_date=self.ref_time + timedelta(10),
+                status="pending",
             )
 
     def tearDown(self):
@@ -207,10 +217,13 @@ class CrossAccountRequestViewTests(IdentityRequest):
         response = client.get(f"{URL_LIST}?query_by=user_id", **self.associate_non_admin_request.META)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(len(response.data["data"]), 2)
-        accounts = [data.get("target_account") for data in response.data["data"]]
-        self.assertTrue(self.account in accounts)
-        self.assertTrue(self.another_account in accounts)
+        self.assertEqual(len(response.data["data"]), 3)
+        request_ids = [data.get("request_id") for data in response.data["data"]]
+        for request_id in request_ids:
+            self.assertTrue(
+                request_id
+                in [str(self.request_1.request_id), str(self.request_3.request_id), str(self.request_6.request_id)]
+            )
 
     def test_list_requests_query_by_user_id_filter_by_account_success(self):
         """Test listing cross account request based on user id of identity."""
@@ -231,7 +244,7 @@ class CrossAccountRequestViewTests(IdentityRequest):
         )
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(len(response.data["data"]), 2)
+        self.assertEqual(len(response.data["data"]), 3)
 
     def test_list_requests_query_by_user_id_with_combined_filters_success(self):
         """Test listing cross account request based on user id of identity."""
@@ -437,14 +450,34 @@ class CrossAccountRequestViewTests(IdentityRequest):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(response.data.get("errors")[0].get("detail"), "Start date must be within 60 days of today.")
 
-    def test_update_request_success(self):
-        """Test updating an entire CAR."""
+    def test_update_request_denied_for_approver(self):
+        """Test updating an entire CAR denied for approver."""
         self.data4create["target_account"] = self.account
         self.data4create["start_date"] = self.format_date(self.ref_time + timedelta(3))
         self.data4create["end_date"] = self.format_date(self.ref_time + timedelta(5))
         self.data4create["roles"] = ["role_8", "role_9"]
 
         car_uuid = self.request_2.request_id
+        url = reverse("cross-detail", kwargs={"pk": str(car_uuid)})
+
+        client = APIClient()
+        response = client.put(url, self.data4create, format="json", **self.associate_admin_request.META)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(
+            response.data.get("errors")[0].get("detail"), "Only requestor could update the cross access request."
+        )
+
+    def test_update_request_success_for_requestor(self):
+        """Test updating an entire CAR."""
+        self.data4create["target_account"] = self.account
+        self.data4create["start_date"] = self.format_date(self.ref_time + timedelta(3))
+        self.data4create["end_date"] = self.format_date(self.ref_time + timedelta(5))
+        self.data4create["roles"] = ["role_8", "role_9"]
+
+        car_uuid = self.request_1.request_id
+        self.request_1.status = "pending"
+        self.request_1.save()
         url = reverse("cross-detail", kwargs={"pk": str(car_uuid)})
 
         client = APIClient()
@@ -458,59 +491,146 @@ class CrossAccountRequestViewTests(IdentityRequest):
                 continue
             self.assertEqual(self.data4create.get(field), response.data.get(field))
 
-    def test_update_request_fail_acct(self):
+    def test_update_request_fail_acct_for_requestor(self):
         """Test that updating the account of a CAR fails."""
         self.data4create["target_account"] = "10001"
 
-        car_uuid = self.request_1.request_id
+        car_uuid = self.request_6.request_id
         url = reverse("cross-detail", kwargs={"pk": car_uuid})
 
         client = APIClient()
         response = client.put(url, self.data4create, format="json", **self.associate_admin_request.META)
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data.get("errors")[0].get("detail"), "Target account has to stay the same.")
 
-    def test_update_request_expired(self):
+    def test_update_request_expired_for_requestor(self):
         """Test that updating an expired CAR fails."""
         self.data4create["end_date"] = self.format_date(self.ref_time + timedelta(20))
 
-        car_uuid = self.request_5.request_id
+        car_uuid = self.request_3.request_id
+        self.request_3.status = "expired"
+        self.request_3.save()
         url = reverse("cross-detail", kwargs={"pk": car_uuid})
 
         client = APIClient()
         response = client.put(url, self.data4create, format="json", **self.associate_admin_request.META)
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data.get("errors")[0].get("detail"), "Only pending requests could be updated.")
 
-    def test_partial_update_success(self):
-        """Test updating part of a CAR."""
+    def test_partial_update_denied_for_updating_CAR_belong_to_others(self):
+        """Test updating part of a CAR does not have relation with api caller."""
         update_data = {"start_date": self.format_date(self.ref_time + timedelta(2))}
 
+        # request_4's user_id is "2222222", associate_admin_request'user_id is "1111111"
+        # request_4's target_account is "123456", associate_admin_request's account is "xxxxxx"
+        car_uuid = self.request_4.request_id
+        url = reverse("cross-detail", kwargs={"pk": str(car_uuid)})
+
+        client = APIClient()
+        response = client.patch(url, update_data, format="json", **self.associate_admin_request.META)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_partial_update_success_for_approver(self):
+        """Test updating part of a CAR."""
+        # request_2's account is "xxxxxx" same as associate_admin_request's account
         car_uuid = self.request_2.request_id
         url = reverse("cross-detail", kwargs={"pk": str(car_uuid)})
 
         client = APIClient()
+
+        # From pending to approved
+        update_data = {"status": "approved"}
         response = client.patch(url, update_data, format="json", **self.associate_admin_request.META)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data.get("start_date"), update_data.get("start_date"))
+        self.assertEqual(response.data.get("status"), update_data.get("status"))
 
-    def test_partial_update_fail_invalid_field(self):
-        """Test that updating protected fields of a CAR fails."""
-        update_data = {"target_account": "123456"}
+        # From approved to denied
+        update_data = {"status": "denied"}
+        response = client.patch(url, update_data, format="json", **self.associate_admin_request.META)
 
-        car_uuid = self.request_1.request_id
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data.get("status"), update_data.get("status"))
+
+        # From denied to approved
+        update_data = {"status": "approved"}
+        response = client.patch(url, update_data, format="json", **self.associate_admin_request.META)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data.get("status"), update_data.get("status"))
+
+        # From approved to cancelled would fail
+        update_data = {"status": "cancelled"}
+        response = client.patch(url, update_data, format="json", **self.associate_admin_request.META)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_partial_update_invalid_update_denied_for_approver(self):
+        """Test updating part of a CAR fail due to invalid update for approver."""
+        # request_2's account is "xxxxxx" same as associate_admin_request's account
+        car_uuid = self.request_2.request_id
+        url = reverse("cross-detail", kwargs={"pk": str(car_uuid)})
+        client = APIClient()
+
+        # fail to update if approver is not admin
+        update_data = {"status": "approved"}
+        response = client.patch(url, update_data, format="json", **self.associate_non_admin_request.META)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        # fail to update field other than status
+        update_data = {"start_date": self.format_date(self.ref_time + timedelta(2))}
+        response = client.patch(url, update_data, format="json", **self.associate_admin_request.META)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        # fail to update fields more than just status
+        update_data = {"start_date": self.format_date(self.ref_time + timedelta(2)), "status": "approved"}
+        response = client.patch(url, update_data, format="json", **self.associate_admin_request.META)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        # approver fail to update status from pending to cancelled
+        update_data = {"status": "cancelled"}
+        response = client.patch(url, update_data, format="json", **self.associate_admin_request.META)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_partial_update_success_for_requestor(self):
+        """Test updating part of a CAR."""
+        # request_6's user_id is "1111111" same as associate_admin_request's user_id
+        car_uuid = self.request_6.request_id
         url = reverse("cross-detail", kwargs={"pk": str(car_uuid)})
 
         client = APIClient()
+        update_data = {"status": "cancelled"}
+        response = client.patch(url, update_data, format="json", **self.associate_admin_request.META)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data.get("status"), update_data.get("status"))
+
+    def test_partial_update_approved_request_for_requestor(self):
+        """Test that updating protected fields of a CAR fails."""
+        car_uuid = self.request_3.request_id
+        url = reverse("cross-detail", kwargs={"pk": str(car_uuid)})
+
+        client = APIClient()
+
+        # Can not partial update status from approved to other status
+        update_data = {"status": "cancelled"}
         response = client.patch(url, update_data, format="json", **self.associate_admin_request.META)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
-    def test_partial_update_expired(self):
+    def test_partial_update_expired_for_requestor(self):
         """Test that PATCHing an expired CAR fails."""
         update_data = {"end_date": self.format_date(self.ref_time + timedelta(18))}
 
-        car_uuid = self.request_5.request_id
+        car_uuid = self.request_3.request_id
+        self.request_3.status = "expired"
+        self.request_3.save()
         url = reverse("cross-detail", kwargs={"pk": car_uuid})
 
         client = APIClient()
@@ -518,46 +638,41 @@ class CrossAccountRequestViewTests(IdentityRequest):
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
-    def test_update_bmi(self):
-        """Test that PUT with extra fields in body fails."""
-        self.data4create["billy"] = "mandy"
-
-        car_uuid = self.request_5.request_id
-        url = reverse("cross-detail", kwargs={"pk": car_uuid})
-
-        client = APIClient()
-        response = client.put(url, self.data4create, format="json", **self.associate_admin_request.META)
-
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-
-    def test_partial_update_bmi(self):
+    def test_partial_update_bmi_for_requestor(self):
         """Test that PATCH with extra fields in body fails."""
         update_data = {"start_date": self.format_date(self.ref_time + timedelta(2)), "cup": "cake"}
 
-        car_uuid = self.request_1.request_id
+        car_uuid = self.request_6.request_id
         url = reverse("cross-detail", kwargs={"pk": str(car_uuid)})
 
         client = APIClient()
         response = client.patch(url, update_data, format="json", **self.associate_admin_request.META)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
-    def test_update_bad_date_spec(self):
+    def test_update_bad_date_spec_for_requestor(self):
         """Test that PUT with body fields not matching spec fails."""
+        self.data4create["target_account"] = self.account
         self.data4create["end_date"] = 12252021
 
-        car_uuid = self.request_5.request_id
+        car_uuid = self.request_1.request_id
+        self.request_1.status = "pending"
+        self.request_1.save()
         url = reverse("cross-detail", kwargs={"pk": car_uuid})
 
         client = APIClient()
         response = client.put(url, self.data4create, format="json", **self.associate_admin_request.META)
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(
+            response.data.get("errors")[0].get("detail"),
+            "Datetime has wrong format. Use one of these formats instead: MM/DD/YYYY.",
+        )
 
-    def test_partial_update_bad_date_spec(self):
+    def test_partial_update_bad_date_spec_for_requestor(self):
         """Test that PATCH with body fields not matching spec fails."""
         update_data = {"start_date": 12252021}
 
-        car_uuid = self.request_1.request_id
+        car_uuid = self.request_6.request_id
         url = reverse("cross-detail", kwargs={"pk": str(car_uuid)})
 
         client = APIClient()
@@ -584,9 +699,9 @@ class CrossAccountRequestViewTests(IdentityRequest):
     def test_create_principal_on_approval(self):
         """Test that moving a car to approved creates a principal."""
         update_data = {"status": "approved"}
-        tenant_schema = create_schema_name(self.request_4.target_account)
-        principal_name = get_cross_principal_name(self.request_4.target_account, self.request_4.user_id)
-        car_uuid = self.request_4.request_id
+        tenant_schema = create_schema_name(self.request_2.target_account)
+        principal_name = get_cross_principal_name(self.request_2.target_account, self.request_2.user_id)
+        car_uuid = self.request_2.request_id
         url = reverse("cross-detail", kwargs={"pk": str(car_uuid)})
         tenant = Tenant.objects.get(schema_name=tenant_schema)
 
@@ -611,16 +726,16 @@ class CrossAccountRequestViewTests(IdentityRequest):
         )
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(len(response.data["data"]), 2)
+        self.assertEqual(len(response.data["data"]), 3)
         self.assertTrue(response.data["data"][0].get("request_id") < response.data["data"][1].get("request_id"))
 
         # Sorting the dates
-        ## request_1 is created a little bit ealier than request_3, therefore, the
-        ## first should be request_3
+        ## request_1 is created a little bit ealier than request_6, therefore, the
+        ## first should be request_6
         response = client.get(
             f"{URL_LIST}?query_by=user_id&order_by=-created", **self.associate_non_admin_request.META
         )
-        self.assertEqual(response.data["data"][0].get("request_id"), str(self.request_3.request_id))
+        self.assertEqual(response.data["data"][0].get("request_id"), str(self.request_6.request_id))
 
         ## set start_date of request_3 to a day later
         self.request_3.start_date = self.ref_time + timedelta(1)

--- a/tests/api/cross_access/test_view.py
+++ b/tests/api/cross_access/test_view.py
@@ -465,7 +465,7 @@ class CrossAccountRequestViewTests(IdentityRequest):
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(
-            response.data.get("errors")[0].get("detail"), "Only requestor could update the cross access request."
+            response.data.get("errors")[0].get("detail"), "Only the requestor may update the cross access request."
         )
 
     def test_update_request_success_for_requestor(self):
@@ -502,7 +502,7 @@ class CrossAccountRequestViewTests(IdentityRequest):
         response = client.put(url, self.data4create, format="json", **self.associate_admin_request.META)
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEqual(response.data.get("errors")[0].get("detail"), "Target account has to stay the same.")
+        self.assertEqual(response.data.get("errors")[0].get("detail"), "Target account must stay the same.")
 
     def test_update_request_expired_for_requestor(self):
         """Test that updating an expired CAR fails."""
@@ -517,7 +517,7 @@ class CrossAccountRequestViewTests(IdentityRequest):
         response = client.put(url, self.data4create, format="json", **self.associate_admin_request.META)
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEqual(response.data.get("errors")[0].get("detail"), "Only pending requests could be updated.")
+        self.assertEqual(response.data.get("errors")[0].get("detail"), "Only pending requests may be updated.")
 
     def test_partial_update_denied_for_updating_CAR_belong_to_others(self):
         """Test updating part of a CAR does not have relation with api caller."""


### PR DESCRIPTION
## Link(s) to Jira
- https://issues.redhat.com/browse/RHCLOUD-13550

## Description of Intent of Change(s)
1. Only allow approver to change the status from pending/approved/denied
to approved/denied by patching the requests;

2. When requestor patching the request, they are restricted to some operation
and status from pending to canceled;

3. Only allow requestor to put the cross access requests

## Local Testing
Mostly are covered by unit tests

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  -  if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
