### PR TITLE
Add groups-principals to internal integrations views for OCM

### DIFF
--- a/rbac/internal/integration_views.py
+++ b/rbac/internal/integration_views.py
@@ -56,3 +56,9 @@ def roles_for_group_principal(request, org_id, principals, uuid):
     """Pass internal /principal/<username>/groups/<uuid>/roles/ request to /groups/ API."""
     view = GroupViewSet.as_view({"get": "roles"})
     return view(request, uuid=uuid, principals=principals)
+
+
+def principals_for_group(request, org_id, uuid):
+    """Pass internal /groups/<uuid>/principals/ request to /groups/ API."""
+    view = GroupViewSet.as_view({"get": "principals"})
+    return view(request, uuid=uuid)

--- a/rbac/internal/specs/openapi.json
+++ b/rbac/internal/specs/openapi.json
@@ -613,6 +613,115 @@
           }
         }
       }
+    },
+    "/integrations/tenant/{orgId}/groups/{uuid}/principals/": {
+      "get": {
+        "tags": [
+          "Group"
+        ],
+        "summary": "Get a list of principals from a group in a tenant",
+        "description": "By default, responses are sorted in ascending order by username",
+        "operationId": "listPrincipalsForGroup",
+        "parameters": [
+          {
+            "name": "orgId",
+            "in": "path",
+            "description": "Organization ID of the tenant",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "uuid",
+            "in": "path",
+            "description": "ID of group from which to get principals",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "principal_username",
+            "in": "query",
+            "required": false,
+            "description": "Parameter for filtering group principals by principal `username` using string contains search.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/QueryLimit"
+          },
+          {
+            "$ref": "#/components/parameters/QueryOffset"
+          },
+          {
+            "in": "query",
+            "name": "order_by",
+            "required": false,
+            "description": "Parameter for ordering principals by value. For inverse ordering, supply '-' before the param value, such as: ?order_by=-username",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "username"
+              ]
+            }
+          },
+          {
+            "in": "query",
+            "name": "username_only",
+            "required": false,
+            "description": "Parameter for optionally returning only usernames for principals, bypassing a call to IT.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "true",
+                "false"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of principals attached to group",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PrincipalPagination"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Input"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "servers": [
@@ -870,6 +979,76 @@
             }
           }
         ]
+      },
+      "PrincipalPagination": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ListPagination"
+          },
+          {
+            "type": "object",
+            "required": [
+              "data"
+            ],
+            "properties": {
+              "data": {
+                "type": "array",
+                "items": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/Principal"
+                    },
+                    {
+                      "$ref": "#/components/schemas/PrincipalMinimal"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        ]
+      },
+      "Principal": {
+        "required": [
+          "username",
+          "email"
+        ],
+        "properties": {
+          "username": {
+            "type": "string",
+            "example": "smithj"
+          },
+          "email": {
+            "type": "string",
+            "format": "email",
+            "example": "smithj@mytechco.com"
+          },
+          "first_name": {
+            "type": "string",
+            "example": "John"
+          },
+          "last_name": {
+            "type": "string",
+            "example": "Smith"
+          },
+          "is_active": {
+            "type": "boolean"
+          },
+          "is_org_admin": {
+            "type": "boolean"
+          }
+        }
+      },
+      "PrincipalMinimal": {
+        "required": [
+          "username"
+        ],
+        "properties": {
+          "username": {
+            "type": "string",
+            "example": "smithj"
+          }
+        }
       },
       "Role": {
         "required": [

--- a/rbac/internal/urls.py
+++ b/rbac/internal/urls.py
@@ -31,6 +31,11 @@ integration_urlpatterns = [
         name="integration-group-roles",
     ),
     path(
+        "api/v1/integrations/tenant/<str:org_id>/groups/<str:uuid>/principals/",
+        integration_views.principals_for_group,
+        name="integration-group-principals",
+    ),
+    path(
         "api/v1/integrations/tenant/<str:org_id>/principal/<str:principals>/groups/",
         integration_views.groups_for_principal,
         name="integration-princ-groups",


### PR DESCRIPTION
## Link(s) to Jira
- https://issues.redhat.com/browse/RHCLOUD-21334

## Description of Intent of Change(s)
In order to help prevent superfluous API calls to ConsoleDot RBAC from OCM during the data "sync" for tenant data, it would be helpful to have a groups > principals endpoint internally.

## Local Testing
- I should be able to query `_private/api/v1/integrations/tenant/<org_id>/groups/<group_uuid>/principals/` to return all principals for a group
- I should be able to use the `?username_only=true` which exists on `/principals/` already
- The internal API spec should reflect these changes

## Checklist
- [x] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [x] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
