### PR TITLE
Ensure the notifications topic is set in the worker

### DIFF
--- a/deploy/rbac-clowdapp.yml
+++ b/deploy/rbac-clowdapp.yml
@@ -174,6 +174,8 @@ objects:
             value: ${NOTIFICATIONS_ENABLED}
           - name: NOTIFICATIONS_RH_ENABLED
             value: ${NOTIFICATIONS_RH_ENABLED}
+          - name: NOTIFICATIONS_TOPIC
+            value: ${NOTIFICATIONS_TOPIC}
 
     - name: scheduler-service
       minReplicas: ${{MIN_SCHEDULER_REPLICAS}}


### PR DESCRIPTION
When seeds run, we need to ensure we set `NOTIFICATIONS_TOPIC` on the worker pods, otherwise the topic will not be set for the producer, and will cause the client to connect and disconnect indefinitely.
