### PR TITLE
[RHCLOUD-23915] Add access field into roles endpoint

### DIFF
--- a/docs/source/specs/openapi.json
+++ b/docs/source/specs/openapi.json
@@ -1725,7 +1725,8 @@
                 "type": "string",
                 "enum": [
                   "groups_in",
-                  "groups_in_count"
+                  "groups_in_count",
+                  "access"
                 ]
               }
             },

--- a/rbac/management/role/serializer.py
+++ b/rbac/management/role/serializer.py
@@ -247,6 +247,7 @@ class RoleDynamicSerializer(DynamicFieldsModelSerializer):
     groups_in = serializers.SerializerMethodField()
     groups_in_count = serializers.SerializerMethodField()
     accessCount = serializers.IntegerField(read_only=True)
+    access = AccessSerializer(many=True)
     applications = serializers.SerializerMethodField()
     system = serializers.BooleanField(read_only=True)
     platform_default = serializers.BooleanField(read_only=True)
@@ -269,6 +270,7 @@ class RoleDynamicSerializer(DynamicFieldsModelSerializer):
             "groups_in",
             "groups_in_count",
             "accessCount",
+            "access",
             "applications",
             "system",
             "platform_default",

--- a/rbac/management/role/view.py
+++ b/rbac/management/role/view.py
@@ -44,7 +44,7 @@ from .serializer import RoleSerializer
 
 TESTING_APP = os.getenv("TESTING_APPLICATION")
 ADDITIONAL_FIELDS_KEY = "add_fields"
-VALID_FIELD_VALUES = ["groups_in_count", "groups_in"]
+VALID_FIELD_VALUES = ["groups_in_count", "groups_in", "access"]
 LIST_ROLE_FIELDS = [
     "uuid",
     "name",


### PR DESCRIPTION
## Link(s) to Jira
- [RHCLOUD-23915](https://issues.redhat.com/browse/RHCLOUD-23915)

## Description of Intent of Change(s)
we need to add "access" field into /roles endpoint (as additional field)

## Local Testing
can be tested with endpoint
`GET /rbac/v1/roles/?add_fields=access`
response has to contain `access` field with list of permissions
example
```
{
    "meta": {
        "count": 13,
        "limit": 1,
        "offset": 0
    },
    "links": {
        "first": "/api/rbac/v1/roles/?add_fields=access&limit=1&offset=0",
        "next": "/api/rbac/v1/roles/?add_fields=access&limit=1&offset=1",
        "previous": null,
        "last": "/api/rbac/v1/roles/?add_fields=access&limit=1&offset=12"
    },
    "data": [
        {
            "uuid": "ed92e9f8-d553-4839-ba1f-4a81406846cb",
            "name": "Ansible Automation Access Local Test",
            "display_name": "Ansible Automation Access Local Test",
            "description": "An all access role which grants read and write permissions, just for testing locally.",
            "created": "2022-12-14T23:28:50.018341Z",
            "modified": "2022-12-14T23:28:50.018415Z",
            "policyCount": 1,
            "accessCount": 1,
            "access": [
                {
                    "resourceDefinitions": [],
                    "permission": "ansible-automation:*:*"
                }
            ],
            "applications": [
                "ansible-automation"
            ],
            "system": true,
            "platform_default": true,
            "admin_default": false,
            "external_role_id": null,
            "external_tenant": null
        }
    ]
}
```
without `?add_fields=access` the response doesn't contain the `access` field

## Checklist
- [x] if API spec changes are required, is the spec updated?
- [x] are theses changes covered by unit tests?
