### PR TITLE
Add schema sync command

### DIFF
--- a/rbac/management/management/commands/sync_schemas.py
+++ b/rbac/management/management/commands/sync_schemas.py
@@ -1,5 +1,6 @@
-from django.db import connection
 from django.core.management.base import BaseCommand
+
+from django.db.utils import IntegrityError
 from management.models import Group, Role, Policy, Principal
 from api.models import Tenant
 from tenant_schemas.utils import tenant_context
@@ -8,46 +9,62 @@ from tenant_schemas.utils import tenant_context
 class Command(BaseCommand):
     help = "Syncs custom principals, roles, groups, and policies to the public schema"
 
+    def clear_pk(self, entry):
+        entry.id = None
+        entry.pk = None
 
     def copy_custom_principals_to_public(self, tenant):
         principals = Principal.objects.all()
         public_schema = Tenant.objects.get(schema_name="public")
         for principal in principals:
-            print(f"Copying principal {principal.username} to public schema for tenant {tenant}.")
+            self.stdout.write(f"Copying principal {principal.username} to public schema for tenant {tenant}.")
             if not principal.tenant:
                 principal.tenant = tenant
                 principal.save()
             with tenant_context(public_schema):
-                principal.id = None
-                principal.pk = None
-                principal.save()
+                self.clear_pk(principal)
+                try:
+                    principal.save()
+                except IntegrityError as err:
+                    self.stderr.write(f"Couldn't copy principal: {principal.username}. Skipping due to:\n{err}")
+                    continue
+                    
 
 
     def copy_custom_roles_to_public(self, tenant):
         roles = Role.objects.filter(system=False)
         public_schema = Tenant.objects.get(schema_name="public")
         for role in roles:
-            print(f"Copying role {role.name} to public schema for tenant {tenant}.")
+            self.stdout.write(f"Copying role {role.name} to public schema for tenant {tenant}.")
             if not role.tenant:
                 role.tenant = tenant
                 role.save()
             access_list = list(role.access.all())
             with tenant_context(public_schema):
-                role.id = None
-                role.pk = None
-                role.save()
+                self.clear_pk(role)
+                try:
+                    role.save()
+                except IntegrityError as err:
+                    self.stderr.write(f"Couldn't copy role: {role.name}. Skipping due to:\n{err}")
+                    continue
                 for access in access_list:
-                    access.id = None
-                    access.pk = None
+                    self.clear_pk(access)
                     if not access.tenant:
                         access.tenant = tenant
-                        access.role = role
-                    access.save()
+                    access.role = role
+                    try:
+                        access.save()
+                    except IntegrityError as err:
+                        self.stderr.write(f"Couldn't copy access entry: {access}. Skipping due to:\n{err}")
+                        continue
                     for resource_def in access.resourceDefinitions.all():
-                        resource_def.id = None
-                        resource_def.pk = None
+                        self.clear_pk(resource_def)
                         resource_def.access = access
-                        resource_def.save()
+                        try:
+                            resource_def.save()
+                        except IntegrityError as err:
+                            self.stderr.write(f"Couldn't copy {resource_def}. Skipping due to:\n{err}")
+                            continue
                 role.access.set(access_list)
                 role.save()
 
@@ -56,16 +73,19 @@ class Command(BaseCommand):
         groups = Group.objects.filter(system=False)
         public_schema = Tenant.objects.get(schema_name="public")
         for group in groups:
-            print(f"Copying group {group.name} to public schema for tenant {tenant}.")
+            self.stdout.write(f"Copying group {group.name} to public schema for tenant {tenant}.")
             if not group.tenant:
                 group.tenant = tenant
                 group.save()
             principals = list(group.principals.all())
             new_principals = []
             with tenant_context(public_schema):
-                group.pk = None
-                group.id = None
-                group.save()
+                self.clear_pk(group)
+                try:
+                    group.save()
+                except IntegrityError as err:
+                    self.stderr.write(f"Couldn't copy group {group.name}. Skipping due to:\n{err}")
+                    continue
                 for principal in principals:
                     new_principals.append(Principal.objects.get(username=principal.username))
                 group.principals.set(new_principals)
@@ -76,7 +96,7 @@ class Command(BaseCommand):
         policies = Policy.objects.all()
         public_schema = Tenant.objects.get(schema_name="public")
         for policy in policies:
-            print(f"Copying policy {policy.name} to public schema for tenant {tenant}.")
+            self.stdout.write(f"Copying policy {policy.name} to public schema for tenant {tenant}.")
             if not policy.tenant:
                 policy.tenant = tenant
                 policy.save()
@@ -84,9 +104,12 @@ class Command(BaseCommand):
             roles = list(policy.roles.all())
             new_roles = []
             with tenant_context(public_schema):
-                policy.fk = None
-                policy.id = None
-                policy.save()
+                self.clear_pk(policy)
+                try:
+                    policy.save()
+                except IntegrityError as err:
+                    self.stderr.write(f"Couldn't copy policy {policy.name}. Skipping due to:\n{err}")
+                    continue
                 policy.group = Group.objects.get(name=group.name)
                 for role in roles:
                     new_roles.append(Role.objects.get(name=role.name))
@@ -96,7 +119,6 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         tenants = Tenant.objects.exclude(schema_name="public")
-        print(tenants)
         for tenant in tenants:
             with tenant_context(tenant):
                 self.copy_custom_principals_to_public(tenant)

--- a/rbac/management/management/commands/sync_schemas.py
+++ b/rbac/management/management/commands/sync_schemas.py
@@ -1,0 +1,105 @@
+from django.db import connection
+from django.core.management.base import BaseCommand
+from management.models import Group, Role, Policy, Principal
+from api.models import Tenant
+from tenant_schemas.utils import tenant_context
+
+
+class Command(BaseCommand):
+    help = "Syncs custom principals, roles, groups, and policies to the public schema"
+
+
+    def copy_custom_principals_to_public(self, tenant):
+        principals = Principal.objects.all()
+        public_schema = Tenant.objects.get(schema_name="public")
+        for principal in principals:
+            print(f"Copying principal {principal.username} to public schema for tenant {tenant}.")
+            if not principal.tenant:
+                principal.tenant = tenant
+                principal.save()
+            with tenant_context(public_schema):
+                principal.id = None
+                principal.pk = None
+                principal.save()
+
+
+    def copy_custom_roles_to_public(self, tenant):
+        roles = Role.objects.filter(system=False)
+        public_schema = Tenant.objects.get(schema_name="public")
+        for role in roles:
+            print(f"Copying role {role.name} to public schema for tenant {tenant}.")
+            if not role.tenant:
+                role.tenant = tenant
+                role.save()
+            access_list = list(role.access.all())
+            with tenant_context(public_schema):
+                role.id = None
+                role.pk = None
+                role.save()
+                for access in access_list:
+                    access.id = None
+                    access.pk = None
+                    if not access.tenant:
+                        access.tenant = tenant
+                        access.role = role
+                    access.save()
+                    for resource_def in access.resourceDefinitions.all():
+                        resource_def.id = None
+                        resource_def.pk = None
+                        resource_def.access = access
+                        resource_def.save()
+                role.access.set(access_list)
+                role.save()
+
+
+    def copy_custom_groups_to_public(self, tenant):
+        groups = Group.objects.filter(system=False)
+        public_schema = Tenant.objects.get(schema_name="public")
+        for group in groups:
+            print(f"Copying group {group.name} to public schema for tenant {tenant}.")
+            if not group.tenant:
+                group.tenant = tenant
+                group.save()
+            principals = list(group.principals.all())
+            new_principals = []
+            with tenant_context(public_schema):
+                group.pk = None
+                group.id = None
+                group.save()
+                for principal in principals:
+                    new_principals.append(Principal.objects.get(username=principal.username))
+                group.principals.set(new_principals)
+                group.save()
+
+
+    def copy_custom_policies_to_public(self, tenant):
+        policies = Policy.objects.all()
+        public_schema = Tenant.objects.get(schema_name="public")
+        for policy in policies:
+            print(f"Copying policy {policy.name} to public schema for tenant {tenant}.")
+            if not policy.tenant:
+                policy.tenant = tenant
+                policy.save()
+            group = policy.group
+            roles = list(policy.roles.all())
+            new_roles = []
+            with tenant_context(public_schema):
+                policy.fk = None
+                policy.id = None
+                policy.save()
+                policy.group = Group.objects.get(name=group.name)
+                for role in roles:
+                    new_roles.append(Role.objects.get(name=role.name))
+                policy.roles.set(new_roles)
+                policy.save()
+
+
+    def handle(self, *args, **options):
+        tenants = Tenant.objects.exclude(schema_name="public")
+        print(tenants)
+        for tenant in tenants:
+            with tenant_context(tenant):
+                self.copy_custom_principals_to_public(tenant)
+                self.copy_custom_roles_to_public(tenant)
+                self.copy_custom_groups_to_public(tenant)
+                self.copy_custom_policies_to_public(tenant)


### PR DESCRIPTION
Signed-off-by: Chris Mitchell <cmitchel@redhat.com>

## Link(s) to Jira
- https://issues.redhat.com/browse/RHCLOUD-11198

## Description of Intent of Change(s)
This PR sets up a manage.py command that rolls through the existing tenants and attempts to directly replicate any modified entries into the public schema. It catches IntegrityErrors to allow for idempotency, ensuring existing values aren't affected. It also adds tenant IDs to anything it saves that doesn't already have one.

## Local Testing
If you've already got a DB set up locally, then pulling down the branch and running `manage.py sync_schemas` should trigger a run and copy things over to the public schema. Verifying this is a bit more difficult, as we don't currently serve any data from the public schema. I've personally been verifying status post run with a DB inspection tool like pgAdmin.

For setting up a fresh DB with data to test the copy, I've been using the following simple script and a running local server, then running the manage.py command.

```
import requests
from random import randint
import json

base_url = "http://localhost:8000/api/rbac/v1"
group_names = ["planex", "momcorp", "marsU"]
group_uuids = []
role_names = ["crew", "mgmt", "goons", "mom"]
permissions = ["cost-management:*:*", "cost-management:rate:*"]
role_uuids = []
principals = ["user_dev", "user_perms", "user_admin"]
headers = {"admin": "1", "Content-type": "application/json"}

def setup_groups():
    url = f"{base_url}/groups/"
    for name in group_names:
        data = {
            "name": name
        }
        resp = requests.post(url, data=json.dumps(data), headers=headers)
        group_uuids.append(resp.json().get("uuid"))


def setup_roles():
    url = f"{base_url}/roles/"
    for idx, name in enumerate(role_names):
        if idx == 0:
            data = {
                "name": name,
                "access": [
                    {
                        "permission": permissions[randint(0,1)],
                        "resourceDefinitions": [
                            {
                                "attributeFilter": {
                                    "key": "app.attribute.condition",
                                    "value": "value1",
                                    "operation": "equal"
                                }
                            }
                        ]
                    }
                ]
            }
        else:
            data = {
                "name": name,
                "access": [
                    {
                        "permission": permissions[randint(0,1)],
                        "resourceDefinitions": []
                    }
                ]
            }
        resp = requests.post(url, data=json.dumps(data), headers=headers)
        role_uuids.append(resp.json().get("uuid"))


def setup_policies():
    for idx, uuid in enumerate(group_uuids):
        url = f"{base_url}/groups/{uuid}/roles/"
        if idx == 0:
            data = {
                "roles": [
                    role_uuids[0],
                    role_uuids[1]
                ]
            }
        elif idx == 1:
            data = {
                "roles": [
                    role_uuids[2],
                    role_uuids[3]
                ]
            }
        else:
            data = {
                "roles": [
                    role_uuids[0]
                ]
            }
        requests.post(url, data=json.dumps(data), headers=headers)
        
        url = f"{base_url}/groups/{uuid}/principals/"
        data = {
            "principals": [
                {
                    "username": principals[randint(0,2)]
                }
            ]
        }
        requests.post(url, data=json.dumps(data), headers=headers)

def main():
    setup_groups()
    setup_roles()
    setup_policies()

if __name__ == "__main__":
    main()
```

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [x] are there any pre/post merge actions required? if so, document here.
    - Post merge we'll want to run the script to set up the DBs for future moves off of django_tenant_schemas
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  -  if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [x] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
