### PR TITLE
Handle no payload in `/roles/<uuid>/` PATCH

### DIFF
--- a/rbac/management/role/view.py
+++ b/rbac/management/role/view.py
@@ -321,7 +321,7 @@ class RoleViewSet(
     def partial_update(self, request, *args, **kwargs):
         """Patch a role."""
         validate_uuid(kwargs.get("uuid"), "role uuid validation")
-        payload = json.loads(request.body)
+        payload = json.loads(request.body or "{}")
         for field in payload:
             if field not in VALID_PATCH_FIELDS:
                 key = "role"

--- a/tests/management/role/test_view.py
+++ b/tests/management/role/test_view.py
@@ -697,6 +697,22 @@ class RoleViewsetTests(IdentityRequest):
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
+    def test_patch_role_without_payload(self):
+        """Test that we no-op when no payload supplied."""
+        role_name = "role"
+        response = self.create_role(role_name)
+        updated_name = role_name + "_update"
+        updated_description = role_name + "This is a test"
+        role_uuid = response.data.get("uuid")
+        url = reverse("role-detail", kwargs={"uuid": role_uuid})
+        client = APIClient()
+        response = client.patch(
+            url,
+            format="json",
+            **self.headers,
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
     @patch("management.notifications.producer_util.NotificationProducer.send_kafka_message")
     def test_update_role_success(self, send_kafka_message):
         """Test that we can update an existing role."""


### PR DESCRIPTION
## Link(s) to Jira
- https://issues.redhat.com/browse/RHCLOUD-11319

## Description of Intent of Change(s)
Currently we allow an empty payload in `/roles/<uuid>/` `PATCH` requests. However
if you supply _no_ payload, the `json.loads(request.data)` call fails with a 500
because it cannot convert an empty string.

In order to preserve existing behavior, and align an empty payload to behave like
no payload (a no-op) in `PATCH` requests, we'll default the payload to en empty
object.

## Local Testing
Send a local request with:
```
curl http://localhost:8000/api/rbac/v1/roles/<uuid>/ -XPATCH
```
Prior to this change, you'll see a 500 returned. After, you'll get a no-op 200.

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [x] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  -  if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
