### PR TITLE
Dependent Permissions #2 - RBAC integration

### DIFF
--- a/rbac/management/permission/model.py
+++ b/rbac/management/permission/model.py
@@ -29,6 +29,7 @@ class Permission(TenantAwareModel):
     verb = models.TextField(null=False)
     permission = models.TextField(null=False, unique=True)
     description = models.TextField(default="")
+    permissions = models.ManyToManyField("self", symmetrical=False, related_name="requiring_permissions")
 
     def save(self, *args, **kwargs):
         """Populate the application, resource_type and verb field before saving."""

--- a/rbac/management/permission/serializer.py
+++ b/rbac/management/permission/serializer.py
@@ -24,8 +24,14 @@ from rest_framework import serializers
 class PermissionSerializer(SerializerCreateOverrideMixin, serializers.ModelSerializer):
     """Serializer for the Permission model."""
 
+    requires = serializers.SerializerMethodField("get_permissions")
+
     class Meta:
         """Metadata for the serializer."""
 
         model = Permission
-        fields = ("application", "resource_type", "verb", "permission", "description")
+        fields = ("application", "resource_type", "verb", "permission", "description", "requires")
+
+    def get_permissions(self, obj):
+        """Get dependent/required permissions."""
+        return list(obj.permissions.all().values_list("permission", flat=True))

--- a/rbac/management/role/permissions/approval_local_test.json
+++ b/rbac/management/role/permissions/approval_local_test.json
@@ -1,6 +1,44 @@
 {
-    "actions": [{"verb": "create"}, {"verb": "read"}],
-    "requests": [{"verb": "create"}, {"verb": "read"}],
-    "templates": [{"verb": "read", "description": "Approval local test templates read."}],
-    "workflows": [{"verb": "create"}, {"verb": "read"}, {"verb":"update"}, {"verb":"delete"}, {"verb":"link"}, {"verb":"unlink"}]
+  "actions": [
+    {
+      "verb": "create"
+    },
+    {
+      "verb": "read"
+    }
+  ],
+  "requests": [
+    {
+      "verb": "create"
+    },
+    {
+      "verb": "read"
+    }
+  ],
+  "templates": [
+    {
+      "verb": "read",
+      "description": "Approval local test templates read."
+    }
+  ],
+  "workflows": [
+    {
+      "verb": "create"
+    },
+    {
+      "verb": "read"
+    },
+    {
+      "verb": "update"
+    },
+    {
+      "verb": "delete"
+    },
+    {
+      "verb": "link"
+    },
+    {
+      "verb": "unlink"
+    }
+  ]
 }

--- a/rbac/management/role/permissions/catalog_local_test.json
+++ b/rbac/management/role/permissions/catalog_local_test.json
@@ -1,8 +1,73 @@
 {
-    "approval_requests": ["read", {"verb": "write"}],
-    "orders": [{"verb": "read"}, {"verb": "write"}, {"verb": "order"}],
-    "orders_items": [{"verb": "read"}, {"verb": "write"}, {"verb": "order"}],
-    "portfolios": [{"verb": "create"}, {"verb": "read"}, {"verb": "update"}, {"verb": "delete"}, {"verb": "order"}],
-    "portfolio_items": [{"verb": "create"}, {"verb": "read"}, {"verb": "update"}, {"verb": "delete"}, {"verb": "order"}],
-    "progress_messages": [{"verb": "read"}, {"verb": "write"}]
+  "approval_requests": [
+    "read",
+    {
+      "verb": "write"
+    }
+  ],
+  "orders": [
+    {
+      "verb": "read"
+    },
+    {
+      "verb": "write",
+      "requires": ["read"]
+    },
+    {
+      "verb": "order"
+    }
+  ],
+  "orders_items": [
+    {
+      "verb": "read"
+    },
+    {
+      "verb": "write"
+    },
+    {
+      "verb": "order"
+    }
+  ],
+  "portfolios": [
+    {
+      "verb": "create"
+    },
+    {
+      "verb": "read"
+    },
+    {
+      "verb": "update"
+    },
+    {
+      "verb": "delete"
+    },
+    {
+      "verb": "order"
+    }
+  ],
+  "portfolio_items": [
+    {
+      "verb": "create"
+    },
+    {
+      "verb": "read"
+    },
+    {
+      "verb": "update"
+    },
+    {
+      "verb": "delete"
+    },
+    {
+      "verb": "order"
+    }
+  ],
+  "progress_messages": [
+    {
+      "verb": "read"
+    },
+    {
+      "verb": "write"
+    }
+  ]
 }

--- a/tests/management/permission/test_model.py
+++ b/tests/management/permission/test_model.py
@@ -32,8 +32,10 @@ class PermissionModelTests(IdentityRequest):
         super().setUp()
 
         with tenant_context(self.tenant):
-            self.permission = Permission.objects.create(permission="rbac:roles:read")
+            self.dependency_permission = Permission.objects.create(permission="rbac:roles:read")
+            self.permission = Permission.objects.create(permission="rbac:roles:write")
             self.permission.save()
+            self.permission.permissions.add(self.dependency_permission)
 
     def tearDown(self):
         """Tear down permission model tests."""
@@ -45,5 +47,7 @@ class PermissionModelTests(IdentityRequest):
         with tenant_context(self.tenant):
             self.assertEqual(self.permission.application, "rbac")
             self.assertEqual(self.permission.resource_type, "roles")
-            self.assertEqual(self.permission.verb, "read")
-            self.assertEqual(self.permission.permission, "rbac:roles:read")
+            self.assertEqual(self.permission.verb, "write")
+            self.assertEqual(self.permission.permission, "rbac:roles:write")
+            self.assertEqual(list(self.permission.permissions.all()), [self.dependency_permission])
+            self.assertEqual(list(self.dependency_permission.requiring_permissions.all()), [self.permission])

--- a/tests/management/permission/test_view.py
+++ b/tests/management/permission/test_view.py
@@ -55,6 +55,7 @@ class PermissionViewsetTests(IdentityRequest):
             self.permissionG = Permission.objects.create(permission="*:*:baz")
             self.permissionH = Permission.objects.create(permission="*:bar:baz")
             self.permissionI = Permission.objects.create(permission="foo:bar:*", description="Description test.")
+            self.permissionI.permissions.add(self.permissionA)
 
             self.roleA = Role.objects.create(name="roleA", tenant=self.tenant)
             self.roleB = Role.objects.create(name="roleB", tenant=self.tenant)
@@ -86,8 +87,10 @@ class PermissionViewsetTests(IdentityRequest):
             self.assertIsNotNone(perm.get("permission"))
             if perm["permission"] == "foo:bar:*":
                 self.assertEqual(perm["description"], "Description test.")
+                self.assertEqual(perm["requires"], ["rbac:roles:read"])
             else:
                 self.assertEqual(perm["description"], "")
+                self.assertEqual(perm["requires"], [])
 
     def test_read_permission_list_application_filter(self):
         """Test that we can filter a list of permissions by application."""


### PR DESCRIPTION
_**NOTE:** this branch is based on the branch in #559 and will be rebased once that migration PR is merged, and the migration will drop from this PR._

## Link(s) to Jira
- https://issues.redhat.com/browse/RHCLOUD-16599

## Description of Intent of Change(s)
At a high level, we need to integrate support for `requires` from [rbac-config changes](https://github.com/RedHatInsights/rbac-config/pull/213) so that seeding will create the necessary relations, and that we'll now return those required permissions on `/permissions/`. Additionally, we need to validate these permissions are supplied as part of a POST/PUT request to a role.

**cf65dcd**
Reformats the JSON and adds a test `requires: ["read"]` value to `catalog_local_test.json`

**72e25f2**
Since permissions cannot be created in the API, we'll be relating them when we
seed permission data.

We cannot do this as part of the initial permission seed creation, because of the
fact that there may be a dependency on a permission which has not yet been created.

Instead, we'll map out any permission seed data which has `requires` after we've
created the permissions, and make the associations at that point.

There were some issues with catching errors in `transaction.atomic()` [1] so this
moves the initial transaction block and adds another.

[1] https://stackoverflow.com/questions/42586967/using-nested-django-transaction-atomic-to-handle-exceptions

**9490028**
This will return the `requires` in the API requests for `/api/rbac/v1/permissions/`:

```
{
  "data": [
    {
      "application": "catalog_local_test",
      "resource_type": "orders",
      "verb": "write",
      "permission": "catalog_local_test:orders:write",
      "description": "",
      "requires": [
        "catalog_local_test:orders:read"
      ]
    }
  ]
}
```

**0f9c789**
If a role is created or updated with a permission which has dependent permissions,
and those permissions are not part of the payload, we'll 400 the request with
a message, similar to: `Permission 'app:*:write' requires: '['app:*:read']'`.

## Local Testing
- To test the new relation, ensure you run migrations in #559, starting clean with `make reinitdb`
- Then run seeds: `./rbac/manage.py` and note there should be one permission relation now
- Test the relation:
```
# access the dependency
permission_with_dependency.permissions.all() #=> [dependent_permission]
# no dependent permissions
permission_with_dependency.requiring_permissions.all() #=> []

# no dependencies
dependent_permission.permissions.all() #=> []
# access dependent permission
dependent_permission.requiring_permissions.all() #=> [permission_with_dependency]
```
- Test the permissions payload against `/api/rbac/v1/permissions/?limit=1000` and note the `requires` field, which should be populated for the permission above, empty for others.
- Create/update a role with the permission which has a dependency, _without_ the dependency permission, and note a 400. 
- Create/update a role with the permission which has a dependency, _with_ the dependency permission, and note a 200. 

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  -  if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
