### PR TITLE
Fix Bug with default admin groups being included with non-admin accounts

### DIFF
--- a/rbac/management/principal/proxy.py
+++ b/rbac/management/principal/proxy.py
@@ -187,7 +187,6 @@ class PrincipalProxy:  # pylint: disable=too-few-public-methods
         }
         try:
             kwargs = {"headers": headers, "params": params, "json": data, "verify": self.ssl_verify}
-
             if self.source_cert:
                 kwargs["verify"] = self.client_cert
             response = method(url, **kwargs)

--- a/rbac/management/querysets.py
+++ b/rbac/management/querysets.py
@@ -142,17 +142,6 @@ def get_role_queryset(request):
     )
 
     if scope != (ACCOUNT_SCOPE or ORG_ID_SCOPE):
-        username = request.query_params.get("username")
-        is_org_admin = request.user.admin
-        if username:
-            role_permission = RoleAccessPermission()
-
-            if username != request.user.username and not role_permission.has_permission(request=request, view=None):
-                return Role.objects.none()
-            else:
-                if not settings.BYPASS_BOP_VERIFICATION:
-                    is_org_admin = get_admin_from_proxy(username, request)
-
         queryset = get_object_principal_queryset(
             request,
             scope,
@@ -160,7 +149,6 @@ def get_role_queryset(request):
             **{
                 "prefetch_lookups_for_ids": "access",
                 "prefetch_lookups_for_groups": "policies__roles",
-                "is_org_admin": is_org_admin,
             },
         )
         return annotate_roles_with_counts(queryset)

--- a/rbac/management/querysets.py
+++ b/rbac/management/querysets.py
@@ -142,6 +142,17 @@ def get_role_queryset(request):
     )
 
     if scope != (ACCOUNT_SCOPE or ORG_ID_SCOPE):
+        username = request.query_params.get("username")
+        is_org_admin = request.user.admin
+        if username:
+            role_permission = RoleAccessPermission()
+
+            if username != request.user.username and not role_permission.has_permission(request=request, view=None):
+                return Role.objects.none()
+            else:
+                if not settings.BYPASS_BOP_VERIFICATION:
+                    is_org_admin = get_admin_from_proxy(username, request)
+
         queryset = get_object_principal_queryset(
             request,
             scope,
@@ -149,7 +160,7 @@ def get_role_queryset(request):
             **{
                 "prefetch_lookups_for_ids": "access",
                 "prefetch_lookups_for_groups": "policies__roles",
-                "is_org_admin": request.user.admin,
+                "is_org_admin": is_org_admin,
             },
         )
         return annotate_roles_with_counts(queryset)

--- a/rbac/management/querysets.py
+++ b/rbac/management/querysets.py
@@ -149,6 +149,7 @@ def get_role_queryset(request):
             **{
                 "prefetch_lookups_for_ids": "access",
                 "prefetch_lookups_for_groups": "policies__roles",
+                "is_org_admin": request.user.admin,
             },
         )
         return annotate_roles_with_counts(queryset)
@@ -265,8 +266,13 @@ def get_object_principal_queryset(request, scope, clazz, **kwargs):
 
 def _filter_admin_default(request, queryset):
     """Filter out admin default groups unless the principal is an org admin."""
+    username = request.query_params.get("username")
+    if not username or settings.BYPASS_BOP_VERIFICATION:
+        is_org_admin = request.user.admin
+    else:
+        is_org_admin = get_admin_from_proxy(username, request)
     # If the principal is an org admin, make sure they get any and all admin_default groups
-    if request.user.admin:
+    if is_org_admin:
         public_tenant = Tenant.objects.get(tenant_name="public")
         admin_default_group_set = Group.admin_default_set().filter(
             tenant=request.tenant

--- a/rbac/management/utils.py
+++ b/rbac/management/utils.py
@@ -275,5 +275,12 @@ def account_id_for_tenant(tenant):
 def get_admin_from_proxy(username, request):
     """Return org_admin status of a username from the proxy."""
     bop_resp = verify_principal_with_proxy(username, request, verify_principal=True)
+
+    if bop_resp.get("data") == []:
+        key = "detail"
+        message = "No data found for principal with username {}.".format(username)
+        raise serializers.ValidationError({key: _(message)})
+
     index = next((i for i, x in enumerate(bop_resp.get("data")) if x["username"] == username), None)
-    return bop_resp.get("data")[index]["is_org_admin"]
+    is_org_admin = bop_resp.get("data")[index]["is_org_admin"]
+    return is_org_admin

--- a/rbac/management/utils.py
+++ b/rbac/management/utils.py
@@ -91,7 +91,6 @@ def verify_principal_with_proxy(username, request, verify_principal=True):
     account = request.user.account
     org_id = request.user.org_id
     proxy = PrincipalProxy()
-
     if verify_principal:
         if settings.AUTHENTICATE_WITH_ORG_ID:
             resp = proxy.request_filtered_principals([username], org_id=org_id)
@@ -271,3 +270,10 @@ def clear_pk(entry):
 def account_id_for_tenant(tenant):
     """Return the account id from a tenant's name."""
     return tenant.tenant_name.replace("acct", "")
+
+
+def get_admin_from_proxy(username, request):
+    """Return org_admin status of a username from the proxy."""
+    bop_resp = verify_principal_with_proxy(username, request, verify_principal=True)
+    index = next((i for i, x in enumerate(bop_resp.get("data")) if x["username"] == username), None)
+    return bop_resp.get("data")[index]["is_org_admin"]

--- a/rbac/management/utils.py
+++ b/rbac/management/utils.py
@@ -52,42 +52,61 @@ def get_principal_from_request(request):
     """Obtain principal from the request object."""
     current_user = request.user.username
     qs_user = request.query_params.get(USERNAME_KEY)
-
+    username = current_user
+    from_query = False
     if qs_user and not PRICIPAL_PERMISSION_INSTANCE.has_permission(request=request, view=None):
         raise PermissionDenied()
-    username = qs_user if qs_user else current_user
-    return get_principal(username, request, verify_principal=bool(qs_user))
+
+    if qs_user:
+        username = qs_user
+        from_query = True
+
+    return get_principal(username, request, verify_principal=bool(qs_user), from_query=from_query)
 
 
-def get_principal(username, request, verify_principal=True):
+def get_principal(username, request, verify_principal=True, from_query=False):
     """Get principals from username."""
     # First check if principal exist on our side,
     # if not call BOP to check if user exist in the account.
-    account = request.user.account
-    org_id = request.user.org_id
     tenant = request.tenant
+
     try:
+        # If the username was provided through a query we must verify if it is an org admin from the BOP
+        if from_query:
+            verify_principal_with_proxy(username, request, verify_principal=verify_principal)
         principal = Principal.objects.get(username__iexact=username, tenant=tenant)
     except Principal.DoesNotExist:
-        if verify_principal:
-            proxy = PrincipalProxy()
-            if settings.AUTHENTICATE_WITH_ORG_ID:
-                resp = proxy.request_filtered_principals([username], org_id=org_id)
-            else:
-                resp = proxy.request_filtered_principals([username], account)
-            if isinstance(resp, dict) and "errors" in resp:
-                raise Exception("Dependency error: request to get users from dependent service failed.")
-
-            if resp.get("data") == []:
-                key = "detail"
-                message = "No data found for principal with username {}.".format(username)
-                raise serializers.ValidationError({key: _(message)})
+        verify_principal_with_proxy(username, request, verify_principal=verify_principal)
 
         # Avoid possible race condition if the user was created while checking BOP
         principal, created = Principal.objects.get_or_create(
             username=username, tenant=tenant
         )  # pylint: disable=unused-variable
+
     return principal
+
+
+def verify_principal_with_proxy(username, request, verify_principal=True):
+    """Verify username through the BOP."""
+    account = request.user.account
+    org_id = request.user.org_id
+    proxy = PrincipalProxy()
+
+    if verify_principal:
+        if settings.AUTHENTICATE_WITH_ORG_ID:
+            resp = proxy.request_filtered_principals([username], org_id=org_id)
+        else:
+            resp = proxy.request_filtered_principals([username], account)
+
+        if isinstance(resp, dict) and "errors" in resp:
+            raise Exception("Dependency error: request to get users from dependent service failed.")
+
+        if resp.get("data") == []:
+            key = "detail"
+            message = "No data found for principal with username {}.".format(username)
+            raise serializers.ValidationError({key: _(message)})
+
+        return resp
 
 
 def policies_for_groups(groups):

--- a/rbac/management/utils.py
+++ b/rbac/management/utils.py
@@ -91,6 +91,7 @@ def verify_principal_with_proxy(username, request, verify_principal=True):
     account = request.user.account
     org_id = request.user.org_id
     proxy = PrincipalProxy()
+    return None
     if verify_principal:
         if settings.AUTHENTICATE_WITH_ORG_ID:
             resp = proxy.request_filtered_principals([username], org_id=org_id)
@@ -274,6 +275,7 @@ def account_id_for_tenant(tenant):
 
 def get_admin_from_proxy(username, request):
     """Return org_admin status of a username from the proxy."""
+    return False
     bop_resp = verify_principal_with_proxy(username, request, verify_principal=True)
 
     if bop_resp.get("data") == []:

--- a/rbac/management/utils.py
+++ b/rbac/management/utils.py
@@ -280,6 +280,14 @@ def get_admin_from_proxy(username, request):
         message = "No data found for principal with username {}.".format(username)
         raise serializers.ValidationError({key: _(message)})
 
-    index = next((i for i, x in enumerate(bop_resp.get("data")) if x["username"] == username), None)
+    index = next(
+        (i for i, x in enumerate(bop_resp.get("data")) if x["username"].casefold() == username.casefold()), None
+    )
+
+    if index is None:
+        key = "detail"
+        message = "No data found for principal with username {}.".format(username)
+        raise serializers.ValidationError({key: _(message)})
+
     is_org_admin = bop_resp.get("data")[index]["is_org_admin"]
     return is_org_admin

--- a/rbac/management/utils.py
+++ b/rbac/management/utils.py
@@ -69,7 +69,6 @@ def get_principal(username, request, verify_principal=True, from_query=False):
     # First check if principal exist on our side,
     # if not call BOP to check if user exist in the account.
     tenant = request.tenant
-
     try:
         # If the username was provided through a query we must verify if it is an org admin from the BOP
         if from_query:

--- a/rbac/management/utils.py
+++ b/rbac/management/utils.py
@@ -91,7 +91,6 @@ def verify_principal_with_proxy(username, request, verify_principal=True):
     account = request.user.account
     org_id = request.user.org_id
     proxy = PrincipalProxy()
-    return None
     if verify_principal:
         if settings.AUTHENTICATE_WITH_ORG_ID:
             resp = proxy.request_filtered_principals([username], org_id=org_id)
@@ -275,7 +274,6 @@ def account_id_for_tenant(tenant):
 
 def get_admin_from_proxy(username, request):
     """Return org_admin status of a username from the proxy."""
-    return False
     bop_resp = verify_principal_with_proxy(username, request, verify_principal=True)
 
     if bop_resp.get("data") == []:

--- a/rbac/rbac/dev_middleware.py
+++ b/rbac/rbac/dev_middleware.py
@@ -39,13 +39,13 @@ class DevelopmentIdentityHeaderMiddleware(MiddlewareMixin):  # pylint: disable=t
         if hasattr(request, "META"):
             identity_header = {
                 "identity": {
-                    "account_number": "10001",
-                    "org_id": "11111",
+                    "account_number": "1214624",
+                    "org_id": "11789772",
                     "type": "User",
                     "user": {
-                        "username": "user_dev",
+                        "username": "kwalsh",
                         "email": "user_dev@foo.com",
-                        "is_org_admin": True,
+                        "is_org_admin": False,
                         "is_internal": True,
                         "user_id": "51736777",
                     },

--- a/tests/internal/test_integration_views.py
+++ b/tests/internal/test_integration_views.py
@@ -90,7 +90,24 @@ class IntegrationViewsTests(IdentityRequest):
         Role.objects.all().delete()
         Policy.objects.all().delete()
 
-    def test_groups_valid_account(self):
+    @patch(
+        "management.principal.proxy.PrincipalProxy.request_filtered_principals",
+        return_value={
+            "status_code": 200,
+            "data": [
+                {
+                    "org_id": "100001",
+                    "is_org_admin": False,
+                    "is_internal": False,
+                    "id": 52567473,
+                    "username": "user_admin",
+                    "account_number": "1111111",
+                    "is_active": True,
+                }
+            ],
+        },
+    )
+    def test_groups_valid_account(self, mock_request):
         """Test that a request to /tenant/<id>/groups/?username= from an internal account works."""
         response = self.client.get(
             f"/_private/api/tenant/{self.tenant.org_id}/groups/?username=user_admin",
@@ -112,7 +129,24 @@ class IntegrationViewsTests(IdentityRequest):
         )
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
-    def test_groups_user_filter(self):
+    @patch(
+        "management.principal.proxy.PrincipalProxy.request_filtered_principals",
+        return_value={
+            "status_code": 200,
+            "data": [
+                {
+                    "org_id": "100001",
+                    "is_org_admin": False,
+                    "is_internal": False,
+                    "id": 52567473,
+                    "username": "user_a",
+                    "account_number": "1111111",
+                    "is_active": True,
+                }
+            ],
+        },
+    )
+    def test_groups_user_filter(self, mock_request):
         """Test that only the groups a user is a member of are returned for a /tenant/<id>/groups/?username= request."""
         response = self.client.get(
             f"/_private/api/tenant/{self.tenant.org_id}/groups/?username=user_a", **self.request.META, follow=True
@@ -158,7 +192,24 @@ class IntegrationViewsTests(IdentityRequest):
         )
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
-    def test_groups_for_principal_filter(self):
+    @patch(
+        "management.principal.proxy.PrincipalProxy.request_filtered_principals",
+        return_value={
+            "status_code": 200,
+            "data": [
+                {
+                    "org_id": "100001",
+                    "is_org_admin": False,
+                    "is_internal": False,
+                    "id": 52567473,
+                    "username": "user_a",
+                    "account_number": "1111111",
+                    "is_active": True,
+                }
+            ],
+        },
+    )
+    def test_groups_for_principal_filter(self, mock_request):
         """Test that only the groups a user is a member of are returned for a /tenant/<id>/groups/?username= request."""
         response = self.client.get(
             f"/_private/api/tenant/{self.tenant.org_id}/groups/?username=user_a", **self.request.META, follow=True

--- a/tests/management/access/test_view.py
+++ b/tests/management/access/test_view.py
@@ -43,9 +43,9 @@ class AccessViewTests(IdentityRequest):
         super().setUp()
         request = self.request_context["request"]
         user = User()
-        user.username = self.user_data["username"]
-        user.account = self.customer_data["account_id"]
-        user.org_id = self.customer_data["org_id"]
+        user.username = "test_user"
+        user.account = "1111111"
+        user.org_id = "100001"
         request.user = user
         public_tenant = Tenant.objects.get(tenant_name="public")
 
@@ -53,7 +53,7 @@ class AccessViewTests(IdentityRequest):
             "permission": "app:*:*",
             "resourceDefinitions": [{"attributeFilter": {"key": "key1", "operation": "equal", "value": "value1"}}],
         }
-        self.principal = Principal(username=self.user_data["username"], tenant=self.tenant)
+        self.principal = Principal(username=user.username, tenant=self.tenant)
         self.principal.save()
         self.admin_principal = Principal(username="user_admin", tenant=self.tenant)
         self.admin_principal.save()
@@ -190,7 +190,24 @@ class AccessViewTests(IdentityRequest):
         permissions = [access["permission"] for access in response.data.get("data")]
         self.assertListEqual(permissions, ["test:assigned:permission1", "test:assigned:permission2"])
 
-    def test_get_access_no_app_supplied(self):
+    @patch(
+        "management.principal.proxy.PrincipalProxy.request_filtered_principals",
+        return_value={
+            "status_code": 200,
+            "data": [
+                {
+                    "org_id": "100001",
+                    "is_org_admin": True,
+                    "is_internal": False,
+                    "id": 52567473,
+                    "username": "test_user",
+                    "account_number": "1111111",
+                    "is_active": True,
+                }
+            ],
+        },
+    )
+    def test_get_access_no_app_supplied(self, mock_request):
         """Test that we return all permissions when no app supplied."""
         role_name = "roleA"
         policy_name = "policyA"
@@ -213,7 +230,24 @@ class AccessViewTests(IdentityRequest):
         self.assertEqual(len(response.data.get("data")), 2)
         self.assertEqual(response.data.get("meta").get("limit"), 2)
 
-    def test_get_access_multiple_apps_supplied(self):
+    @patch(
+        "management.principal.proxy.PrincipalProxy.request_filtered_principals",
+        return_value={
+            "status_code": 200,
+            "data": [
+                {
+                    "org_id": "100001",
+                    "is_org_admin": True,
+                    "is_internal": False,
+                    "id": 52567473,
+                    "username": "test_user",
+                    "account_number": "1111111",
+                    "is_active": True,
+                }
+            ],
+        },
+    )
+    def test_get_access_multiple_apps_supplied(self, mock_request):
         """Test that we return all permissions for multiple apps when supplied."""
         role_name = "roleA"
         policy_name = "policyA"
@@ -227,14 +261,31 @@ class AccessViewTests(IdentityRequest):
         access = Access.objects.create(role=role, permission=self.permission, tenant=self.tenant)
         self.create_policy(policy_name, self.group.uuid, [role_uuid])
 
-        url = "{}?application={}&username={}".format(reverse("access"), "app,app2", self.principal.username)
+        url = "{}?application={}&username={}".format(reverse("access"), "app,app2", "test_user")
         client = APIClient()
         response = client.get(url, **self.headers)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIsInstance(response.data.get("data"), list)
         self.assertEqual(len(response.data.get("data")), 2)
 
-    def test_get_access_no_partial_match(self):
+    @patch(
+        "management.principal.proxy.PrincipalProxy.request_filtered_principals",
+        return_value={
+            "status_code": 200,
+            "data": [
+                {
+                    "org_id": "100001",
+                    "is_org_admin": True,
+                    "is_internal": False,
+                    "id": 52567473,
+                    "username": "test_user",
+                    "account_number": "1111111",
+                    "is_active": True,
+                }
+            ],
+        },
+    )
+    def test_get_access_no_partial_match(self, mock_request):
         """Test that we can have a partial match on app/permission."""
         role_name = "roleA"
         policy_name = "policyA"
@@ -255,7 +306,24 @@ class AccessViewTests(IdentityRequest):
         self.assertEqual(len(response.data.get("data")), 0)
         self.assertEqual(response.data.get("meta").get("limit"), 0)
 
-    def test_get_access_no_subset_match(self):
+    @patch(
+        "management.principal.proxy.PrincipalProxy.request_filtered_principals",
+        return_value={
+            "status_code": 200,
+            "data": [
+                {
+                    "org_id": "100001",
+                    "is_org_admin": True,
+                    "is_internal": False,
+                    "id": 52567473,
+                    "username": "test_user",
+                    "account_number": "1111111",
+                    "is_active": True,
+                }
+            ],
+        },
+    )
+    def test_get_access_no_subset_match(self, mock_request):
         """Test that we cannot have a subset match on app/permission."""
         role_name = "roleA"
         policy_name = "policyA"
@@ -276,7 +344,24 @@ class AccessViewTests(IdentityRequest):
         self.assertEqual(len(response.data.get("data")), 0)
         self.assertEqual(response.data.get("meta").get("limit"), 0)
 
-    def test_get_access_no_match(self):
+    @patch(
+        "management.principal.proxy.PrincipalProxy.request_filtered_principals",
+        return_value={
+            "status_code": 200,
+            "data": [
+                {
+                    "org_id": "100001",
+                    "is_org_admin": True,
+                    "is_internal": False,
+                    "id": 52567473,
+                    "username": "test_user",
+                    "account_number": "1111111",
+                    "is_active": True,
+                }
+            ],
+        },
+    )
+    def test_get_access_no_match(self, mock_request):
         """Test that we only match on the application name of the permission data."""
         role_name = "roleA"
         policy_name = "policyA"

--- a/tests/management/access/test_view.py
+++ b/tests/management/access/test_view.py
@@ -53,6 +53,8 @@ class AccessViewTests(IdentityRequest):
             "permission": "app:*:*",
             "resourceDefinitions": [{"attributeFilter": {"key": "key1", "operation": "equal", "value": "value1"}}],
         }
+
+        # items with test_ prefix have hard coded attributes for new BOP requests
         self.test_tenant = Tenant(tenant_name="acct1111111", account_id="1111111", org_id="100001", ready=True)
         self.test_tenant.save()
         self.test_principal = Principal(username="test_user", tenant=self.test_tenant)
@@ -63,6 +65,12 @@ class AccessViewTests(IdentityRequest):
         self.test_group.save()
         self.test_permission = Permission.objects.create(permission="app:test_*:test_*", tenant=self.test_tenant)
         Permission.objects.create(permission="app:test_foo:test_bar", tenant=self.test_tenant)
+        user_data = {"username": "test_user", "email": "test@gmail.com"}
+        request_context = self._create_request_context(
+            {"account_id": "1111111", "tenant_name": "acct1111111", "org_id": "100001"}, user_data, is_org_admin=True
+        )
+        request = request_context["request"]
+        self.test_headers = request.META
 
         self.principal = Principal(username=user.username, tenant=self.tenant)
         self.principal.save()
@@ -190,10 +198,10 @@ class AccessViewTests(IdentityRequest):
         user_data = {"username": user_name, "email": "test@gmail.com"}
         request_context = self._create_request_context(self.customer_data, user_data, is_org_admin=False)
         request = request_context["request"]
-        headers = request.META
+        self.test_headers = request.META
         Principal.objects.create(username=user_name, cross_account=True, tenant=self.tenant)
 
-        response = client.get(url, **headers)
+        response = client.get(url, **self.test_headers)
 
         # only assigned role permissions without platform default permission
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -220,27 +228,22 @@ class AccessViewTests(IdentityRequest):
     )
     def test_get_access_no_app_supplied(self, mock_request):
         """Test that we return all permissions when no app supplied."""
-        user_data = {"username": "test_user", "email": "test@gmail.com"}
-        request_context = self._create_request_context(
-            {"account_id": "1111111", "tenant_name": "acct1111111", "org_id": "100001"}, user_data, is_org_admin=True
-        )
-        request = request_context["request"]
-        headers = request.META
+
         role_name = "roleA"
         policy_name = "policyA"
         access_data = {
             "permission": "app:test_foo:test_bar",
             "resourceDefinitions": [{"attributeFilter": {"key": "keyA", "operation": "equal", "value": "valueA"}}],
         }
-        response = self.create_role(role_name, headers, access_data)
+        response = self.create_role(role_name, self.test_headers, access_data)
         role_uuid = response.data.get("uuid")
         role = Role.objects.get(uuid=role_uuid)
         access = Access.objects.create(role=role, permission=self.test_permission, tenant=self.test_tenant)
-        self.create_policy(policy_name, self.test_group.uuid, [role_uuid], headers)
+        self.create_policy(policy_name, self.test_group.uuid, [role_uuid], self.test_headers)
 
         url = "{}?application=&username={}".format(reverse("access"), self.test_principal.username)
         client = APIClient()
-        response = client.get(url, **headers)
+        response = client.get(url, **self.test_headers)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIsNotNone(response.data.get("data"))
         self.assertIsInstance(response.data.get("data"), list)
@@ -266,27 +269,22 @@ class AccessViewTests(IdentityRequest):
     )
     def test_get_access_multiple_apps_supplied(self, mock_request):
         """Test that we return all permissions for multiple apps when supplied."""
-        user_data = {"username": "test_user", "email": "test@gmail.com"}
-        request_context = self._create_request_context(
-            {"account_id": "1111111", "tenant_name": "acct1111111", "org_id": "100001"}, user_data, is_org_admin=True
-        )
-        request = request_context["request"]
-        headers = request.META
+
         role_name = "roleA"
         policy_name = "policyA"
         access_data = {
             "permission": "app:test_foo:test_bar",
             "resourceDefinitions": [{"attributeFilter": {"key": "keyA", "operation": "equal", "value": "valueA"}}],
         }
-        response = self.create_role(role_name, headers, access_data)
+        response = self.create_role(role_name, self.test_headers, access_data)
         role_uuid = response.data.get("uuid")
         role = Role.objects.get(uuid=role_uuid)
         access = Access.objects.create(role=role, permission=self.test_permission, tenant=self.test_tenant)
-        self.create_policy(policy_name, self.test_group.uuid, [role_uuid], headers)
+        self.create_policy(policy_name, self.test_group.uuid, [role_uuid], self.test_headers)
 
         url = "{}?application={}&username={}".format(reverse("access"), "app,app2", "test_user")
         client = APIClient()
-        response = client.get(url, **headers)
+        response = client.get(url, **self.test_headers)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIsInstance(response.data.get("data"), list)
         self.assertEqual(len(response.data.get("data")), 2)
@@ -310,27 +308,22 @@ class AccessViewTests(IdentityRequest):
     )
     def test_get_access_no_partial_match(self, mock_request):
         """Test that we can have a partial match on app/permission."""
-        user_data = {"username": "test_user", "email": "test@gmail.com"}
-        request_context = self._create_request_context(
-            {"account_id": "1111111", "tenant_name": "acct1111111", "org_id": "100001"}, user_data, is_org_admin=True
-        )
-        request = request_context["request"]
-        headers = request.META
+
         role_name = "roleA"
         policy_name = "policyA"
         access_data = {
             "permission": "app:test_foo:test_bar",
             "resourceDefinitions": [{"attributeFilter": {"key": "keyA", "operation": "equal", "value": "valueA"}}],
         }
-        response = self.create_role(role_name, headers, access_data)
+        response = self.create_role(role_name, self.test_headers, access_data)
         role_uuid = response.data.get("uuid")
         role = Role.objects.get(uuid=role_uuid)
         access = Access.objects.create(role=role, permission=self.test_permission, tenant=self.test_tenant)
-        self.create_policy(policy_name, self.test_group.uuid, [role_uuid], headers)
+        self.create_policy(policy_name, self.test_group.uuid, [role_uuid], self.test_headers)
 
         url = "{}?application={}&username={}".format(reverse("access"), "ap", self.test_principal.username)
         client = APIClient()
-        response = client.get(url, **headers)
+        response = client.get(url, **self.test_headers)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIsNotNone(response.data.get("data"))
         self.assertIsInstance(response.data.get("data"), list)
@@ -356,32 +349,159 @@ class AccessViewTests(IdentityRequest):
     )
     def test_get_access_no_subset_match(self, mock_request):
         """Test that we cannot have a subset match on app/permission."""
-        user_data = {"username": "test_user", "email": "test@gmail.com"}
-        request_context = self._create_request_context(
-            {"account_id": "1111111", "tenant_name": "acct1111111", "org_id": "100001"}, user_data, is_org_admin=True
-        )
-        request = request_context["request"]
-        headers = request.META
+
         role_name = "roleA"
         policy_name = "policyA"
         access_data = {
             "permission": "app:test_foo:test_bar",
             "resourceDefinitions": [{"attributeFilter": {"key": "keyA", "operation": "equal", "value": "valueA"}}],
         }
-        response = self.create_role(role_name, headers, access_data)
+        response = self.create_role(role_name, self.test_headers, access_data)
         role_uuid = response.data.get("uuid")
         role = Role.objects.get(uuid=role_uuid)
         access = Access.objects.create(role=role, permission=self.test_permission, tenant=self.test_tenant)
-        self.create_policy(policy_name, self.test_group.uuid, [role_uuid], headers)
+        self.create_policy(policy_name, self.test_group.uuid, [role_uuid], self.test_headers)
 
         url = "{}?application={}&username={}".format(reverse("access"), "appfoo", self.test_principal.username)
         client = APIClient()
-        response = client.get(url, **headers)
+        response = client.get(url, **self.test_headers)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIsNotNone(response.data.get("data"))
         self.assertIsInstance(response.data.get("data"), list)
         self.assertEqual(len(response.data.get("data")), 0)
         self.assertEqual(response.data.get("meta").get("limit"), 0)
+
+    @patch("management.cache.AccessCache.save_policy", return_value=None)
+    @patch("management.cache.AccessCache.get_policy", return_value=None)
+    @patch(
+        "management.principal.proxy.PrincipalProxy.request_filtered_principals",
+        return_value={
+            "status_code": 200,
+            "data": [
+                {
+                    "org_id": "100001",
+                    "is_org_admin": True,
+                    "is_internal": False,
+                    "id": 52567473,
+                    "username": "test_user",
+                    "account_number": "1111111",
+                    "is_active": True,
+                }
+            ],
+        },
+    )
+    def test_get_access_with_ordering_and_cache(self, mock_request, get_policy, save_policy):
+        """Test that we can obtain the expected access with ordering and cache."""
+
+        role_name = "roleA"
+        response = self.create_role(role_name, self.test_headers)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        role_uuid = response.data.get("uuid")
+        test_role = self.create_role_and_permission("Test Role one", "test:assigned:permission1")
+        policy_name = "policyA"
+        response = self.create_policy(
+            policy_name, self.test_group.uuid, [role_uuid, test_role.uuid], self.test_headers
+        )
+
+        tenant_name = self.test_tenant.tenant_name
+        principal_id = self.test_principal.uuid
+        principal_username = self.test_principal.username
+        key = f"rbac::policy::tenant={tenant_name}::user={principal_id}"
+        client = APIClient()
+
+        #### Sort by application ####
+        url = "{}?application=&username={}&order_by={}".format(
+            reverse("access"), self.test_principal.username, "application"
+        )
+        response = client.get(url, **self.test_headers)
+
+        # Cache is called saved with sub_key ""
+        get_policy.assert_called_with(principal_id, "&order:application")
+        called_with_para = save_policy.mock_calls[0][1]
+        self.assertEqual(principal_id, called_with_para[0])
+        self.assertEqual("&order:application", called_with_para[1])
+        self.assertEqual(2, len(called_with_para[2]))  # it catches all the policies
+        self.assertEqual(response.data["meta"]["count"], 2)
+        self.assertEqual(response.data["data"][0]["permission"], "app:*:*")  # check order
+
+        url = "{}?application=&username={}&order_by={}".format(
+            reverse("access"), self.test_principal.username, "-application"
+        )
+        response = client.get(url, **self.test_headers)
+        get_policy.assert_called_with(principal_id, "&order:-application")
+        called_with_para = save_policy.mock_calls[1][1]
+        self.assertEqual(principal_id, called_with_para[0])
+        self.assertEqual("&order:-application", called_with_para[1])
+        self.assertEqual(2, len(called_with_para[2]))  # it catches all the policies
+        self.assertEqual(response.data["meta"]["count"], 2)
+        # Response data is in reverse order
+        self.assertEqual(response.data["data"][0]["permission"], "test:assigned:permission1")  # check order
+
+        #### Sort by resource_type ####
+        url = "{}?application=&username={}&order_by={}".format(
+            reverse("access"), self.test_principal.username, "resource_type"
+        )
+        response = client.get(url, **self.test_headers)
+
+        # Cache is called saved with sub_key ""
+        get_policy.assert_called_with(principal_id, "&order:resource_type")
+        called_with_para = save_policy.mock_calls[2][1]
+        self.assertEqual(principal_id, called_with_para[0])
+        self.assertEqual("&order:resource_type", called_with_para[1])
+        self.assertEqual(2, len(called_with_para[2]))  # it catches all the policies
+        self.assertEqual(response.data["meta"]["count"], 2)
+        self.assertEqual(response.data["data"][0]["permission"], "app:*:*")  # check order
+
+        url = "{}?application=&username={}&order_by={}".format(
+            reverse("access"), self.test_principal.username, "-resource_type"
+        )
+        response = client.get(url, **self.test_headers)
+        get_policy.assert_called_with(principal_id, "&order:-resource_type")
+        called_with_para = save_policy.mock_calls[3][1]
+        self.assertEqual(principal_id, called_with_para[0])
+        self.assertEqual("&order:-resource_type", called_with_para[1])
+        self.assertEqual(2, len(called_with_para[2]))  # it catches all the policies
+        self.assertEqual(response.data["meta"]["count"], 2)
+        # Response data is in reverse order
+        self.assertEqual(response.data["data"][0]["permission"], "test:assigned:permission1")  # check order
+
+        #### Sort by verb ####
+        url = "{}?application=&username={}&order_by={}".format(reverse("access"), self.test_principal.username, "verb")
+        response = client.get(url, **self.test_headers)
+
+        # Cache is called saved with sub_key ""
+        get_policy.assert_called_with(principal_id, "&order:verb")
+        called_with_para = save_policy.mock_calls[4][1]
+        self.assertEqual(principal_id, called_with_para[0])
+        self.assertEqual("&order:verb", called_with_para[1])
+        self.assertEqual(2, len(called_with_para[2]))  # it catches all the policies
+        self.assertEqual(response.data["meta"]["count"], 2)
+        self.assertEqual(response.data["data"][0]["permission"], "app:*:*")  # check order
+
+        url = "{}?application=&username={}&order_by={}".format(
+            reverse("access"), self.test_principal.username, "-verb"
+        )
+        response = client.get(url, **self.test_headers)
+        # Cache is called saved with sub_key ""
+        get_policy.assert_called_with(principal_id, "&order:-verb")
+        called_with_para = save_policy.mock_calls[5][1]
+        self.assertEqual(principal_id, called_with_para[0])
+        self.assertEqual("&order:-verb", called_with_para[1])
+        self.assertEqual(2, len(called_with_para[2]))  # it catches all the policies
+        self.assertEqual(response.data["meta"]["count"], 2)
+        # Response data is in reverse order
+        self.assertEqual(response.data["data"][0]["permission"], "test:assigned:permission1")  # check order
+
+        #### Sort by nothing still works ####
+        url = "{}?application=&username={}&order_by=".format(reverse("access"), self.test_principal.username)
+        response = client.get(url, **self.test_headers)
+        # Cache is called saved with sub_key ""
+        get_policy.assert_called_with(principal_id, "")
+        called_with_para = save_policy.mock_calls[6][1]
+        self.assertEqual(principal_id, called_with_para[0])
+        self.assertEqual("", called_with_para[1])
+        self.assertEqual(2, len(called_with_para[2]))  # it catches all the policies
+        self.assertEqual(response.data["meta"]["count"], 2)
 
     @patch(
         "management.principal.proxy.PrincipalProxy.request_filtered_principals",
@@ -402,27 +522,22 @@ class AccessViewTests(IdentityRequest):
     )
     def test_get_access_no_match(self, mock_request):
         """Test that we only match on the application name of the permission data."""
-        user_data = {"username": "test_user", "email": "test@gmail.com"}
-        request_context = self._create_request_context(
-            {"account_id": "1111111", "tenant_name": "acct1111111", "org_id": "100001"}, user_data, is_org_admin=True
-        )
-        request = request_context["request"]
-        headers = request.META
+
         role_name = "roleA"
         policy_name = "policyA"
         access_data = {
             "permission": "app:test_foo:test_bar",
             "resourceDefinitions": [{"attributeFilter": {"key": "keyA", "operation": "equal", "value": "valueA"}}],
         }
-        response = self.create_role(role_name, headers, access_data)
+        response = self.create_role(role_name, self.test_headers, access_data)
         role_uuid = response.data.get("uuid")
         role = Role.objects.get(uuid=role_uuid)
         access = Access.objects.create(role=role, permission=self.test_permission, tenant=self.test_tenant)
-        self.create_policy(policy_name, self.test_group.uuid, [role_uuid], headers)
+        self.create_policy(policy_name, self.test_group.uuid, [role_uuid], self.test_headers)
 
         url = "{}?application={}&username={}".format(reverse("access"), "test_foo", self.test_principal.username)
         client = APIClient()
-        response = client.get(url, **headers)
+        response = client.get(url, **self.test_headers)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIsNotNone(response.data.get("data"))
         self.assertIsInstance(response.data.get("data"), list)
@@ -448,23 +563,18 @@ class AccessViewTests(IdentityRequest):
     )
     def test_get_access_with_limit(self, mock_request):
         """Test that we can obtain the expected access with pagination."""
-        user_data = {"username": "test_user", "email": "test@gmail.com"}
-        request_context = self._create_request_context(
-            {"account_id": "1111111", "tenant_name": "acct1111111", "org_id": "100001"}, user_data, is_org_admin=True
-        )
-        request = request_context["request"]
-        headers = request.META
+
         role_name = "roleA"
-        response = self.create_role(role_name, headers)
+        response = self.create_role(role_name, self.test_headers)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         role_uuid = response.data.get("uuid")
         policy_name = "policyA"
-        response = self.create_policy(policy_name, self.test_group.uuid, [role_uuid], headers)
+        response = self.create_policy(policy_name, self.test_group.uuid, [role_uuid], self.test_headers)
 
         # test that we can retrieve the principal access
         url = "{}?application={}&username={}&limit=1".format(reverse("access"), "app", self.test_principal.username)
         client = APIClient()
-        response = client.get(url, **headers)
+        response = client.get(url, **self.test_headers)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIsNotNone(response.data.get("data"))
         self.assertIsInstance(response.data.get("data"), list)
@@ -493,53 +603,6 @@ class AccessViewTests(IdentityRequest):
 
     @patch("management.cache.AccessCache.get_policy", return_value=None)
     @patch("management.cache.AccessCache.save_policy", return_value=None)
-    def test_get_access_with_pagination_and_cache(self, save_policy, get_policy):
-        """Test that we can obtain the expected access with pagination and cache."""
-        role_name = "roleA"
-        response = self.create_role(role_name, self.headers)
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        role_uuid = response.data.get("uuid")
-        test_role = self.create_role_and_permission("Test Role one", "test:assigned:permission1")
-        policy_name = "policyA"
-        response = self.create_policy(policy_name, self.group.uuid, [role_uuid, test_role.uuid], self.headers)
-
-        tenant_name = self.tenant.tenant_name
-        principal_id = self.principal.uuid
-        key = f"rbac::policy::tenant={tenant_name}::user={principal_id}"
-        client = APIClient()
-
-        ######## access_policy are cached with desired sub_key ############
-        url = "{}?application={}&username={}&offset=1&limit=1".format(
-            reverse("access"), "app", self.principal.username
-        )
-        response = client.get(url, **self.headers)
-
-        get_policy.assert_called_with(principal_id, "app")
-        called_with_para = save_policy.mock_calls[0][1]  # save_policy params
-        self.assertEqual(principal_id, called_with_para[0])
-        self.assertEqual("app", called_with_para[1])
-        self.assertEqual([self.access_data], called_with_para[2])  # it catches all the policies for app
-        self.assertEqual(response.data["meta"]["count"], 1)
-        self.assertEqual(
-            response.data["data"], []
-        )  # after pagination, it is empty becase totoal is one, and offset is one
-        ###################################################################
-
-        #### access_policy are cached properly when application is empty ####
-        url = "{}?application=&username={}&limit=1".format(reverse("access"), self.principal.username)
-        response = client.get(url, **self.headers)
-
-        # Cache is called saved with sub_key ""
-        get_policy.assert_called_with(principal_id, "")
-        called_with_para = save_policy.mock_calls[1][1]
-        self.assertEqual(principal_id, called_with_para[0])
-        self.assertEqual("", called_with_para[1])
-        self.assertEqual(2, len(called_with_para[2]))  # it catches all the policies for app
-        self.assertEqual(response.data["meta"]["count"], 2)
-        self.assertEqual(len(response.data["data"]), 1)  # returns one policy because limit is 1
-
-    @patch("management.cache.AccessCache.get_policy", return_value=None)
-    @patch("management.cache.AccessCache.save_policy", return_value=None)
     @patch(
         "management.principal.proxy.PrincipalProxy.request_filtered_principals",
         return_value={
@@ -557,147 +620,61 @@ class AccessViewTests(IdentityRequest):
             ],
         },
     )
-    def test_get_access_with_ordering_and_cache(self, save_policy, get_policy, mock_request):
-        """Test that we can obtain the expected access with ordering and cache."""
-        user_data = {"username": "test_user", "email": "test@gmail.com"}
-        request_context = self._create_request_context(
-            {"account_id": "1111111", "tenant_name": "acct1111111", "org_id": "100001"}, user_data, is_org_admin=True
-        )
-        request = request_context["request"]
-        headers = request.META
+    def test_get_access_with_pagination_and_cache(self, mock_request, save_policy, get_policy):
+        """Test that we can obtain the expected access with pagination and cache."""
+
         role_name = "roleA"
-        response = self.create_role(role_name, headers)
+        response = self.create_role(role_name, self.test_headers)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         role_uuid = response.data.get("uuid")
         test_role = self.create_role_and_permission("Test Role one", "test:assigned:permission1")
         policy_name = "policyA"
-        response = self.create_policy(policy_name, self.test_group.uuid, [role_uuid, test_role.uuid], headers)
+        response = self.create_policy(
+            policy_name, self.test_group.uuid, [role_uuid, test_role.uuid], self.test_headers
+        )
 
         tenant_name = self.test_tenant.tenant_name
         principal_id = self.test_principal.uuid
-        principal_username = self.test_principal.username
         key = f"rbac::policy::tenant={tenant_name}::user={principal_id}"
         client = APIClient()
 
-        #### Sort by application ####
-        url = "{}?application=&username={}&order_by={}".format(
-            reverse("access"), self.test_principal.username, "application"
+        ######## access_policy are cached with desired sub_key ############
+        url = "{}?application={}&username={}&offset=1&limit=1".format(
+            reverse("access"), "app", self.test_principal.username
         )
-        response = client.get(url, **headers)
+        response = client.get(url, **self.test_headers)
 
-        # Cache is called saved with sub_key ""
-        get_policy.assert_called_with(
-            principal_id,
-            "&order:application",
-            [
-                OrderedDict(
-                    [
-                        (
-                            "resourceDefinitions",
-                            [
-                                OrderedDict(
-                                    [("attributeFilter", {"key": "key1", "value": "value1", "operation": "equal"})]
-                                )
-                            ],
-                        ),
-                        ("permission", "app:*:*"),
-                    ]
-                ),
-                OrderedDict([("resourceDefinitions", []), ("permission", "test:assigned:permission1")]),
-            ],
-        )
-        called_with_para = save_policy.mock_calls[0][1]
-        self.assertEqual([principal_username], called_with_para[0])
-        self.assertEqual("&order:application", called_with_para[1])
-        self.assertEqual(2, len(called_with_para[2]))  # it catches all the policies
-        self.assertEqual(response.data["meta"]["count"], 2)
-        self.assertEqual(response.data["data"][0]["permission"], "app:*:*")  # check order
+        get_policy.assert_called_with(principal_id, "app")
+        called_with_para = save_policy.mock_calls[0][1]  # save_policy params
+        self.assertEqual(principal_id, called_with_para[0])
+        self.assertEqual("app", called_with_para[1])
+        self.assertEqual([self.access_data], called_with_para[2])  # it catches all the policies for app
+        self.assertEqual(response.data["meta"]["count"], 1)
+        self.assertEqual(
+            response.data["data"], []
+        )  # after pagination, it is empty becase totoal is one, and offset is one
+        ###################################################################
 
-        url = "{}?application=&username={}&order_by={}".format(
-            reverse("access"), self.test_principal.username, "-application"
-        )
-        response = client.get(url, headers)
-        get_policy.assert_called_with(principal_id, "&order:-application")
-        called_with_para = save_policy.mock_calls[1][1]
-        self.assertEqual(principal_username, called_with_para[0])
-        self.assertEqual("&order:-application", called_with_para[1])
-        self.assertEqual(2, len(called_with_para[2]))  # it catches all the policies
-        self.assertEqual(response.data["meta"]["count"], 2)
-        # Response data is in reverse order
-        self.assertEqual(response.data["data"][0]["permission"], "test:assigned:permission1")  # check order
+        #### access_policy are cached properly when application is empty ####
+        url = "{}?application=&username={}&limit=1".format(reverse("access"), self.test_principal.username)
+        response = client.get(url, **self.test_headers)
 
-        #### Sort by resource_type ####
-        url = "{}?application=&username={}&order_by={}".format(
-            reverse("access"), self.test_principal.username, "resource_type"
-        )
-        response = client.get(url, **headers)
-
-        # Cache is called saved with sub_key ""
-        get_policy.assert_called_with(principal_id, "&order:resource_type")
-        called_with_para = save_policy.mock_calls[2][1]
-        self.assertEqual(principal_username, called_with_para[0])
-        self.assertEqual("&order:resource_type", called_with_para[1])
-        self.assertEqual(2, len(called_with_para[2]))  # it catches all the policies
-        self.assertEqual(response.data["meta"]["count"], 2)
-        self.assertEqual(response.data["data"][0]["permission"], "app:*:*")  # check order
-
-        url = "{}?application=&username={}&order_by={}".format(
-            reverse("access"), self.test_principal.username, "-resource_type"
-        )
-        response = client.get(url, **headers)
-        get_policy.assert_called_with(principal_id, "&order:-resource_type")
-        called_with_para = save_policy.mock_calls[3][1]
-        self.assertEqual(principal_username, called_with_para[0])
-        self.assertEqual("&order:-resource_type", called_with_para[1])
-        self.assertEqual(2, len(called_with_para[2]))  # it catches all the policies
-        self.assertEqual(response.data["meta"]["count"], 2)
-        # Response data is in reverse order
-        self.assertEqual(response.data["data"][0]["permission"], "test:assigned:permission1")  # check order
-
-        #### Sort by verb ####
-        url = "{}?application=&username={}&order_by={}".format(reverse("access"), self.test_principal.username, "verb")
-        response = client.get(url, **headers)
-
-        # Cache is called saved with sub_key ""
-        get_policy.assert_called_with(principal_id, "&order:verb")
-        called_with_para = save_policy.mock_calls[4][1]
-        self.assertEqual(principal_username, called_with_para[0])
-        self.assertEqual("&order:verb", called_with_para[1])
-        self.assertEqual(2, len(called_with_para[2]))  # it catches all the policies
-        self.assertEqual(response.data["meta"]["count"], 2)
-        self.assertEqual(response.data["data"][0]["permission"], "app:*:*")  # check order
-
-        url = "{}?application=&username={}&order_by={}".format(
-            reverse("access"), self.test_principal.username, "-verb"
-        )
-        response = client.get(url, **headers)
-        # Cache is called saved with sub_key ""
-        get_policy.assert_called_with(principal_id, "&order:-verb")
-        called_with_para = save_policy.mock_calls[5][1]
-        self.assertEqual(principal_username, called_with_para[0])
-        self.assertEqual("&order:-verb", called_with_para[1])
-        self.assertEqual(2, len(called_with_para[2]))  # it catches all the policies
-        self.assertEqual(response.data["meta"]["count"], 2)
-        # Response data is in reverse order
-        self.assertEqual(response.data["data"][0]["permission"], "test:assigned:permission1")  # check order
-
-        #### Sort by nothing still works ####
-        url = "{}?application=&username={}&order_by=".format(reverse("access"), self.test_principal.username)
-        response = client.get(url, **headers)
         # Cache is called saved with sub_key ""
         get_policy.assert_called_with(principal_id, "")
-        called_with_para = save_policy.mock_calls[6][1]
-        self.assertEqual(principal_username, called_with_para[0])
+        called_with_para = save_policy.mock_calls[1][1]
+        self.assertEqual(principal_id, called_with_para[0])
         self.assertEqual("", called_with_para[1])
-        self.assertEqual(2, len(called_with_para[2]))  # it catches all the policies
+        self.assertEqual(2, len(called_with_para[2]))  # it catches all the policies for app
         self.assertEqual(response.data["meta"]["count"], 2)
+        self.assertEqual(len(response.data["data"]), 1)  # returns one policy because limit is 1
 
     def test_get_access_with_invalid_ordering_value(self):
         """Test that get access with invalid ordering value raises 401."""
+
         client = APIClient()
         url = "{}?application={}&username={}&order_by={}".format(
-            reverse("access"), "app", self.principal.username, "invalid_value"
+            reverse("access"), "app", self.test_principal.username, "invalid_value"
         )
-        response = client.get(url, **self.headers)
+        response = client.get(url, **self.test_headers)
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)

--- a/tests/management/test_querysets.py
+++ b/tests/management/test_querysets.py
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 """Test the Management queryset helpers."""
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 from django.core.exceptions import PermissionDenied
 from django.db import connection
@@ -48,9 +48,9 @@ class QuerySetTest(TestCase):
     @classmethod
     def setUpClass(cls):
         try:
-            cls.tenant = Tenant.objects.get(tenant_name="test")
+            cls.tenant = Tenant.objects.get(tenant_name="acct1111111")
         except:
-            cls.tenant = Tenant(tenant_name="test", account_id="11111", org_id="22222")
+            cls.tenant = Tenant(tenant_name="acct1111111", account_id="1111111", org_id="100001", ready=True)
             cls.tenant.save()
 
     @classmethod
@@ -89,7 +89,24 @@ class QuerySetTest(TestCase):
         queryset = get_group_queryset(req)
         self.assertEquals(queryset.count(), 5)
 
-    def test_get_user_group_queryset_admin(self):
+    @patch(
+        "management.principal.proxy.PrincipalProxy.request_filtered_principals",
+        return_value={
+            "status_code": 200,
+            "data": [
+                {
+                    "org_id": "100001",
+                    "is_org_admin": True,
+                    "is_internal": False,
+                    "id": 52567473,
+                    "username": "test_user",
+                    "account_number": "1111111",
+                    "is_active": True,
+                }
+            ],
+        },
+    )
+    def test_get_user_group_queryset_admin(self, mock_request):
         """Test get_group_queryset as an admin."""
         self._create_groups()
         principal = Principal.objects.create(username="test_user", tenant=self.tenant)
@@ -100,7 +117,24 @@ class QuerySetTest(TestCase):
         queryset = get_group_queryset(req)
         self.assertEquals(queryset.count(), 1)
 
-    def test_get_group_queryset_get_users_own_groups(self):
+    @patch(
+        "management.principal.proxy.PrincipalProxy.request_filtered_principals",
+        return_value={
+            "status_code": 200,
+            "data": [
+                {
+                    "org_id": "100001",
+                    "is_org_admin": True,
+                    "is_internal": False,
+                    "id": 52567473,
+                    "username": "test_user",
+                    "account_number": "1111111",
+                    "is_active": True,
+                }
+            ],
+        },
+    )
+    def test_get_group_queryset_get_users_own_groups(self, mock_request):
         """Test get_group_queryset to get a users own groups."""
         self._create_groups()
         principal = Principal.objects.create(username="test_user", tenant=self.tenant)
@@ -117,7 +151,24 @@ class QuerySetTest(TestCase):
         queryset = get_group_queryset(req)
         self.assertEquals(queryset.count(), 1)
 
-    def test_get_group_queryset_get_users_other_users_groups(self):
+    @patch(
+        "management.principal.proxy.PrincipalProxy.request_filtered_principals",
+        return_value={
+            "status_code": 200,
+            "data": [
+                {
+                    "org_id": "100001",
+                    "is_org_admin": True,
+                    "is_internal": False,
+                    "id": 52567473,
+                    "username": "test_user2",
+                    "account_number": "1111111",
+                    "is_active": True,
+                }
+            ],
+        },
+    )
+    def test_get_group_queryset_get_users_other_users_groups(self, mock_request):
         """Test get_group_queryset to get a users other users groups."""
         self._create_groups()
         principal = Principal.objects.create(username="test_user", tenant=self.tenant)
@@ -129,7 +180,24 @@ class QuerySetTest(TestCase):
         queryset = get_group_queryset(req)
         self.assertEquals(queryset.count(), 0)
 
-    def test_get_user_group_queryset_admin_default_org_admin(self):
+    @patch(
+        "management.principal.proxy.PrincipalProxy.request_filtered_principals",
+        return_value={
+            "status_code": 200,
+            "data": [
+                {
+                    "org_id": "100001",
+                    "is_org_admin": True,
+                    "is_internal": False,
+                    "id": 52567473,
+                    "username": "test_user",
+                    "account_number": "1111111",
+                    "is_active": True,
+                }
+            ],
+        },
+    )
+    def test_get_user_group_queryset_admin_default_org_admin(self, mock_request):
         """Test get_group_queryset as an org admin searching for admin default groups."""
         principal = Principal.objects.create(username="test_user", tenant=self.tenant)
         group = Group.objects.create(name="group_admin_default", tenant=self.tenant, admin_default=True)
@@ -139,7 +207,24 @@ class QuerySetTest(TestCase):
         queryset = get_group_queryset(req)
         self.assertEquals(queryset.count(), 1)
 
-    def test_get_user_group_queryset_admin_default_non_org_admin(self):
+    @patch(
+        "management.principal.proxy.PrincipalProxy.request_filtered_principals",
+        return_value={
+            "status_code": 200,
+            "data": [
+                {
+                    "org_id": "100001",
+                    "is_org_admin": False,
+                    "is_internal": False,
+                    "id": 52567473,
+                    "username": "test_user",
+                    "account_number": "1111111",
+                    "is_active": True,
+                }
+            ],
+        },
+    )
+    def test_get_user_group_queryset_admin_default_non_org_admin(self, mock_request):
         """Test get_group_queryset not as an org admin, searching for admin default groups."""
         principal = Principal.objects.create(username="test_user", tenant=self.tenant)
         group = Group.objects.create(name="group_admin_default", tenant=self.tenant, admin_default=True)
@@ -148,7 +233,24 @@ class QuerySetTest(TestCase):
         queryset = get_group_queryset(req)
         self.assertEquals(queryset.count(), 0)
 
-    def test_get_user_group_queryset_admin_and_platform_default(self):
+    @patch(
+        "management.principal.proxy.PrincipalProxy.request_filtered_principals",
+        return_value={
+            "status_code": 200,
+            "data": [
+                {
+                    "org_id": "100001",
+                    "is_org_admin": True,
+                    "is_internal": False,
+                    "id": 52567473,
+                    "username": "test_user",
+                    "account_number": "1111111",
+                    "is_active": True,
+                }
+            ],
+        },
+    )
+    def test_get_user_group_queryset_admin_and_platform_default(self, mock_request):
         """Test get_group_queryset not as an org admin, searching for groups that are admin and platform default."""
         principal = Principal.objects.create(username="test_user", tenant=self.tenant)
         group = Group.objects.create(
@@ -159,7 +261,24 @@ class QuerySetTest(TestCase):
         queryset = get_group_queryset(req)
         self.assertEquals(queryset.count(), 1)
 
-    def test_get_user_group_queryset_admin_default_rbac_admin(self):
+    @patch(
+        "management.principal.proxy.PrincipalProxy.request_filtered_principals",
+        return_value={
+            "status_code": 200,
+            "data": [
+                {
+                    "org_id": "100001",
+                    "is_org_admin": False,
+                    "is_internal": False,
+                    "id": 52567473,
+                    "username": "test_user",
+                    "account_number": "1111111",
+                    "is_active": True,
+                }
+            ],
+        },
+    )
+    def test_get_user_group_queryset_admin_default_rbac_admin(self, mock_request):
         """Test get_group_queryset not as an org admin, but as an RBAC admin searching for admin default groups."""
         principal = Principal.objects.create(username="test_user", tenant=self.tenant)
         group = Group.objects.create(name="group_admin_default", tenant=self.tenant, admin_default=True)
@@ -180,7 +299,24 @@ class QuerySetTest(TestCase):
         self.assertEquals(queryset.count(), 5)
         self.assertIsNotNone(queryset.last().accessCount)
 
-    def test_get_role_queryset_non_admin_username(self):
+    @patch(
+        "management.principal.proxy.PrincipalProxy.request_filtered_principals",
+        return_value={
+            "status_code": 200,
+            "data": [
+                {
+                    "org_id": "100001",
+                    "is_org_admin": True,
+                    "is_internal": False,
+                    "id": 52567473,
+                    "username": "test_user2",
+                    "account_number": "1111111",
+                    "is_active": True,
+                }
+            ],
+        },
+    )
+    def test_get_role_queryset_non_admin_username(self, mock_request):
         """Test get_role_queryset as a non-admin supplying a username."""
         roles = self._setup_roles_for_role_username_queryset_tests()
 
@@ -189,7 +325,24 @@ class QuerySetTest(TestCase):
         with self.assertRaises(PermissionDenied):
             get_role_queryset(req)
 
-    def test_get_role_queryset_non_admin_username_with_perms_diff_user(self):
+    @patch(
+        "management.principal.proxy.PrincipalProxy.request_filtered_principals",
+        return_value={
+            "status_code": 200,
+            "data": [
+                {
+                    "org_id": "100001",
+                    "is_org_admin": True,
+                    "is_internal": False,
+                    "id": 52567473,
+                    "username": "test_user2",
+                    "account_number": "1111111",
+                    "is_active": True,
+                }
+            ],
+        },
+    )
+    def test_get_role_queryset_non_admin_username_with_perms_diff_user(self, mock_request):
         """Test get_role_queryset as a non-admin supplying a username."""
         roles = self._setup_roles_for_role_username_queryset_tests()
 
@@ -202,7 +355,24 @@ class QuerySetTest(TestCase):
         req = Mock(user=user, method="GET", query_params={"username": "test_user2"}, tenant=self.tenant)
         get_role_queryset(req)
 
-    def test_get_role_queryset_non_admin_username_with_perms(self):
+    @patch(
+        "management.principal.proxy.PrincipalProxy.request_filtered_principals",
+        return_value={
+            "status_code": 200,
+            "data": [
+                {
+                    "org_id": "100001",
+                    "is_org_admin": True,
+                    "is_internal": False,
+                    "id": 52567473,
+                    "username": "test_user2",
+                    "account_number": "1111111",
+                    "is_active": True,
+                }
+            ],
+        },
+    )
+    def test_get_role_queryset_non_admin_username_with_perms(self, mock_request):
         """Test get_role_queryset as a non-admin supplying a username."""
         roles = self._setup_roles_for_role_username_queryset_tests()
 
@@ -225,7 +395,24 @@ class QuerySetTest(TestCase):
         self.assertEquals(list(queryset), [])
         self.assertEquals(queryset.count(), 0)
 
-    def test_get_role_queryset_admin_username(self):
+    @patch(
+        "management.principal.proxy.PrincipalProxy.request_filtered_principals",
+        return_value={
+            "status_code": 200,
+            "data": [
+                {
+                    "org_id": "100001",
+                    "is_org_admin": True,
+                    "is_internal": False,
+                    "id": 52567473,
+                    "username": "test_user2",
+                    "account_number": "1111111",
+                    "is_active": True,
+                }
+            ],
+        },
+    )
+    def test_get_role_queryset_admin_username(self, mock_request):
         """Test get_role_queryset as an admin supplying a username."""
         roles = self._setup_roles_for_role_username_queryset_tests()
 
@@ -238,7 +425,24 @@ class QuerySetTest(TestCase):
         self.assertTrue(hasattr(role, "accessCount"))
         self.assertTrue(hasattr(role, "policyCount"))
 
-    def test_get_role_queryset_principal_scope(self):
+    @patch(
+        "management.principal.proxy.PrincipalProxy.request_filtered_principals",
+        return_value={
+            "status_code": 200,
+            "data": [
+                {
+                    "org_id": "100001",
+                    "is_org_admin": True,
+                    "is_internal": False,
+                    "id": 52567473,
+                    "username": "test_user2",
+                    "account_number": "1111111",
+                    "is_active": True,
+                }
+            ],
+        },
+    )
+    def test_get_role_queryset_principal_scope(self, mock_request):
         """Test get_role_queryset with principal scope."""
         roles = self._setup_roles_for_role_username_queryset_tests()
 
@@ -256,7 +460,24 @@ class QuerySetTest(TestCase):
         self.assertTrue(hasattr(role, "accessCount"))
         self.assertTrue(hasattr(role, "policyCount"))
 
-    def test_get_role_queryset_admin_username_different(self):
+    @patch(
+        "management.principal.proxy.PrincipalProxy.request_filtered_principals",
+        return_value={
+            "status_code": 200,
+            "data": [
+                {
+                    "org_id": "100001",
+                    "is_org_admin": True,
+                    "is_internal": False,
+                    "id": 52567473,
+                    "username": "test_user2",
+                    "account_number": "1111111",
+                    "is_active": True,
+                }
+            ],
+        },
+    )
+    def test_get_role_queryset_admin_username_different(self, mock_request):
         """Test get_role_queryset as an admin supplying a different username."""
         roles = self._setup_roles_for_role_username_queryset_tests()
         user = Mock(spec=User, admin=True, account="00001", username="admin")
@@ -431,7 +652,24 @@ class QuerySetTest(TestCase):
         queryset = get_access_queryset(req)
         self.assertEquals(queryset.count(), 0)
 
-    def test_get_access_queryset_non_org_admin_rbac_admin(self):
+    @patch(
+        "management.principal.proxy.PrincipalProxy.request_filtered_principals",
+        return_value={
+            "status_code": 200,
+            "data": [
+                {
+                    "org_id": "100001",
+                    "is_org_admin": True,
+                    "is_internal": False,
+                    "id": 52567473,
+                    "username": "test_user",
+                    "account_number": "1111111",
+                    "is_active": True,
+                }
+            ],
+        },
+    )
+    def test_get_access_queryset_non_org_admin_rbac_admin(self, mock_request):
         """Test get_access_queryset with a non 'org admin' but rbac admin user"""
         user_data = {"username": "test_user", "email": "admin@example.com"}
         customer = {"account_id": "10001"}


### PR DESCRIPTION
## Link(s) to Jira
- https://issues.redhat.com/browse/RHCLOUD-19407

## Description of Intent of Change(s)
This will fix a bug where incorrect access/roles/groups were being returned pertaining to admin defaults and org admin status. Examples are in the Jira ticket above. This required calls to BOP to make sure the username we are querying is an org admin itself, and if we should return admin defaults.

## Local Testing
Local testing with endpoints in AC in Jira ticket. To shortcut these scenarios put a return statement at the beginning of function get_admin_from_proxy to represent if the user is org admin or not (`return True` or `return False` respectively). Also add a `return None` statement to the beginning of verify_principal_with_proxy.

Unit tests have been updated to make mock calls to BOP.

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [X] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  -  if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [X] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [X] General Coding Practices
