### PR TITLE
Fix group union in serializer

### DIFF
--- a/rbac/management/role/serializer.py
+++ b/rbac/management/role/serializer.py
@@ -294,8 +294,11 @@ def obtain_groups_in(obj, request):
         if settings.SERVE_FROM_PUBLIC_SCHEMA:
             public_tenant = Tenant.objects.get(schema_name="public")
             return (
-                assigned_groups | Group.platform_default_set().filter(tenant=request.tenant)
-                or Group.platform_default_set().filter(tenant=public_tenant)
+                assigned_groups
+                | (
+                    Group.platform_default_set().filter(tenant=request.tenant_schema)
+                    or Group.platform_default_set().filter(tenant=public_tenant)
+                )
             ).distinct()
         else:
             return (assigned_groups | Group.platform_default_set()).distinct()


### PR DESCRIPTION
This currently will short-circuit if there's no tenant-default group, instead of
returning the platform default.

```
set(["custom group"]) | set(["custom default group"]) or set(["platform default group"])   # {'custom default group', 'custom group'}
set(["custom group"]) | (set(["custom default group"]) or set(["platform default group"])) # {'custom default group', 'custom group'}
set(["custom group"]) | set([]) or set(["platform default group"])                         # {'custom group'}
set(["custom group"]) | (set([]) or set(["platform default group"]))                       # {'custom group', 'platform default group'}
```
Trying to see if there's a good way to test this in unit tests.