### PR TITLE
Safely access `account_number` from identity

### DIFF
--- a/rbac/rbac/middleware.py
+++ b/rbac/rbac/middleware.py
@@ -202,7 +202,7 @@ class IdentityHeaderMiddleware(MiddlewareMixin):
         user = User()
         try:
             _, json_rh_auth = extract_header(request, self.header)
-            user.account = json_rh_auth.get("identity", {})["account_number"]
+            user.account = json_rh_auth.get("identity", {}).get("account_number")
             user.org_id = json_rh_auth.get("identity", {}).get("org_id") or json_rh_auth.get("identity").get(
                 "internal"
             ).get("org_id")


### PR DESCRIPTION
## Description of Intent of Change(s)
Currently if the `account_number` key doesn't exist on the identity header,
RBAC will 401. This safely accesses that key and defaults to `None`.

## Local Testing
- Update your dev middleware to remove `account_number` and verify 401 prior but not after these changes

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
