### PR TITLE
tox config update for linters

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -178,7 +178,7 @@ This will rebuild the tox virtual env and then run all tests.
 
 To run unit tests specifically::
 
-    tox -e py36
+    tox -e py38
 
 To lint the code base ::
 

--- a/tox.ini
+++ b/tox.ini
@@ -34,13 +34,10 @@ setenv =
   MOCK_KAFKA=True
   KAFKA_ENABLED=True
 deps =
-  pipenv
   codecov
+  faker
 commands =
-  pipenv install psycopg2==2.8.6
-  pipenv install psycopg2-binary==2.8.6
-  pipenv run pip install -U pip
-  pipenv install --dev --ignore-pipfile
+  pip install -r requirements.txt
   coverage run {toxinidir}/rbac/manage.py test --failfast -v 2 {posargs: tests/}
   coverage report --show-missing
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,9 +3,11 @@ envlist = lint, py38
 skipsdist = True
 
 [flake8]
+; Q000 = Remove bad quotes (warning from flake8-quotes)
 ; D106 = Missing docstring in public nested class
-; D212 = Multi-line docstring summary should start at the first line
-ignore = Q000,D106,D212,W503,C901
+; W503 = Line break before binary operator
+; C901 = Function is too complex
+ignore = Q000,D106,W503,C901
 max-complexity = 10
 max-line-length = 120
 exclude =
@@ -48,14 +50,9 @@ deps =
   flake8-docstrings
   flake8-import-order
   flake8-quotes
-  pipenv
   black
 setenv =
   PYTHONPATH={toxinidir}
 commands =
   flake8 rbac
-  pipenv install psycopg2==2.8.6
-  pipenv install psycopg2-binary==2.8.6
-  pipenv run pip install -U pip
-  pipenv install --dev --ignore-pipfile
-  pipenv run black --check -t py38 -l 119 rbac tests
+  black --check -t py38 -l 119 rbac tests


### PR DESCRIPTION
## Description of Intent of Change(s)
Because tests and linters check via tox is not running on my MacBook with Apple chip (I think it is because incompatibility with module pipenv - the virtual env is created via pipenv but I am not able to install dependencies). I believe this solution is more simple and faster (because for running linters we dont install not needed dependencies).

Tox config update for running linters.
1. added description of all ignored types of flake8 warnings
2. D212 warning removed because it is not present in the codebase so it is not needed to skip it
3. removed not needed commands - for running linters we dont need install project dependencies 

Tox config update for running tests
1. dependencies are installed from requirements.txt

## Local Testing
run linters check `tox -elint` 
run tests `tox -epy38`