### PR TITLE
[RHCLOUD-24274] Default the roles ordering by name 

### DIFF
--- a/rbac/management/group/view.py
+++ b/rbac/management/group/view.py
@@ -707,18 +707,14 @@ class GroupViewSet(
         exclude = validate_and_get_key(request.query_params, EXCLUDE_KEY, VALID_EXCLUDE_VALUES, "false")
 
         roles = group.roles_with_access() if exclude == "false" else self.obtain_roles_with_exclusion(request, group)
-
         filtered_roles = self.filtered_roles(roles, request)
-
         annotated_roles = filtered_roles.annotate(policyCount=Count("policies", distinct=True))
-
+        # add default order by name
+        order_field = "name"
         if ORDERING_PARAM in request.query_params:
-            ordered_roles = self.order_queryset(
-                annotated_roles, VALID_ROLE_ORDER_FIELDS, request.query_params.get(ORDERING_PARAM)
-            )
-
-            return [RoleMinimumSerializer(role).data for role in ordered_roles]
-        return [RoleMinimumSerializer(role).data for role in annotated_roles]
+            order_field = request.query_params.get(ORDERING_PARAM)
+        ordered_roles = self.order_queryset(annotated_roles, VALID_ROLE_ORDER_FIELDS, order_field)
+        return [RoleMinimumSerializer(role).data for role in ordered_roles]
 
     def obtain_roles_with_exclusion(self, request, group):
         """Obtain the queryset for roles based on scope."""


### PR DESCRIPTION
## Link(s) to Jira
- [RHCLOUD-24274](https://issues.redhat.com/browse/RHCLOUD-24274)

## Description of Intent of Change(s)
Prior to the Django 3.2 update, roles were ordered by name by default. Although I am unsure of how Django affected this change, I added name as the default order field for the roles. 

## Local Testing
1. Bring this branch up as normal 
2. Hit the groups endpoint to get a UUID for a group (http://localhost:8000/api/rbac/v1/groups/)
3. Hit this endpoint to return the roles for that group replacing {YOUR_UUID} with a UUID for your group (http://localhost:8000/api/rbac/v1/groups/{YOUR_UUID}/roles/) - make sure the default ordering works 
4. Add other order_by fields to make sure they bypass the default (http://localhost:8000/api/rbac/v1/groups/{YOUR_UUID}/roles/?order_by=-name)
(http://localhost:8000/api/rbac/v1/groups/{YOUR_UUID}/roles/?order_by=policyCount)

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
