### PR TITLE
Revert "Temporarily disable haberdasher/platform logging"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,7 +67,7 @@ chmod 755 /usr/bin/haberdasher
 
 USER 1001
 
-# ENTRYPOINT ["/usr/bin/haberdasher"]
+ENTRYPOINT ["/usr/bin/haberdasher"]
 
 # Set the default CMD to print the usage of the language image.
 CMD $STI_SCRIPTS_PATH/run


### PR DESCRIPTION
Reverts RedHatInsights/insights-rbac#450 and re-enables haberdasher in our images