### PR TITLE
Fix `username_only` spec type

### DIFF
--- a/docs/source/specs/openapi.json
+++ b/docs/source/specs/openapi.json
@@ -638,10 +638,10 @@
             "required": false,
             "description": "Parameter for optionally returning only usernames for principals, bypassing a call to IT.",
             "schema": {
-              "type": "string",
+              "type": "boolean",
               "enum": [
-                "true",
-                "false"
+                true,
+                false
               ]
             }
           }
@@ -1210,10 +1210,10 @@
             "required": false,
             "description": "Parameter for optionally returning only usernames for principals, bypassing a call to IT.",
             "schema": {
-              "type": "string",
+              "type": "boolean",
               "enum": [
-                "true",
-                "false"
+                true,
+                false
               ]
             }
           }

--- a/rbac/internal/specs/openapi.json
+++ b/rbac/internal/specs/openapi.json
@@ -675,10 +675,10 @@
             "required": false,
             "description": "Parameter for optionally returning only usernames for principals, bypassing a call to IT.",
             "schema": {
-              "type": "string",
+              "type": "boolean",
               "enum": [
-                "true",
-                "false"
+                true,
+                false
               ]
             }
           }


### PR DESCRIPTION
## Description of Intent of Change(s)
The `username_only` param should be updated in both internal and external API specs to a boolean, to be consistent with other params.
