### PR TITLE
Allow accessing permission endpoint for rbac admins

### DIFF
--- a/rbac/management/permission/view.py
+++ b/rbac/management/permission/view.py
@@ -22,7 +22,7 @@ from django_filters import rest_framework as filters
 from management.filters import CommonFilters
 from management.models import Access, Permission, Role
 from management.permission.serializer import PermissionSerializer
-from management.permissions.admin_access import AdminAccessPermission
+from management.permissions.permission_access import PermissionAccessPermission
 from management.utils import validate_and_get_key, validate_uuid
 from rest_framework import mixins, viewsets
 from rest_framework.decorators import action
@@ -80,7 +80,7 @@ class PermissionViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
     """
 
     queryset = Permission.objects.all()
-    permission_classes = (AdminAccessPermission,)
+    permission_classes = (PermissionAccessPermission,)
     filter_backends = (filters.DjangoFilterBackend, OrderingFilter)
     serializer_class = PermissionSerializer
     filterset_class = PermissionFilter

--- a/rbac/management/permissions/permission_access.py
+++ b/rbac/management/permissions/permission_access.py
@@ -1,0 +1,36 @@
+#
+# Copyright 2019 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""Defines the Permission Access Permissions class."""
+from rest_framework import permissions
+
+from rbac.env import ENVIRONMENT
+
+
+class PermissionAccessPermission(permissions.BasePermission):
+    """Determines if a user has access to Role APIs."""
+
+    def has_permission(self, request, view):
+        """Check permission based on the defined access."""
+        if ENVIRONMENT.get_value("ALLOW_ANY", default=False, cast=bool):
+            return True
+        if request.user.admin:
+            return True
+        if request.method in permissions.SAFE_METHODS:
+            permission_read = request.user.access.get("permission", {}).get("read", [])
+            if permission_read:
+                return True
+        return False

--- a/rbac/rbac/middleware.py
+++ b/rbac/rbac/middleware.py
@@ -123,6 +123,7 @@ class IdentityHeaderMiddleware(BaseTenantMiddleware):
             "role": {"read": [], "write": []},
             "policy": {"read": [], "write": []},
             "principal": {"read": [], "write": []},
+            "permission": {"read": [], "write": []},
         }
 
         if settings.SERVE_FROM_PUBLIC_SCHEMA:
@@ -143,7 +144,7 @@ class IdentityHeaderMiddleware(BaseTenantMiddleware):
                         operation = "write"
                     res_list = ["*"]
                     if resource_type == "*":
-                        for resource in ("group", "role", "policy", "principal"):
+                        for resource in ("group", "role", "policy", "principal", "permission"):
                             if (
                                 resource in access.keys()
                                 and operation in access.get(resource, {}).keys()  # noqa: W504

--- a/tests/rbac/test_middleware.py
+++ b/tests/rbac/test_middleware.py
@@ -347,6 +347,7 @@ class AccessHandlingTest(TestCase):
             "role": {"read": [], "write": []},
             "policy": {"read": [], "write": []},
             "principal": {"read": [], "write": []},
+            "permission": {"read": [], "write": []},
         }
         access = IdentityHeaderMiddleware._get_access_for_user("test_user", self.tenant)
         self.assertEqual(expected, access)
@@ -359,6 +360,7 @@ class AccessHandlingTest(TestCase):
             "role": {"read": [], "write": []},
             "policy": {"read": [], "write": []},
             "principal": {"read": [], "write": []},
+            "permission": {"read": [], "write": []},
         }
         access = IdentityHeaderMiddleware._get_access_for_user("test_user", self.tenant)
         self.assertEqual(expected, access)
@@ -381,6 +383,7 @@ class AccessHandlingTest(TestCase):
             "role": {"read": [], "write": []},
             "policy": {"read": [], "write": []},
             "principal": {"read": [], "write": []},
+            "permission": {"read": [], "write": []},
         }
         self.assertEqual(expected, access)
 
@@ -413,6 +416,7 @@ class AccessHandlingTest(TestCase):
             "role": {"read": [], "write": []},
             "policy": {"read": [], "write": []},
             "principal": {"read": [], "write": []},
+            "permission": {"read": [], "write": []},
         }
         self.assertEqual(expected, access)
 
@@ -443,6 +447,7 @@ class AccessHandlingTest(TestCase):
             "role": {"read": [], "write": []},
             "policy": {"read": [], "write": []},
             "principal": {"read": [], "write": []},
+            "permission": {"read": [], "write": []},
         }
         self.assertEqual(expected, access)
 
@@ -464,5 +469,6 @@ class AccessHandlingTest(TestCase):
             "role": {"read": ["*"], "write": ["*"]},
             "policy": {"read": ["*"], "write": ["*"]},
             "principal": {"read": ["*"], "write": ["*"]},
+            "permission": {"read": ["*"], "write": ["*"]},
         }
         self.assertEqual(expected, access)


### PR DESCRIPTION
## Link(s) to Jira
- https://issues.redhat.com/browse/RHCLOUD-17158

## Description of Intent of Change(s)
Non org admin users should be able to access permission endpoint
when they are assigned rbac admin permissions.

## Local Testing
Unit test

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  -  if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
