### PR TITLE
Revert "Add DB lock during tenant creation"

### DIFF
--- a/rbac/rbac/middleware.py
+++ b/rbac/rbac/middleware.py
@@ -78,16 +78,11 @@ class IdentityHeaderMiddleware(BaseTenantMiddleware):
                     raise Http404()
             else:
                 with transaction.atomic():
-                    try:
-                        tenant = Tenant.objects.get(schema_name=tenant_schema)
-                    except Tenant.DoesNotExist:
-                        cursor = transaction.get_connection().cursor()
-                        cursor.execute("LOCK TABLE public.api_tenant in SHARE ROW EXCLUSIVE MODE")
-                        tenant, created = Tenant.objects.get_or_create(schema_name=tenant_schema)
-                        if created:
-                            seed_permissions(tenant=tenant)
-                            seed_roles(tenant=tenant)
-                            seed_group(tenant=tenant)
+                    tenant, created = Tenant.objects.get_or_create(schema_name=tenant_schema)
+                    if created:
+                        seed_permissions(tenant=tenant)
+                        seed_roles(tenant=tenant)
+                        seed_group(tenant=tenant)
             TENANTS.save_tenant(tenant)
         return tenant
 


### PR DESCRIPTION
Reverts RedHatInsights/insights-rbac#454

In an effort to resolve the DB lock/latency issues we've been seeing in RBAC prod, we may need to roll this back to see whether or not this is contributing to the issue.

We understand this will add an edge-case bug back in, where during schema creation if multiple requests for the tenant come in in parallel, the last request will win, and those before will fail due to a deadlock. One potential resolution may be to add a status column to the Tenant table which we can flag as pending while the schema is being created and migrations/seeds are run. During that time, subsequent requests could either return a 400 to retry, or we could wait/poll the requests until the status is clear.