### PR TITLE
Update internal integration URLs

### DIFF
--- a/rbac/internal/urls.py
+++ b/rbac/internal/urls.py
@@ -21,26 +21,29 @@ from django.urls import path
 
 from . import integration_views, views
 
-urlpatterns = [
-    path("api/tenant/unmodified/", views.list_unmodified_tenants),
-    path("api/tenant/", views.list_tenants),
-    path("api/tenant/<str:tenant_name>/", views.tenant_view),
-    path("api/tenant/<str:org_id>/groups/", integration_views.groups, name="integration-groups"),
+integration_urlpatterns = [
+    path("api/integrations/tenant/<str:org_id>/groups/", integration_views.groups, name="integration-groups"),
     path(
-        "api/tenant/<str:org_id>/groups/<str:uuid>/roles/",
+        "api/integrations/tenant/<str:org_id>/groups/<str:uuid>/roles/",
         integration_views.roles_for_group,
         name="integration-group-roles",
     ),
     path(
-        "api/tenant/<str:org_id>/principal/<str:principals>/groups/",
+        "api/integrations/tenant/<str:org_id>/principal/<str:principals>/groups/",
         integration_views.groups_for_principal,
         name="integration-princ-groups",
     ),
     path(
-        "api/tenant/<str:org_id>/principal/<str:principals>/groups/<str:uuid>/roles/",
+        "api/integrations/tenant/<str:org_id>/principal/<str:principals>/groups/<str:uuid>/roles/",
         integration_views.roles_for_group_principal,
         name="integration-princ-roles",
     ),
+]
+
+urlpatterns = [
+    path("api/tenant/unmodified/", views.list_unmodified_tenants),
+    path("api/tenant/", views.list_tenants),
+    path("api/tenant/<str:tenant_name>/", views.tenant_view),
     path("api/migrations/run/", views.run_migrations),
     path("api/migrations/progress/", views.migration_progress),
     path("api/seeds/run/", views.run_seeds),
@@ -50,3 +53,5 @@ urlpatterns = [
     path("api/utils/populate_tenant_account_id/", views.populate_tenant_account_id),
     path("api/utils/invalid_default_admin_groups/", views.invalid_default_admin_groups),
 ]
+
+urlpatterns.extend(integration_urlpatterns)

--- a/tests/internal/test_integration_views.py
+++ b/tests/internal/test_integration_views.py
@@ -110,7 +110,7 @@ class IntegrationViewsTests(IdentityRequest):
     def test_groups_valid_account(self, mock_request):
         """Test that a request to /tenant/<id>/groups/?username= from an internal account works."""
         response = self.client.get(
-            f"/_private/api/tenant/{self.tenant.org_id}/groups/?username=user_admin",
+            f"/_private/api/integrations/tenant/{self.tenant.org_id}/groups/?username=user_admin",
             **self.request.META,
             follow=True,
         )
@@ -125,7 +125,9 @@ class IntegrationViewsTests(IdentityRequest):
         )
         request = external_request_context["request"]
         response = self.client.get(
-            f"/_private/api/tenant/{self.tenant.org_id}/groups/?username=user_a", **request.META, follow=True
+            f"/_private/api/integrations/tenant/{self.tenant.org_id}/groups/?username=user_a",
+            **request.META,
+            follow=True,
         )
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
@@ -149,7 +151,9 @@ class IntegrationViewsTests(IdentityRequest):
     def test_groups_user_filter(self, mock_request):
         """Test that only the groups a user is a member of are returned for a /tenant/<id>/groups/?username= request."""
         response = self.client.get(
-            f"/_private/api/tenant/{self.tenant.org_id}/groups/?username=user_a", **self.request.META, follow=True
+            f"/_private/api/integrations/tenant/{self.tenant.org_id}/groups/?username=user_a",
+            **self.request.META,
+            follow=True,
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         # Expecting ["Group All", "Group A"]
@@ -166,14 +170,16 @@ class IntegrationViewsTests(IdentityRequest):
     def test_groups_nonexistent_user(self, mock_request):
         """Test that a request for groups of a nonexistent user returns 0."""
         response = self.client.get(
-            f"/_private/api/tenant/{self.tenant.org_id}/groups/?username=user_x", **self.request.META, follow=True
+            f"/_private/api/integrations/tenant/{self.tenant.org_id}/groups/?username=user_x",
+            **self.request.META,
+            follow=True,
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_groups_for_principal_valid_account(self):
         """Test that a request to /tenant/<id>/principal/<username>/groups/ from an internal account works."""
         response = self.client.get(
-            f"/_private/api/tenant/{self.tenant.org_id}/principal/user_admin/groups/",
+            f"/_private/api/integrations/tenant/{self.tenant.org_id}/principal/user_admin/groups/",
             **self.request.META,
             follow=True,
         )
@@ -188,7 +194,9 @@ class IntegrationViewsTests(IdentityRequest):
         )
         request = external_request_context["request"]
         response = self.client.get(
-            f"/_private/api/tenant/{self.tenant.org_id}/principal/user_a/groups/", **request.META, follow=True
+            f"/_private/api/integrations/tenant/{self.tenant.org_id}/principal/user_a/groups/",
+            **request.META,
+            follow=True,
         )
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
@@ -212,7 +220,9 @@ class IntegrationViewsTests(IdentityRequest):
     def test_groups_for_principal_filter(self, mock_request):
         """Test that only the groups a user is a member of are returned for a /tenant/<id>/groups/?username= request."""
         response = self.client.get(
-            f"/_private/api/tenant/{self.tenant.org_id}/groups/?username=user_a", **self.request.META, follow=True
+            f"/_private/api/integrations/tenant/{self.tenant.org_id}/groups/?username=user_a",
+            **self.request.META,
+            follow=True,
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         # Expecting ["Group All", "Group A"]
@@ -225,7 +235,9 @@ class IntegrationViewsTests(IdentityRequest):
     def test_groups_for_principal_nonexistant_user(self, mock_request):
         """Test that an error is return for nonexistant ."""
         response = self.client.get(
-            f"/_private/api/tenant/{self.tenant.org_id}/groups/?username=user_x", **self.request.META, follow=True
+            f"/_private/api/integrations/tenant/{self.tenant.org_id}/groups/?username=user_x",
+            **self.request.META,
+            follow=True,
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
@@ -233,7 +245,7 @@ class IntegrationViewsTests(IdentityRequest):
         """Test that a valid request to /tenant/<id>/groups/<uuid>/roles/ from an internal account works."""
         group_all_uuid = Group.objects.get(name="Group All").uuid
         response = self.client.get(
-            f"/_private/api/tenant/{self.tenant.org_id}/groups/{group_all_uuid}/roles/",
+            f"/_private/api/integrations/tenant/{self.tenant.org_id}/groups/{group_all_uuid}/roles/",
             **self.request.META,
             follow=True,
         )
@@ -244,7 +256,7 @@ class IntegrationViewsTests(IdentityRequest):
     def test_roles_from_group_invalid_uuid(self):
         """Test that a request to /tenant/<id>/groups/<uuid>/roles/ with an invalid uuid fails."""
         response = self.client.get(
-            f"/_private/api/tenant/{self.tenant.org_id}/groups/{uuid.uuid4}/roles/",
+            f"/_private/api/integrations/tenant/{self.tenant.org_id}/groups/{uuid.uuid4}/roles/",
             **self.request.META,
             follow=True,
         )
@@ -258,7 +270,7 @@ class IntegrationViewsTests(IdentityRequest):
         )
         request = external_request_context["request"]
         response = self.client.get(
-            f"/_private/api/tenant/{self.tenant.org_id}/groups/{group_all_uuid}/roles/",
+            f"/_private/api/integrations/tenant/{self.tenant.org_id}/groups/{group_all_uuid}/roles/",
             **request.META,
             follow=True,
         )
@@ -268,7 +280,7 @@ class IntegrationViewsTests(IdentityRequest):
         """Test that a valid request to /tenant/<id>/groups/<uuid>/roles/ from an internal properly filters groups."""
         group_a_uuid = Group.objects.get(name="Group A").uuid
         response = self.client.get(
-            f"/_private/api/tenant/{self.tenant.org_id}/groups/{group_a_uuid}/roles/",
+            f"/_private/api/integrations/tenant/{self.tenant.org_id}/groups/{group_a_uuid}/roles/",
             **self.request.META,
             follow=True,
         )
@@ -280,7 +292,7 @@ class IntegrationViewsTests(IdentityRequest):
         """Test that a valid request to /tenant/<id>/principal/user_admin/groups/<uuid>/roles/ from an internal account works."""
         group_all_uuid = Group.objects.get(name="Group All").uuid
         response = self.client.get(
-            f"/_private/api/tenant/{self.tenant.org_id}/principal/user_admin/groups/{group_all_uuid}/roles/",
+            f"/_private/api/integrations/tenant/{self.tenant.org_id}/principal/user_admin/groups/{group_all_uuid}/roles/",
             **self.request.META,
             follow=True,
         )
@@ -296,7 +308,7 @@ class IntegrationViewsTests(IdentityRequest):
         )
         request = external_request_context["request"]
         response = self.client.get(
-            f"/_private/api/tenant/{self.tenant.org_id}/principal/user_admin/groups/{group_all_uuid}/roles/",
+            f"/_private/api/integrations/tenant/{self.tenant.org_id}/principal/user_admin/groups/{group_all_uuid}/roles/",
             **request.META,
             follow=True,
         )
@@ -306,7 +318,7 @@ class IntegrationViewsTests(IdentityRequest):
         """Test that a request to /tenant/<id>/principal/user_admin/groups/<uuid>/roles/ with an invalid uuid fails."""
         group_all_uuid = Group.objects.get(name="Group All").uuid
         response = self.client.get(
-            f"/_private/api/tenant/{self.tenant.org_id}/principal/user_admin/groups/{uuid.uuid4}/roles/",
+            f"/_private/api/integrations/tenant/{self.tenant.org_id}/principal/user_admin/groups/{uuid.uuid4}/roles/",
             **self.request.META,
             follow=True,
         )
@@ -317,7 +329,7 @@ class IntegrationViewsTests(IdentityRequest):
         # user_a in Group A
         group_a_uuid = Group.objects.get(name="Group A").uuid
         response = self.client.get(
-            f"/_private/api/tenant/{self.tenant.org_id}/principal/user_a/groups/{group_a_uuid}/roles/",
+            f"/_private/api/integrations/tenant/{self.tenant.org_id}/principal/user_a/groups/{group_a_uuid}/roles/",
             **self.request.META,
             follow=True,
         )
@@ -328,7 +340,7 @@ class IntegrationViewsTests(IdentityRequest):
         # user_b not in Group A
         group_a_uuid = Group.objects.get(name="Group A").uuid
         response = self.client.get(
-            f"/_private/api/tenant/{self.tenant.org_id}/principal/user_b/groups/{group_a_uuid}/roles/",
+            f"/_private/api/integrations/tenant/{self.tenant.org_id}/principal/user_b/groups/{group_a_uuid}/roles/",
             **self.request.META,
             follow=True,
         )


### PR DESCRIPTION
- splits the integration url patterns into their own list, which we extend `urlpatterns`
  with to include them all. this is mostly for organization.

- namespaces the integration urls into `_private/api/integrations/*` so that we
  can lock them down in Turnpike, independent of the other internal urls.
