### PR TITLE
Delay initiation until send message in worker

### DIFF
--- a/rbac/management/notifications/producer_util.py
+++ b/rbac/management/notifications/producer_util.py
@@ -43,12 +43,16 @@ notification_topic = "platform.notifications.ingress"
 class NotificationProducer:
     """Kafka message producer to emit events to notification service."""
 
-    def __init__(self):
+    def get_producer(self):
         """Init method to return fake kafka when flag is set to false."""
+        if hasattr(self, "producer"):
+            return self.producer
+
         if settings.NOTIFICATIONS_ENABLED:
             self.producer = KafkaProducer(bootstrap_servers=settings.KAFKA_SERVER)
         else:
             self.producer = FakeKafkaProducer()
+        return self.producer
 
     def create_message(self, event_type, account_id, payload):
         """Create message based on template."""
@@ -61,10 +65,11 @@ class NotificationProducer:
 
     def send_kafka_message(self, event_type, account_id, payload):
         """Send message to kafka server."""
+        producer = self.get_producer()
         message = self.create_message(event_type, account_id, payload)
         serialized_data = pickle.dumps(message)
 
-        self.producer.send(notification_topic, value=serialized_data, headers=[("rh-message-id", uuid4().bytes)])
+        producer.send(notification_topic, value=serialized_data, headers=[("rh-message-id", uuid4().bytes)])
 
 
 """


### PR DESCRIPTION
## Link(s) to Jira
- https://issues.redhat.com/browse/RHCLOUD-17744

## Description of Intent of Change(s)
The producer is initiated in the main process, the kafka producer uses
internal threads which will not be forked into workers:
https://github.com/confluentinc/confluent-kafka-python/issues/351#issuecomment-379270066

So we have to deplay the initiation in each worker.

## Local Testing
`make gunicorn-serve` to start the server

Start local kafka:
`zookeeper-server-start /usr/local/etc/kafka/zookeeper.properties`
`kafka-server-start /usr/local/etc/kafka/server.properties`
`kafka-console-consumer --bootstrap-server localhost:9092 --topic platform.notifications.ingress --formatter kafka.tools.DefaultMessageFormatter`

Then create a group
`curl -X POST -d '{"name":"test2"}' "0.0.0.0:8000/api/rbac/v1/groups/"  -H 'Content-Type: application/json'`

You will observe the message

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  -  if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
