### PR TITLE
Add internal endpoint for querying/deleting invalid default admin groups

### DIFF
--- a/rbac/internal/urls.py
+++ b/rbac/internal/urls.py
@@ -33,4 +33,5 @@ urlpatterns = [
     path("api/sentry_debug/", trigger_error),
     path("api/utils/sync_schemas/", views.sync_schemas),
     path("api/utils/populate_tenant_account_id/", views.populate_tenant_account_id),
+    path("api/utils/invalid_default_admin_groups/", views.invalid_default_admin_groups),
 ]

--- a/rbac/internal/views.py
+++ b/rbac/internal/views.py
@@ -293,7 +293,7 @@ def invalid_default_admin_groups(request):
     if request.method == "GET":
         payload = {
             "invalid_default_admin_groups": list(invalid_default_admin_groups.values("name")),
-            "invalid_default_admin_groups_count": invalid_default_admin_groups.count()
+            "invalid_default_admin_groups_count": invalid_default_admin_groups.count(),
         }
         return HttpResponse(json.dumps(payload), content_type="application/json")
     if request.method == "DELETE":

--- a/rbac/internal/views.py
+++ b/rbac/internal/views.py
@@ -292,7 +292,9 @@ def invalid_default_admin_groups(request):
 
     if request.method == "GET":
         payload = {
-            "invalid_default_admin_groups": list(invalid_default_admin_groups.values("name")),
+            "invalid_default_admin_groups": list(
+                invalid_default_admin_groups.values("name", "admin_default", "system", "platform_default", "tenant")
+            ),
             "invalid_default_admin_groups_count": invalid_default_admin_groups.count(),
         }
         return HttpResponse(json.dumps(payload), content_type="application/json")

--- a/rbac/internal/views.py
+++ b/rbac/internal/views.py
@@ -288,7 +288,9 @@ def invalid_default_admin_groups(request):
     """
     logger.info(f"Invalid default admin groups: {request.method} {request.user.username}")
     public_tenant = Tenant.objects.get(tenant_name="public")
-    invalid_default_admin_groups = Group.objects.filter(admin_default=True, system=False).exclude(tenant=public_tenant)
+    invalid_default_admin_groups = Group.objects.filter(
+        admin_default=True, system=False, platform_default=False
+    ).exclude(tenant=public_tenant)
 
     if request.method == "GET":
         payload = {

--- a/rbac/internal/views.py
+++ b/rbac/internal/views.py
@@ -280,6 +280,30 @@ def populate_tenant_account_id(request):
     return HttpResponse('Invalid method, only "POST" is allowed.', status=405)
 
 
+def invalid_default_admin_groups(request):
+    """View method for querying/removing invalid default admin groups.
+
+    GET /_private/api/utils/invalid_default_admin_groups/
+    DELETE /_private/api/utils/invalid_default_admin_groups/
+    """
+    logger.info(f"Invalid default admin groups: {request.method} {request.user.username}")
+    public_tenant = Tenant.objects.get(tenant_name="public")
+    invalid_default_admin_groups = Group.objects.filter(admin_default=True, system=False).exclude(tenant=public_tenant)
+
+    if request.method == "GET":
+        payload = {
+            "invalid_default_admin_groups": list(invalid_default_admin_groups.values("name")),
+            "invalid_default_admin_groups_count": invalid_default_admin_groups.count()
+        }
+        return HttpResponse(json.dumps(payload), content_type="application/json")
+    if request.method == "DELETE":
+        if not destructive_ok():
+            return HttpResponse("Destructive operations disallowed.", status=400)
+        invalid_default_admin_groups.delete()
+        return HttpResponse(status=204)
+    return HttpResponse('Invalid method, only "DELETE" and "GET" are allowed.', status=405)
+
+
 class SentryDiagnosticError(Exception):
     """Raise this to create an event in Sentry."""
 

--- a/tests/internal/test_views.py
+++ b/tests/internal/test_views.py
@@ -249,8 +249,12 @@ class InternalViewsetTests(IdentityRequest):
 
     def test_get_invalid_default_admin_groups(self):
         """Test that we can get invalid groups."""
-        invalid_admin_default_group = Group.objects.create(admin_default=True, system=False, tenant=self.tenant, name="Invalid Default Admin Group")
-        valid_admin_default_group = Group.objects.create(admin_default=True, system=True, tenant=self.public_tenant, name="Valid Default Admin Group")
+        invalid_admin_default_group = Group.objects.create(
+            admin_default=True, system=False, tenant=self.tenant, name="Invalid Default Admin Group"
+        )
+        valid_admin_default_group = Group.objects.create(
+            admin_default=True, system=True, tenant=self.public_tenant, name="Valid Default Admin Group"
+        )
         response = self.client.get(f"/_private/api/utils/invalid_default_admin_groups/", **self.request.META)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         response_data = json.loads(response.content)
@@ -267,8 +271,12 @@ class InternalViewsetTests(IdentityRequest):
     @override_settings(INTERNAL_DESTRUCTIVE_API_OK_UNTIL=valid_destructive_time())
     def test_delete_invalid_default_admin_groups(self):
         """Test that we can delete invalid groups when allowed."""
-        invalid_admin_default_group = Group.objects.create(admin_default=True, system=False, tenant=self.tenant, name="Invalid Default Admin Group")
-        valid_admin_default_group = Group.objects.create(admin_default=True, system=True, tenant=self.public_tenant, name="Valid Default Admin Group")
+        invalid_admin_default_group = Group.objects.create(
+            admin_default=True, system=False, tenant=self.tenant, name="Invalid Default Admin Group"
+        )
+        valid_admin_default_group = Group.objects.create(
+            admin_default=True, system=True, tenant=self.public_tenant, name="Valid Default Admin Group"
+        )
         self.assertEqual(Group.objects.count(), 3)
         response = self.client.delete(f"/_private/api/utils/invalid_default_admin_groups/", **self.request.META)
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)

--- a/tests/internal/test_views.py
+++ b/tests/internal/test_views.py
@@ -64,6 +64,7 @@ class InternalViewsetTests(IdentityRequest):
         self.policy.save()
         self.group.policies.add(self.policy)
         self.group.save()
+        self.public_tenant = Tenant.objects.get(tenant_name="public")
 
     def tearDown(self):
         """Tear down internal viewset tests."""
@@ -245,3 +246,32 @@ class InternalViewsetTests(IdentityRequest):
         populate_mock.assert_not_called()
         self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
         self.assertEqual(response.content.decode(), 'Invalid method, only "POST" is allowed.')
+
+    def test_get_invalid_default_admin_groups(self):
+        """Test that we can get invalid groups."""
+        invalid_admin_default_group = Group.objects.create(admin_default=True, system=False, tenant=self.tenant, name="Invalid Default Admin Group")
+        valid_admin_default_group = Group.objects.create(admin_default=True, system=True, tenant=self.public_tenant, name="Valid Default Admin Group")
+        response = self.client.get(f"/_private/api/utils/invalid_default_admin_groups/", **self.request.META)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response_data = json.loads(response.content)
+        self.assertEqual(response_data["invalid_default_admin_groups_count"], 1)
+        self.assertEqual(len(response_data["invalid_default_admin_groups"]), 1)
+        self.assertEqual(response_data["invalid_default_admin_groups"][0], {"name": invalid_admin_default_group.name})
+
+    def test_delete_invalid_default_admin_groups_disallowed(self):
+        """Test that we cannot delete invalid groups when disallowed."""
+        response = self.client.delete(f"/_private/api/utils/invalid_default_admin_groups/", **self.request.META)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.content.decode(), "Destructive operations disallowed.")
+
+    @override_settings(INTERNAL_DESTRUCTIVE_API_OK_UNTIL=valid_destructive_time())
+    def test_delete_invalid_default_admin_groups(self):
+        """Test that we can delete invalid groups when allowed."""
+        invalid_admin_default_group = Group.objects.create(admin_default=True, system=False, tenant=self.tenant, name="Invalid Default Admin Group")
+        valid_admin_default_group = Group.objects.create(admin_default=True, system=True, tenant=self.public_tenant, name="Valid Default Admin Group")
+        self.assertEqual(Group.objects.count(), 3)
+        response = self.client.delete(f"/_private/api/utils/invalid_default_admin_groups/", **self.request.META)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertEqual(Group.objects.count(), 2)
+        self.assertEqual(Group.objects.filter(id=valid_admin_default_group.id).exists(), True)
+        self.assertEqual(Group.objects.filter(id=invalid_admin_default_group.id).exists(), False)

--- a/tests/internal/test_views.py
+++ b/tests/internal/test_views.py
@@ -260,7 +260,16 @@ class InternalViewsetTests(IdentityRequest):
         response_data = json.loads(response.content)
         self.assertEqual(response_data["invalid_default_admin_groups_count"], 1)
         self.assertEqual(len(response_data["invalid_default_admin_groups"]), 1)
-        self.assertEqual(response_data["invalid_default_admin_groups"][0], {"name": invalid_admin_default_group.name})
+        self.assertEqual(
+            response_data["invalid_default_admin_groups"][0],
+            {
+                "name": invalid_admin_default_group.name,
+                "admin_default": invalid_admin_default_group.admin_default,
+                "system": invalid_admin_default_group.system,
+                "platform_default": invalid_admin_default_group.platform_default,
+                "tenant": invalid_admin_default_group.tenant.id,
+            },
+        )
 
     def test_delete_invalid_default_admin_groups_disallowed(self):
         """Test that we cannot delete invalid groups when disallowed."""


### PR DESCRIPTION
## Link(s) to Jira
- https://issues.redhat.com/browse/RHCLOUD-19222

## Description of Intent of Change(s)
Surfaces the following internal endpoint in Turnpike:
```
/_private/api/utils/invalid_default_admin_groups/
```
which can be requested with a `GET` or `DELETE` method. A `GET` will return all
invalid groups' names as well as a count. A `DELETE` (when enabled) will remove
the groups.

This is to remediate data related to https://github.com/RedHatInsights/insights-rbac/pull/694

## Local Testing
Exercise the new internal endpoint.

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  -  if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
