### PR TITLE
[RHCLOUD-24172] RBAC service should return error for non existing user

### DIFF
--- a/rbac/management/utils.py
+++ b/rbac/management/utils.py
@@ -61,7 +61,7 @@ def get_principal_from_request(request):
         username = qs_user
         from_query = True
 
-    return get_principal(username, request, verify_principal=bool(qs_user), from_query=from_query)
+    return get_principal(username, request, verify_principal=True, from_query=from_query)
 
 
 def get_principal(username, request, verify_principal=True, from_query=False):
@@ -99,9 +99,9 @@ def verify_principal_with_proxy(username, request, verify_principal=True):
         if isinstance(resp, dict) and "errors" in resp:
             raise Exception("Dependency error: request to get users from dependent service failed.")
 
-        if resp.get("data") == []:
+        if not resp.get("data"):
             key = "detail"
-            message = "No data found for principal with username {}.".format(username)
+            message = "No data found for principal with username '{}'.".format(username)
             raise serializers.ValidationError({key: _(message)})
 
         return resp

--- a/tests/management/test_querysets.py
+++ b/tests/management/test_querysets.py
@@ -620,7 +620,24 @@ class QuerySetTest(TestCase):
         with self.assertRaises(serializers.ValidationError):
             get_policy_queryset(req)
 
-    def test_get_access_queryset_org_admin(self):
+    @patch(
+        "management.principal.proxy.PrincipalProxy.request_filtered_principals",
+        return_value={
+            "status_code": 200,
+            "data": [
+                {
+                    "org_id": "100001",
+                    "is_org_admin": True,
+                    "is_internal": False,
+                    "id": 52567473,
+                    "username": "test_user",
+                    "account_number": "1111111",
+                    "is_active": True,
+                }
+            ],
+        },
+    )
+    def test_get_access_queryset_org_admin(self, mock_request):
         """Test get_access_queryset with an org admin user"""
         user_data = {"username": "test_user", "email": "admin@example.com"}
         customer = {"account_id": "10001"}
@@ -636,7 +653,24 @@ class QuerySetTest(TestCase):
         queryset = get_access_queryset(req)
         self.assertEquals(queryset.count(), 1)
 
-    def test_get_access_queryset_non_org_admin(self):
+    @patch(
+        "management.principal.proxy.PrincipalProxy.request_filtered_principals",
+        return_value={
+            "status_code": 200,
+            "data": [
+                {
+                    "org_id": "100001",
+                    "is_org_admin": False,
+                    "is_internal": False,
+                    "id": 52567473,
+                    "username": "test_user",
+                    "account_number": "1111111",
+                    "is_active": True,
+                }
+            ],
+        },
+    )
+    def test_get_access_queryset_non_org_admin(self, mock_request):
         """Test get_access_queryset with a non 'org admin' user"""
         user_data = {"username": "test_user", "email": "admin@example.com"}
         customer = {"account_id": "10001"}


### PR DESCRIPTION
## Link(s) to Jira
- [RHCLOUD-24172](https://issues.redhat.com/browse/RHCLOUD-24172)

## Description of Intent of Change(s)
if x-rh-identity header contains non existing username, we should return 400 bad request
we already had this check for non existing usernames that were given in the query
e.g. `GET /api/rbac/v1/access/?application=&username=blabla`

this PR adds the same check for usernames from the x-rh-identity header
e.g. `GET /api/rbac/v1/access/?application=`
with x-rh-identity header
```
{
  "identity": {
    "type": "User",
    "user": {
      "username": "non_existing_username_lksjfhskdfhl"
    },
    "internal": {
      "org_id": "12345"
    }
  }
}
```
the response will be 400 Bad Request
```
{
    "errors": [
        {
            "detail": "No data found for principal with username 'non_existing_username_lksjfhskdfhl'.",
            "source": "detail",
            "status": "400"
        }
    ]
}
```
