### PR TITLE
[RHCLOUD-18703] make lint check consistent with tox config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,18 +1,18 @@
 default_language_version:
   python: python3.9
 repos:
-- repo: https://github.com/psf/black
-  rev: 22.3.0
-  hooks:
-  - id: black
-    args: ["-l", "119", "-t", "py39"]
-    require_serial: true
 - repo: https://github.com/PyCQA/flake8
   rev: "3.7.9"
   hooks:
   - id: flake8
     args: ["rbac"]
     pass_filenames: false
+    require_serial: true
+- repo: https://github.com/psf/black
+  rev: 22.3.0
+  hooks:
+  - id: black
+    args: ["--check", "-l", "119", "-t", "py39", "rbac", "tests"]
     require_serial: true
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v2.3.0


### PR DESCRIPTION
## Link(s) to Jira
- [RHCLOUD-18703](https://issues.redhat.com/browse/RHCLOUD-18703)

## Description of Intent of Change(s)
this makes lint check consistent with tox config
- set same parameters
- set same order of linters

so now `pre-commit` and `tox -elint` should give same results
