### PR TITLE
Set `tenant` on create

### DIFF
--- a/rbac/api/cross_access/util.py
+++ b/rbac/api/cross_access/util.py
@@ -70,6 +70,6 @@ def create_principal_with_tenant(principal_name, schema_name, associate_tenant):
     tenant = Tenant.objects.get(schema_name=schema_name)
     with tenant_context(tenant):
         cross_account_principal, _ = Principal.objects.get_or_create(
-            username=principal_name, cross_account=True, tenant=tenant
+            username=principal_name, cross_account=True, tenant=associate_tenant
         )
     return cross_account_principal

--- a/rbac/api/cross_access/util.py
+++ b/rbac/api/cross_access/util.py
@@ -69,13 +69,7 @@ def create_principal_with_tenant(principal_name, schema_name, associate_tenant):
     """Create cross-account principal in tenant."""
     tenant = Tenant.objects.get(schema_name=schema_name)
     with tenant_context(tenant):
-        cross_account_principal, _ = Principal.objects.get_or_create(username=principal_name, cross_account=True)
-
-        # NOTE: after we ensure/enforce all object have a tenant_id FK, we can add tenant=tenant
-        # to the get_or_create. We cannot currently, because records without would fail the GET
-        # and would create duplicate records. This ensures we temporarily do an update if
-        # obj.tenant_id is NULL
-        if not cross_account_principal.tenant:
-            cross_account_principal.tenant = associate_tenant
-            cross_account_principal.save()
+        cross_account_principal, _ = Principal.objects.get_or_create(
+            username=principal_name, cross_account=True, tenant=tenant
+        )
     return cross_account_principal

--- a/rbac/management/group/definer.py
+++ b/rbac/management/group/definer.py
@@ -45,16 +45,10 @@ def seed_group(tenant):
             )
 
             group, group_created = Group.objects.get_or_create(
-                platform_default=True, defaults={"description": group_description, "name": name, "system": True}
+                platform_default=True,
+                defaults={"description": group_description, "name": name, "system": True},
+                tenant=tenant,
             )
-
-            # NOTE: after we ensure/enforce all object have a tenant_id FK, we can add tenant=tenant
-            # to the get_or_create. We cannot currently, because records without would fail the GET
-            # and would create duplicate records. This ensures we temporarily do an update if
-            # obj.tenant_id is NULL
-            if not group.tenant:
-                group.tenant = tenant
-                group.save()
 
             if group.system:
                 platform_roles = Role.objects.filter(platform_default=True)

--- a/rbac/management/role/definer.py
+++ b/rbac/management/role/definer.py
@@ -41,15 +41,7 @@ def _make_role(tenant, data):
         version=data.get("version", 1),
         platform_default=data.get("platform_default", False),
     )
-    role, created = Role.objects.get_or_create(name=name, defaults=defaults)
-
-    # NOTE: after we ensure/enforce all object have a tenant_id FK, we can add tenant=tenant
-    # to the get_or_create. We cannot currently, because records without would fail the GET
-    # and would create duplicate records. This ensures we temporarily do an update if
-    # obj.tenant_id is NULL
-    if not role.tenant:
-        role.tenant = tenant
-        role.save()
+    role, created = Role.objects.get_or_create(name=name, defaults=defaults, tenant=tenant)
 
     if created:
         if role.display_name != display_name:
@@ -66,15 +58,7 @@ def _make_role(tenant, data):
             return role
     for access_item in access_list:
         resource_def_list = access_item.pop("resourceDefinitions", [])
-        permission, created = Permission.objects.get_or_create(**access_item)
-
-        # NOTE: after we ensure/enforce all object have a tenant_id FK, we can add tenant=tenant
-        # to the get_or_create. We cannot currently, because records without would fail the GET
-        # and would create duplicate records. This ensures we temporarily do an update if
-        # obj.tenant_id is NULL
-        if not permission.tenant:
-            permission.tenant = tenant
-            permission.save()
+        permission, created = Permission.objects.get_or_create(**access_item, tenant=tenant)
 
         access_obj = Access.objects.create(permission=permission, role=role, tenant=tenant)
         for resource_def_item in resource_def_list:
@@ -152,18 +136,12 @@ def seed_permissions(tenant):
                                     permission, created = Permission.objects.update_or_create(
                                         permission=f"{app_name}:{resource}:{operation}",
                                         defaults={"description": permission_description},
+                                        tenant=tenant,
                                     )
                                 else:
                                     permission, created = Permission.objects.update_or_create(
-                                        permission=f"{app_name}:{resource}:{operation_object}"
+                                        permission=f"{app_name}:{resource}:{operation_object}", tenant=tenant
                                     )
-                                # NOTE: after we ensure/enforce all object have a tenant_id FK, we can add tenant=tenant
-                                # to the get_or_create. We cannot currently, because records without would fail the GET
-                                # and would create duplicate records. This ensures we temporarily do an update if
-                                # obj.tenant_id is NULL
-                                if not permission.tenant:
-                                    permission.tenant = tenant
-                                    permission.save()
                                 if created:
                                     logger.info(
                                         f"Created permission {permission.permission} "

--- a/tests/management/role/test_definer.py
+++ b/tests/management/role/test_definer.py
@@ -102,7 +102,7 @@ class RoleDefinerTests(IdentityRequest):
         permission_string = "approval_local_test:templates:read"
         with tenant_context(self.tenant):
             self.assertFalse(len(Permission.objects.all()))
-            Permission.objects.create(permission=permission_string)
+            Permission.objects.create(permission=permission_string, tenant=self.tenant)
 
         try:
             seed_permissions(self.tenant)


### PR DESCRIPTION
## Link(s) to Jira
- https://issues.redhat.com/browse/RHCLOUD-13436

## Description of Intent of Change(s)
Now that we've ensured all objects in prod have a `tenant_id` relation being set,
we no longer need to be concerned about creating duplicates with `get|update_or_create`
actions.

We'll need to set these prior to the db constraints being added to not allow
NULL values, otherwise these creates will fail.

We'll have a follow-up which will add the actual db constraints.

## Local Testing
Run seeds, and everything should behave as normal.

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  -  if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
