### PR TITLE
Pass filters to proxy

### DIFF
--- a/docs/source/specs/openapi.json
+++ b/docs/source/specs/openapi.json
@@ -540,7 +540,7 @@
             "in": "query",
             "name": "match_criteria",
             "required": false,
-            "description": "Parameter for specifying the matching criteria for an object's name or email.",
+            "description": "Parameter for specifying the matching criteria for an object's name and/or email.",
             "schema": {
               "type": "string",
               "enum": [
@@ -585,7 +585,7 @@
           {
             "name": "status",
             "in": "query",
-            "description": "Set the status of users to get back. Could not be used with: usernames, email, admin_only",
+            "description": "Set the status of users to get back.",
             "required": false,
             "schema": {
               "type": "string",

--- a/rbac/api/cross_access/view.py
+++ b/rbac/api/cross_access/view.py
@@ -273,17 +273,17 @@ class CrossAccountRequestViewSet(
                 )
             if request.data.get("status") not in ["approved", "denied"]:
                 self.throw_validation_error(
-                    "cross-accont partial update", f"Request status may only be updated to approved/denied."
+                    "cross-accont partial update", "Request status may only be updated to approved/denied."
                 )
             if len(request.data.keys()) > 1 or next(iter(request.data)) != "status":
-                self.throw_validation_error("cross-accont partial update", f"Only status may be updated.")
+                self.throw_validation_error("cross-accont partial update", "Only status may be updated.")
         elif request.user.user_id == update_obj.user_id:
             """ For requestors updating their requests, the request status may
                 only be updated from pending to cancelled.
             """
             if update_obj.status != "pending" or request.data.get("status") != "cancelled":
                 self.throw_validation_error(
-                    "cross-accont partial update", f"Request status may only be updated from pending to cancelled."
+                    "cross-accont partial update", "Request status may only be updated from pending to cancelled."
                 )
             for field in request.data:
                 if field not in VALID_PATCH_FIELDS:
@@ -293,7 +293,7 @@ class CrossAccountRequestViewSet(
                     )
         else:
             self.throw_validation_error(
-                "cross-accont partial update", f"User does not have permission to update the request."
+                "cross-accont partial update", "User does not have permission to update the request."
             )
 
     def check_update_permission(self, request, update_obj):

--- a/rbac/management/management/commands/sync_schemas.py
+++ b/rbac/management/management/commands/sync_schemas.py
@@ -1,5 +1,6 @@
-from django.db import connection
 from django.core.management.base import BaseCommand
+
+from django.db.utils import IntegrityError
 from management.models import Group, Role, Policy, Principal
 from api.models import Tenant
 from tenant_schemas.utils import tenant_context
@@ -8,46 +9,62 @@ from tenant_schemas.utils import tenant_context
 class Command(BaseCommand):
     help = "Syncs custom principals, roles, groups, and policies to the public schema"
 
+    def clear_pk(self, entry):
+        entry.id = None
+        entry.pk = None
 
     def copy_custom_principals_to_public(self, tenant):
         principals = Principal.objects.all()
         public_schema = Tenant.objects.get(schema_name="public")
         for principal in principals:
-            print(f"Copying principal {principal.username} to public schema for tenant {tenant}.")
+            self.stdout.write(f"Copying principal {principal.username} to public schema for tenant {tenant}.")
             if not principal.tenant:
                 principal.tenant = tenant
                 principal.save()
             with tenant_context(public_schema):
-                principal.id = None
-                principal.pk = None
-                principal.save()
+                self.clear_pk(principal)
+                try:
+                    principal.save()
+                except IntegrityError as err:
+                    self.stderr.write(f"Couldn't copy principal: {principal.username}. Skipping due to:\n{err}")
+                    continue
+                    
 
 
     def copy_custom_roles_to_public(self, tenant):
         roles = Role.objects.filter(system=False)
         public_schema = Tenant.objects.get(schema_name="public")
         for role in roles:
-            print(f"Copying role {role.name} to public schema for tenant {tenant}.")
+            self.stdout.write(f"Copying role {role.name} to public schema for tenant {tenant}.")
             if not role.tenant:
                 role.tenant = tenant
                 role.save()
             access_list = list(role.access.all())
             with tenant_context(public_schema):
-                role.id = None
-                role.pk = None
-                role.save()
+                self.clear_pk(role)
+                try:
+                    role.save()
+                except IntegrityError as err:
+                    self.stderr.write(f"Couldn't copy role: {role.name}. Skipping due to:\n{err}")
+                    continue
                 for access in access_list:
-                    access.id = None
-                    access.pk = None
+                    self.clear_pk(access)
                     if not access.tenant:
                         access.tenant = tenant
-                        access.role = role
-                    access.save()
+                    access.role = role
+                    try:
+                        access.save()
+                    except IntegrityError as err:
+                        self.stderr.write(f"Couldn't copy access entry: {access}. Skipping due to:\n{err}")
+                        continue
                     for resource_def in access.resourceDefinitions.all():
-                        resource_def.id = None
-                        resource_def.pk = None
+                        self.clear_pk(resource_def)
                         resource_def.access = access
-                        resource_def.save()
+                        try:
+                            resource_def.save()
+                        except IntegrityError as err:
+                            self.stderr.write(f"Couldn't copy {resource_def}. Skipping due to:\n{err}")
+                            continue
                 role.access.set(access_list)
                 role.save()
 
@@ -56,16 +73,19 @@ class Command(BaseCommand):
         groups = Group.objects.filter(system=False)
         public_schema = Tenant.objects.get(schema_name="public")
         for group in groups:
-            print(f"Copying group {group.name} to public schema for tenant {tenant}.")
+            self.stdout.write(f"Copying group {group.name} to public schema for tenant {tenant}.")
             if not group.tenant:
                 group.tenant = tenant
                 group.save()
             principals = list(group.principals.all())
             new_principals = []
             with tenant_context(public_schema):
-                group.pk = None
-                group.id = None
-                group.save()
+                self.clear_pk(group)
+                try:
+                    group.save()
+                except IntegrityError as err:
+                    self.stderr.write(f"Couldn't copy group {group.name}. Skipping due to:\n{err}")
+                    continue
                 for principal in principals:
                     new_principals.append(Principal.objects.get(username=principal.username))
                 group.principals.set(new_principals)
@@ -76,7 +96,7 @@ class Command(BaseCommand):
         policies = Policy.objects.all()
         public_schema = Tenant.objects.get(schema_name="public")
         for policy in policies:
-            print(f"Copying policy {policy.name} to public schema for tenant {tenant}.")
+            self.stdout.write(f"Copying policy {policy.name} to public schema for tenant {tenant}.")
             if not policy.tenant:
                 policy.tenant = tenant
                 policy.save()
@@ -84,9 +104,12 @@ class Command(BaseCommand):
             roles = list(policy.roles.all())
             new_roles = []
             with tenant_context(public_schema):
-                policy.fk = None
-                policy.id = None
-                policy.save()
+                self.clear_pk(policy)
+                try:
+                    policy.save()
+                except IntegrityError as err:
+                    self.stderr.write(f"Couldn't copy policy {policy.name}. Skipping due to:\n{err}")
+                    continue
                 policy.group = Group.objects.get(name=group.name)
                 for role in roles:
                     new_roles.append(Role.objects.get(name=role.name))
@@ -96,7 +119,6 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         tenants = Tenant.objects.exclude(schema_name="public")
-        print(tenants)
         for tenant in tenants:
             with tenant_context(tenant):
                 self.copy_custom_principals_to_public(tenant)

--- a/rbac/management/management/commands/sync_schemas.py
+++ b/rbac/management/management/commands/sync_schemas.py
@@ -1,0 +1,105 @@
+from django.db import connection
+from django.core.management.base import BaseCommand
+from management.models import Group, Role, Policy, Principal
+from api.models import Tenant
+from tenant_schemas.utils import tenant_context
+
+
+class Command(BaseCommand):
+    help = "Syncs custom principals, roles, groups, and policies to the public schema"
+
+
+    def copy_custom_principals_to_public(self, tenant):
+        principals = Principal.objects.all()
+        public_schema = Tenant.objects.get(schema_name="public")
+        for principal in principals:
+            print(f"Copying principal {principal.username} to public schema for tenant {tenant}.")
+            if not principal.tenant:
+                principal.tenant = tenant
+                principal.save()
+            with tenant_context(public_schema):
+                principal.id = None
+                principal.pk = None
+                principal.save()
+
+
+    def copy_custom_roles_to_public(self, tenant):
+        roles = Role.objects.filter(system=False)
+        public_schema = Tenant.objects.get(schema_name="public")
+        for role in roles:
+            print(f"Copying role {role.name} to public schema for tenant {tenant}.")
+            if not role.tenant:
+                role.tenant = tenant
+                role.save()
+            access_list = list(role.access.all())
+            with tenant_context(public_schema):
+                role.id = None
+                role.pk = None
+                role.save()
+                for access in access_list:
+                    access.id = None
+                    access.pk = None
+                    if not access.tenant:
+                        access.tenant = tenant
+                        access.role = role
+                    access.save()
+                    for resource_def in access.resourceDefinitions.all():
+                        resource_def.id = None
+                        resource_def.pk = None
+                        resource_def.access = access
+                        resource_def.save()
+                role.access.set(access_list)
+                role.save()
+
+
+    def copy_custom_groups_to_public(self, tenant):
+        groups = Group.objects.filter(system=False)
+        public_schema = Tenant.objects.get(schema_name="public")
+        for group in groups:
+            print(f"Copying group {group.name} to public schema for tenant {tenant}.")
+            if not group.tenant:
+                group.tenant = tenant
+                group.save()
+            principals = list(group.principals.all())
+            new_principals = []
+            with tenant_context(public_schema):
+                group.pk = None
+                group.id = None
+                group.save()
+                for principal in principals:
+                    new_principals.append(Principal.objects.get(username=principal.username))
+                group.principals.set(new_principals)
+                group.save()
+
+
+    def copy_custom_policies_to_public(self, tenant):
+        policies = Policy.objects.all()
+        public_schema = Tenant.objects.get(schema_name="public")
+        for policy in policies:
+            print(f"Copying policy {policy.name} to public schema for tenant {tenant}.")
+            if not policy.tenant:
+                policy.tenant = tenant
+                policy.save()
+            group = policy.group
+            roles = list(policy.roles.all())
+            new_roles = []
+            with tenant_context(public_schema):
+                policy.fk = None
+                policy.id = None
+                policy.save()
+                policy.group = Group.objects.get(name=group.name)
+                for role in roles:
+                    new_roles.append(Role.objects.get(name=role.name))
+                policy.roles.set(new_roles)
+                policy.save()
+
+
+    def handle(self, *args, **options):
+        tenants = Tenant.objects.exclude(schema_name="public")
+        print(tenants)
+        for tenant in tenants:
+            with tenant_context(tenant):
+                self.copy_custom_principals_to_public(tenant)
+                self.copy_custom_roles_to_public(tenant)
+                self.copy_custom_groups_to_public(tenant)
+                self.copy_custom_policies_to_public(tenant)

--- a/rbac/management/principal/proxy.py
+++ b/rbac/management/principal/proxy.py
@@ -193,13 +193,8 @@ class PrincipalProxy:  # pylint: disable=too-few-public-methods
     def request_principals(self, account, input=None, limit=None, offset=None, options={}):
         """Request principals for an account."""
         if input:
+            payload = input
             account_principals_path = f"/v1/accounts/{account}/usersBy"
-            if options["search_by"] == "partial_email":
-                payload = {"emailStartsWith": input}
-            elif options["search_by"] == "email":
-                payload = {"primaryEmail": input}
-            else:
-                payload = {"principalStartsWith": input}
             method = requests.post
         else:
             account_principals_path = f"/v2/accounts/{account}/users"

--- a/tests/management/principal/test_view.py
+++ b/tests/management/principal/test_view.py
@@ -156,12 +156,12 @@ class PrincipalViewsetTests(IdentityRequest):
     )
     def test_read_principal_filtered_list_success(self, mock_request):
         """Test that we can read a filtered list of principals."""
-        url = f'{reverse("principals")}?usernames=test_user&offset=30'
+        url = f'{reverse("principals")}?usernames=test_user75&offset=30'
         client = APIClient()
         response = client.get(url, **self.headers)
 
         mock_request.assert_called_once_with(
-            ["test_user"], account=ANY, limit=10, offset=30, options={"sort_order": "asc"}
+            ["test_user75"], account=ANY, limit=10, offset=30, options={"sort_order": "asc"}
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         for keyname in ["meta", "links", "data"]:
@@ -186,10 +186,10 @@ class PrincipalViewsetTests(IdentityRequest):
 
         mock_request.assert_called_once_with(
             ANY,
-            input="test_us",
+            input={"principalStartsWith": "test_us"},
             limit=10,
             offset=30,
-            options={"sort_order": "asc", "status": "enabled", "search_by": "partial_name"},
+            options={"sort_order": "asc", "status": "enabled"},
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         for keyname in ["meta", "links", "data"]:
@@ -317,7 +317,11 @@ class PrincipalViewsetTests(IdentityRequest):
         self.assertEqual(len(resp), 1)
 
         mock_request.assert_called_once_with(
-            ANY, input="test_user@example.com", limit=10, offset=0, options={"sort_order": "asc", "search_by": "email"}
+            ANY,
+            input={"primaryEmail": "test_user@example.com"},
+            limit=10,
+            offset=0,
+            options={"sort_order": "asc", "status": "enabled"},
         )
 
         self.assertEqual(resp[0]["username"], "test_user")
@@ -405,10 +409,10 @@ class PrincipalViewsetTests(IdentityRequest):
 
         mock_request.assert_called_once_with(
             ANY,
-            input="test_use",
+            input={"emailStartsWith": "test_use"},
             limit=10,
             offset=0,
-            options={"sort_order": "asc", "status": "enabled", "search_by": "partial_email"},
+            options={"sort_order": "asc", "status": "enabled"},
         )
 
         self.assertEqual(resp[0]["username"], "test_user")


### PR DESCRIPTION
## Link(s) to Jira
- https://issues.redhat.com/browse/RHCLOUD-13956

## Description of Intent of Change(s)
Updates how we build and pass multiple partial search filters to the principal proxy.

## Local Testing
Unit tests have been updated with a new test to check how we're calling the proxy.

Alternatively, with a local instance of the BOP running, configuring your .env as below will pass the newly formatted queries out to your local instance, which should need no changes:

PRINCIPAL_PROXY_SERVICE_PROTOCOL=http
PRINCIPAL_PROXY_SERVICE_HOST=localhost
PRINCIPAL_PROXY_SERVICE_PORT=8082
PRINCIPAL_PROXY_SERVICE_PATH=/


## Checklist
- [x] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [x] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  -  if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
