### PR TITLE
Re add unintentionally removed default seed code

### DIFF
--- a/rbac/management/group/definer.py
+++ b/rbac/management/group/definer.py
@@ -54,6 +54,24 @@ def seed_group(tenant):
             add_roles(group, platform_roles, tenant, replace=True)
             logger.info("Finished seeding default group.")
 
+        # Default admin group
+        admin_name = "Default admin access"
+        admin_group_description = (
+            "This group contains the roles that all org admin users inherit by default. "
+            "Adding or removing roles in this group will affect permissions for all org admin users in your org."
+        )
+        admin_group, admin_group_created = Group.objects.get_or_create(
+            admin_default=True,
+            defaults={"description": admin_group_description, "name": admin_name, "system": True},
+            tenant=tenant,
+        )
+        if admin_group.system:
+            platform_roles = Role.objects.filter(admin_default=True)
+            add_roles(admin_group, platform_roles, tenant, replace=True)
+            logger.info("Finished seeding default org admin group %s for tenant %s.", name, tenant.tenant_name)
+        else:
+            logger.info("Default admin group %s is managed by tenant %s.", name, tenant.tenant_name)
+
 
 def set_system_flag_before_update(group, tenant):
     """Update system flag on default groups."""

--- a/tests/management/group/test_definer.py
+++ b/tests/management/group/test_definer.py
@@ -87,3 +87,19 @@ class GroupDefinerTests(IdentityRequest):
 
         group.system = system
         group.save()
+
+    def test_admin_default_group_seeding_properly(self):
+        """Test that admin default group are seeded properly."""
+        group = Group.objects.get(admin_default=True)
+
+        system_policy = group.policies.get(name="System Policy for Group {}".format(group.uuid))
+        self.assertEqual(group.admin_default, True)
+        self.assertEqual(group.system, True)
+        self.assertEqual(group.name, "Default admin access")
+        self.assertEqual(group.tenant, self.public_tenant)
+        self.assertEqual(system_policy.system, True)
+        self.assertEqual(system_policy.tenant, self.public_tenant)
+        # only admin_default roles would be assigned to the admin_default group
+        for role in group.roles():
+            self.assertTrue(role.admin_default)
+            self.assertEqual(role.tenant, self.public_tenant)


### PR DESCRIPTION
DTS removal MR #660 inadvertently removed the default group seeding changes from #662 so this PR should add those back in.
