### PR TITLE
Simplify `/status/` payload

### DIFF
--- a/docs/source/specs/openapi.json
+++ b/docs/source/specs/openapi.json
@@ -3893,41 +3893,6 @@
           "commit": {
             "type": "string",
             "example": "178d2ea"
-          },
-          "server_address": {
-            "type": "string",
-            "example": "127.0.0.1:8000"
-          },
-          "platform_info": {
-            "type": "object",
-            "example": {
-              "system": "Darwin",
-              "node": "node-1.example.com",
-              "release": "17.5.0",
-              "version": "Darwin Kernel Version 17.5.0",
-              "machine": "x86_64",
-              "processor": "i386"
-            }
-          },
-          "python_version": {
-            "type": "string",
-            "example": "3.6.1"
-          },
-          "modules": {
-            "type": "object",
-            "example": {
-              "coverage": "4.5.1",
-              "coverage.version": "4.5.1",
-              "coverage.xmlreport": "4.5.1",
-              "cryptography": "2.0.3",
-              "ctypes": "1.1.0",
-              "ctypes.macholib": "1.0",
-              "decimal": "1.70",
-              "django": "1.11.5",
-              "django.utils.six": "1.10.0",
-              "django_filters": "1.0.4",
-              "http.server": "0.6"
-            }
           }
         }
       },

--- a/rbac/api/status/model.py
+++ b/rbac/api/status/model.py
@@ -17,15 +17,10 @@
 
 """Models to capture server status."""
 
-import logging
 import os
-import platform
 import subprocess
-import sys
 
 from api import API_VERSION
-
-logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
 
 class Status:
@@ -45,52 +40,6 @@ class Status:
         return commit_info
 
     @property
-    def platform_info(self):  # pylint: disable=R0201
-        """Collect the platform information.
-
-        :returns: A dictionary of platform data
-        """
-        return platform.uname()._asdict()
-
-    @property
-    def python_version(self):  # pylint: disable=R0201
-        """Collect the python version information.
-
-        :returns: The python version string.
-        """
-        return sys.version.replace("\n", "")
-
-    @property
-    def modules(self):  # pylint: disable=R0201
-        """Collect the installed modules.
-
-        :returns: A dictonary of module names and versions.
-        """
-        module_data = {}
-        for name, module in sorted(sys.modules.items()):
-            if hasattr(module, "__version__"):
-                module_data[str(name)] = str(module.__version__)
-        return module_data
-
-    @property
     def api_version(self):
         """Return the API version."""
         return API_VERSION
-
-    def startup(self):
-        """Log startup information."""
-        logger.info("Platform:")
-        for name, value in self.platform_info.items():
-            logger.info("%s - %s ", name, value)
-
-        logger.info("Python: %s", self.python_version)
-        module_list = []
-        for mod, version in self.modules.items():
-            module_list.append("{mod} - {ver}".format(mod=mod, ver=version))
-
-        if module_list:
-            logger.info("Modules: %s", ", ".join(module_list))
-        else:
-            logger.info("Modules: None")
-        logger.info("Commit: %s", self.commit)
-        logger.info("API Version: %s", self.api_version)

--- a/rbac/api/status/serializer.py
+++ b/rbac/api/status/serializer.py
@@ -27,9 +27,6 @@ class StatusSerializer(serializers.Serializer):
 
     api_version = serializers.IntegerField()
     commit = serializers.CharField()
-    modules = serializers.DictField()
-    platform_info = serializers.DictField()
-    python_version = serializers.CharField()
 
     class Meta:
         """Metadata for the serializer."""

--- a/rbac/api/status/view.py
+++ b/rbac/api/status/view.py
@@ -75,5 +75,4 @@ def status(request):
     status_info = Status()
     serializer = StatusSerializer(status_info)
     server_info = serializer.data
-    server_info["server_address"] = request.META.get("HTTP_HOST", "localhost")
     return Response(server_info)

--- a/tests/api/status/test_status.py
+++ b/tests/api/status/test_status.py
@@ -71,50 +71,6 @@ class StatusModelTest(TestCase):
         result = self.status_info.commit
         self.assertEqual(result, expected)
 
-    @patch("platform.uname")
-    def test_platform_info(self, mock_platform):
-        """Test the platform_info method."""
-        platform_record = namedtuple("Platform", ["os", "version"])
-        a_plat = platform_record("Red Hat", "7.4")
-        mock_platform.return_value = a_plat
-        result = self.status_info.platform_info
-        self.assertEqual(result["os"], "Red Hat")
-        self.assertEqual(result["version"], "7.4")
-
-    @patch("sys.version")
-    def test_python_version(self, mock_sys_ver):
-        """Test the python_version method."""
-        expected = "Python 3.6"
-        mock_sys_ver.replace.return_value = expected
-        result = self.status_info.python_version
-        self.assertEqual(result, expected)
-
-    @patch("sys.modules")
-    def test_modules(self, mock_modules):
-        """Test the modules method."""
-        expected = {"module1": "version1", "module2": "version2"}
-        mod1 = Mock(__version__="version1")
-        mod2 = Mock(__version__="version2")
-        mock_modules.items.return_value = (("module1", mod1), ("module2", mod2))
-        result = self.status_info.modules
-        self.assertEqual(result, expected)
-
-    @patch("api.status.model.logger.info")
-    def test_startup_with_modules(self, mock_logger):  # pylint: disable=no-self-use
-        """Test the startup method with a module list."""
-        self.status_info.startup()
-        mock_logger.assert_called_with(ANY, ANY)
-
-    @patch("api.status.model.Status.modules", new_callable=PropertyMock)
-    def test_startup_without_modules(self, mock_mods):  # pylint: disable=no-self-use
-        """Test the startup method without a module list."""
-        mock_mods.return_value = {}
-        expected = "INFO:api.status.model:Modules: None"
-
-        with self.assertLogs("api.status.model", level="INFO") as logger:
-            self.status_info.startup()
-            self.assertIn(expected, logger.output)
-
 
 class StatusViewTest(TestCase):
     """Tests the status view."""
@@ -124,5 +80,3 @@ class StatusViewTest(TestCase):
         url = reverse("server-status")
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        # json_result = response.json()
-        # self.assertEqual(json_result['api_version'], 1)


### PR DESCRIPTION
## Description of Intent of Change(s)
Pare down the `/status/` payload, since most of this is superfluous for our healthchecks:

```json
{
  "api_version": "<version>",
  "commit": "<commit>"
}
```

## Local Testing
- send a request to `/api/rbac/v1/status/` and validate the payload

## Checklist
- [x] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [x] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  -  if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
