### PR TITLE
Set the default `MAX_SEED_THREADS` in Clowder template

### DIFF
--- a/deploy/rbac-clowdapp.yml
+++ b/deploy/rbac-clowdapp.yml
@@ -334,6 +334,9 @@ objects:
                 key: sentry-dsn
                 name: rbac-secret
                 optional: true
+          - name: MAX_SEED_THREADS
+            value: ${MAX_SEED_THREADS}
+
     - name: scheduler-service
       minReplicas: ${{MIN_SCHEDULER_REPLICAS}}
       podSpec:
@@ -1791,3 +1794,6 @@ parameters:
   value: "30"
 - name: CELERY_PERIOD_SEC
   value: "300"
+- description: Default number of threads to use for seeding
+  name: MAX_SEED_THREADS
+  value: "2"


### PR DESCRIPTION
Without this set, when we trigger seeds via Turnpike, it uses the default value for
`max_workers in `ThreadPoolExecutor` [1] which ends up killing our stage environment
because of resource issues.

[1] https://docs.python.org/3/library/concurrent.futures.html#threadpoolexecutor

