### PR TITLE
Add external role info to get views

### DIFF
--- a/docs/source/specs/openapi.json
+++ b/docs/source/specs/openapi.json
@@ -1367,6 +1367,15 @@
             }
           },
           {
+            "name": "role_external_tenant",
+            "in": "query",
+            "required": false,
+            "description": "Parameter for filtering group roles by role `external_tenant` using string search.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
             "$ref": "#/components/parameters/QueryLimit"
           },
           {
@@ -1720,6 +1729,15 @@
             "in": "query",
             "description": "The permission(s) to filter roles by. This is an exact match. You may also use a comma-separated list to match on multiple permissions.",
             "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "external_tenant",
+            "in": "query",
+            "required": false,
+            "description": "Parameter for filtering roles by external tenant name using string search.",
             "schema": {
               "type": "string"
             }

--- a/docs/source/specs/openapi.json
+++ b/docs/source/specs/openapi.json
@@ -3737,6 +3737,14 @@
               "admin_default": {
                 "type": "boolean",
                 "default": false
+              },
+              "external_role_id": {
+                "type": "string",
+                "example": "ExternalRoleId"
+              },
+              "external_tenant_name": {
+                "type": "string",
+                "example": "ExternalTenant"
               }
             }
           }
@@ -3800,6 +3808,14 @@
                 "items": {
                   "$ref": "#/components/schemas/AdditionalGroup"
                 }
+              },
+              "external_role_id": {
+                "type": "string",
+                "example": "ExternalRoleId"
+              },
+              "external_tenant_name": {
+                "type": "string",
+                "example": "ExternalTenant"
               }
             }
           }

--- a/docs/source/specs/openapi.json
+++ b/docs/source/specs/openapi.json
@@ -3760,7 +3760,7 @@
                 "type": "string",
                 "example": "ExternalRoleId"
               },
-              "external_tenant_name": {
+              "external_tenant": {
                 "type": "string",
                 "example": "ExternalTenant"
               }
@@ -3831,7 +3831,7 @@
                 "type": "string",
                 "example": "ExternalRoleId"
               },
-              "external_tenant_name": {
+              "external_tenant": {
                 "type": "string",
                 "example": "ExternalTenant"
               }

--- a/rbac/management/group/view.py
+++ b/rbac/management/group/view.py
@@ -680,7 +680,15 @@ class GroupViewSet(
     def filtered_roles(self, roles, request):
         """Return filtered roles for group from query params."""
         role_filters = self.filters_from_params(VALID_GROUP_ROLE_FILTERS, "role", request)
+        role_filters = self.add_role_external_tenant_filter(role_filters, request)
         return roles.filter(**role_filters)
+
+    def add_role_external_tenant_filter(self, role_filters, request):
+        """Add role external tenant filter if param is on the request."""
+        role_external_tenant = request.query_params.get("role_external_tenant")
+        if role_external_tenant:
+            role_filters["ext_relation__ext_tenant__name__iexact"] = role_external_tenant
+        return role_filters
 
     def filtered_principals(self, group, request):
         """Return filtered principals for group from query params."""

--- a/rbac/management/role/model.py
+++ b/rbac/management/role/model.py
@@ -66,6 +66,14 @@ class Role(TenantAwareModel):
             self.display_name = self.name
         super(Role, self).save(*args, **kwargs)
 
+    def external_role_id(self):
+        """Return external role id."""
+        return self.ext_relation.ext_id if hasattr(self, "ext_relation") else None
+
+    def external_tenant_name(self):
+        """Return external tenant name."""
+        return self.ext_relation.ext_tenant.name if hasattr(self, "ext_relation") else None
+
 
 class Access(TenantAwareModel):
     """An access object."""

--- a/rbac/management/role/serializer.py
+++ b/rbac/management/role/serializer.py
@@ -99,7 +99,7 @@ class RoleSerializer(serializers.ModelSerializer):
     created = serializers.DateTimeField(read_only=True)
     modified = serializers.DateTimeField(read_only=True)
     external_role_id = serializers.SerializerMethodField()
-    external_tenant_name = serializers.SerializerMethodField()
+    external_tenant = serializers.SerializerMethodField()
 
     class Meta:
         """Metadata for the serializer."""
@@ -120,7 +120,7 @@ class RoleSerializer(serializers.ModelSerializer):
             "created",
             "modified",
             "external_role_id",
-            "external_tenant_name",
+            "external_tenant",
         )
 
     def get_applications(self, obj):
@@ -159,7 +159,7 @@ class RoleSerializer(serializers.ModelSerializer):
         """Get the external role id if it's from an external tenant."""
         return obj.external_role_id()
 
-    def get_external_tenant_name(self, obj):
+    def get_external_tenant(self, obj):
         """Get the external tenant name if it's from an external tenant."""
         return obj.external_tenant_name()
 
@@ -180,7 +180,7 @@ class RoleMinimumSerializer(SerializerCreateOverrideMixin, serializers.ModelSeri
     platform_default = serializers.BooleanField(read_only=True)
     admin_default = serializers.BooleanField(read_only=True)
     external_role_id = serializers.SerializerMethodField()
-    external_tenant_name = serializers.SerializerMethodField()
+    external_tenant = serializers.SerializerMethodField()
 
     class Meta:
         """Metadata for the serializer."""
@@ -200,7 +200,7 @@ class RoleMinimumSerializer(SerializerCreateOverrideMixin, serializers.ModelSeri
             "platform_default",
             "admin_default",
             "external_role_id",
-            "external_tenant_name",
+            "external_tenant",
         )
 
     def get_applications(self, obj):
@@ -211,7 +211,7 @@ class RoleMinimumSerializer(SerializerCreateOverrideMixin, serializers.ModelSeri
         """Get the external role id if it's from an external tenant."""
         return obj.external_role_id()
 
-    def get_external_tenant_name(self, obj):
+    def get_external_tenant(self, obj):
         """Get the external tenant name if it's from an external tenant."""
         return obj.external_tenant_name()
 
@@ -252,7 +252,7 @@ class RoleDynamicSerializer(DynamicFieldsModelSerializer):
     platform_default = serializers.BooleanField(read_only=True)
     admin_default = serializers.BooleanField(read_only=True)
     external_role_id = serializers.SerializerMethodField()
-    external_tenant_name = serializers.SerializerMethodField()
+    external_tenant = serializers.SerializerMethodField()
 
     class Meta:
         """Metadata for the serializer."""
@@ -274,7 +274,7 @@ class RoleDynamicSerializer(DynamicFieldsModelSerializer):
             "platform_default",
             "admin_default",
             "external_role_id",
-            "external_tenant_name",
+            "external_tenant",
         )
 
     def get_applications(self, obj):
@@ -295,7 +295,7 @@ class RoleDynamicSerializer(DynamicFieldsModelSerializer):
         """Get the external role id if it's from an external tenant."""
         return obj.external_role_id()
 
-    def get_external_tenant_name(self, obj):
+    def get_external_tenant(self, obj):
         """Get the external tenant name if it's from an external tenant."""
         return obj.external_tenant_name()
 

--- a/rbac/management/role/serializer.py
+++ b/rbac/management/role/serializer.py
@@ -98,6 +98,8 @@ class RoleSerializer(serializers.ModelSerializer):
     admin_default = serializers.BooleanField(read_only=True)
     created = serializers.DateTimeField(read_only=True)
     modified = serializers.DateTimeField(read_only=True)
+    external_role_id = serializers.SerializerMethodField()
+    external_tenant_name = serializers.SerializerMethodField()
 
     class Meta:
         """Metadata for the serializer."""
@@ -117,6 +119,8 @@ class RoleSerializer(serializers.ModelSerializer):
             "admin_default",
             "created",
             "modified",
+            "external_role_id",
+            "external_tenant_name",
         )
 
     def get_applications(self, obj):
@@ -151,6 +155,14 @@ class RoleSerializer(serializers.ModelSerializer):
         role_obj_change_notification_handler(instance, "updated", self.context["request"].user)
         return instance
 
+    def get_external_role_id(self, obj):
+        """Get the external role id if it's from an external tenant."""
+        return obj.external_role_id()
+
+    def get_external_tenant_name(self, obj):
+        """Get the external tenant name if it's from an external tenant."""
+        return obj.external_tenant_name()
+
 
 class RoleMinimumSerializer(SerializerCreateOverrideMixin, serializers.ModelSerializer):
     """Serializer for the Role model that doesn't return access info."""
@@ -167,6 +179,8 @@ class RoleMinimumSerializer(SerializerCreateOverrideMixin, serializers.ModelSeri
     system = serializers.BooleanField(read_only=True)
     platform_default = serializers.BooleanField(read_only=True)
     admin_default = serializers.BooleanField(read_only=True)
+    external_role_id = serializers.SerializerMethodField()
+    external_tenant_name = serializers.SerializerMethodField()
 
     class Meta:
         """Metadata for the serializer."""
@@ -185,11 +199,21 @@ class RoleMinimumSerializer(SerializerCreateOverrideMixin, serializers.ModelSeri
             "system",
             "platform_default",
             "admin_default",
+            "external_role_id",
+            "external_tenant_name",
         )
 
     def get_applications(self, obj):
         """Get the list of applications in the role."""
         return obtain_applications(obj)
+
+    def get_external_role_id(self, obj):
+        """Get the external role id if it's from an external tenant."""
+        return obj.external_role_id()
+
+    def get_external_tenant_name(self, obj):
+        """Get the external tenant name if it's from an external tenant."""
+        return obj.external_tenant_name()
 
 
 class DynamicFieldsModelSerializer(SerializerCreateOverrideMixin, serializers.ModelSerializer):
@@ -227,6 +251,8 @@ class RoleDynamicSerializer(DynamicFieldsModelSerializer):
     system = serializers.BooleanField(read_only=True)
     platform_default = serializers.BooleanField(read_only=True)
     admin_default = serializers.BooleanField(read_only=True)
+    external_role_id = serializers.SerializerMethodField()
+    external_tenant_name = serializers.SerializerMethodField()
 
     class Meta:
         """Metadata for the serializer."""
@@ -247,6 +273,8 @@ class RoleDynamicSerializer(DynamicFieldsModelSerializer):
             "system",
             "platform_default",
             "admin_default",
+            "external_role_id",
+            "external_tenant_name",
         )
 
     def get_applications(self, obj):
@@ -262,6 +290,14 @@ class RoleDynamicSerializer(DynamicFieldsModelSerializer):
         """Get the groups where the role is in."""
         request = self.context.get("request")
         return obtain_groups_in(obj, request).values("name", "uuid", "description")
+
+    def get_external_role_id(self, obj):
+        """Get the external role id if it's from an external tenant."""
+        return obj.external_role_id()
+
+    def get_external_tenant_name(self, obj):
+        """Get the external tenant name if it's from an external tenant."""
+        return obj.external_tenant_name()
 
 
 class RolePatchSerializer(RoleSerializer):

--- a/rbac/management/role/view.py
+++ b/rbac/management/role/view.py
@@ -58,6 +58,8 @@ LIST_ROLE_FIELDS = [
     "system",
     "platform_default",
     "admin_default",
+    "external_role_id",
+    "external_tenant_name",
 ]
 VALID_PATCH_FIELDS = ["name", "display_name", "description"]
 

--- a/rbac/management/role/view.py
+++ b/rbac/management/role/view.py
@@ -59,7 +59,7 @@ LIST_ROLE_FIELDS = [
     "platform_default",
     "admin_default",
     "external_role_id",
-    "external_tenant_name",
+    "external_tenant",
 ]
 VALID_PATCH_FIELDS = ["name", "display_name", "description"]
 
@@ -88,7 +88,7 @@ class RoleFilter(CommonFilters):
         """Filter to lookup display_name, partial or exact."""
         return self.name_filter(queryset, field, value, "display_name")
 
-    def external_tenant_name_filter(self, queryset, field, value):
+    def external_tenant_filter(self, queryset, field, value):
         """Filter to lookup external tenant name, partial or exact."""
         return queryset.filter(ext_relation__ext_tenant__name__iexact=value)
 
@@ -97,7 +97,7 @@ class RoleFilter(CommonFilters):
     application = filters.CharFilter(field_name="application", method="application_filter")
     permission = filters.CharFilter(field_name="permission", method="permission_filter")
     system = filters.BooleanFilter(field_name="system")
-    external_tenant = filters.CharFilter(field_name="external_tenant_name", method="external_tenant_name_filter")
+    external_tenant = filters.CharFilter(field_name="external_tenant", method="external_tenant_filter")
 
     class Meta:
         model = Role

--- a/rbac/management/role/view.py
+++ b/rbac/management/role/view.py
@@ -88,11 +88,16 @@ class RoleFilter(CommonFilters):
         """Filter to lookup display_name, partial or exact."""
         return self.name_filter(queryset, field, value, "display_name")
 
+    def external_tenant_name_filter(self, queryset, field, value):
+        """Filter to lookup external tenant name, partial or exact."""
+        return queryset.filter(ext_relation__ext_tenant__name__iexact=value)
+
     name = filters.CharFilter(field_name="name", method="name_filter")
     display_name = filters.CharFilter(field_name="display_name", method="display_name_filter")
     application = filters.CharFilter(field_name="application", method="application_filter")
     permission = filters.CharFilter(field_name="permission", method="permission_filter")
     system = filters.BooleanFilter(field_name="system")
+    external_tenant = filters.CharFilter(field_name="external_tenant_name", method="external_tenant_name_filter")
 
     class Meta:
         model = Role

--- a/tests/management/role/test_view.py
+++ b/tests/management/role/test_view.py
@@ -69,7 +69,7 @@ class RoleViewsetTests(IdentityRequest):
             "platform_default",
             "admin_default",
             "external_role_id",
-            "external_tenant_name",
+            "external_tenant",
         }
 
         self.test_tenant = Tenant(tenant_name="acct1111111", account_id="1111111", org_id="100001", ready=True)

--- a/tests/management/role/test_view.py
+++ b/tests/management/role/test_view.py
@@ -68,6 +68,8 @@ class RoleViewsetTests(IdentityRequest):
             "modified",
             "platform_default",
             "admin_default",
+            "external_role_id",
+            "external_tenant_name",
         }
 
         self.test_tenant = Tenant(tenant_name="acct1111111", account_id="1111111", org_id="100001", ready=True)


### PR DESCRIPTION
## Link(s) to Jira
- https://issues.redhat.com/browse/RHCLOUD-19319

## Description of Intent of Change(s)
We'll need to ensure we're returning the external identifier on the role data for OCM to consume, and also support filtering based on their external roles only, to avoid superfluous roles which are not theirs.

- Roles which have external role relations to external tenants should have the external identifier and external tenant included in the GET payloads:
-- /api/rbac/v1/roles/
-- /api/rbac/v1/roles/<uuid>/
-- /api/rbac/v1/groups/<uuid>/roles/

- The new OCM role endpoints should include a filter `?external_tenant=foo` to filter by roles with external relations for the tenant supplied.
-- /api/rbac/v1/roles/?external_tenant=foo
-- /api/rbac/v1/groups/<uuid>/roles/?external_tenant=foo

## Local Testing
Test the above endpoints to see the filtering and payload data returned, based on the changes to the spec.

## Checklist
- [x] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [x] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  -  if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
