### PR TITLE
Admin default seeding

### DIFF
--- a/docs/source/specs/openapi.json
+++ b/docs/source/specs/openapi.json
@@ -813,6 +813,15 @@
             }
           },
           {
+            "name": "admin_default",
+            "in": "query",
+            "description": "An optional flag to return either admin default or non-admin default groups.",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
             "name": "system",
             "in": "query",
             "description": "An optional flag to return either system or non-system groups.",
@@ -3096,6 +3105,10 @@
               "platform_default": {
                 "type": "boolean",
                 "default": false
+              },
+              "admin_default": {
+                "type": "boolean",
+                "default": false
               }
             }
           }
@@ -3709,6 +3722,10 @@
               "platform_default": {
                 "type": "boolean",
                 "default": false
+              },
+              "admin_default": {
+                "type": "boolean",
+                "default": false
               }
             }
           }
@@ -3732,7 +3749,8 @@
               "accessCount",
               "applications",
               "system",
-              "platform_default"
+              "platform_default",
+              "admin_default"
             ],
             "properties": {
               "policyCount": {
@@ -3755,6 +3773,10 @@
                 "default": false
               },
               "platform_default": {
+                "type": "boolean",
+                "default": false
+              },
+              "admin_default": {
                 "type": "boolean",
                 "default": false
               },

--- a/rbac/management/group/definer.py
+++ b/rbac/management/group/definer.py
@@ -61,8 +61,8 @@ def seed_group(tenant):
             # Default admin group
             admin_name = "Default admin access"
             admin_group_description = (
-                "This group contains the roles that all admin users inherit by default. "
-                "Adding or removing roles in this group will affect permissions for all admin users in your org."
+                "This group contains the roles that all org admin users inherit by default. "
+                "Adding or removing roles in this group will affect permissions for all org admin users in your org."
             )
             admin_group, admin_group_created = Group.objects.get_or_create(
                 admin_default=True,
@@ -72,7 +72,7 @@ def seed_group(tenant):
             if admin_group.system:
                 platform_roles = Role.objects.filter(admin_default=True)
                 add_roles(admin_group, platform_roles, tenant, replace=True)
-                logger.info("Finished seeding default admin group %s for tenant %s.", name, tenant.schema_name)
+                logger.info("Finished seeding default org admin group %s for tenant %s.", name, tenant.schema_name)
             else:
                 logger.info("Default admin group %s is managed by tenant %s.", name, tenant.schema_name)
     return tenant

--- a/rbac/management/group/definer.py
+++ b/rbac/management/group/definer.py
@@ -62,7 +62,7 @@ def seed_group(tenant):
             admin_name = "Default Admin access"
             admin_group_description = (
                 "This group contains the roles that all admin users inherit by default. "
-                "Adding or removing roles in this group will affect permissions for all admin users in your organization."
+                "Adding or removing roles in this group will affect permissions for all admin users in your org."
             )
             admin_group, admin_group_created = Group.objects.get_or_create(
                 admin_default=True,

--- a/rbac/management/group/definer.py
+++ b/rbac/management/group/definer.py
@@ -59,7 +59,7 @@ def seed_group(tenant):
                 logger.info("Default group %s is managed by tenant %s.", name, tenant.schema_name)
 
             # Default admin group
-            admin_name = "Default Admin access"
+            admin_name = "Default admin access"
             admin_group_description = (
                 "This group contains the roles that all admin users inherit by default. "
                 "Adding or removing roles in this group will affect permissions for all admin users in your org."

--- a/rbac/management/group/definer.py
+++ b/rbac/management/group/definer.py
@@ -57,6 +57,24 @@ def seed_group(tenant):
                 logger.info("Finished seeding default group %s for tenant %s.", name, tenant.schema_name)
             else:
                 logger.info("Default group %s is managed by tenant %s.", name, tenant.schema_name)
+
+            # Default admin group
+            admin_name = "Default Admin access"
+            admin_group_description = (
+                "This group contains the roles that all admin users inherit by default. "
+                "Adding or removing roles in this group will affect permissions for all admin users in your organization."
+            )
+            admin_group, admin_group_created = Group.objects.get_or_create(
+                admin_default=True,
+                defaults={"description": admin_group_description, "name": admin_name, "system": True},
+                tenant=tenant,
+            )
+            if admin_group.system:
+                platform_roles = Role.objects.filter(admin_default=True)
+                add_roles(admin_group, platform_roles, tenant, replace=True)
+                logger.info("Finished seeding default admin group %s for tenant %s.", name, tenant.schema_name)
+            else:
+                logger.info("Default admin group %s is managed by tenant %s.", name, tenant.schema_name)
     return tenant
 
 

--- a/rbac/management/group/serializer.py
+++ b/rbac/management/group/serializer.py
@@ -32,6 +32,7 @@ class GroupInputSerializer(SerializerCreateOverrideMixin, serializers.ModelSeria
     description = serializers.CharField(allow_null=True, required=False)
     principalCount = serializers.IntegerField(read_only=True)
     platform_default = serializers.BooleanField(read_only=True)
+    admin_default = serializers.BooleanField(read_only=True)
     system = serializers.BooleanField(read_only=True)
     roleCount = serializers.SerializerMethodField()
     created = serializers.DateTimeField(read_only=True)
@@ -51,6 +52,7 @@ class GroupInputSerializer(SerializerCreateOverrideMixin, serializers.ModelSeria
             "description",
             "principalCount",
             "platform_default",
+            "admin_default",
             "roleCount",
             "created",
             "modified",
@@ -66,6 +68,7 @@ class GroupSerializer(SerializerCreateOverrideMixin, serializers.ModelSerializer
     description = serializers.CharField(allow_null=True, required=False)
     principals = PrincipalSerializer(read_only=True, many=True)
     platform_default = serializers.BooleanField(read_only=True)
+    admin_default = serializers.BooleanField(read_only=True)
     system = serializers.BooleanField(read_only=True)
     roles = serializers.SerializerMethodField()
     roleCount = serializers.SerializerMethodField()
@@ -82,6 +85,7 @@ class GroupSerializer(SerializerCreateOverrideMixin, serializers.ModelSerializer
             "description",
             "principals",
             "platform_default",
+            "admin_default",
             "created",
             "modified",
             "roles",

--- a/rbac/management/migrations/0037_auto_20220114_1822.py
+++ b/rbac/management/migrations/0037_auto_20220114_1822.py
@@ -7,18 +7,10 @@ import django.db.models.deletion
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('management', '0036_auto_20211118_1956'),
+        ("management", "0036_auto_20211118_1956"),
     ]
 
     operations = [
-        migrations.AddField(
-            model_name='group',
-            name='admin_default',
-            field=models.BooleanField(default=False),
-        ),
-        migrations.AddField(
-            model_name='role',
-            name='admin_default',
-            field=models.BooleanField(default=False),
-        )
+        migrations.AddField(model_name="group", name="admin_default", field=models.BooleanField(default=False),),
+        migrations.AddField(model_name="role", name="admin_default", field=models.BooleanField(default=False),),
     ]

--- a/rbac/management/role/definer.py
+++ b/rbac/management/role/definer.py
@@ -40,6 +40,7 @@ def _make_role(tenant, data):
         system=True,
         version=data.get("version", 1),
         platform_default=data.get("platform_default", False),
+        admin_default=data.get("admin_default", False),
     )
     role, created = Role.objects.get_or_create(name=name, defaults=defaults, tenant=tenant)
 

--- a/rbac/management/role/definitions/rbac_local_test.json
+++ b/rbac/management/role/definitions/rbac_local_test.json
@@ -4,7 +4,8 @@
       "name": "RBAC Administrator Local Test",
       "description": "Grants a non-org admin full access to configure and manage user access to services hosted on cloud.redhat.com. This role can only be viewed and assigned by Organization Administrators.",
       "system": true,
-      "version": 2,
+      "version": 3,
+      "admin_default": true,
       "access": [
         {
           "permission": "rbac:*:*"

--- a/rbac/management/role/serializer.py
+++ b/rbac/management/role/serializer.py
@@ -95,6 +95,7 @@ class RoleSerializer(serializers.ModelSerializer):
     applications = serializers.SerializerMethodField()
     system = serializers.BooleanField(read_only=True)
     platform_default = serializers.BooleanField(read_only=True)
+    admin_default = serializers.BooleanField(read_only=True)
     created = serializers.DateTimeField(read_only=True)
     modified = serializers.DateTimeField(read_only=True)
 
@@ -113,6 +114,7 @@ class RoleSerializer(serializers.ModelSerializer):
             "applications",
             "system",
             "platform_default",
+            "admin_default",
             "created",
             "modified",
         )
@@ -162,6 +164,7 @@ class RoleMinimumSerializer(SerializerCreateOverrideMixin, serializers.ModelSeri
     applications = serializers.SerializerMethodField()
     system = serializers.BooleanField(read_only=True)
     platform_default = serializers.BooleanField(read_only=True)
+    admin_default = serializers.BooleanField(read_only=True)
 
     class Meta:
         """Metadata for the serializer."""
@@ -179,6 +182,7 @@ class RoleMinimumSerializer(SerializerCreateOverrideMixin, serializers.ModelSeri
             "applications",
             "system",
             "platform_default",
+            "admin_default",
         )
 
     def get_applications(self, obj):
@@ -220,6 +224,7 @@ class RoleDynamicSerializer(DynamicFieldsModelSerializer):
     applications = serializers.SerializerMethodField()
     system = serializers.BooleanField(read_only=True)
     platform_default = serializers.BooleanField(read_only=True)
+    admin_default = serializers.BooleanField(read_only=True)
 
     class Meta:
         """Metadata for the serializer."""
@@ -239,6 +244,7 @@ class RoleDynamicSerializer(DynamicFieldsModelSerializer):
             "applications",
             "system",
             "platform_default",
+            "admin_default",
         )
 
     def get_applications(self, obj):

--- a/rbac/management/role/view.py
+++ b/rbac/management/role/view.py
@@ -56,6 +56,7 @@ LIST_ROLE_FIELDS = [
     "applications",
     "system",
     "platform_default",
+    "admin_default",
 ]
 VALID_PATCH_FIELDS = ["name", "display_name", "description"]
 

--- a/tests/management/group/test_definer.py
+++ b/tests/management/group/test_definer.py
@@ -95,17 +95,16 @@ class GroupDefinerTests(IdentityRequest):
 
     def test_admin_default_group_seeding_properly(self):
         """Test that admin default group are seeded properly."""
-        with tenant_context(self.public_tenant):
-            group = Group.objects.get(admin_default=True)
+        group = Group.objects.get(admin_default=True)
 
-            system_policy = group.policies.get(name="System Policy for Group {}".format(group.uuid))
-            self.assertEqual(group.admin_default, True)
-            self.assertEqual(group.system, True)
-            self.assertEqual(group.name, "Default Admin access")
-            self.assertEqual(group.tenant, self.public_tenant)
-            self.assertEqual(system_policy.system, True)
-            self.assertEqual(system_policy.tenant, self.public_tenant)
-            # only admin_default roles would be assigned to the admin_default group
-            for role in group.roles():
-                self.assertTrue(role.admin_default)
-                self.assertEqual(role.tenant, self.public_tenant)
+        system_policy = group.policies.get(name="System Policy for Group {}".format(group.uuid))
+        self.assertEqual(group.admin_default, True)
+        self.assertEqual(group.system, True)
+        self.assertEqual(group.name, "Default admin access")
+        self.assertEqual(group.tenant, self.public_tenant)
+        self.assertEqual(system_policy.system, True)
+        self.assertEqual(system_policy.tenant, self.public_tenant)
+        # only admin_default roles would be assigned to the admin_default group
+        for role in group.roles():
+            self.assertTrue(role.admin_default)
+            self.assertEqual(role.tenant, self.public_tenant)

--- a/tests/management/group/test_definer.py
+++ b/tests/management/group/test_definer.py
@@ -92,3 +92,20 @@ class GroupDefinerTests(IdentityRequest):
 
             group.system = system
             group.save()
+
+    def test_admin_default_group_seeding_properly(self):
+        """Test that admin default group are seeded properly."""
+        with tenant_context(self.public_tenant):
+            group = Group.objects.get(admin_default=True)
+
+            system_policy = group.policies.get(name="System Policy for Group {}".format(group.uuid))
+            self.assertEqual(group.admin_default, True)
+            self.assertEqual(group.system, True)
+            self.assertEqual(group.name, "Default Admin access")
+            self.assertEqual(group.tenant, self.public_tenant)
+            self.assertEqual(system_policy.system, True)
+            self.assertEqual(system_policy.tenant, self.public_tenant)
+            # only admin_default roles would be assigned to the admin_default group
+            for role in group.roles():
+                self.assertTrue(role.admin_default)
+                self.assertEqual(role.tenant, self.public_tenant)

--- a/tests/management/role/test_view.py
+++ b/tests/management/role/test_view.py
@@ -59,6 +59,7 @@ class RoleViewsetTests(IdentityRequest):
             "accessCount",
             "modified",
             "platform_default",
+            "admin_default",
         }
 
         self.principal = Principal(username=self.user_data["username"], tenant=self.tenant)


### PR DESCRIPTION
## Link(s) to Jira
- https://issues.redhat.com/browse/RHCLOUD-16783

## Description of Intent of Change(s)
Added seeding to default_admin flag, where it will default to False.
### Note
This is waiting for PR https://github.com/RedHatInsights/insights-rbac/pull/591 to go in first!

## Local Testing
Tested locally in RBAC, using the role RBAC Administrator Local Test.

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  -  if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
