### PR TITLE
Add two unit tests, sort order invalid parameter

### DIFF
--- a/tests/management/group/test_view.py
+++ b/tests/management/group/test_view.py
@@ -271,7 +271,7 @@ class GroupViewsetTests(IdentityRequest):
     def test_get_group_invalid_sort_order_ignored(self):
         """Test that an invalid sort order value is ignored when getting groups."""
         url = reverse("group-list")
-        url = "{}?order_by=potato"
+        url = "{}?order_by=potato".format(url)
         client = APIClient()
         response = client.get(url, **self.headers)
         self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/tests/management/group/test_view.py
+++ b/tests/management/group/test_view.py
@@ -268,6 +268,14 @@ class GroupViewsetTests(IdentityRequest):
         response = client.get(url, **self.headers)
         self.assertEqual(response.data.get("meta").get("count"), 0)
 
+    def test_get_group_invalid_sort_order_ignored(self):
+        """Test that an invalid sort order value is ignored when getting groups."""
+        url = reverse("group-list")
+        url = "{}?order_by=potato"
+        client = APIClient()
+        response = client.get(url, **self.headers)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
     def test_filter_group_list_by_uuid_success(self):
         """Test that we can filter a list of groups by uuid."""
         url = f"{reverse('group-list')}?uuid={self.group.uuid}"

--- a/tests/management/role/test_view.py
+++ b/tests/management/role/test_view.py
@@ -621,6 +621,13 @@ class RoleViewsetTests(IdentityRequest):
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
+    def test_list_role_with_invalid_sort_order(self):
+        """Test that an invalid sort order is ignored."""
+        url = "{}?sort_field=zombie"
+        client = APIClient()
+        response = client.get(url, **self.headers)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
     def test_patch_role_success(self):
         """Test that we can patch an existing role."""
         role_name = "role"

--- a/tests/management/role/test_view.py
+++ b/tests/management/role/test_view.py
@@ -623,7 +623,7 @@ class RoleViewsetTests(IdentityRequest):
 
     def test_list_role_with_invalid_sort_order(self):
         """Test that an invalid sort order is ignored."""
-        url = "{}?sort_field=zombie"
+        url = "{}?sort_field=zombie".format(URL)
         client = APIClient()
         response = client.get(url, **self.headers)
         self.assertEqual(response.status_code, status.HTTP_200_OK)


### PR DESCRIPTION
## Link(s) to Jira
- RHCLOUD-12890
- RHCLOUD-12891

## Description of Intent of Change(s)
Restoring order to the galactic republic through unit test reform.

## Local Testing
How can the feature be exercised? 
How can the bug be exploited and fix confirmed?
Is any special local setup required?

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  -  if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
