### PR TITLE
Account for tenants with no schema during pruning

### DIFF
--- a/rbac/internal/views.py
+++ b/rbac/internal/views.py
@@ -34,7 +34,7 @@ from management.tasks import (
     run_seeds_in_worker,
     run_sync_schemas_in_worker,
 )
-from tenant_schemas.utils import tenant_context
+from tenant_schemas.utils import schema_exists, tenant_context
 
 from api.models import Tenant
 from api.tasks import cross_account_cleanup
@@ -50,16 +50,22 @@ def destructive_ok():
     return now < settings.INTERNAL_DESTRUCTIVE_API_OK_UNTIL
 
 
-def tenant_is_modified():
+def tenant_is_modified(schema_name):
     """Determine whether or not the tenant is modified."""
-    return (Role.objects.filter(system=True).count() != Role.objects.count()) or (
+    has_custom_data = (Role.objects.filter(system=True).count() != Role.objects.count()) or (
         Group.objects.filter(system=True).count() != Group.objects.count()
     )
 
+    # we need to check if the schema exists because if we don't, and it doesn't exist,
+    # the search_path on the query will fall back to using the public schema, in
+    # which case there will be custom groups/roles, and we won't be able to propertly
+    # prune the tenant which has been created without a valid schema
+    return has_custom_data and schema_exists(schema_name)
 
-def tenant_is_unmodified():
+
+def tenant_is_unmodified(schema_name):
     """Determine whether or not the tenant is unmodified."""
-    return not tenant_is_modified()
+    return not tenant_is_modified(schema_name)
 
 
 def list_unmodified_tenants(request):
@@ -78,7 +84,7 @@ def list_unmodified_tenants(request):
     to_return = []
     for tenant_obj in tenant_qs:
         with tenant_context(tenant_obj):
-            if tenant_is_unmodified():
+            if tenant_is_unmodified(tenant_obj.schema_name):
                 to_return.append(tenant_obj.schema_name)
     payload = {
         "unmodified_tenants": to_return,
@@ -101,7 +107,7 @@ def tenant_view(request, tenant_schema_name):
         tenant_obj = get_object_or_404(Tenant, schema_name=tenant_schema_name)
         with transaction.atomic():
             with tenant_context(tenant_obj):
-                if tenant_is_unmodified():
+                if tenant_is_unmodified(tenant_obj.schema_name):
                     logger.warning(f"Deleting tenant {tenant_schema_name}. Requested by {request.user.username}")
                     TENANTS.delete_tenant(tenant_schema_name)
                     tenant_obj.delete()

--- a/rbac/internal/views.py
+++ b/rbac/internal/views.py
@@ -52,15 +52,16 @@ def destructive_ok():
 
 def tenant_is_modified(schema_name):
     """Determine whether or not the tenant is modified."""
-    has_custom_data = (Role.objects.filter(system=True).count() != Role.objects.count()) or (
-        Group.objects.filter(system=True).count() != Group.objects.count()
-    )
-
     # we need to check if the schema exists because if we don't, and it doesn't exist,
     # the search_path on the query will fall back to using the public schema, in
     # which case there will be custom groups/roles, and we won't be able to propertly
     # prune the tenant which has been created without a valid schema
-    return has_custom_data and schema_exists(schema_name)
+    if not schema_exists(schema_name):
+        return False
+
+    return (Role.objects.filter(system=True).count() != Role.objects.count()) or (
+        Group.objects.filter(system=True).count() != Group.objects.count()
+    )
 
 
 def tenant_is_unmodified(schema_name):


### PR DESCRIPTION
In the event an RBAC service pod restarts during the creation of a schema, there is
an edge case exposed where a `Tenant` object will be created, but not a schema.

We cannot have both the `Tenant` and schema creation in a transaction currently,
because of a deadlock issue which this PR helped to resolve: https://github.com/RedHatInsights/insights-rbac/pull/519

A more robust fix would be to know when a schema has not been created for a given
tenant, and remove the `Tenant` object. This is a stop-gap until we move off
of schema-based tenancy in the near future, to allow us to manually remove these
via Turnpike.

It ensures that in the check to see if a tenant has been modified, we confirm
the schema exists. We need to do this because if we don't, and it doesn't exist,
the `search_path` on the query will fall back to using the public schema, in
which case there will be custom groups/roles, and we won't be able to propertly
prune the tenant which has been created without a valid schema.

