### PR TITLE
openapi update - added 'access' property in the RoleOutDynamic section

### DIFF
--- a/docs/source/specs/openapi.json
+++ b/docs/source/specs/openapi.json
@@ -3910,6 +3910,12 @@
               "external_tenant": {
                 "type": "string",
                 "example": "ExternalTenant"
+              },
+              "access": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Access"
+                }
               }
             }
           }


### PR DESCRIPTION
related with https://github.com/RedHatInsights/insights-rbac/pull/803
we need to add `access` property in the `RoleOutDynamic` section in openapi spec