### PR TITLE
Add translator host and port as parameters

### DIFF
--- a/deploy/rbac-clowdapp.yml
+++ b/deploy/rbac-clowdapp.yml
@@ -441,10 +441,6 @@ objects:
             - --ean-translator-addr
             - http://${TENANT_TRANSLATOR_HOST}:${TENANT_TRANSLATOR_PORT}
           env:
-            - name: TENANT_TRANSLATOR_HOST
-              value: ${TENANT_TRANSLATOR_HOST}
-            - name: TENANT_TRANSLATOR_PORT
-              value: ${TENANT_TRANSLATOR_PORT}
             - name: LOG_FORMAT
               value: ${LOG_FORMAT}
             - name: LOG_BATCH_FREQUENCY
@@ -471,10 +467,6 @@ objects:
             - --ean-translator-addr
             - http://${TENANT_TRANSLATOR_HOST}:${TENANT_TRANSLATOR_PORT}
           env:
-            - name: TENANT_TRANSLATOR_HOST
-              value: ${TENANT_TRANSLATOR_HOST}
-            - name: TENANT_TRANSLATOR_PORT
-              value: ${TENANT_TRANSLATOR_PORT}
             - name: LOG_FORMAT
               value: ${LOG_FORMAT}
             - name: LOG_BATCH_FREQUENCY
@@ -2085,3 +2077,7 @@ parameters:
 - description: Enable RBAC tenancy using Org ID
   name: AUTHENTICATE_WITH_ORG_ID
   value: 'False'
+- name: TENANT_TRANSLATOR_HOST
+  required: true
+- name: TENANT_TRANSLATOR_PORT
+  value: '8892'


### PR DESCRIPTION
Add translator host and port as parameters

You should be able to deploy this in the ephemeral env using the following command:

`bonfire deploy rbac -p rbac/TENANT_TRANSLATOR_HOST=apicast.3scale-dev.svc.cluster.local`
