### PR TITLE
Fix internal openapi.json spec route

### DIFF
--- a/rbac/internal/openapi.py
+++ b/rbac/internal/openapi.py
@@ -23,7 +23,7 @@ from rest_framework.decorators import api_view, permission_classes, renderer_cla
 from rest_framework.renderers import JSONRenderer
 from rest_framework.response import Response
 
-OPENAPI_FILE_PATH_DEFAULT = "rbac/internal/specs"
+OPENAPI_FILE_PATH_DEFAULT = "internal/specs"
 OPENAPI_FILE_NAME = "openapi.json"
 
 


### PR DESCRIPTION
This was working locally because of the server being run not being gunicorn. Once
deployed, this started throwing a 500. Locally it was resolving, but also silently
recording a 404 against the `_private/` path.

Testing with `make gunicorn-serve` locally exposed the issue. The prefix change
resolves the problem and renders the json without warnings or errors.
