### PR TITLE
Fix the access cache key when serving from public

### DIFF
--- a/rbac/management/group/model.py
+++ b/rbac/management/group/model.py
@@ -20,7 +20,7 @@ import logging
 from uuid import uuid4
 
 from django.conf import settings
-from django.db import connections, models
+from django.db import models
 from django.db.models import signals
 from django.utils import timezone
 from management.cache import AccessCache
@@ -74,7 +74,7 @@ class Group(TenantAwareModel):
 def group_deleted_cache_handler(sender=None, instance=None, using=None, **kwargs):
     """Signal handler to purge principal caches when a Group is deleted."""
     logger.info("Handling signal for deleted group %s - invalidating policy cache for users in group", instance)
-    cache = AccessCache(connections[using].schema_name)
+    cache = AccessCache(instance.tenant.schema_name)
     for principal in instance.principals.all():
         cache.delete_policy(principal.uuid)
 
@@ -83,7 +83,7 @@ def principals_to_groups_cache_handler(
     sender=None, instance=None, action=None, reverse=None, model=None, pk_set=None, using=None, **kwargs
 ):
     """Signal handler to purge caches when Group membership changes."""
-    cache = AccessCache(connections[using].schema_name)
+    cache = AccessCache(instance.tenant.schema_name)
     if action in ("post_add", "pre_remove"):
         logger.info("Handling signal for %s group membership change - invalidating policy cache", instance)
         if isinstance(instance, Group):

--- a/rbac/management/policy/model.py
+++ b/rbac/management/policy/model.py
@@ -20,7 +20,7 @@ import logging
 from uuid import uuid4
 
 from django.conf import settings
-from django.db import connections, models
+from django.db import models
 from django.db.models import signals
 from django.utils import timezone
 from management.cache import AccessCache
@@ -55,7 +55,7 @@ class Policy(TenantAwareModel):
 def policy_changed_cache_handler(sender=None, instance=None, using=None, **kwargs):
     """Signal handler for Principal cache expiry on Policy deletion."""
     logger.info("Handling signal for deleted policy %s - invalidating associated user cache keys", instance)
-    cache = AccessCache(connections[using].schema_name)
+    cache = AccessCache(instance.tenant.schema_name)
     if instance.group:
         principals = instance.group.principals.all()
         if instance.group.platform_default:
@@ -68,7 +68,7 @@ def policy_to_roles_cache_handler(
     sender=None, instance=None, action=None, reverse=None, model=None, pk_set=None, using=None, **kwargs  # noqa: C901
 ):
     """Signal handler for Principal cache expiry on Policy/Role m2m change."""
-    cache = AccessCache(connections[using].schema_name)
+    cache = AccessCache(instance.tenant.schema_name)
     if action in ("post_add", "pre_remove"):
         logger.info("Handling signal for %s roles change - invalidating policy cache", instance)
         if isinstance(instance, Policy):

--- a/rbac/management/role/model.py
+++ b/rbac/management/role/model.py
@@ -21,7 +21,7 @@ from uuid import uuid4
 
 from django.conf import settings
 from django.contrib.postgres.fields import JSONField
-from django.db import connections, models
+from django.db import models
 from django.db.models import signals
 from django.utils import timezone
 from management.cache import AccessCache
@@ -97,7 +97,7 @@ def role_related_obj_change_cache_handler(sender=None, instance=None, using=None
         "invalidating associated user cache keys",
         instance,
     )
-    cache = AccessCache(connections[using].schema_name)
+    cache = AccessCache(instance.tenant.schema_name)
     if instance.role:
         for principal in Principal.objects.filter(group__policies__roles__pk=instance.role.pk):
             cache.delete_policy(principal.uuid)


### PR DESCRIPTION
Since we always set the access policy cache key based on the `request.tenant.schema_name` [1]
which is what we want so that it's specific to each account, we need to ensure that
when we invalidate the cache, we're using the correct key.

These changes will ensure we key off the schema name from the object in the signal,
vs the case where the `public` schema is being used and the current code will
cause a miss on the key lookup.

[1] https://github.com/RedHatInsights/insights-rbac/blob/master/rbac/management/access/view.py#L108
