### PR TITLE
[WIP]RHCLOUD-23690 Add principal into group - empty list of principals in the request

### DIFF
--- a/docs/source/specs/openapi.json
+++ b/docs/source/specs/openapi.json
@@ -1122,7 +1122,14 @@
             }
           },
           "400": {
-            "description": "Bad Input"
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorBadRequest"
+                }
+              }
+            }
           },
           "401": {
             "description": "Unauthorized"
@@ -2918,6 +2925,37 @@
                 "status": {
                   "type": "string",
                   "example": "403"
+                }
+              }
+            }
+          }
+        }
+      },
+      "ErrorBadRequest": {
+        "description": "Error structure for the \"Bad Request\" responses.",
+        "required": [
+          "errors"
+        ],
+        "properties": {
+          "errors": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "detail": {
+                  "description": "Detail of the error.",
+                  "type": "string",
+                  "example": "Bad Request."
+                },
+                "status": {
+                  "description": "Status of the response",
+                  "type": "string",
+                  "example": "400"
+                },
+                "source": {
+                  "description": "Source of the error.",
+                  "type": "string",
+                  "example": "principals"
                 }
               }
             }

--- a/rbac/management/principal/proxy.py
+++ b/rbac/management/principal/proxy.py
@@ -292,7 +292,10 @@ class PrincipalProxy:  # pylint: disable=too-few-public-methods
         else:
             account_filter = True
         if not principals:
-            return {"status_code": status.HTTP_200_OK, "data": []}
+            return {
+                "status_code": status.HTTP_400_BAD_REQUEST,
+                "errors": [{"detail": "No principals in request.", "status": "400", "source": "principals"}],
+            }
         filtered_principals_path = "/v1/users"
         params = self._create_params(limit, offset, options)
         payload = {"users": principals, "include_permissions": False}

--- a/tests/management/principal/test_proxy.py
+++ b/tests/management/principal/test_proxy.py
@@ -127,7 +127,10 @@ class PrincipalProxyTest(TestCase):
         """Test the call to request filtered principals."""
         proxy = PrincipalProxy()
         result = proxy.request_filtered_principals(principals=[], account="1234")
-        expected = {"status_code": status.HTTP_200_OK, "data": []}
+        expected = {
+            "status_code": status.HTTP_400_BAD_REQUEST,
+            "errors": [{"detail": "No principals in request.", "status": "400", "source": "principals"}],
+        }
         self.assertEqual(expected, result)
 
     def test__request_principals_404(self):


### PR DESCRIPTION
## Link(s) to Jira
- [RHCLOUD-23690](https://issues.redhat.com/browse/RHCLOUD-23690)

## Description of Intent of Change(s)
here is [PR](https://github.com/RedHatInsights/insights-rbac/pull/777) change for response that contains non-existent principal in request for adding principal into group

related to the discussion around ^^^, we decided to change the response for
POST /groups/uuid/principals/ with empty list of principals
```
{ 
    "principals": [] 
}
```
response now is 200

this PR changes the response into 400 Bad Request
example:
```
[
    {
        "detail": "No principals in request.",
        "status": "404",
        "source": "principals"
    }
]
```

## Local Testing
POST /groups/uuid/principals/ with empty list of principals and check the response

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
