### PR TITLE
bumping request to adhere to req/limit ratio requirement

### DIFF
--- a/deploy/rbac-clowdapp.yml
+++ b/deploy/rbac-clowdapp.yml
@@ -72,7 +72,7 @@ objects:
             memory: ${MEMORY_LIMIT}
           requests:
             cpu: 200m
-            memory: 256Mi
+            memory: 512Mi
         env:
           - name: SENTRY_DSN
             valueFrom:


### PR DESCRIPTION
## Description of Intent of Change(s)

The ephemeral cluster now requires a 2:1 ratio in regards to memory limits/request. With bumping the request to 512MB and having the limit at 1Gi, that satisfies the requirement. This unblocks every deployment that uses RBAC as a dependency and RBAC itself