### PR TITLE
Add the `system` flag to the internal integration spec

### DIFF
--- a/rbac/internal/specs/openapi.json
+++ b/rbac/internal/specs/openapi.json
@@ -262,6 +262,15 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "system",
+            "in": "query",
+            "required": false,
+            "description": "Parameter for filtering resource by system flag.",
+            "schema": {
+              "type": "boolean"
+            }
           }
         ],
         "responses": {


### PR DESCRIPTION
The internal integrations endpoint for `/_private/api/v1/integrations/tenant/11111/groups/` currently supports `?system=true|false` to filter in or out system groups, but it's not reflected in the spec.

This will add it to the spec which should allow clients to use the param.
