### PR TITLE
Run smoke tests via Clowder in PR checks

### DIFF
--- a/deploy/rbac-cji-smoketest.yml
+++ b/deploy/rbac-cji-smoketest.yml
@@ -1,0 +1,14 @@
+apiVersion: cloud.redhat.com/v1alpha1
+kind: ClowdJobInvocation
+metadata:
+  name: rbac-smoke-tests
+spec:
+  appName: rbac
+  testing:
+    iqe:
+      # set the test run options
+      ui:
+        enabled: false
+      marker: "rbac_smoke"
+      dynaconfEnvName: "clowder_smoke"
+      filter: ""

--- a/deploy/rbac-clowdapp.yml
+++ b/deploy/rbac-clowdapp.yml
@@ -10,6 +10,8 @@ objects:
     name: rbac
   spec:
     envName: ${ENV_NAME}
+    testing:
+      iqePlugin: rbac
     database:
       name: rbac
     inMemoryDb: true

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -1,18 +1,27 @@
 #!/bin/bash
 
-APP_NAME="rbac"  # name of app-sre "application" folder this component lives in
-COMPONENT_NAME="rbac"  # name of app-sre "resourceTemplate" in deploy.yaml for this component
-IMAGE="quay.io/cloudservices/rbac"  # the image location on quay
+export APP_NAME="rbac"  # name of app-sre "application" folder this component lives in
+export COMPONENT_NAME="rbac"  # name of app-sre "resourceTemplate" in deploy.yaml for this component
+export IMAGE="quay.io/cloudservices/rbac"  # the image location on quay
 
-IQE_PLUGINS="rbac"  # name of the IQE plugin for this APP
-IQE_MARKER_EXPRESSION="rbac_smoke"  # This is the value passed to pytest -m
-IQE_FILTER_EXPRESSION=""  # This is the value passed to pytest -k
+export IQE_PLUGINS="rbac"  # name of the IQE plugin for this APP
+export IQE_MARKER_EXPRESSION="rbac_smoke"  # This is the value passed to pytest -m
+export IQE_FILTER_EXPRESSION=""  # This is the value passed to pytest -k
+export IQE_CJI_TIMEOUT="30m"  # This is the time to wait for smoke test to complete or fail
 
 # Install bonfire repo/initialize
 CICD_URL=https://raw.githubusercontent.com/RedHatInsights/bonfire/master/cicd
 curl -s $CICD_URL/bootstrap.sh > .cicd_bootstrap.sh && source .cicd_bootstrap.sh
 
+# Build the image and push to quay
 source $CICD_ROOT/build.sh
 
+# Run the unit tests with an ephemeral db
 source $APP_ROOT/unit_test.sh
+
+# Deploy rbac to an ephemeral namespace for testing
+source $CICD_ROOT/deploy_ephemeral_env.sh
+
+# Run somke tests with ClowdJobInvocation
+source $CICD_ROOT/cji_smoke_test.sh
 

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -17,7 +17,7 @@ curl -s $CICD_URL/bootstrap.sh > .cicd_bootstrap.sh && source .cicd_bootstrap.sh
 source $CICD_ROOT/build.sh
 
 # Run the unit tests with an ephemeral db
-source $APP_ROOT/unit_test.sh
+# source $APP_ROOT/unit_test.sh
 
 # Deploy rbac to an ephemeral namespace for testing
 source $CICD_ROOT/deploy_ephemeral_env.sh

--- a/unit_test.sh
+++ b/unit_test.sh
@@ -5,7 +5,7 @@ source $CICD_ROOT/deploy_ephemeral_db.sh
 export PGPASSWORD=$DATABASE_ADMIN_PASSWORD
 
 python3 -m venv app-venv
-. app-venv/bin/activate
+source app-venv/bin/activate
 pip install --upgrade pip setuptools wheel pipenv tox psycopg2-binary
 tox -r
 result=$?

--- a/unit_test.sh
+++ b/unit_test.sh
@@ -1,5 +1,4 @@
 # Deploy ephemeral db
-
 source $CICD_ROOT/deploy_ephemeral_db.sh
 
 # Map env vars set by `deploy_ephemeral_db.sh` if vars the app uses are different
@@ -10,6 +9,7 @@ python3 -m venv app-venv
 pip install --upgrade pip setuptools wheel pipenv tox psycopg2-binary
 tox -r
 result=$?
+source .bonfire_venv/bin/activate
 
 # TODO: add unittest-xml-reporting to rbac so that junit results can be parsed by jenkins
 mkdir -p $WORKSPACE/artifacts


### PR DESCRIPTION
## Link(s) to Jira
- https://issues.redhat.com/browse/RHCLOUD-15207 

## Description of Intent of Change(s)
RBAC smoke tests will now run in an ephemeral env with a pr_check. Using bonfire's [cji_smoke_test.sh](https://github.com/RedHatInsights/bonfire/blob/master/cicd/cji_smoke_test.sh), RBAC will be able to run smoke tests in a Kubernetes native fashion against an instance deployed in an ephemeral namespace.

## Local Testing
How can the feature be exercised? You can manually deploy rbac with clowder and `oc apply -f deploy/rbac-cji-smoketest.yml`