### PR TITLE
Passing the "org_id" value to request filtered principals

### DIFF
--- a/rbac/management/principal/view.py
+++ b/rbac/management/principal/view.py
@@ -158,6 +158,7 @@ class PrincipalView(APIView):
                 resp = proxy.request_filtered_principals(
                     principals,
                     account=user.account,
+                    org_id=user.org_id,
                     limit=limit,
                     offset=offset,
                     options={"sort_order": options["sort_order"]},

--- a/tests/management/principal/test_view.py
+++ b/tests/management/principal/test_view.py
@@ -217,7 +217,12 @@ class PrincipalViewsetTests(IdentityRequest):
         response = client.get(url, **self.headers)
 
         mock_request.assert_called_once_with(
-            ["test_user", "cross_account_user"], account=ANY, limit=10, offset=30, options={"sort_order": "asc"}
+            ["test_user", "cross_account_user"],
+            account=ANY,
+            org_id=ANY,
+            limit=10,
+            offset=30,
+            options={"sort_order": "asc"},
         )
         # Cross account user won't be returned.
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -244,7 +249,7 @@ class PrincipalViewsetTests(IdentityRequest):
         response = client.get(url, **self.headers)
 
         mock_request.assert_called_once_with(
-            ["test_user75"], account=ANY, limit=10, offset=30, options={"sort_order": "asc"}
+            ["test_user75"], account=ANY, org_id=ANY, limit=10, offset=30, options={"sort_order": "asc"}
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         for keyname in ["meta", "links", "data"]:
@@ -360,7 +365,7 @@ class PrincipalViewsetTests(IdentityRequest):
         response = client.get(url, **self.headers)
 
         mock_request.assert_called_once_with(
-            ["test_user"], account=ANY, limit=10, offset=30, options={"sort_order": "desc"}
+            ["test_user"], account=ANY, org_id=ANY, limit=10, offset=30, options={"sort_order": "desc"}
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         for keyname in ["meta", "links", "data"]:


### PR DESCRIPTION
## Link(s) to Jira
- https://issues.redhat.com/browse/RHCLOUD-18430

## Description of Intent of Change(s)
Update the function `request_filtered_principals` to pass the `org_id` forward and get the correct result when the flag `AUTHENTICATE_WITH_ORG_ID` is `True`

## Local Testing
How can the feature be exercised? 
We have an username called "toto" in another OrgId, and this result couldn't be in the data response when we pass the CURL below with a `x-rh-identity` with the `org_id` param in the header:
curl -v -u iqe_rbac_admin:redhatqa "http://rbac:8080/api/rbac/v1/principals/?usernames=toto" -H "accept: application/json" -H "x-rh-identity: <x-rh-identity_with_org_id>"

How can the bug be exploited and fix confirmed?
Is any special local setup required?

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  -  if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
