### PR TITLE
Support sorting for access endpoint

### DIFF
--- a/docs/source/specs/openapi.json
+++ b/docs/source/specs/openapi.json
@@ -2373,6 +2373,20 @@
             }
           },
           {
+            "name": "order_by",
+            "in": "query",
+            "description": "Parameter for ordering roles by value. For inverse ordering, supply '-' before the param value, such as: ?order_by=-application",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "application",
+                "resource_type",
+                "verb"
+              ]
+            }
+          },
+          {
             "$ref": "#/components/parameters/QueryLimit"
           },
           {

--- a/rbac/management/access/view.py
+++ b/rbac/management/access/view.py
@@ -31,7 +31,7 @@ from rest_framework.settings import api_settings
 from rest_framework.views import APIView
 
 ORDER_FIELD = "order_by"
-VALID_ORDER_VALUES = ["unordered", "application", "resource_type", "verb", "-application", "-resource_type", "-verb"]
+VALID_ORDER_VALUES = ["application", "resource_type", "verb", "-application", "-resource_type", "-verb"]
 
 
 class AccessView(APIView):
@@ -89,7 +89,7 @@ class AccessView(APIView):
     def get_queryset(self, ordering):
         """Define the query set."""
         access_queryset = get_access_queryset(self.request)
-        if ordering != "unordered":
+        if ordering:
             if ordering[0] == "-":
                 order_sign = "-"
                 field = ordering[1:]
@@ -143,7 +143,7 @@ class AccessView(APIView):
         validate_limit_and_offset(params)
         app = params.get(APPLICATION_KEY)
         sub_key = app
-        ordering = validate_and_get_key(params, ORDER_FIELD, VALID_ORDER_VALUES, "unordered")
-        if ordering != "unordered":
+        ordering = validate_and_get_key(params, ORDER_FIELD, VALID_ORDER_VALUES, required=False)
+        if ordering:
             sub_key = f"{app}&order:{ordering}"
         return sub_key, ordering

--- a/rbac/management/access/view.py
+++ b/rbac/management/access/view.py
@@ -19,11 +19,19 @@
 from management.cache import AccessCache
 from management.querysets import get_access_queryset
 from management.role.serializer import AccessSerializer
-from management.utils import APPLICATION_KEY, get_principal_from_request, validate_limit_and_offset
+from management.utils import (
+    APPLICATION_KEY,
+    get_principal_from_request,
+    validate_and_get_key,
+    validate_limit_and_offset,
+)
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 from rest_framework.settings import api_settings
 from rest_framework.views import APIView
+
+ORDER_FIELD = "order_by"
+VALID_ORDER_VALUES = ["unordered", "application", "resource_type", "verb", "-application", "-resource_type", "-verb"]
 
 
 class AccessView(APIView):
@@ -78,21 +86,31 @@ class AccessView(APIView):
     pagination_class = api_settings.DEFAULT_PAGINATION_CLASS
     permission_classes = (AllowAny,)
 
-    def get_queryset(self):
+    def get_queryset(self, ordering):
         """Define the query set."""
-        return get_access_queryset(self.request)
+        access_queryset = get_access_queryset(self.request)
+        if ordering != "unordered":
+            if ordering[0] == "-":
+                order_sign = "-"
+                field = ordering[1:]
+            else:
+                order_sign = ""
+                field = ordering
+            return access_queryset.order_by(f"{order_sign}permission__{field}")
+        return access_queryset
 
     def get(self, request):
         """Provide access data for principal."""
-        validate_limit_and_offset(request.query_params)
-        app = request.query_params.get(APPLICATION_KEY)
+        # Parameter extraction
+        sub_key, ordering = self.validate_and_get_param(request.query_params)
+
         principal = get_principal_from_request(request)
         cache = AccessCache(request.tenant.schema_name)
-        access_policy = cache.get_policy(principal.uuid, app)
+        access_policy = cache.get_policy(principal.uuid, sub_key)
         if access_policy is None:
-            queryset = self.get_queryset()
+            queryset = self.get_queryset(ordering)
             access_policy = self.serializer_class(queryset, many=True).data
-            cache.save_policy(principal.uuid, app, access_policy)
+            cache.save_policy(principal.uuid, sub_key, access_policy)
 
         page = self.paginate_queryset(access_policy)
         if page is not None:
@@ -119,3 +137,13 @@ class AccessView(APIView):
         """Return a paginated style `Response` object for the given output data."""
         assert self.paginator is not None
         return self.paginator.get_paginated_response(data)
+
+    def validate_and_get_param(self, params):
+        """Validate input parameters and get ordering and sub_key."""
+        validate_limit_and_offset(params)
+        app = params.get(APPLICATION_KEY)
+        sub_key = app
+        ordering = validate_and_get_key(params, ORDER_FIELD, VALID_ORDER_VALUES, "unordered")
+        if ordering != "unordered":
+            sub_key = f"{app}&order:{ordering}"
+        return sub_key, ordering

--- a/rbac/management/utils.py
+++ b/rbac/management/utils.py
@@ -164,15 +164,17 @@ def queryset_by_id(objects, clazz, **kwargs):
     return query
 
 
-def validate_and_get_key(params, query_key, valid_values, default_value):
+def validate_and_get_key(params, query_key, valid_values, default_value=None, required=True):
     """Validate the key."""
     value = params.get(query_key, default_value)
     if not value:
-        key = "detail"
-        message = "Query parameter '{}' is required.".format(query_key)
-        raise serializers.ValidationError({key: _(message)})
+        if required:
+            key = "detail"
+            message = "Query parameter '{}' is required.".format(query_key)
+            raise serializers.ValidationError({key: _(message)})
+        return None
 
-    if value.lower() not in valid_values:
+    elif value.lower() not in valid_values:
         key = "detail"
         message = "{} query parameter value '{}' is invalid. {} are valid inputs.".format(
             query_key, value, valid_values

--- a/tests/management/access/test_view.py
+++ b/tests/management/access/test_view.py
@@ -379,3 +379,68 @@ class AccessViewTests(IdentityRequest):
         self.assertEqual(2, len(called_with_para[2]))  # it catches all the policies for app
         self.assertEqual(response.data["meta"]["count"], 2)
         self.assertEqual(len(response.data["data"]), 1)  # returns one policy because limit is 1
+
+    @patch("management.cache.AccessCache.get_policy", return_value=None)
+    @patch("management.cache.AccessCache.save_policy", return_value=None)
+    def test_get_access_with_ordering_and_cache(self, save_policy, get_policy):
+        """Test that we can obtain the expected access with ordering and cache."""
+        role_name = "roleA"
+        response = self.create_role(role_name)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        role_uuid = response.data.get("uuid")
+        test_role = self.create_role_and_permission("Test Role one", "test:assigned:permission1")
+        policy_name = "policyA"
+        response = self.create_policy(policy_name, self.group.uuid, [role_uuid, test_role.uuid])
+
+        schema_name = self.tenant.schema_name
+        principal_id = self.principal.uuid
+        key = f"rbac::policy::tenant={schema_name}::user={principal_id}"
+        client = APIClient()
+
+        ######## access_policy are cached with desired sub_key ############
+        url = "{}?application={}&username={}&order_by={}".format(
+            reverse("access"), "app", self.principal.username, "resource_type"
+        )
+        response = client.get(url, **self.headers)
+
+        get_policy.assert_called_with(principal_id, "app&order:resource_type")
+        called_with_para = save_policy.mock_calls[0][1]  # save_policy params
+        self.assertEqual(principal_id, called_with_para[0])
+        self.assertEqual("app&order:resource_type", called_with_para[1])
+        self.assertEqual([self.access_data], called_with_para[2])  # it catches all the policies for app
+        ###################################################################
+
+        #### access_policy are cached properly when application is empty ####
+        url = "{}?application=&username={}&order_by={}".format(reverse("access"), self.principal.username, "verb")
+        response = client.get(url, **self.headers)
+
+        # Cache is called saved with sub_key ""
+        get_policy.assert_called_with(principal_id, "&order:verb")
+        called_with_para = save_policy.mock_calls[1][1]
+        self.assertEqual(principal_id, called_with_para[0])
+        self.assertEqual("&order:verb", called_with_para[1])
+        self.assertEqual(2, len(called_with_para[2]))  # it catches all the policies
+        self.assertEqual(response.data["meta"]["count"], 2)
+        self.assertEqual(response.data["data"][0]["permission"], "app:*:*")  # check order
+
+        url = "{}?application=&username={}&order_by={}".format(reverse("access"), self.principal.username, "-verb")
+        response = client.get(url, **self.headers)
+        # Cache is called saved with sub_key ""
+        get_policy.assert_called_with(principal_id, "&order:-verb")
+        called_with_para = save_policy.mock_calls[2][1]
+        self.assertEqual(principal_id, called_with_para[0])
+        self.assertEqual("&order:-verb", called_with_para[1])
+        self.assertEqual(2, len(called_with_para[2]))  # it catches all the policies
+        self.assertEqual(response.data["meta"]["count"], 2)
+        # Response data is in reverse order
+        self.assertEqual(response.data["data"][0]["permission"], "test:assigned:permission1")  # check order
+
+    def test_get_access_with_invalid_ordering_value(self):
+        """Test that get access with invalid ordering value raises 401."""
+        client = APIClient()
+        url = "{}?application={}&username={}&order_by={}".format(
+            reverse("access"), "app", self.principal.username, "invalid_value"
+        )
+        response = client.get(url, **self.headers)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)

--- a/tests/management/access/test_view.py
+++ b/tests/management/access/test_view.py
@@ -478,6 +478,17 @@ class AccessViewTests(IdentityRequest):
         # Response data is in reverse order
         self.assertEqual(response.data["data"][0]["permission"], "test:assigned:permission1")  # check order
 
+        #### Sort by nothing still works ####
+        url = "{}?application=&username={}&order_by=".format(reverse("access"), self.principal.username)
+        response = client.get(url, **self.headers)
+        # Cache is called saved with sub_key ""
+        get_policy.assert_called_with(principal_id, "")
+        called_with_para = save_policy.mock_calls[6][1]
+        self.assertEqual(principal_id, called_with_para[0])
+        self.assertEqual("", called_with_para[1])
+        self.assertEqual(2, len(called_with_para[2]))  # it catches all the policies
+        self.assertEqual(response.data["meta"]["count"], 2)
+
     def test_get_access_with_invalid_ordering_value(self):
         """Test that get access with invalid ordering value raises 401."""
         client = APIClient()


### PR DESCRIPTION
## Link(s) to Jira
- https://issues.redhat.com/browse/RHCLOUD-13949

## Description of Intent of Change(s)
Sort by application/resource_type/verb of permission

## Local Testing
Unit test
Setup server, run and observe the difference:
curl -v GET "http://0.0.0.0:8080/r/insights/platform/rbac/v1/access/?application=catalog&order_by=-verb"
curl -v GET "http://0.0.0.0:8080/r/insights/platform/rbac/v1/access/?application=catalog&order_by=verb"

## Checklist
- [x] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [x] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  -  if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
