### PR TITLE
Update `unit_test.sh` exit

### DIFF
--- a/unit_test.sh
+++ b/unit_test.sh
@@ -19,4 +19,9 @@ cat << EOF > $WORKSPACE/artifacts/junit-dummy.xml
 </testsuite>
 EOF
 
-exit $result
+if [ $result -ne 0 ]; then
+  echo '====================================='
+  echo '====  ✖ ERROR: UNIT TEST FAILED  ===='
+  echo '====================================='
+  exit 1
+fi


### PR DESCRIPTION
Updating the `unit_test.sh` script to exit only on failure, to ensure smoke
tests will execute on success.

This is still currently commented out in `pr_check.sh`, but there has been an
explicit check [1] implemented to ensure this is configured correctly which is
currently failing for us.

[1] https://github.com/RedHatInsights/bonfire/pull/148
