### PR TITLE
Multi user filter

### DIFF
--- a/docs/source/specs/openapi.json
+++ b/docs/source/specs/openapi.json
@@ -540,7 +540,7 @@
             "in": "query",
             "name": "match_criteria",
             "required": false,
-            "description": "Parameter for specifying the matching criteria for an object's name or email.",
+            "description": "Parameter for specifying the matching criteria for an object's name and/or email.",
             "schema": {
               "type": "string",
               "enum": [
@@ -585,7 +585,7 @@
           {
             "name": "status",
             "in": "query",
-            "description": "Set the status of users to get back. Could not be used with: usernames, email, admin_only",
+            "description": "Set the status of users to get back.",
             "required": false,
             "schema": {
               "type": "string",

--- a/rbac/management/principal/proxy.py
+++ b/rbac/management/principal/proxy.py
@@ -193,13 +193,8 @@ class PrincipalProxy:  # pylint: disable=too-few-public-methods
     def request_principals(self, account, input=None, limit=None, offset=None, options={}):
         """Request principals for an account."""
         if input:
+            payload = input
             account_principals_path = f"/v1/accounts/{account}/usersBy"
-            if options["search_by"] == "partial_email":
-                payload = {"emailStartsWith": input}
-            elif options["search_by"] == "email":
-                payload = {"primaryEmail": input}
-            else:
-                payload = {"principalStartsWith": input}
             method = requests.post
         else:
             account_principals_path = f"/v2/accounts/{account}/users"

--- a/tests/management/principal/test_view.py
+++ b/tests/management/principal/test_view.py
@@ -156,12 +156,12 @@ class PrincipalViewsetTests(IdentityRequest):
     )
     def test_read_principal_filtered_list_success(self, mock_request):
         """Test that we can read a filtered list of principals."""
-        url = f'{reverse("principals")}?usernames=test_user&offset=30'
+        url = f'{reverse("principals")}?usernames=test_user75&offset=30'
         client = APIClient()
         response = client.get(url, **self.headers)
 
         mock_request.assert_called_once_with(
-            ["test_user"], account=ANY, limit=10, offset=30, options={"sort_order": "asc"}
+            ["test_user75"], account=ANY, limit=10, offset=30, options={"sort_order": "asc"}
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         for keyname in ["meta", "links", "data"]:
@@ -186,10 +186,10 @@ class PrincipalViewsetTests(IdentityRequest):
 
         mock_request.assert_called_once_with(
             ANY,
-            input="test_us",
+            input={"principalStartsWith": "test_us"},
             limit=10,
             offset=30,
-            options={"sort_order": "asc", "status": "enabled", "search_by": "partial_name"},
+            options={"sort_order": "asc", "status": "enabled"},
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         for keyname in ["meta", "links", "data"]:
@@ -317,7 +317,11 @@ class PrincipalViewsetTests(IdentityRequest):
         self.assertEqual(len(resp), 1)
 
         mock_request.assert_called_once_with(
-            ANY, input="test_user@example.com", limit=10, offset=0, options={"sort_order": "asc", "search_by": "email"}
+            ANY,
+            input={"primaryEmail": "test_user@example.com"},
+            limit=10,
+            offset=0,
+            options={"sort_order": "asc", "status": "enabled"},
         )
 
         self.assertEqual(resp[0]["username"], "test_user")
@@ -405,10 +409,10 @@ class PrincipalViewsetTests(IdentityRequest):
 
         mock_request.assert_called_once_with(
             ANY,
-            input="test_use",
+            input={"emailStartsWith": "test_use"},
             limit=10,
             offset=0,
-            options={"sort_order": "asc", "status": "enabled", "search_by": "partial_email"},
+            options={"sort_order": "asc", "status": "enabled"},
         )
 
         self.assertEqual(resp[0]["username"], "test_user")


### PR DESCRIPTION
## Link(s) to Jira
- https://issues.redhat.com/browse/RHCLOUD-13956

## Description of Intent of Change(s)
Updates how we build and pass multiple partial search filters to the principal proxy.

## Local Testing
Unit tests have been updated with a new test to check how we're calling the proxy.

Alternatively, with a local instance of the BOP running, configuring your .env as below will pass the newly formatted queries out to your local instance, which should need no changes:

PRINCIPAL_PROXY_SERVICE_PROTOCOL=http
PRINCIPAL_PROXY_SERVICE_HOST=localhost
PRINCIPAL_PROXY_SERVICE_PORT=8082
PRINCIPAL_PROXY_SERVICE_PATH=/

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [x] are theses changes covered by unit tests?
- [x] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  -  if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
