### PR TITLE
Fix default value on `build_internal_user`

### DIFF
--- a/rbac/internal/utils.py
+++ b/rbac/internal/utils.py
@@ -36,8 +36,6 @@ def build_internal_user(request, json_rh_auth):
         user.username = json_rh_auth["identity"]["associate"]["email"]
         user.admin = True
         user.org_id = resolve(request.path).kwargs.get("org_id")
-        if not user.org_id:
-            user.org_id = json_rh_auth["identity"]["org_id"]
         return user
     except KeyError:
         return None


### PR DESCRIPTION
Since `org_id` doesn't exist on a Turnpike user's identity, we can't default
the value if we aren't able to find it off the request path.

In this case, it means we're accessing an internal endpoint that's not specific
to an org/tenant anyway, so we do not need it on the user.

