### PR TITLE
Fix count

### DIFF
--- a/rbac/management/access/view.py
+++ b/rbac/management/access/view.py
@@ -104,14 +104,15 @@ class AccessView(APIView):
         """Return the paginator instance associated with the view, or `None`."""
         if not hasattr(self, "_paginator"):
             self._paginator = self.pagination_class()
-            if self.pagination_class is None or "limit" not in self.request.query_params:
-                self._paginator.default_limit = self._paginator.max_limit
+            self._paginator.max_limit = None
         return self._paginator
 
     def paginate_queryset(self, queryset):
         """Return a single page of results, or `None` if pagination is disabled."""
         if self.paginator is None:
             return None
+        if "limit" not in self.request.query_params:
+            self.paginator.default_limit = len(queryset)
         return self.paginator.paginate_queryset(queryset, self.request, view=self)
 
     def get_paginated_response(self, data):

--- a/tests/management/access/test_view.py
+++ b/tests/management/access/test_view.py
@@ -134,7 +134,7 @@ class AccessViewTests(IdentityRequest):
         self.assertIsNotNone(response.data.get("data"))
         self.assertIsInstance(response.data.get("data"), list)
         self.assertEqual(len(response.data.get("data")), 2)
-        self.assertEqual(response.data.get("meta").get("limit"), 1000)
+        self.assertEqual(response.data.get("meta").get("limit"), 2)
         self.assertEqual(self.access_data, response.data.get("data")[0])
 
         # the platform default permission could also be retrieved
@@ -205,7 +205,7 @@ class AccessViewTests(IdentityRequest):
         self.assertIsNotNone(response.data.get("data"))
         self.assertIsInstance(response.data.get("data"), list)
         self.assertEqual(len(response.data.get("data")), 2)
-        self.assertEqual(response.data.get("meta").get("limit"), 1000)
+        self.assertEqual(response.data.get("meta").get("limit"), 2)
 
     def test_get_access_multiple_apps_supplied(self):
         """Test that we return all permissions for multiple apps when supplied."""
@@ -247,7 +247,7 @@ class AccessViewTests(IdentityRequest):
         self.assertIsNotNone(response.data.get("data"))
         self.assertIsInstance(response.data.get("data"), list)
         self.assertEqual(len(response.data.get("data")), 0)
-        self.assertEqual(response.data.get("meta").get("limit"), 1000)
+        self.assertEqual(response.data.get("meta").get("limit"), 0)
 
     def test_get_access_no_subset_match(self):
         """Test that we cannot have a subset match on app/permission."""
@@ -268,7 +268,7 @@ class AccessViewTests(IdentityRequest):
         self.assertIsNotNone(response.data.get("data"))
         self.assertIsInstance(response.data.get("data"), list)
         self.assertEqual(len(response.data.get("data")), 0)
-        self.assertEqual(response.data.get("meta").get("limit"), 1000)
+        self.assertEqual(response.data.get("meta").get("limit"), 0)
 
     def test_get_access_no_match(self):
         """Test that we only match on the application name of the permission data."""
@@ -289,7 +289,7 @@ class AccessViewTests(IdentityRequest):
         self.assertIsNotNone(response.data.get("data"))
         self.assertIsInstance(response.data.get("data"), list)
         self.assertEqual(len(response.data.get("data")), 0)
-        self.assertEqual(response.data.get("meta").get("limit"), 1000)
+        self.assertEqual(response.data.get("meta").get("limit"), 0)
 
     def test_get_access_with_limit(self):
         """Test that we can obtain the expected access with pagination."""


### PR DESCRIPTION
## Link(s) to Jira
- https://issues.redhat.com/browse/RHCLOUD-14004

## Description of Intent of Change(s)
The count was always the total number of return records becasue that
is what was paginated. Instead, the whole queryset should be paginated.
    
And removing the limit of return records, when not limit is supplied, all
records will be returned.

## Local Testing
Unit test

Start the server, attach a few roles to the default group, then call the /access endpoint with/without limit

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  -  if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
