### PR TITLE
Add ability to run seeds by schema

### DIFF
--- a/rbac/internal/views.py
+++ b/rbac/internal/views.py
@@ -260,6 +260,9 @@ def run_seeds(request):
     POST /_private/api/seeds/run/?seed_types=permissions,roles,groups
     """
     if request.method == "POST":
+        schema_list = None
+        if request.body:
+            schema_list = json.loads(request.body).get("schemas")
         args = {}
         option_key = "seed_types"
         valid_values = ["permissions", "roles", "groups"]
@@ -269,7 +272,8 @@ def run_seeds(request):
             if not all([value in valid_values for value in seed_types]):
                 return HttpResponse(f'Valid options for "{option_key}": {valid_values}.', status=400)
             args = {type: True for type in seed_types}
-        logger.info(f"Running seeds: {request.method} {request.user.username}")
+        logger.info(f"Running seeds: {request.method} {request.user.username} {schema_list}")
+        args["schema_list"] = schema_list
         run_seeds_in_worker.delay(args)
         return HttpResponse("Seeds are running in a background worker.", status=202)
     return HttpResponse('Invalid method, only "POST" is allowed.', status=405)

--- a/rbac/management/management/commands/seeds.py
+++ b/rbac/management/management/commands/seeds.py
@@ -33,6 +33,7 @@ class Command(BaseCommand):
         parser.add_argument("--permissions", action="store_true")
         parser.add_argument("--roles", action="store_true")
         parser.add_argument("--groups", action="store_true")
+        parser.add_argument("--schema_list", action="store_true")
 
     def handle(self, *args, **options):
         """Handle method for command."""
@@ -40,15 +41,15 @@ class Command(BaseCommand):
 
         if options["permissions"] or seed_all:
             logger.info("*** Seeding permissions... ***")
-            permission_seeding()
+            permission_seeding(options["schema_list"])
             logger.info("*** Permission seeding completed. ***\n")
 
         if options["roles"] or seed_all:
             logger.info("*** Seeding roles... ***")
-            role_seeding()
+            role_seeding(options["schema_list"])
             logger.info("*** Role seeding completed. ***\n")
 
         if options["groups"] or seed_all:
             logger.info("*** Seeding groups... ***")
-            group_seeding()
+            group_seeding(options["schema_list"])
             logger.info("*** Group seeding completed. ***\n")

--- a/rbac/management/seeds.py
+++ b/rbac/management/seeds.py
@@ -34,17 +34,17 @@ def on_complete(completed_log_message, tenant, future):
     logger.info(completed_log_message)
 
 
-def role_seeding(schema_list):
+def role_seeding(schema_list=None):
     """Execute role seeding."""
     run_seeds("role", schema_list)
 
 
-def group_seeding(schema_list):
+def group_seeding(schema_list=None):
     """Execute group seeding."""
     run_seeds("group", schema_list)
 
 
-def permission_seeding(schema_list):
+def permission_seeding(schema_list=None):
     """Execute permission seeding."""
     run_seeds("permission", schema_list)
 

--- a/rbac/management/seeds.py
+++ b/rbac/management/seeds.py
@@ -34,22 +34,22 @@ def on_complete(completed_log_message, tenant, future):
     logger.info(completed_log_message)
 
 
-def role_seeding():
+def role_seeding(schema_list):
     """Execute role seeding."""
-    run_seeds("role")
+    run_seeds("role", schema_list)
 
 
-def group_seeding():
+def group_seeding(schema_list):
     """Execute group seeding."""
-    run_seeds("group")
+    run_seeds("group", schema_list)
 
 
-def permission_seeding():
+def permission_seeding(schema_list):
     """Execute permission seeding."""
-    run_seeds("permission")
+    run_seeds("permission", schema_list)
 
 
-def run_seeds(seed_type):
+def run_seeds(seed_type, schema_list=None):
     """Update platform objects at startup."""
     # noqa: E402 pylint: disable=C0413
     from api.models import Tenant
@@ -61,7 +61,10 @@ def run_seeds(seed_type):
 
     try:
         with concurrent.futures.ThreadPoolExecutor(max_workers=MAX_SEED_THREADS) as executor:
-            tenants = Tenant.objects.all()
+            if schema_list:
+                tenants = Tenant.objects.filter(schema_name__in=schema_list)
+            else:
+                tenants = Tenant.objects.all()
             tenant_count = tenants.count()
             for idx, tenant in enumerate(list(tenants)):
                 logger.info(


### PR DESCRIPTION
This allows seeds to be run for a specific schema/set of schemas. This will help
us to run seeds for the public schema only, as we transition away from tenant
schemas, similar to the same ability for migrations.

This will allow for:
```
curl https://internal.console.redhat.com/api/rbac/seeds/run/ -H 'Content-Type: application/json' -d '{"schemas": ["public"]}'
```
