### PR TITLE
Creating a "Custom default access" group should only use public tenant roles by default

### DIFF
--- a/rbac/management/group/definer.py
+++ b/rbac/management/group/definer.py
@@ -85,6 +85,7 @@ def set_system_flag_before_update(group, tenant, user):
 
 def clone_default_group_in_public_schema(group, tenant):
     """Clone the default group for a tenant into the public schema."""
+    public_tenant = Tenant.objects.get(tenant_name="public")
     tenant_default_policy = group.policies.get(system=True)
     group.name = "Custom default access"
     group.system = False
@@ -97,7 +98,7 @@ def clone_default_group_in_public_schema(group, tenant):
     tenant_default_policy.tenant = tenant
     if Group.objects.filter(name=group.name, platform_default=group.platform_default, tenant=tenant):
         return
-    public_default_roles = Role.objects.filter(platform_default=True)
+    public_default_roles = Role.objects.filter(platform_default=True, tenant=public_tenant)
 
     group.save()
     tenant_default_policy.group = group


### PR DESCRIPTION
## Link(s) to Jira
- https://issues.redhat.com/browse/RHCLOUD-20603

## Description of Intent of Change(s)
Currently the query to grab roles for a custom default group [1] has an implicit
expectation that any `platform_default` roles will be coming from the public tenant
as that's the only way they can be created via seeds.

There's an edge-case where in stage, as part of our public schema data migration,
one role from a non-public tenant (an old `platform_default` role from the tenant's
schema) was copied into the public schema, still tied to that tenant.

This in turn means that when a new custom default group is cut in stage, it will
include that duplicate group since the filter doesn't explicitly require the
tenant be the public tenant.

These changes close that edge-case.

[1] https://github.com/RedHatInsights/insights-rbac/blob/master/rbac/management/group/definer.py#L100

## Local Testing
- on master, manually create a duplicate `platform_default` role, which already exists
  for the public tenant, and update the `tenant_id` to be that of another tenant
- update the "Default access" group, which will create a "Custom default access"
  group, and note that if you query `/rbac/api/v1/groups/<uuid>/roles/` you'll
  see the duplicate role from the non-public tenant
- check these changes out and run the same test as above, and note the duplicate
  role does not exist on the new "Custom default access" group

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [x] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
