### PR TITLE
Wait for schema to be ready before serving requests

### DIFF
--- a/rbac/api/models.py
+++ b/rbac/api/models.py
@@ -25,11 +25,14 @@ from api.status.model import Status  # noqa: F401
 class Tenant(TenantMixin):
     """The model used to create a tenant schema."""
 
+    ready = models.BooleanField(default=False)
+
     # Override the mixin domain url to make it nullable, non-unique
     domain_url = None
 
     # Delete all schemas when a tenant is removed
     auto_drop_schema = True
+    auto_create_schema = False
 
     def __str__(self):
         """Get string representation of Tenant."""

--- a/rbac/rbac/middleware.py
+++ b/rbac/rbac/middleware.py
@@ -18,6 +18,7 @@
 """Custom RBAC Middleware."""
 import binascii
 import logging
+import time
 from json.decoder import JSONDecodeError
 
 from django.conf import settings
@@ -77,17 +78,20 @@ class IdentityHeaderMiddleware(BaseTenantMiddleware):
                 except Tenant.DoesNotExist:
                     raise Http404()
             else:
+                tenant, created = Tenant.objects.get_or_create(schema_name=tenant_schema)
                 with transaction.atomic():
-                    try:
-                        tenant = Tenant.objects.get(schema_name=tenant_schema)
-                    except Tenant.DoesNotExist:
-                        cursor = transaction.get_connection().cursor()
-                        cursor.execute("LOCK TABLE public.api_tenant in SHARE ROW EXCLUSIVE MODE")
-                        tenant, created = Tenant.objects.get_or_create(schema_name=tenant_schema)
-                        if created:
-                            seed_permissions(tenant=tenant)
-                            seed_roles(tenant=tenant)
-                            seed_group(tenant=tenant)
+                    if created:
+                        tenant.create_schema(check_if_exists=True)
+                        seed_permissions(tenant=tenant)
+                        seed_roles(tenant=tenant)
+                        seed_group(tenant=tenant)
+                        tenant.ready = True
+                        tenant.save()
+
+                    else:
+                        while not tenant.ready:
+                            tenant.refresh_from_db()
+                            time.sleep(0.5)
             TENANTS.save_tenant(tenant)
         return tenant
 

--- a/rbac/rbac/middleware.py
+++ b/rbac/rbac/middleware.py
@@ -90,8 +90,8 @@ class IdentityHeaderMiddleware(BaseTenantMiddleware):
 
                     else:
                         while not tenant.ready:
-                            tenant.refresh_from_db()
                             time.sleep(0.5)
+                            tenant.refresh_from_db()
             TENANTS.save_tenant(tenant)
         return tenant
 

--- a/tests/api/cross_access/test_view.py
+++ b/tests/api/cross_access/test_view.py
@@ -79,7 +79,10 @@ class CrossAccountRequestViewTests(IdentityRequest):
         }
 
         with tenant_context(Tenant.objects.get(schema_name="public")):
-            Tenant.objects.create(schema_name=f"acct{self.data4create['target_account']}")
+            t = Tenant.objects.create(schema_name=f"acct{self.data4create['target_account']}")
+            t.create_schema()
+            t.ready = True
+            t.save()
             self.role_1 = Role.objects.create(name="role_1", system=True)
             self.role_2 = Role.objects.create(name="role_2", system=True)
             self.role_9 = Role.objects.create(name="role_9", system=True)

--- a/tests/api/status/test_status.py
+++ b/tests/api/status/test_status.py
@@ -45,10 +45,11 @@ class StatusModelTest(TestCase):
     def setUp(self):
         """Create test case setup."""
         super().setUp()
-        t, _ = Tenant.objects.get_or_create(schema_name="public")
-        t.create_schema()
-        t.ready = True
-        t.save()
+        t, created = Tenant.objects.get_or_create(schema_name="public")
+        if created:
+            t.create_schema()
+            t.ready = True
+            t.save()
 
     @patch("os.environ")
     def test_commit_with_env(self, mock_os):

--- a/tests/api/status/test_status.py
+++ b/tests/api/status/test_status.py
@@ -45,7 +45,10 @@ class StatusModelTest(TestCase):
     def setUp(self):
         """Create test case setup."""
         super().setUp()
-        Tenant.objects.get_or_create(schema_name="public")
+        t = Tenant.objects.get_or_create(schema_name="public")
+        t.create_schema()
+        t.ready = True
+        t.save()
 
     @patch("os.environ")
     def test_commit_with_env(self, mock_os):

--- a/tests/api/status/test_status.py
+++ b/tests/api/status/test_status.py
@@ -45,7 +45,7 @@ class StatusModelTest(TestCase):
     def setUp(self):
         """Create test case setup."""
         super().setUp()
-        t = Tenant.objects.get_or_create(schema_name="public")
+        t, _ = Tenant.objects.get_or_create(schema_name="public")
         t.create_schema()
         t.ready = True
         t.save()

--- a/tests/identity_request.py
+++ b/tests/identity_request.py
@@ -42,8 +42,9 @@ class IdentityRequest(TestCase):
         cls.user_data = cls._create_user_data()
         cls.request_context = cls._create_request_context(cls.customer_data, cls.user_data)
         cls.schema_name = cls.customer_data.get("schema_name")
-        cls.tenant = Tenant(schema_name=cls.schema_name)
+        cls.tenant = Tenant(schema_name=cls.schema_name, ready=True)
         cls.tenant.save()
+        cls.tenant.create_schema()
         cls.headers = cls.request_context["request"].META
 
     @classmethod

--- a/tests/identity_request.py
+++ b/tests/identity_request.py
@@ -85,6 +85,7 @@ class IdentityRequest(TestCase):
         if create_tenant:
             tenant = Tenant(schema_name=schema_name)
             tenant.save()
+            tenant.create_schema()
         return tenant
 
     @classmethod

--- a/tests/internal/test_views.py
+++ b/tests/internal/test_views.py
@@ -141,6 +141,11 @@ class InternalViewsetTests(IdentityRequest):
         modified_tenant_roles = Tenant.objects.create(schema_name="acctmodifiedroles")
         unmodified_tenant_2 = Tenant.objects.create(schema_name="acctunmodified2")
 
+        for t in [modified_tenant_groups, modified_tenant_roles, unmodified_tenant_2]:
+            t.create_schema()
+            t.ready = True
+            t.save()
+
         with tenant_context(modified_tenant_groups):
             Group.objects.create(name="Custom Group")
 

--- a/tests/internal/test_views.py
+++ b/tests/internal/test_views.py
@@ -189,6 +189,8 @@ class InternalViewsetTests(IdentityRequest):
         app_name = "foo_app"
         tenant_migrations_complete = Tenant.objects.create(schema_name="acctcomplete")
         tenant_migrations_incomplete = Tenant.objects.create(schema_name="acctincomplete")
+        for t in [tenant_migrations_complete, tenant_migrations_incomplete]:
+            t.create_schema()
 
         with tenant_context(tenant_migrations_complete):
             migrations_have_run = MigrationRecorder.Migration.objects.create(name=migration_name, app=app_name)

--- a/tests/management/test_querysets.py
+++ b/tests/management/test_querysets.py
@@ -42,6 +42,7 @@ class QuerySetTest(TestCase):
         except:
             cls.tenant = Tenant(schema_name="test")
             cls.tenant.save(verbosity=0)
+            cls.tenant.create_schema()
 
         connection.set_tenant(cls.tenant)
 

--- a/tests/rbac/test_cache.py
+++ b/tests/rbac/test_cache.py
@@ -36,6 +36,9 @@ class AccessCacheTest(TestCase):
         """Set up the tenant."""
         super().setUpClass()
         self.tenant = Tenant.objects.create(schema_name="acct12345")
+        self.tenant.create_schema()
+        self.tenant.ready = True
+        self.tenant.save()
         connection.set_schema("acct12345")
 
     def setUp(self):

--- a/tests/rbac/test_middleware.py
+++ b/tests/rbac/test_middleware.py
@@ -330,8 +330,9 @@ class AccessHandlingTest(TestCase):
         try:
             cls.tenant = Tenant.objects.get(schema_name="test")
         except:
-            cls.tenant = Tenant(schema_name="test")
+            cls.tenant = Tenant(schema_name="test", ready=True)
             cls.tenant.save(verbosity=0)
+            cls.tenant.create_schema()
 
         connection.set_tenant(cls.tenant)
 

--- a/tests/rbac/test_middleware.py
+++ b/tests/rbac/test_middleware.py
@@ -244,7 +244,11 @@ class ServiceToService(IdentityRequest):
 
     def test_no_identity_and_invalid_psk_returns_401(self):
         connection.set_schema_to_public()
-        Tenant.objects.create(schema_name=f"acct{self.account_id}")
+        t = Tenant.objects.create(schema_name=f"acct{self.account_id}")
+        t.create_schema()
+        t.ready = True
+        t.save()
+
         url = reverse("group-list")
         client = APIClient()
         self.service_headers["HTTP_X_RH_RBAC_PSK"] = "xyz"
@@ -254,7 +258,10 @@ class ServiceToService(IdentityRequest):
 
     def test_no_identity_and_invalid_account_returns_404(self):
         connection.set_schema_to_public()
-        Tenant.objects.create(schema_name=f"acct{self.account_id}")
+        t = Tenant.objects.create(schema_name=f"acct{self.account_id}")
+        t.create_schema()
+        t.ready = True
+        t.save()
         url = reverse("group-list")
         client = APIClient()
         self.service_headers["HTTP_X_RH_RBAC_ACCOUNT"] = "1212"
@@ -264,7 +271,10 @@ class ServiceToService(IdentityRequest):
 
     def test_no_identity_and_invalid_client_id_returns_401(self):
         connection.set_schema_to_public()
-        Tenant.objects.create(schema_name=f"acct{self.account_id}")
+        t = Tenant.objects.create(schema_name=f"acct{self.account_id}")
+        t.create_schema()
+        t.ready = True
+        t.save()
         url = reverse("group-list")
         client = APIClient()
         self.service_headers["HTTP_X_RH_RBAC_CLIENT_ID"] = "bad-service"
@@ -274,7 +284,10 @@ class ServiceToService(IdentityRequest):
 
     def test_no_identity_and_valid_psk_client_id_and_account_returns_200(self):
         connection.set_schema_to_public()
-        Tenant.objects.create(schema_name=f"acct{self.account_id}")
+        t = Tenant.objects.create(schema_name=f"acct{self.account_id}")
+        t.create_schema()
+        t.ready = True
+        t.save()
         url = reverse("group-list")
         client = APIClient()
         response = client.get(url, **self.service_headers)


### PR DESCRIPTION
This does serveral things:
- defer the creation of the schema, so it doesn't happen as a create hook
- add a `ready` boolean field to `api.tenant`
- if the tenant is created, run migrations explicitly and then seeds
- then set the tenant to `ready=True`
- concurrent requests will get the tenant object, but will poll the db until the schema
  is ready before continuing

## Local Testing
Send concurrent requests to a new account, and all should succeed.
