### PR TITLE
Add optional `system` and `platform_default` filters to /groups/

### DIFF
--- a/docs/source/specs/openapi.json
+++ b/docs/source/specs/openapi.json
@@ -802,6 +802,24 @@
                 "policyCount"
               ]
             }
+          },
+          {
+            "name": "platform_default",
+            "in": "query",
+            "description": "An optional flag to return either platform default or non-platform default groups.",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "system",
+            "in": "query",
+            "description": "An optional flag to return either system or non-system groups.",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
           }
         ],
         "responses": {

--- a/rbac/management/group/view.py
+++ b/rbac/management/group/view.py
@@ -95,6 +95,8 @@ class GroupFilter(CommonFilters):
     name = filters.CharFilter(field_name="name", method="name_filter")
     role_names = filters.CharFilter(field_name="role_names", method="roles_filter")
     uuid = filters.CharFilter(field_name="uuid", method="uuid_filter")
+    system = filters.BooleanFilter(field_name="system")
+    platform_default = filters.BooleanFilter(field_name="platform_default")
 
     class Meta:
         model = Group


### PR DESCRIPTION
## Link(s) to Jira
- https://issues.redhat.com/browse/RHCLOUD-17859

## Description of Intent of Change(s)
Allows for two new optional query parameters to be used with the `/groups/` endpoint:

- `/api/rbac/v1/groups/?system=true|false` which when specified with one of the
  two valid boolean values will either return all system or non-system groups.

- `/api/rbac/v1/groups/?platform_default=true|false` which when specified with one of the
  two valid boolean values will either return all platform default or non-platform default groups.

Both of these are additive, optional params, and are documented in the updated spec.

## Local Testing
Supply the provided query filter(s) referencing the acceptance criteria in the ticket above.

## Checklist
- [x] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [x] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  -  if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
