### PR TITLE
Admin default group

### DIFF
--- a/rbac/management/querysets.py
+++ b/rbac/management/querysets.py
@@ -248,6 +248,4 @@ def _filter_admin_default(request, queryset):
 
         return queryset | admin_default_group_set
 
-    # if the principal is not an org admin, they don't get any admin_default groups
-    # EXCEPT if the admin_default group(s) is also a platform_default group(s), then we include it.
     return queryset

--- a/rbac/management/querysets.py
+++ b/rbac/management/querysets.py
@@ -15,7 +15,6 @@
 #    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 """Queryset helpers for management module."""
-
 from django.conf import settings
 from django.db.models.aggregates import Count
 from django.urls import reverse
@@ -242,16 +241,13 @@ def _filter_admin_default(request, queryset):
     """Filter out admin default groups unless the principal is an org admin."""
     # If the principal is an org admin, make sure they get any and all admin_default groups
     if request.user.admin:
-        if settings.SERVE_FROM_PUBLIC_SCHEMA:
-            public_tenant = Tenant.objects.get(schema_name="public")
-            admin_default_group_set = Group.admin_default_set().filter(
-                tenant=request.tenant
-            ) or Group.admin_default_set().filter(tenant=public_tenant)
-        else:
-            admin_default_group_set = Group.admin_default_set()
+        public_tenant = Tenant.objects.get(schema_name="public")
+        admin_default_group_set = Group.admin_default_set().filter(
+            tenant=request.tenant
+        ) or Group.admin_default_set().filter(tenant=public_tenant)
 
         return queryset | admin_default_group_set
 
     # if the principal is not an org admin, they don't get any admin_default groups
     # with the caveat that the admin default group isn't also platform default
-    return queryset.filter(platform_default=False).filter(admin_default=False)
+    return queryset.filter(admin_default=False) | queryset.filter(platform_default=True)

--- a/rbac/management/querysets.py
+++ b/rbac/management/querysets.py
@@ -249,5 +249,5 @@ def _filter_admin_default(request, queryset):
         return queryset | admin_default_group_set
 
     # if the principal is not an org admin, they don't get any admin_default groups
-    # with the caveat that the admin default group isn't also platform default
+    # EXCEPT if the admin_default group(s) is also a platform_default group(s), then we include it.
     return queryset.filter(admin_default=False) | queryset.filter(platform_default=True)

--- a/rbac/management/querysets.py
+++ b/rbac/management/querysets.py
@@ -250,4 +250,4 @@ def _filter_admin_default(request, queryset):
 
     # if the principal is not an org admin, they don't get any admin_default groups
     # EXCEPT if the admin_default group(s) is also a platform_default group(s), then we include it.
-    return queryset.filter(admin_default=False) | queryset.filter(platform_default=True)
+    return queryset

--- a/rbac/management/querysets.py
+++ b/rbac/management/querysets.py
@@ -16,8 +16,6 @@
 #
 """Queryset helpers for management module."""
 
-import logging
-
 from django.conf import settings
 from django.db.models.aggregates import Count
 from django.urls import reverse
@@ -53,7 +51,6 @@ PRINCIPAL_QUERYSET_MAP = {
     Policy.__name__: policies_for_principal,
     Role.__name__: roles_for_principal,
 }
-logger = logging.getLogger(__name__)
 
 
 def get_annotated_groups():

--- a/rbac/management/querysets.py
+++ b/rbac/management/querysets.py
@@ -244,6 +244,7 @@ def get_object_principal_queryset(request, scope, clazz, **kwargs):
 
 
 def _filter_admin_default(request, queryset):
+    # If the principal is an org admin, make sure they get any and all admin_default groups
     if request.user.admin:
         if settings.SERVE_FROM_PUBLIC_SCHEMA:
             public_tenant = Tenant.objects.get(schema_name="public")
@@ -255,4 +256,5 @@ def _filter_admin_default(request, queryset):
 
         return queryset | admin_default_group_set
 
+    # if the principal is not an org admin, they don't get any admin_default groups
     return queryset.filter(admin_default=False)

--- a/tests/management/test_querysets.py
+++ b/tests/management/test_querysets.py
@@ -133,6 +133,39 @@ class QuerySetTest(TestCase):
         queryset = get_group_queryset(req)
         self.assertEquals(queryset.count(), 0)
 
+    def test_get_user_group_queryset_admin_default_org_admin(self):
+        """Test get_group_queryset as an org admin searching for admin default groups."""
+        principal = Principal.objects.create(username="test_user", tenant=self.tenant)
+        group = Group.objects.create(name="group_admin_default", tenant=self.tenant, admin_default=True)
+        group.principals.add(principal)
+        user = Mock(spec=User, admin=True, account="00001", username="test_user")
+        req = Mock(user=user, tenant=self.tenant, query_params={"username": "test_user"})
+        queryset = get_group_queryset(req)
+        self.assertEquals(queryset.count(), 1)
+
+    def test_get_user_group_queryset_admin_default_non_org_admin(self):
+        """Test get_group_queryset not as an org admin, searching for admin default groups."""
+        principal = Principal.objects.create(username="test_user", tenant=self.tenant)
+        group = Group.objects.create(name="group_admin_default", tenant=self.tenant, admin_default=True)
+        group.principals.add(principal)
+        user = Mock(spec=User, admin=False, account="00001", username="test_user")
+        req = Mock(user=user, tenant=self.tenant, query_params={"username": "test_user"})
+        queryset = get_group_queryset(req)
+        self.assertEquals(queryset.count(), 0)
+
+    def test_get_user_group_queryset_admin_default_rbac_admin(self):
+        """Test get_group_queryset not as an org admin, but as an RBAC admin searching for admin default groups."""
+        principal = Principal.objects.create(username="test_user", tenant=self.tenant)
+        group = Group.objects.create(name="group_admin_default", tenant=self.tenant, admin_default=True)
+        group.principals.add(principal)
+        permission = Permission.objects.create(permission="rbac:*:*", tenant=self.tenant)
+        rbac_admin_role = Role.objects.create(name="RBAC admin role", tenant=self.tenant)
+        access = Access.objects.create(permission=permission, role=rbac_admin_role, tenant=self.tenant)
+        user = Mock(spec=User, admin=False, account="00001", username="test_user", access=access)
+        req = Mock(user=user, tenant=self.tenant, query_params={"username": "test_user"})
+        queryset = get_group_queryset(req)
+        self.assertEquals(queryset.count(), 0)
+
     def test_get_role_queryset_admin(self):
         """Test get_role_queryset as an admin."""
         self._create_roles()

--- a/tests/management/test_querysets.py
+++ b/tests/management/test_querysets.py
@@ -147,7 +147,6 @@ class QuerySetTest(TestCase):
         """Test get_group_queryset not as an org admin, searching for admin default groups."""
         principal = Principal.objects.create(username="test_user", tenant=self.tenant)
         group = Group.objects.create(name="group_admin_default", tenant=self.tenant, admin_default=True)
-        group.principals.add(principal)
         user = Mock(spec=User, admin=False, account="00001", username="test_user")
         req = Mock(user=user, tenant=self.tenant, query_params={"username": "test_user"})
         queryset = get_group_queryset(req)
@@ -159,7 +158,6 @@ class QuerySetTest(TestCase):
         group = Group.objects.create(
             name="group_admin_default", tenant=self.tenant, admin_default=True, platform_default=True
         )
-        group.principals.add(principal)
         user = Mock(spec=User, admin=False, account="00001", username="test_user")
         req = Mock(user=user, tenant=self.tenant, query_params={"username": "test_user"})
         queryset = get_group_queryset(req)
@@ -169,7 +167,6 @@ class QuerySetTest(TestCase):
         """Test get_group_queryset not as an org admin, but as an RBAC admin searching for admin default groups."""
         principal = Principal.objects.create(username="test_user", tenant=self.tenant)
         group = Group.objects.create(name="group_admin_default", tenant=self.tenant, admin_default=True)
-        group.principals.add(principal)
         permission = Permission.objects.create(permission="rbac:*:*", tenant=self.tenant)
         rbac_admin_role = Role.objects.create(name="RBAC admin role", tenant=self.tenant)
         access = Access.objects.create(permission=permission, role=rbac_admin_role, tenant=self.tenant)

--- a/tests/management/test_querysets.py
+++ b/tests/management/test_querysets.py
@@ -153,6 +153,18 @@ class QuerySetTest(TestCase):
         queryset = get_group_queryset(req)
         self.assertEquals(queryset.count(), 0)
 
+    def test_get_user_group_queryset_admin_and_platform_default(self):
+        """Test get_group_queryset not as an org admin, searching for groups that are admin and platform default."""
+        principal = Principal.objects.create(username="test_user", tenant=self.tenant)
+        group = Group.objects.create(
+            name="group_admin_default", tenant=self.tenant, admin_default=True, platform_default=True
+        )
+        group.principals.add(principal)
+        user = Mock(spec=User, admin=False, account="00001", username="test_user")
+        req = Mock(user=user, tenant=self.tenant, query_params={"username": "test_user"})
+        queryset = get_group_queryset(req)
+        self.assertEquals(queryset.count(), 1)
+
     def test_get_user_group_queryset_admin_default_rbac_admin(self):
         """Test get_group_queryset not as an org admin, but as an RBAC admin searching for admin default groups."""
         principal = Principal.objects.create(username="test_user", tenant=self.tenant)


### PR DESCRIPTION
## Link(s) to Jira
- https://issues.redhat.com/browse/RHCLOUD-16785

## Description of Intent of Change(s)
This change is to return the default admin access group for org admins on /groups/ and any subdirectories. The access group will not be returned if the principal is a non org admin, including users with RBAC admin access.

## Local Testing
It passed local tox testing with new unit tests for this new feature.

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [X] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  -  if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
