### PR TITLE
Draft: Add unit tests for /groups

### DIFF
--- a/tests/management/group/test_view.py
+++ b/tests/management/group/test_view.py
@@ -177,7 +177,8 @@ class GroupViewsetTests(IdentityRequest):
         url = "{}?uuids=invalid"
         client = APIClient()
         response = client.get(url, **self.headers)
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        # FIXME: This seems inconsistent with GUID validation we added elsewhere
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     @patch(
         "management.principal.proxy.PrincipalProxy.request_filtered_principals",

--- a/tests/management/group/test_view.py
+++ b/tests/management/group/test_view.py
@@ -172,6 +172,13 @@ class GroupViewsetTests(IdentityRequest):
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
+    def test_group_filter_by_guids_with_invalid_guid(self):
+        """ Test that an invalid guid in a list of guids returns an error."""
+        url = "{}?uuids=invalid"
+        client = APIClient()
+        response = client.get(url, **self.headers)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
     @patch(
         "management.principal.proxy.PrincipalProxy.request_filtered_principals",
         return_value={"status_code": 200, "data": []},
@@ -339,6 +346,13 @@ class GroupViewsetTests(IdentityRequest):
         response = client.put(url, {}, format="json", **self.headers)
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
+    def test_update_group_invalid_guid(self):
+        """Test that an invalid GUID on update causes a 400."""
+        url = reverse("group-detail", kwargs={"uuid": "invalid_guid"})
+        client = APIClient()
+        response = client.put(url, {}, format="json", **self.headers)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
     def test_delete_group_success(self):
         """Test that we can delete an existing group."""
         group = Group.objects.first()
@@ -365,6 +379,13 @@ class GroupViewsetTests(IdentityRequest):
         response = client.delete(url, **self.headers)
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
+    def test_delete_group_invalid_guid(self):
+        """Test that deleting group with an invalid GUID returns an error."""
+        url = reverse("group-detail", kwargs={"uuid": "invalid_guid"})
+        client = APIClient()
+        response = client.delete(url, **self.headers)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
     def test_group_principals_invalid_method(self):
         """Test that using an unsupported REST method returns an error."""
         url = reverse("group-principals", kwargs={"uuid": uuid4()})
@@ -386,7 +407,7 @@ class GroupViewsetTests(IdentityRequest):
         },
     )
     def test_add_group_principals_failure(self, mock_request):
-        """Test that adding a principal to a group returns has proper response when it is failed."""
+        """Test that adding a principal to a group returns the proper response on failure."""
         url = reverse("group-principals", kwargs={"uuid": self.group.uuid})
         client = APIClient()
         new_username = uuid4()
@@ -396,6 +417,14 @@ class GroupViewsetTests(IdentityRequest):
         self.assertEqual(response.data[0]["detail"], "Unexpected error.")
         self.assertEqual(response.data[0]["status"], 500)
         self.assertEqual(response.data[0]["source"], "principals")
+
+    def test_add_group_principal_invalid_guid(self):
+        """Test that adding a principal to a group with an invalid GUID causes a 400. """
+        url = reverse("group-principals", kwargs={"uuid": "invalid_guid"})
+        client = APIClient()
+        test_data = {"principals": [{"username": self.principal.username}]}
+        response = client.post(url, test_data, format="json", **self.headers)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     @patch(
         "management.principal.proxy.PrincipalProxy.request_filtered_principals",
@@ -435,6 +464,12 @@ class GroupViewsetTests(IdentityRequest):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get("meta").get("count"), 0)
         self.assertEqual(response.data.get("data"), [])
+
+    def test_get_group_principals_invalid_guid(self):
+        client = APIClient()
+        url = reverse("group-principals", kwargs={"uuid": "invalid"})
+        response = client.get(url, **self.headers)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_get_group_principals_invalid_sort_order(self):
         """Test that an invalid value for sort order is rejected."""
@@ -481,6 +516,13 @@ class GroupViewsetTests(IdentityRequest):
     def test_remove_group_principals_invalid(self):
         """Test that removing a principal returns an error with invalid data format."""
         url = reverse("group-principals", kwargs={"uuid": self.group.uuid})
+        client = APIClient()
+        response = client.delete(url, format="json", **self.headers)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_remove_group_principals_invalid_guid(self):
+        """Test that removing a principal returns an error when GUID is invalid."""
+        url = reverse("group-principals", kwargs={"uuid": "invalid"})
         client = APIClient()
         response = client.delete(url, format="json", **self.headers)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
## Link(s) to Jira
- RHCLOUD-12890

## Description of Intent of Change(s)
Migrate existing tests of /groups from iqe-rbac-plugin that would function better as unit tests.

## Local Testing
How can the feature be exercised? 
How can the bug be exploited and fix confirmed?
Is any special local setup required?

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  -  if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
