### PR TITLE
Optionally run `sync_schemas` witth list of schemas

### DIFF
--- a/rbac/internal/views.py
+++ b/rbac/internal/views.py
@@ -180,9 +180,14 @@ def sync_schemas(request):
     POST /_private/api/utils/sync_schemas/
     """
     if request.method == "POST":
+        args = {}
+        schema_list_param = request.GET.get("schemas")
+        if schema_list_param:
+            schema_list = schema_list_param.split(",")
+            args = {"schema_list": schema_list}
         msg = "Running schema sync in background worker."
         logger.info(msg)
-        run_sync_schemas_in_worker.delay()
+        run_sync_schemas_in_worker.delay(args)
         return HttpResponse(msg, status=202)
 
     return HttpResponse(f'Method "{request.method}" not allowed.', status=405)

--- a/rbac/management/management/commands/sync_schemas.py
+++ b/rbac/management/management/commands/sync_schemas.py
@@ -165,10 +165,23 @@ class Command(BaseCommand):
                 policy.roles.set(new_roles)
                 policy.save()
 
+    def add_arguments(self, parser):
+        """Add arguments to command."""
+        parser.add_argument("--schema_list", action="store_true")
+
     def handle(self, *args, **options):
         """Actually do the work when the command is run."""
-        tenants = Tenant.objects.exclude(schema_name="public")
         try:
+            schema_list = options.get("schema_list")
+            if schema_list:
+                tenants = Tenant.objects.exclude(schema_name="public").filter(schema_name__in=schema_list)
+            else:
+                tenants = Tenant.objects.exclude(schema_name="public")
+
+            if not tenants:
+                self.stdout.write(f"*** No schemas to sync ***")
+                return
+
             for idx, tenant in enumerate(list(tenants)):
                 self.stdout.write(
                     f"*** Syncing Schemas for '{tenant.id}' - '{tenant.schema_name}' ({idx + 1} of {len(tenants)}) ***"

--- a/rbac/management/tasks.py
+++ b/rbac/management/tasks.py
@@ -47,6 +47,6 @@ def run_reconcile_tenant_relations_in_worker(kwargs):
 
 
 @shared_task
-def run_sync_schemas_in_worker():
+def run_sync_schemas_in_worker(kwargs):
     """Celery task to sync schemas."""
-    call_command("sync_schemas")
+    call_command("sync_schemas", **kwargs)


### PR DESCRIPTION
By default, we'll continue to run `sync_schemas` for all (non-public) schemas.
You may now optionally supply a list of comma-seperated schema names to run against
as well. For instance:

```
http://internal.console.redhat.com/api/rbac/utils/sync_schemas/?schemas=acct10001,acct10002
```

To test locally:
- update your `dev_middleware.py` to be `"type": "Associate"` and change the `"user"`
key to `"associate"`
- within `/rbac/`, run `celery worker -A rbac.celery --broker=redis://127.0.0.1:6379/0 --loglevel=INFO` after `pipenv shell` to start a celery worker
- run `curl http://localhost:8000/_private/api/utils/sync_schemas/?schemas=acct10001,acct10002 -XPOST`

## Link(s) to Jira
- 

## Description of Intent of Change(s)
The what, why and how.

## Local Testing
How can the feature be exercised? 
How can the bug be exploited and fix confirmed?
Is any special local setup required?

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  -  if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
