### PR TITLE
Remove tenant_id associations on Permissions

### DIFF
--- a/rbac/management/role/serializer.py
+++ b/rbac/management/role/serializer.py
@@ -138,14 +138,6 @@ class RoleSerializer(serializers.ModelSerializer):
             access_permission = access_item.pop("permission")
             permission, created = Permission.objects.get_or_create(**access_permission)
 
-            # NOTE: after we ensure/enforce all object have a tenant_id FK, we can add tenant=tenant
-            # to the get_or_create. We cannot currently, because records without would fail the GET
-            # and would create duplicate records. This ensures we temporarily do an update if
-            # obj.tenant_id is NULL
-            if not permission.tenant:
-                permission.tenant = tenant
-                permission.save()
-
             access_obj = Access.objects.create(permission=permission, role=role, tenant=tenant)
             for resource_def_item in resource_def_list:
                 ResourceDefinition.objects.create(**resource_def_item, access=access_obj, tenant=tenant)
@@ -170,14 +162,6 @@ class RoleSerializer(serializers.ModelSerializer):
             resource_def_list = access_item.pop("resourceDefinitions")
             access_permission = access_item.pop("permission")
             permission, created = Permission.objects.get_or_create(**access_permission)
-
-            # NOTE: after we ensure/enforce all object have a tenant_id FK, we can add tenant=tenant
-            # to the get_or_create. We cannot currently, because records without would fail the GET
-            # and would create duplicate records. This ensures we temporarily do an update if
-            # obj.tenant_id is NULL
-            if not permission.tenant:
-                permission.tenant = tenant
-                permission.save()
 
             access_obj = Access.objects.create(permission=permission, role=instance, tenant=tenant)
             for resource_def_item in resource_def_list:


### PR DESCRIPTION
Permissions are not able to currently be created via the API. This means that
permissions can be shared from the public schema for all tenants.

Currently, seeding requires we seed data in all tenant schemas, so we'll keep
the current setting of tenant_id in the seeds, but remove them from the serializer.

Once we move to serving from the public schema, this will ensure we do not have
superfluous permission data, and we'll just serve permissions out of the public
schema.

