### PR TITLE
Account for schemas which haven't been seeded in "unmodified" logic

### DIFF
--- a/rbac/internal/views.py
+++ b/rbac/internal/views.py
@@ -50,13 +50,16 @@ def destructive_ok():
     return now < settings.INTERNAL_DESTRUCTIVE_API_OK_UNTIL
 
 
+def tenant_is_modified():
+    """Determine whether or not the tenant is modified."""
+    return (Role.objects.filter(system=True).count() != Role.objects.count()) or (
+        Group.objects.filter(system=True).count() != Group.objects.count()
+    )
+
+
 def tenant_is_unmodified():
-    """Determine whether or not the tenant has been modified."""
-    if Role.objects.filter(system=True).count() != Role.objects.count():
-        return False
-    if Group.objects.filter(system=True).count() != Group.objects.count():
-        return False
-    return True
+    """Determine whether or not the tenant is unmodified."""
+    return not tenant_is_modified()
 
 
 def list_unmodified_tenants(request):

--- a/rbac/internal/views.py
+++ b/rbac/internal/views.py
@@ -54,9 +54,7 @@ def tenant_is_unmodified():
     """Determine whether or not the tenant has been modified."""
     if Role.objects.filter(system=True).count() != Role.objects.count():
         return False
-    if Group.objects.count() != 1:
-        return False
-    if Group.objects.filter(system=True).count() != 1:
+    if Group.objects.filter(system=True).count() != Group.objects.count():
         return False
     return True
 


### PR DESCRIPTION
In the case where a schema has not yet been seeded, the check around:

```
Group.objects.filter(system=True).count() != 1
```

will cause the method to return `False`, since there will be no groups at all.
Instead, we should just do the same check we do with roles, and compare the number
of system groups to total groups.
