### PR TITLE
Revert "Added apiPath for clowder"

### DIFF
--- a/deploy/rbac-clowdapp.yml
+++ b/deploy/rbac-clowdapp.yml
@@ -18,10 +18,7 @@ objects:
     deployments:
     - name: service
       minReplicas: ${{MIN_REPLICAS}}
-      webService: 
-        public:
-          enabled: true
-          apiPath: rbac
+      web: true
       podSpec:
         image: ${IMAGE}:${IMAGE_TAG}
         initContainers:


### PR DESCRIPTION
Reverts RedHatInsights/insights-rbac#552

It seems this change may be interfering with our `public` service port for `rbac-service`.