### PR TITLE
Admin default access

### DIFF
--- a/rbac/management/group/model.py
+++ b/rbac/management/group/model.py
@@ -63,6 +63,10 @@ class Group(TenantAwareModel):
         """Queryset for platform default group."""
         return Group.objects.filter(platform_default=True)
 
+    def admin_default_set():
+        """Queryset for admin default group."""
+        return Group.objects.filter(admin_default=True)
+
     def __policy_ids(self):
         """Policy IDs for a group."""
         return self.policies.values_list("id", flat=True)

--- a/rbac/management/querysets.py
+++ b/rbac/management/querysets.py
@@ -16,8 +16,6 @@
 #
 """Queryset helpers for management module."""
 
-import logging
-
 from django.conf import settings
 from django.db.models.aggregates import Count
 from django.urls import reverse
@@ -53,7 +51,6 @@ PRINCIPAL_QUERYSET_MAP = {
     Policy.__name__: policies_for_principal,
     Role.__name__: roles_for_principal,
 }
-logger = logging.getLogger(__name__)
 
 
 def get_annotated_groups():

--- a/rbac/management/utils.py
+++ b/rbac/management/utils.py
@@ -126,6 +126,10 @@ def groups_for_principal(principal, tenant, **kwargs):
         assigned_group_set = assigned_group_set.prefetch_related(prefetch_lookups)
         platform_default_group_set = platform_default_group_set.prefetch_related(prefetch_lookups)
 
+    if kwargs.get("is_org_admin"):
+        admin_default_group_set = Group.objects.filter(name="Default admin access")
+        return set(assigned_group_set | platform_default_group_set | admin_default_group_set)
+
     return set(assigned_group_set | platform_default_group_set)
 
 

--- a/rbac/management/utils.py
+++ b/rbac/management/utils.py
@@ -160,7 +160,6 @@ def queryset_by_id(objects, clazz, **kwargs):
     wanted_ids = [obj.id for obj in objects]
     prefetch_lookups = kwargs.get("prefetch_lookups_for_ids")
     query = clazz.objects.filter(id__in=wanted_ids).order_by("id")
-
     if prefetch_lookups:
         query = query.prefetch_related(prefetch_lookups)
 

--- a/rbac/management/utils.py
+++ b/rbac/management/utils.py
@@ -118,8 +118,13 @@ def groups_for_principal(principal, tenant, **kwargs):
         platform_default_group_set = Group.platform_default_set().filter(
             tenant=tenant
         ) or Group.platform_default_set().filter(tenant=public_tenant)
+
+        admin_default_group_set = Group.admin_default_set().filter(tenant=tenant) or Group.admin_default_set().filter(
+            tenant=public_tenant
+        )
     else:
         platform_default_group_set = Group.platform_default_set()
+        admin_default_group_set = Group.admin_default_set()
     prefetch_lookups = kwargs.get("prefetch_lookups_for_groups")
 
     if prefetch_lookups:
@@ -127,7 +132,6 @@ def groups_for_principal(principal, tenant, **kwargs):
         platform_default_group_set = platform_default_group_set.prefetch_related(prefetch_lookups)
 
     if kwargs.get("is_org_admin"):
-        admin_default_group_set = Group.objects.filter(admin_default=True)
         return set(assigned_group_set | platform_default_group_set | admin_default_group_set)
 
     return set(assigned_group_set | platform_default_group_set)

--- a/rbac/management/utils.py
+++ b/rbac/management/utils.py
@@ -127,7 +127,7 @@ def groups_for_principal(principal, tenant, **kwargs):
         platform_default_group_set = platform_default_group_set.prefetch_related(prefetch_lookups)
 
     if kwargs.get("is_org_admin"):
-        admin_default_group_set = Group.objects.filter(name="Default admin access")
+        admin_default_group_set = Group.objects.filter(admin_default=True)
         return set(assigned_group_set | platform_default_group_set | admin_default_group_set)
 
     return set(assigned_group_set | platform_default_group_set)

--- a/tests/management/test_querysets.py
+++ b/tests/management/test_querysets.py
@@ -370,7 +370,7 @@ class QuerySetTest(TestCase):
 
         self._setup_group_for_org_admin_tests()
 
-        user = Mock(spec=User, account="00001", username="test_user")
+        user = Mock(spec=User, account="00001", username="test_user", admin=True)
         req = Mock(user=user, method="GET", tenant=self.tenant, query_params={APPLICATION_KEY: "app"})
         req.META = encoded_req.META
 
@@ -386,7 +386,29 @@ class QuerySetTest(TestCase):
 
         self._setup_group_for_org_admin_tests()
 
-        user = Mock(spec=User, account="00001", username="test_user")
+        user = Mock(spec=User, account="00001", username="test_user", admin=False)
+        req = Mock(user=user, method="GET", tenant=self.tenant, query_params={APPLICATION_KEY: "app"})
+        req.META = encoded_req.META
+
+        queryset = get_access_queryset(req)
+        self.assertEquals(queryset.count(), 0)
+
+    def test_get_access_queryset_non_org_admin_rbac_admin(self):
+        """Test get_access_queryset with a non 'org admin' but rbac admin user"""
+        user_data = {"username": "test_user", "email": "admin@example.com"}
+        customer = {"account_id": "10001"}
+        request_context = IdentityRequest._create_request_context(customer, user_data, is_org_admin=False)
+        encoded_req = request_context["request"]
+
+        role = Role.objects.create(name="role_admin_default", tenant=self.tenant)
+        policy = Policy.objects.create(name="policy_admin_default", tenant=self.tenant)
+        group = Group.objects.create(name="group_admin_default", tenant=self.tenant, admin_default=True)
+        policy.roles.add(role)
+        group.policies.add(policy)
+        permission = Permission.objects.create(permission="rbac:*:*", tenant=self.tenant)
+        access = Access.objects.create(permission=permission, role=role, tenant=self.tenant)
+
+        user = Mock(spec=User, account="00001", username="test_user", admin=False)
         req = Mock(user=user, method="GET", tenant=self.tenant, query_params={APPLICATION_KEY: "app"})
         req.META = encoded_req.META
 

--- a/tests/management/test_querysets.py
+++ b/tests/management/test_querysets.py
@@ -400,15 +400,12 @@ class QuerySetTest(TestCase):
         request_context = IdentityRequest._create_request_context(customer, user_data, is_org_admin=False)
         encoded_req = request_context["request"]
 
-        role = Role.objects.create(name="role_admin_default", tenant=self.tenant)
-        policy = Policy.objects.create(name="policy_admin_default", tenant=self.tenant)
-        group = Group.objects.create(name="group_admin_default", tenant=self.tenant, admin_default=True)
-        policy.roles.add(role)
-        group.policies.add(policy)
-        permission = Permission.objects.create(permission="rbac:*:*", tenant=self.tenant)
-        access = Access.objects.create(permission=permission, role=role, tenant=self.tenant)
+        self._setup_group_for_org_admin_tests()
 
-        user = Mock(spec=User, account="00001", username="test_user", admin=False)
+        permission = Permission.objects.create(permission="rbac:*:*", tenant=self.tenant)
+        rbac_admin_role = Role.objects.create(name="RBAC admin role", tenant=self.tenant)
+        access = Access.objects.create(permission=permission, role=rbac_admin_role, tenant=self.tenant)
+        user = Mock(spec=User, account="00001", username="test_user", admin=False, access=access)
         req = Mock(user=user, method="GET", tenant=self.tenant, query_params={APPLICATION_KEY: "app"})
         req.META = encoded_req.META
 

--- a/tests/management/test_querysets.py
+++ b/tests/management/test_querysets.py
@@ -26,10 +26,19 @@ from management.group.model import Group
 from management.policy.model import Policy
 from management.principal.model import Principal
 from management.role.model import Role
-from management.querysets import PRINCIPAL_SCOPE, SCOPE_KEY, get_group_queryset, get_policy_queryset, get_role_queryset
+from management.querysets import (
+    PRINCIPAL_SCOPE,
+    SCOPE_KEY,
+    get_group_queryset,
+    get_policy_queryset,
+    get_role_queryset,
+    get_access_queryset,
+)
+from management.utils import APPLICATION_KEY
 from rest_framework import serializers
 
 from api.models import Tenant, User
+from tests.identity_request import IdentityRequest
 
 
 class QuerySetTest(TestCase):
@@ -350,6 +359,24 @@ class QuerySetTest(TestCase):
         req = Mock(user=user, method="GET", tenant=self.tenant, query_params={SCOPE_KEY: "bad"})
         with self.assertRaises(serializers.ValidationError):
             get_policy_queryset(req)
+
+    def test_get_access_queryset_org_admin(self):
+        """Test get_access_queryset with an org admin"""
+        user_data = {"username": "user_dev", "email": "admin@example.com"}
+        customer = {"account_id": "10001"}
+        request_context = IdentityRequest._create_request_context(customer, user_data, is_org_admin=True)
+
+        request = request_context["request"]
+        role = Role.objects.create(name="role_admin_default", tenant=self.tenant)
+        policy = Policy.objects.create(name="policy_admin_default", tenant=self.tenant)
+        principal = Principal(username="test_user", tenant=self.tenant)
+        principal.save()
+        group = Group.objects.create(name="group_admin_default", tenant=self.tenant, admin_default=True)
+        policy.roles.add(role)
+        group.principals.add(principal)
+        group.policies.add(policy)
+        request.query_params = {APPLICATION_KEY: "app"}
+        print(get_access_queryset(request))
 
     def _setup_roles_for_role_username_queryset_tests(self):
         self._create_groups()

--- a/tests/management/test_utils.py
+++ b/tests/management/test_utils.py
@@ -66,7 +66,7 @@ class UtilsTests(IdentityRequest):
         # setup admin default group/role which all tenant admin users
         # should inherit without explicit association
         self.default_admin_role = Role.objects.create(
-            name="default admin role", platform_default=False, system=True, tenant=self.tenant
+            name="default admin role", platform_default=False, system=True, tenant=self.tenant, admin_default=True
         )
         self.default_admin_access = Access.objects.create(
             permission=self.permission, role=self.default_admin_role, tenant=self.tenant

--- a/tests/management/test_utils.py
+++ b/tests/management/test_utils.py
@@ -63,6 +63,21 @@ class UtilsTests(IdentityRequest):
         )
         self.default_group.policies.add(self.default_policy)
 
+        # setup admin default group/role which all tenant admin users
+        # should inherit without explicit association
+        self.default_admin_role = Role.objects.create(
+            name="default admin role", platform_default=False, system=True, tenant=self.tenant
+        )
+        self.default_admin_access = Access.objects.create(
+            permission=self.permission, role=self.default_admin_role, tenant=self.tenant
+        )
+        self.default_admin_policy = Policy.objects.create(name="default admin policy", system=True, tenant=self.tenant)
+        self.default_admin_policy.roles.add(self.default_admin_role)
+        self.default_admin_group = Group.objects.create(
+            name="Default admin access", system=True, platform_default=False, tenant=self.tenant, admin_default=True
+        )
+        self.default_admin_group.policies.add(self.default_admin_policy)
+
     def tearDown(self):
         """Tear down the utils tests."""
         Group.objects.all().delete()
@@ -74,6 +89,18 @@ class UtilsTests(IdentityRequest):
     def test_access_for_principal(self):
         """Test that we get the correct access for a principal."""
         kwargs = {"application": "app"}
+        access = access_for_principal(self.principal, self.tenant, **kwargs)
+        self.assertCountEqual(access, [self.accessA, self.default_access])
+
+    def test_access_for_org_admin(self):
+        """Test that an org admin has access to admin_default groups"""
+        kwargs = {"application": "app", "is_org_admin": True}
+        access = access_for_principal(self.principal, self.tenant, **kwargs)
+        self.assertCountEqual(access, [self.accessA, self.default_access, self.default_admin_access])
+
+    def test_access_for_non_org_admin(self):
+        """Test that an non-(org admin) doesn't have access to admin_default groups"""
+        kwargs = {"application": "app", "is_org_admin": False}
         access = access_for_principal(self.principal, self.tenant, **kwargs)
         self.assertCountEqual(access, [self.accessA, self.default_access])
 

--- a/tests/management/test_utils.py
+++ b/tests/management/test_utils.py
@@ -74,7 +74,7 @@ class UtilsTests(IdentityRequest):
         self.default_admin_policy = Policy.objects.create(name="default admin policy", system=True, tenant=self.tenant)
         self.default_admin_policy.roles.add(self.default_admin_role)
         self.default_admin_group = Group.objects.create(
-            name="Default admin access", system=True, platform_default=False, tenant=self.tenant, admin_default=True
+            name="default admin access", system=True, platform_default=False, tenant=self.tenant, admin_default=True
         )
         self.default_admin_group.policies.add(self.default_admin_policy)
 


### PR DESCRIPTION
## Link(s) to Jira
- https://issues.redhat.com/browse/RHCLOUD-16784

## Description of Intent of Change(s)
The purpose of these changes is to have admin default access be returned on the access endpoint, exclusively for org admins. Non-org admins and users given RBAC admin roles will not be able to see admin default access.

## Local Testing
This passed local tox tests and I created new unit tests for the new feature.

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [X] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  -  if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [X] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [X] General Coding Practices
