### PR TITLE
Explicitly set Kafka API version to 1.0.2

### DIFF
--- a/rbac/management/notifications/producer_util.py
+++ b/rbac/management/notifications/producer_util.py
@@ -49,9 +49,9 @@ class NotificationProducer:
 
         if settings.NOTIFICATIONS_ENABLED:
             if settings.KAFKA_AUTH:
-                self.producer = KafkaProducer(**settings.KAFKA_AUTH)
+                self.producer = KafkaProducer(**settings.KAFKA_AUTH, api_version=(1, 0, 2))
             else:
-                self.producer = KafkaProducer(bootstrap_servers=settings.KAFKA_SERVER)
+                self.producer = KafkaProducer(bootstrap_servers=settings.KAFKA_SERVER, api_version=(1, 0, 2))
         else:
             self.producer = FakeKafkaProducer()
         return self.producer


### PR DESCRIPTION
Context is in #743, but it's been reported that 1.0.2 may resolve some missing
header issues as well. It looks like this is in fact still needed, as we're now
seeing `kafka.errors.UnrecognizedBrokerVersion: UnrecognizedBrokerVersion` with
managed Kafka.

If this does help the issues we're seeing, we should parameterize the version number.
