### PR TITLE
Always run init container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ make-migrations:
 	DJANGO_READ_DOT_ENV_FILE=True $(PYTHON) $(PYDIR)/manage.py makemigrations api management
 
 run-migrations:
-	DJANGO_READ_DOT_ENV_FILE=True $(PYTHON) $(PYDIR)/manage.py migrate_schemas --executor=parallel
+	DJANGO_READ_DOT_ENV_FILE=True $(PYTHON) $(PYDIR)/manage.py migrate_schemas --executor=parallel --schema=public
 
 create-test-db-file: run-migrations
 	sleep 1
@@ -244,7 +244,7 @@ oc-reinit: oc-delete-all oc-create-rbac
 
 oc-run-migrations: oc-forward-ports
 	sleep 3
-	DJANGO_READ_DOT_ENV_FILE=True $(PYTHON) $(PYDIR)/manage.py migrate_schemas
+	DJANGO_READ_DOT_ENV_FILE=True $(PYTHON) $(PYDIR)/manage.py migrate_schemas --schema=public
 	make oc-stop-forwarding-ports
 
 oc-stop-forwarding-ports:

--- a/README.rst
+++ b/README.rst
@@ -87,7 +87,7 @@ If a docker container running Postgres is not feasible, it is possible to run Po
 
 You may also run migrations explicitly, and in parallel, by specifying `TENANT_PARALLEL_MIGRATION_MAX_PROCESSES` (the number of concurrent processes to run migrations) and/or `TENANT_PARALLEL_MIGRATION_CHUNKS` (the number of migrations for each process to run at a time). Both of these values default to 2. *Be mindful of the fact that bumping these values will consume more database connections:*
 
-    TENANT_PARALLEL_MIGRATION_MAX_PROCESSES=4 TENANT_PARALLEL_MIGRATION_CHUNKS=2 ./rbac/manage.py migrate_schemas --executor=parallel
+    TENANT_PARALLEL_MIGRATION_MAX_PROCESSES=4 TENANT_PARALLEL_MIGRATION_CHUNKS=2 ./rbac/manage.py migrate_schemas --executor=parallel --schema=public
 
 Seeds
 ^^^^^
@@ -102,7 +102,7 @@ Locally these are sourced from `/rbac/management/role/definitions/*.json`, while
 
 You can also execute the following Django command to run seeds manually. It's recommended that you disable db signals while running seeds with `ACCESS_CACHE_CONNECT_SIGNALS=False`. Caching will be busted after seeding for each tenant has processed. You may also specify the number of concurrent threads in which seeds should be run, by setting `MAX_SEED_THREADS` either in the process, or the app environment. The default value is 2. *Be mindful of the fact that bumping this value will consume more database connections:* ::
 
-  ACCESS_CACHE_CONNECT_SIGNALS=False MAX_SEED_THREADS=2 ./rbac/manage.py seeds [--roles|--groups|--permissions]
+  ACCESS_CACHE_CONNECT_SIGNALS=False MAX_SEED_THREADS=2 ./rbac/manage.py seeds [--roles|--groups|--permissions|--schema_list]
 
 Server
 ^^^^^^

--- a/deploy/init-container-setup.sh
+++ b/deploy/init-container-setup.sh
@@ -1,18 +1,10 @@
 #!/bin/bash
 
 export ACCESS_CACHE_CONNECT_SIGNALS=False
-export MAX_SEED_THREADS=2
 
 echo "Starting init container script."
-echo "Run in EPH ENV = ${EPH_ENV}"
 
-if [ ${EPH_ENV} == "True" ];
-then
-    echo "Running migrate_schemas <----"
-    python /opt/app-root/src/rbac/manage.py migrate_schemas --noinput --executor=parallel
-    echo "Running seeds <-------"
-    python /opt/app-root/src/rbac/manage.py seeds
-else
-    echo "Not run in EPH ENV, exiting."
-fi
-
+echo "Running schema migrations <----"
+python /opt/app-root/src/rbac/manage.py migrate_schemas --noinput --schema=public
+echo "Running seeds <-------"
+python /opt/app-root/src/rbac/manage.py seeds --schema_list=public

--- a/deploy/rbac-clowdapp.yml
+++ b/deploy/rbac-clowdapp.yml
@@ -28,8 +28,6 @@ objects:
           - env:
             - name: INIT_CONTAINER
               value: "True"
-            - name: EPH_ENV
-              value: ${EPH_ENV}
             inheritEnv: true
             args:
               - sh
@@ -1965,8 +1963,6 @@ parameters:
   value: 'rbac'
 - name: CW_NULL_WORKAROUND
   value: 'true'
-- name: EPH_ENV
-  required: true
 - name: CELERY_INITIAL_DELAY_SEC
   value: "30"
 - name: CELERY_PERIOD_SEC

--- a/openshift/s2i/bin/run
+++ b/openshift/s2i/bin/run
@@ -75,7 +75,7 @@ manage_file=$APP_HOME/manage.py
 if should_migrate; then
   if [[ -f "$manage_file" ]]; then
     echo "---> Migrating database ..."
-    python "$manage_file" migrate_schemas --noinput --executor=parallel
+    python "$manage_file" migrate_schemas --noinput --executor=parallel --schema=public
   else
     echo "WARNING: seems that you're using Django, but we could not find a 'manage.py' file."
     echo "Skipped 'python manage.py migrate'."

--- a/rbac/management/management/commands/seeds.py
+++ b/rbac/management/management/commands/seeds.py
@@ -33,7 +33,7 @@ class Command(BaseCommand):
         parser.add_argument("--permissions", action="store_true")
         parser.add_argument("--roles", action="store_true")
         parser.add_argument("--groups", action="store_true")
-        parser.add_argument("--schema_list", action="store_true")
+        parser.add_argument("--schema_list", action="append")
 
     def handle(self, *args, **options):
         """Handle method for command."""

--- a/run_server.sh
+++ b/run_server.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 sleep 15
-python rbac/manage.py migrate_schemas --executor=parallel
+python rbac/manage.py migrate_schemas --executor=parallel --schema=public
 DJANGO_READ_DOT_ENV_FILE=True python rbac/manage.py runserver 0.0.0.0:8000


### PR DESCRIPTION
## Description of Intent of Change(s)
This will ensure that now we always run the init container when deploying with
Clowder, regardless of environment. The init container will run seeds and migrations.
Currently we still need to explicitly target the public schema, but once DTS
is removed and the updates from #660 are in, we will be able to update our commands
to just run Django migrations with the default command, and seeds will not run
against all schemas.

- updates the Makefile to only run migrations again public (local only)
- updates README for consistency and to avoid confusion
- in the init container script, no longer check for ephemeral env, and run seeds/migrationss
  in the context of the public schema
- remove `EPH_ENV` from the template
- update the OpenShift run script (even though we're not currently using this)
- update the command args to accept a list of `schema_list`

We'll still want to:
- remove the `EPH_ENV` params from app-interface deployments


## Local Testing
You can test by running the updated commands locally:
```
./rbac/manage.py seeds --schema_list=public
./rbac/manage.py migrate_schemas --schema=public
```
