### PR TITLE
Add exclude roles filter to permissions

### DIFF
--- a/docs/source/specs/openapi.json
+++ b/docs/source/specs/openapi.json
@@ -323,7 +323,7 @@
         ],
         "summary": "Update a cross account request",
         "operationId": "putCrossAccountRequest",
-        "description":"Update a cross account request",
+        "description": "Update a cross account request",
         "parameters": [
           {
             "name": "uuid",
@@ -409,7 +409,7 @@
         ],
         "summary": "Update a cross account request",
         "operationId": "patchCrossAccountRequest",
-        "description":"Update a cross account request",
+        "description": "Update a cross account request",
         "parameters": [
           {
             "name": "uuid",
@@ -2508,6 +2508,15 @@
                 "true",
                 "false"
               ]
+            }
+          },
+          {
+            "name": "exclude_roles",
+            "in": "query",
+            "description": "An optional string filter which accepts one or more role UUIDs, comma-separated, to return permissions not associated with the supplied role(s).",
+            "required": false,
+            "schema": {
+              "type": "string"
             }
           }
         ],


### PR DESCRIPTION
## Link(s) to Jira
- https://issues.redhat.com/browse/RHCLOUD-16285

## Description of Intent of Change(s)
This adds the optional `exclude_roles` query param to the `/permissions/` endpoint
so that you may supply a list of role UUIDs to exclude from the permission response.

This will allow a user to filter only permissons which have not already been
associated with one or more roles.

For instance, given `permissionA` and `permissionB`, where `permissionA` has been
added to `roleA` with UUID `abc123`, when I query the following:

```
/api/rbac/v1/permissions/?exclude_roles=abc123
```

I should get back `permissionB` only.

## Local Testing
Confirm that supplying one or more values in `?exclude_roles=` will filter the permissions for that role out of the results.

## Checklist
- [x] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [x] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  -  if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [x] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [x] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
