### PR TITLE
Clone custom default group into the public schema

### DIFF
--- a/rbac/management/group/view.py
+++ b/rbac/management/group/view.py
@@ -586,8 +586,8 @@ class GroupViewSet(
             serializer = GroupRoleSerializerIn(data=request.data)
             if serializer.is_valid(raise_exception=True):
                 roles = request.data.pop(ROLES_KEY, [])
-            add_roles(group, roles, request.tenant, user=request.user, duplicate_in_public=True)
             set_system_flag_post_update(group)
+            add_roles(group, roles, request.tenant, user=request.user, duplicate_in_public=True)
             response_data = GroupRoleSerializerIn(group)
         elif request.method == "GET":
             serialized_roles = self.obtain_roles(request, group)
@@ -603,8 +603,8 @@ class GroupViewSet(
             role_ids = request.query_params.get(ROLES_KEY, "").split(",")
             serializer = GroupRoleSerializerIn(data={"roles": role_ids})
             if serializer.is_valid(raise_exception=True):
-                remove_roles(group, role_ids, request.tenant)
                 set_system_flag_post_update(group)
+                remove_roles(group, role_ids, request.tenant)
 
             return Response(status=status.HTTP_204_NO_CONTENT)
 

--- a/rbac/management/group/view.py
+++ b/rbac/management/group/view.py
@@ -586,7 +586,7 @@ class GroupViewSet(
             serializer = GroupRoleSerializerIn(data=request.data)
             if serializer.is_valid(raise_exception=True):
                 roles = request.data.pop(ROLES_KEY, [])
-            set_system_flag_post_update(group)
+            set_system_flag_post_update(group, request.tenant)
             add_roles(group, roles, request.tenant, user=request.user, duplicate_in_public=True)
             response_data = GroupRoleSerializerIn(group)
         elif request.method == "GET":
@@ -603,7 +603,7 @@ class GroupViewSet(
             role_ids = request.query_params.get(ROLES_KEY, "").split(",")
             serializer = GroupRoleSerializerIn(data={"roles": role_ids})
             if serializer.is_valid(raise_exception=True):
-                set_system_flag_post_update(group)
+                set_system_flag_post_update(group, request.tenant)
                 remove_roles(group, role_ids, request.tenant)
 
             return Response(status=status.HTTP_204_NO_CONTENT)

--- a/rbac/management/utils.py
+++ b/rbac/management/utils.py
@@ -230,3 +230,9 @@ def schema_handler(tenant_schema, include_public=True):
     for schema in schemas:
         with tenant_context(schema):
             yield tenant_schema
+
+
+def clear_pk(entry):
+    """Clear the ID and PK values for provided postgres entry."""
+    entry.id = None
+    entry.pk = None

--- a/tests/management/group/test_view.py
+++ b/tests/management/group/test_view.py
@@ -924,7 +924,7 @@ class GroupViewsetTests(IdentityRequest):
         system_policies = Policy.objects.filter(system=True)
         system_policy = system_policies.get(group=self.group)
 
-        self.assertEqual(len(system_policies), 1)
+        self.assertEqual(len(system_policies), 2)
         self.assertCountEqual([system_policy, self.policy], list(self.group.policies.all()))
         self.assertCountEqual([self.roleB], list(system_policy.roles.all()))
         self.assertCountEqual([self.role], list(self.policy.roles.all()))
@@ -1010,7 +1010,7 @@ class GroupViewsetTests(IdentityRequest):
         system_policy = system_policies.get(group=self.group)
         system_policyB = system_policies.get(group=self.groupB)
 
-        self.assertEqual(len(system_policies), 2)
+        self.assertEqual(len(system_policies), 3)
         self.assertCountEqual([self.roleB], list(system_policy.roles.all()))
         self.assertCountEqual([self.roleB], list(system_policyB.roles.all()))
         self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/tests/management/group/test_view.py
+++ b/tests/management/group/test_view.py
@@ -21,6 +21,8 @@ from decimal import Decimal
 from unittest.mock import patch, ANY
 from uuid import uuid4
 
+from django.core.management import call_command
+from django.db import transaction
 from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APIClient
@@ -69,6 +71,8 @@ class GroupViewsetTests(IdentityRequest):
             self.defGroup.save()
             self.defGroup.principals.add(self.principal)
             self.defGroup.save()
+            self.defPolicy = Policy(name="defPolicy", system=True, tenant=self.tenant, group=self.defGroup)
+            self.defPolicy.save()
 
             self.emptyGroup = Group(name="groupE")
             self.emptyGroup.save()
@@ -94,6 +98,11 @@ class GroupViewsetTests(IdentityRequest):
             Group.objects.create(name="groupA", tenant=self.tenant)
             Group.objects.create(name="groupB", tenant=self.tenant)
             Group.objects.create(name="groupDef", tenant=self.tenant)
+
+    @classmethod
+    def setUpClass(self):
+        super().setUpClass()
+        call_command("seeds")
 
     def tearDown(self):
         """Tear down group viewset tests."""
@@ -929,19 +938,36 @@ class GroupViewsetTests(IdentityRequest):
 
     def test_system_flag_update_on_add(self):
         """Test that adding a role to a platform_default group flips the system flag."""
+        public_tenant = Tenant.objects.get(schema_name="public")
+
+        with tenant_context(public_tenant):
+            Role.objects.create(name=self.roleB.name, system=False, tenant=public_tenant)
+
         url = reverse("group-roles", kwargs={"uuid": self.defGroup.uuid})
         client = APIClient()
         test_data = {"roles": [self.roleB.uuid, self.dummy_role_id]}
 
         self.assertTrue(self.defGroup.system)
+        self.assertEqual(self.defGroup.roles().count(), 0)
         response = client.post(url, test_data, format="json", **self.headers)
+        self.assertEqual(self.defGroup.roles().count(), 1)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.defGroup.refresh_from_db()
         self.assertEqual(self.defGroup.name, "Custom default access")
         self.assertFalse(self.defGroup.system)
 
+        with tenant_context(public_tenant):
+            public_default_group = Group.objects.get(name="Custom default access", tenant=self.tenant)
+            new_role = public_default_group.roles().filter(name=self.roleB.name)
+            self.assertEqual(len(new_role), 1)
+
     def test_system_flag_update_on_remove(self):
         """Test that removing a role from a platform_default group flips the system flag."""
+        public_tenant = Tenant.objects.get(schema_name="public")
+
+        with tenant_context(public_tenant):
+            Role.objects.create(name=self.roleB.name, system=False, tenant=public_tenant)
+
         url = reverse("group-roles", kwargs={"uuid": self.defGroup.uuid})
         client = APIClient()
         url = "{}?roles={}".format(url, self.roleB.uuid)
@@ -957,6 +983,11 @@ class GroupViewsetTests(IdentityRequest):
         self.defGroup.refresh_from_db()
         self.assertEqual(self.defGroup.name, "Custom default access")
         self.assertFalse(self.defGroup.system)
+
+        with tenant_context(public_tenant):
+            public_default_group = Group.objects.get(name="Custom default access", tenant=self.tenant)
+            new_role = public_default_group.roles().filter(name=self.roleB.name)
+            self.assertEqual(len(new_role), 0)
 
     def test_add_group_roles_bad_group_guid(self):
         group_url = reverse("group-roles", kwargs={"uuid": "master_exploder"})

--- a/tests/management/role/test_view.py
+++ b/tests/management/role/test_view.py
@@ -94,9 +94,9 @@ class RoleViewsetTests(IdentityRequest):
 
         # Create permission in public schema
         with tenant_context(Tenant.objects.get(schema_name="public")):
-            Permission.objects.create(permission="cost-management:*:*")
-            Permission.objects.create(permission="app:*:*")
-            Permission.objects.create(permission="app2:*:*")
+            Permission.objects.get_or_create(permission="cost-management:*:*")
+            Permission.objects.get_or_create(permission="app:*:*")
+            Permission.objects.get_or_create(permission="app2:*:*")
 
     def create_role(self, role_name, role_display="", in_access_data=None):
         """Create a role."""


### PR DESCRIPTION
https://issues.redhat.com/browse/RHCLOUD-14680

Currently when an org modifies their `Default access` group, we change the `system` flag to `False` so that the platform no longer manages it via seeds, and we update the name to `Custom default access`. 

Since the `Default access` and `Custom default access` groups in the public schema should make use of the system roles and not duplicate them (sharing the `Default access` group across all tenants in the public schema), we need to account for orgs modifying the creating a new custom default group by creating a new group, vs renaming it in the public schema.

Before we begin serving data out of the public schema, we'll need to have a condition to serve permissions out of the `Custom default access` group if one exists for the tenant, vs the `Default access` group shared by all tenants.

**Test Locally:**
- make reinitdb
- ./rbac/manage.py seeds
- make serve
- curl http://localhost:8000/api/rbac/v1/groups/
- find your default group and list the roles
- curl http://localhost:8000/api/rbac/v1/groups/<uuid>/roles/
- find a role and remove it from the default group
- curl http://localhost:8000/api/rbac/v1/groups/<uuid>/roles/?roles=<uuid> -DELETE
- confirm the role was removed from both schemas
- find a role and add it to the default group
- curl http://localhost:8000/api/rbac/v1/groups/<uuid>/roles/ -POST -H 'Content-Type: application/json' -d '{"roles": [<uuid>]}'
- confirm the role exists in both schemas