### PR TITLE
set black version in the tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -47,7 +47,7 @@ deps =
   flake8-docstrings
   flake8-import-order
   flake8-quotes
-  black
+  black==22.3.0
 setenv =
   PYTHONPATH={toxinidir}
 commands =


### PR DESCRIPTION
set concrete version (same as is on other places - in pipfile, in rtd_requirements.txt) of black package

why? because we need to control concrete version of black package and because without it the 23.1.0 version is installed and with this new version checks failed ... I believe the bump of black package to new version can be solved in next PR