### PR TITLE
Use queryset in permission filter for `allowed_only`

### DIFF
--- a/rbac/management/permission/view.py
+++ b/rbac/management/permission/view.py
@@ -60,7 +60,7 @@ class PermissionFilter(CommonFilters):
         """Filter to return only permissions from roles in the ROLE_CREATE_ALLOW_LIST."""
         query_field = validate_and_get_key(self.request.query_params, field, VALID_BOOLEAN_PARAM_VALS, "false")
         if query_field == "true":
-            queryset = Permission.objects.filter(application__in=settings.ROLE_CREATE_ALLOW_LIST)
+            queryset = queryset.filter(application__in=settings.ROLE_CREATE_ALLOW_LIST)
         return queryset
 
     application = filters.CharFilter(field_name="application", method="multiple_values_in")

--- a/tests/management/permission/test_view.py
+++ b/tests/management/permission/test_view.py
@@ -421,6 +421,12 @@ class PermissionViewsetTests(IdentityRequest):
         self.assertEqual(len(response.data.get("data")), 1)
         self.assertCountEqual(expected, response_permissions)
 
+    def test_allowed_only_filters_any_roles_not_in_allow_list_out_when_true_in_chain(self):
+        """Test that we filter out any permissions not in the allow list when allowed_only=true, chained with other filters."""
+        response = CLIENT.get(f"{LIST_URL}?allowed_only=true&exclude_globals=true", **self.headers)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data.get("data")), 0)
+
     def test_allowed_only_filters_no_permissions_out_when_false(self):
         """Test that we do not filter out any permissions not in the allow list when allowed_only=false."""
         with tenant_context(self.tenant):


### PR DESCRIPTION
## Link(s) to Jira
- https://issues.redhat.com/browse/RHCLOUD-17024

## Description of Intent of Change(s)
**Fix for issue in #584** 

When we do not use the `queryset` passed into the filter, this causes an edge-case
where chaining filters like `/permissions/?exclude_roles=123,456&allowed_only=true`
will not behave as expected, because `exclude_roles` will filter the set, but then
we query the entire collection (not the filtered queryset) on `allowed_only`, negating
the previous filter(s).

## Local Testing
Chain filters in a call to `/permissions/` and note that they are additive with this fix.

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  -  if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
