### PR TITLE
Fix the internal tenant list offset/limit

### DIFF
--- a/rbac/internal/views.py
+++ b/rbac/internal/views.py
@@ -106,13 +106,12 @@ def list_tenants(request):
     ready = request.GET.get("ready")
     tenant_qs = Tenant.objects.exclude(schema_name="public").values_list("schema_name", flat=True)
 
-    if limit:
-        tenant_qs = tenant_qs[offset : (limit + offset)]  # noqa: E203
-
     if ready == "true":
         tenant_qs = tenant_qs.filter(ready=True)
     if ready == "false":
         tenant_qs = tenant_qs.filter(ready=False)
+    if limit:
+        tenant_qs = tenant_qs[offset : (limit + offset)]  # noqa: E203
 
     ready_tenants = tenant_qs.filter(ready=True)
     not_ready_tenants = tenant_qs.filter(ready=False)


### PR DESCRIPTION
## Description of Intent of Change(s)
We need to apply the limit/offset on the queryset after we've finished filtering.

## Local Testing
Currently the `?limit=` and `?offset=` params when supplied, will cause `/_private/api/tenant/` to fail. This fixes the issue.

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  -  if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
