### PR TITLE
Add `sync_schemas` command to internal Turnpike view

### DIFF
--- a/rbac/internal/urls.py
+++ b/rbac/internal/urls.py
@@ -31,4 +31,5 @@ urlpatterns = [
     path("api/cars/expire/", views.car_expiry),
     path("api/sentry_debug/", trigger_error),
     path("api/utils/tenant_reconciliation/", views.tenant_reconciliation),
+    path("api/utils/sync_schemas/", views.sync_schemas),
 ]

--- a/rbac/internal/views.py
+++ b/rbac/internal/views.py
@@ -177,7 +177,6 @@ def sync_schemas(request):
 
     POST /_private/api/utils/sync_schemas/
     """
-
     if request.method == "POST":
         msg = "Running schema sync in background worker."
         logger.info(msg)

--- a/rbac/internal/views.py
+++ b/rbac/internal/views.py
@@ -27,7 +27,12 @@ from django.http import HttpResponse
 from django.shortcuts import get_object_or_404
 from management.cache import TenantCache
 from management.models import Group, Role
-from management.tasks import run_migrations_in_worker, run_reconcile_tenant_relations_in_worker, run_seeds_in_worker
+from management.tasks import (
+    run_migrations_in_worker,
+    run_reconcile_tenant_relations_in_worker,
+    run_seeds_in_worker,
+    run_sync_schemas_in_worker,
+)
 from tenant_schemas.utils import tenant_context
 
 from api.models import Tenant
@@ -162,6 +167,21 @@ def tenant_reconciliation(request):
     if request.method in ["GET", "POST"]:
         logger.info(msg)
         run_reconcile_tenant_relations_in_worker.delay(args)
+        return HttpResponse(msg, status=202)
+
+    return HttpResponse(f'Method "{request.method}" not allowed.', status=405)
+
+
+def sync_schemas(request):
+    """View method for syncing public and tenant schemas.
+
+    POST /_private/api/utils/sync_schemas/
+    """
+
+    if request.method == "POST":
+        msg = "Running schema sync in background worker."
+        logger.info(msg)
+        run_sync_schemas_in_worker.delay()
         return HttpResponse(msg, status=202)
 
     return HttpResponse(f'Method "{request.method}" not allowed.', status=405)

--- a/rbac/management/management/commands/sync_schemas.py
+++ b/rbac/management/management/commands/sync_schemas.py
@@ -143,9 +143,15 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         """Actually do the work when the command is run."""
         tenants = Tenant.objects.exclude(schema_name="public")
-        for tenant in tenants:
-            with tenant_context(tenant):
-                self.copy_custom_principals_to_public(tenant)
-                self.copy_custom_roles_to_public(tenant)
-                self.copy_custom_groups_to_public(tenant)
-                self.copy_custom_policies_to_public(tenant)
+        try:
+            for idx, tenant in enumerate(list(tenants)):
+                self.stdout.write(
+                    f"*** Syncing Schemas for '{tenant.id}' - '{tenant.schema_name}' ({idx + 1} of {len(tenants)}) ***"
+                )
+                with tenant_context(tenant):
+                    self.copy_custom_principals_to_public(tenant)
+                    self.copy_custom_roles_to_public(tenant)
+                    self.copy_custom_groups_to_public(tenant)
+                    self.copy_custom_policies_to_public(tenant)
+        except Exception as e:
+            self.stderr(f"Failure: {str(e)}")

--- a/rbac/management/tasks.py
+++ b/rbac/management/tasks.py
@@ -42,5 +42,11 @@ def run_seeds_in_worker(kwargs):
 
 @shared_task
 def run_reconcile_tenant_relations_in_worker(kwargs):
-    """Celery task to run seeds."""
+    """Celery task to reconcile tenant relations."""
     call_command("reconcile_tenant_relations", **kwargs)
+
+
+@shared_task
+def run_sync_schemas_in_worker():
+    """Celery task to sync schemas."""
+    call_command("sync_schemas")


### PR DESCRIPTION
This adds `POST /_private/api/utils/sync_schemas/` to the internal views, in order
to run the `sync_schemas` command from Turnpike via `http://internal.cloud.redhat.com/api/rbac/utils/sync_schemas/`

To test locally:
- update your `dev_middleware.py` to be `"type": "Associate"` and change the `"user"`
  key to `"associate"`
- within `/rbac/`, run `celery worker -A rbac.celery --broker=redis://127.0.0.1:6379/0 --loglevel=INFO` after `pipenv shell` to start a celery worker
