### PR TITLE
Add internal endpoint for initializing tenants

### DIFF
--- a/rbac/internal/urls.py
+++ b/rbac/internal/urls.py
@@ -24,6 +24,7 @@ from .views import trigger_error
 
 urlpatterns = [
     path("api/tenant/unmodified/", views.list_unmodified_tenants),
+    path("api/tenant/", views.list_tenants),
     path("api/tenant/<str:tenant_schema_name>/", views.tenant_view),
     path("api/tenant/<str:tenant_schema_name>/init/", views.tenant_init),
     path("api/migrations/run/", views.run_migrations),

--- a/rbac/internal/urls.py
+++ b/rbac/internal/urls.py
@@ -25,6 +25,7 @@ from .views import trigger_error
 urlpatterns = [
     path("api/tenant/unmodified/", views.list_unmodified_tenants),
     path("api/tenant/<str:tenant_schema_name>/", views.tenant_view),
+    path("api/tenant/<str:tenant_schema_name>/init/", views.tenant_init),
     path("api/migrations/run/", views.run_migrations),
     path("api/migrations/progress/", views.migration_progress),
     path("api/seeds/run/", views.run_seeds),

--- a/rbac/internal/views.py
+++ b/rbac/internal/views.py
@@ -132,10 +132,11 @@ def tenant_init(request, tenant_schema_name):
         tenant = get_object_or_404(Tenant, schema_name=tenant_schema_name)
         with transaction.atomic():
             with tenant_context(tenant):
-                tenant.create_schema(check_if_exists=True)
-                seed_permissions(tenant=tenant)
-                seed_roles(tenant=tenant)
-                seed_group(tenant=tenant)
+                created = tenant.create_schema(check_if_exists=True)
+                if created is not False:
+                    seed_permissions(tenant=tenant)
+                    seed_roles(tenant=tenant)
+                    seed_group(tenant=tenant)
                 tenant.ready = True
                 tenant.save()
 

--- a/rbac/internal/views.py
+++ b/rbac/internal/views.py
@@ -29,11 +29,11 @@ from django.shortcuts import get_object_or_404
 from management.cache import TenantCache
 from management.models import Group, Role
 from management.tasks import (
+    run_init_tenant_in_worker,
     run_migrations_in_worker,
     run_reconcile_tenant_relations_in_worker,
     run_seeds_in_worker,
     run_sync_schemas_in_worker,
-    run_init_tenant_in_worker,
 )
 from tenant_schemas.utils import schema_exists, tenant_context
 

--- a/rbac/management/management/commands/init_tenant.py
+++ b/rbac/management/management/commands/init_tenant.py
@@ -1,0 +1,55 @@
+#
+# Copyright 2019 Red Hat, Inc.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""Seeds command."""
+import logging
+
+from django.core.management.base import BaseCommand
+from django.db import transaction
+from tenant_schemas.utils import tenant_context
+from api.models import Tenant
+from management.group.definer import seed_group
+from management.role.definer import seed_permissions, seed_roles
+
+logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
+
+
+class Command(BaseCommand):
+    """Command class for running seeds."""
+
+    help = "Initialize a tenant: create a schema, migrate and seed."
+
+    def add_arguments(self, parser):
+        """Add arguments to command."""
+        parser.add_argument("tenant_schema_name")
+
+    def handle(self, *args, **options):
+        """Handle method for command."""
+        tenant_schema_name = options["tenant_schema_name"]
+
+        try:
+            tenant = Tenant.objects.get(schema_name=tenant_schema_name)
+            with transaction.atomic():
+                with tenant_context(tenant):
+                    created = tenant.create_schema(check_if_exists=True)
+                    if created is not False:
+                        seed_permissions(tenant=tenant)
+                        seed_roles(tenant=tenant)
+                        seed_group(tenant=tenant)
+                    tenant.ready = True
+                    tenant.save()
+        except Tenant.DoesNotExist:
+            logger.error(f"Tenant `{tenant_schema_name}` does not exist.")

--- a/rbac/management/management/commands/init_tenant.py
+++ b/rbac/management/management/commands/init_tenant.py
@@ -19,10 +19,11 @@ import logging
 
 from django.core.management.base import BaseCommand
 from django.db import transaction
-from tenant_schemas.utils import tenant_context
-from api.models import Tenant
 from management.group.definer import seed_group
 from management.role.definer import seed_permissions, seed_roles
+from tenant_schemas.utils import tenant_context
+
+from api.models import Tenant
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 

--- a/rbac/management/tasks.py
+++ b/rbac/management/tasks.py
@@ -55,3 +55,9 @@ def run_reconcile_tenant_relations_in_worker(kwargs):
 def run_sync_schemas_in_worker(kwargs):
     """Celery task to sync schemas."""
     call_command("sync_schemas", **kwargs)
+
+
+@shared_task
+def run_init_tenant_in_worker(tenant_schema_name):
+    """Initialize tenant."""
+    call_command("init_tenant", tenant_schema_name)


### PR DESCRIPTION
## Description of Intent of Change(s)
This will add `POST /_private/api/tenant/<schema-name>/init/` which will be an
idempotent way to do the following for a tenant:

- create a schema and run migrations if one does not exists for the tenant
- run seeds after the schema is configured
- flip `ready=True`

This will allow us to manage `Tenant` objects which are in a "hung" state, by
running the schema creation and migrations/seeds if the schema does not exist.
If it does exist, it will skip the schema creation and migration, and just run
seeds, which will not be an issue.

Tenants are able to get into this state when the service restarts during the tenant
creation process. We're not able to run the tenant object creation, and schema
setup in a transaction because of an edge-case with concurrent requests during
creation. This means we have the potential to orphan Tenant records, leaving them
in a state where `ready=False`, and subsequent requests will hang.

We'll also check to see that the schema has been created, and if it has, run the seeds. 
Otherwise this means the schema is setup, and we just need to flip the flag.

Context: https://github.com/bernardopires/django-tenant-schemas/blob/7f72d7af039e6cf2a15520d525636d6e11e72efc/tenant_schemas/models.py#L108-L109

`_private/api/tenant/?ready=true|false`
We're also adding an endpoint to collect the `ready=false` tenants. This will allow 
us to collect the schema names for any tenants in a "bad", not ready state, 
to run against the "init" endpoint.


## Local Testing
- create a tenant that's `ready=false`, without schema (just manually in the DB to simulate an orphaned row)
- update dev middleware identity to use that account
- confirm it hangs when you try to make a request (this is the edge-case where it gets stuck in the loop in middleware)
- update dev middleware to be an `associate` so you can run internal requests
- hit `/_private/api/tenant/` and confirm your newly created tenant is not ready
- POST to `/_private/api/tenant/<schema-name>/init/` with your schema name and confirm it runs migrations/seeds and resolves the issue
- POST to `/_private/api/tenant/<schema-name>/init/` with an existing schema name and confirm it does nothing


## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  -  if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
