### PR TITLE
Parameterize gunicorn worker count multiplier

### DIFF
--- a/deploy/rbac-clowdapp.yml
+++ b/deploy/rbac-clowdapp.yml
@@ -425,8 +425,8 @@ objects:
             value: ${AUTHENTICATE_WITH_ORG_ID}
           - name: NOTIFICATIONS_ENABLED
             value: ${NOTIFICATIONS_ENABLED}
-          - name: SERVER_WORKER_MULTIPLIER
-            value: ${SERVER_WORKER_MULTIPLIER}
+          - name: GUNICORN_WORKER_MULTIPLIER
+            value: ${GUNICORN_WORKER_MULTIPLIER}
     jobs:
       - name: tenant-org-id-populator
         podSpec:
@@ -2087,5 +2087,5 @@ parameters:
   required: true
 - name: TENANT_TRANSLATOR_PORT
   value: '8892'
-- name: SERVER_WORKER_MULTIPLIER
+- name: GUNICORN_WORKER_MULTIPLIER
   value: '2'

--- a/deploy/rbac-clowdapp.yml
+++ b/deploy/rbac-clowdapp.yml
@@ -425,6 +425,8 @@ objects:
             value: ${AUTHENTICATE_WITH_ORG_ID}
           - name: NOTIFICATIONS_ENABLED
             value: ${NOTIFICATIONS_ENABLED}
+          - name: SERVER_WORKER_MULTIPLIER
+            value: ${SERVER_WORKER_MULTIPLIER}
     jobs:
       - name: tenant-org-id-populator
         podSpec:
@@ -2085,3 +2087,5 @@ parameters:
   required: true
 - name: TENANT_TRANSLATOR_PORT
   value: '8892'
+- name: SERVER_WORKER_MULTIPLIER
+  value: '2'

--- a/rbac/gunicorn.py
+++ b/rbac/gunicorn.py
@@ -4,6 +4,6 @@ import os
 
 bind = "unix:/var/run/rbac/gunicorn.sock"
 cpu_resources = int(os.environ.get("POD_CPU_LIMIT", multiprocessing.cpu_count()))
-workers = cpu_resources * 4
+workers = cpu_resources * int(os.environ.get("SERVER_WORKER_MULTIPLIER", 2))
 threads = 10
 limit_request_field_size = 16380

--- a/rbac/gunicorn.py
+++ b/rbac/gunicorn.py
@@ -4,6 +4,6 @@ import os
 
 bind = "unix:/var/run/rbac/gunicorn.sock"
 cpu_resources = int(os.environ.get("POD_CPU_LIMIT", multiprocessing.cpu_count()))
-workers = cpu_resources * int(os.environ.get("SERVER_WORKER_MULTIPLIER", 2))
+workers = cpu_resources * int(os.environ.get("GUNICORN_WORKER_MULTIPLIER", 2))
 threads = 10
 limit_request_field_size = 16380


### PR DESCRIPTION
A follow-up to #733 where we bumped the multiplier from 2 to 4. This defaults
to 2 (as it was) and will allow us to override the param in production to bump
as needed.

