### PR TITLE
Reverse `tox` command ordering

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36, lint
+envlist = lint, py36
 skipsdist = True
 
 [flake8]


### PR DESCRIPTION
Instead of running specs first only to find out linting has failed in CI, we should
fail fast if linting doesn't pass, first.

