### PR TITLE
Allow role and permission removal during seeding

### DIFF
--- a/rbac/management/role/definer.py
+++ b/rbac/management/role/definer.py
@@ -23,10 +23,10 @@ import os
 from django.conf import settings
 from django.db import transaction
 from django.utils import timezone
+from internal.views import destructive_ok
 from management.notifications.notification_handlers import role_obj_change_notification_handler
 from management.permission.model import Permission
 from management.role.model import Access, ExtRoleRelation, ExtTenant, ResourceDefinition, Role
-from internal.views import destructive_ok
 
 from api.models import Tenant
 

--- a/rbac/management/role/definer.py
+++ b/rbac/management/role/definer.py
@@ -140,7 +140,7 @@ def seed_roles():
     if destructive_ok():
         logger.info(f"Removing the following role(s): {roles_to_delete.values()}")
         # Actually remove roles no longer in config
-        Role.objects.filter(system=True).exclude(id__in=current_role_ids).delete()
+        roles_to_delete.delete()
 
 
 def seed_permissions():
@@ -204,4 +204,4 @@ def seed_permissions():
     if destructive_ok():
         logger.info(f"Removing the following role(s): {perms_to_delete.values()}")
         # Actually remove perms no longer in DB
-        Permission.objects.exclude(id__in=current_permission_ids).delete()
+        perms_to_delete.delete()

--- a/rbac/management/role/definer.py
+++ b/rbac/management/role/definer.py
@@ -20,10 +20,10 @@ import json
 import logging
 import os
 
+from core.utils import destructive_ok
 from django.conf import settings
 from django.db import transaction
 from django.utils import timezone
-from internal.views import destructive_ok
 from management.notifications.notification_handlers import role_obj_change_notification_handler
 from management.permission.model import Permission
 from management.role.model import Access, ExtRoleRelation, ExtTenant, ResourceDefinition, Role

--- a/rbac/management/role/definer.py
+++ b/rbac/management/role/definer.py
@@ -202,6 +202,6 @@ def seed_permissions():
         f"The following '{perms_to_delete.count()}' permission(s) eligible for removal: {perms_to_delete.values()}"
     )
     if destructive_ok():
-        logger.info(f"Removing the following role(s): {perms_to_delete.values()}")
+        logger.info(f"Removing the following permissions(s): {perms_to_delete.values()}")
         # Actually remove perms no longer in DB
         perms_to_delete.delete()


### PR DESCRIPTION
Signed-off-by: Chris Mitchell <cmitchel@redhat.com>

## Link(s) to Jira
- https://issues.redhat.com/browse/RHCLOUD-4009

## Description of Intent of Change(s)
Previously we didn't have functionality for removing roles and permissions that had been seeded and were no longer needed. This adds a check  for system roles nor permissions present that don't have a corresponding file in the seeding directory. If we allow destructive operations, it will remove any matching entries from the DB.

## Local Testing
Pull down the code, refresh db, and run seeds. After checking to ensure everything is present/matching, move one of the seed files from rbac/management/role/definitions/ or rbac/management/role/permissions/ and re-run seeds with destructive operations enabled or the check commented out. Check to ensure the Roles/Permissions referenced in the moved file have been removed.

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
