### PR TITLE
pre-commit-config - updated link to flake8 github repo

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
   - id: black
     args: ["-l", "119", "-t", "py39"]
     require_serial: true
-- repo: https://gitlab.com/pycqa/flake8
+- repo: https://github.com/PyCQA/flake8
   rev: "3.7.9"
   hooks:
   - id: flake8


### PR DESCRIPTION
flake8 project was moved to github so we need to update this in our pre-commit config