### PR TITLE
Use utf-8 instead of build in bytes method of uuid

### DIFF
--- a/rbac/management/notifications/producer_util.py
+++ b/rbac/management/notifications/producer_util.py
@@ -68,7 +68,7 @@ class NotificationProducer:
         message = self.create_message(event_type, account_id, payload)
         json_data = json.dumps(message).encode("utf-8")
 
-        producer.send(notification_topic, value=json_data, headers=[("rh-message-id", uuid4().bytes)])
+        producer.send(notification_topic, value=json_data, headers=[("rh-message-id", str(uuid4()).encode("utf-8"))])
 
 
 """


### PR DESCRIPTION
## Link(s) to Jira
- https://issues.redhat.com/browse/RHCLOUD-17744

## Description of Intent of Change(s)
The kafka message header of uuid could not be decoded properly although it
is bytes. It could only be decoded when it is utf-8 encoded.

## Local Testing
It does not break the unit tests.

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  -  if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
