### PR TITLE
[RHCLOUD-24243] Added 'exclude_username' param into groups endpoint

### DIFF
--- a/docs/source/specs/openapi.json
+++ b/docs/source/specs/openapi.json
@@ -770,6 +770,15 @@
             }
           },
           {
+            "name": "exclude_username",
+            "in": "query",
+            "description": "A username for a principal to filter for groups where principal is not a member and can be added manually",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
             "name": "uuid",
             "in": "query",
             "description": "A list of UUIDs to filter listed groups.",


### PR DESCRIPTION
## Link(s) to Jira
- [RHCLOUD-24243](https://issues.redhat.com/browse/RHCLOUD-24243)

## Description of Intent of Change(s)
we need to list groups for specific username is not member (and can be added manually) => the output should not include default groups (default access group, default admin access group)

example for 5 groups for the tenant and user is member of "Default access" and "GroupC" groups

all groups `GET /api/rbac/v1/groups/`
```
{
    "meta": { "count": 5, "limit": 10, "offset": 0 },
    "links": { ... },
    "data": [
        { "name": "Default access", .... },
        { "name": "Default admin access", .... },
        { "name": "GroupA", ..... },
        { "name": "GroupB", ..... },
        { "name": "GroupC", ..... }
    ]
}
```

groups where principal is member `GET /api/rbac/v1/groups/?username=pcihalov`
```
{
    "meta": { "count": 2, "limit": 10, "offset": 0 },
    "links": { ... },
    "data": [
        { "name": "Default access", .... },
        { "name": "GroupC", ..... }
    ]
}
```

groups where principal can be added manually `GET /api/rbac/v1/groups/?exclude_username=pcihalov`
```
{
    "meta": { "count": 2, "limit": 10, "offset": 0 },
    "links": { ... },
    "data": [
        { "name": "GroupA", ..... },
        { "name": "GroupB", ..... }
    ]
}
```

it is not possible to use `username` and `exclude_username` in the same time => 400 Bad Request
```
{
    "errors": [
        {
            "detail": "Not possible to use both parameters [username, exclude_username].",
            "source": "detail",
            "status": "400"
        }
    ]
}
```

## Checklist
- [x] `exclude_username` param added
- [x] unit tests
- [x] open api spec update
