### PR TITLE
Solve parsing problem of kafka message

### DIFF
--- a/rbac/management/notifications/producer_util.py
+++ b/rbac/management/notifications/producer_util.py
@@ -17,7 +17,6 @@
 """Producer to send messages to kafka server."""
 import json
 import os
-import pickle
 from datetime import datetime
 from uuid import uuid4
 
@@ -67,9 +66,9 @@ class NotificationProducer:
         """Send message to kafka server."""
         producer = self.get_producer()
         message = self.create_message(event_type, account_id, payload)
-        serialized_data = pickle.dumps(message)
+        json_data = json.dumps(message)
 
-        producer.send(notification_topic, value=serialized_data, headers=[("rh-message-id", uuid4().bytes)])
+        producer.send(notification_topic, value=json_data, headers=[("rh-message-id", uuid4().bytes)])
 
 
 """

--- a/rbac/management/notifications/producer_util.py
+++ b/rbac/management/notifications/producer_util.py
@@ -66,7 +66,7 @@ class NotificationProducer:
         """Send message to kafka server."""
         producer = self.get_producer()
         message = self.create_message(event_type, account_id, payload)
-        json_data = json.dumps(message)
+        json_data = json.dumps(message).encode("utf-8")
 
         producer.send(notification_topic, value=json_data, headers=[("rh-message-id", uuid4().bytes)])
 

--- a/tests/management/notifications/test_producer_util.py
+++ b/tests/management/notifications/test_producer_util.py
@@ -37,4 +37,4 @@ class ProducerTest(TestCase):
         NotificationProducer().send_kafka_message(self.event_type, self.account_id, self.payload)
 
         producer.send.assert_called_once()
-        producer.send.assert_called_once_with(self.topic, headers=TypeMatcher(list), value=TypeMatcher(bytes))
+        producer.send.assert_called_once_with(self.topic, headers=TypeMatcher(list), value=TypeMatcher(str))

--- a/tests/management/notifications/test_producer_util.py
+++ b/tests/management/notifications/test_producer_util.py
@@ -37,4 +37,4 @@ class ProducerTest(TestCase):
         NotificationProducer().send_kafka_message(self.event_type, self.account_id, self.payload)
 
         producer.send.assert_called_once()
-        producer.send.assert_called_once_with(self.topic, headers=TypeMatcher(list), value=TypeMatcher(str))
+        producer.send.assert_called_once_with(self.topic, headers=TypeMatcher(list), value=TypeMatcher(bytes))


### PR DESCRIPTION
## Link(s) to Jira
- https://issues.redhat.com/browse/RHCLOUD-17744

## Description of Intent of Change(s)
The notifications team can't parse the bytes message. Update it
to json string instead.

## Local Testing
Updated unit test to confirm sending out string

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  -  if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
