### PR TITLE
Add DATABASE_HOST, DATABASE_PORT, API_PATH_PREFIX to rbac_server container 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,9 @@ services:
         - DATABASE_NAME=postgres
         - POSTGRES_SQL_SERVICE_HOST=db
         - POSTGRES_SQL_SERVICE_PORT=5432
+        - DATABASE_HOST=db
+        - DATABASE_PORT=5432
+        - API_PATH_PREFIX=/api/rbac
         - DATABASE_USER=postgres
         - DATABASE_PASSWORD=postgres
         - DJANGO_LOG_HANDLERS=console,ecs
@@ -73,7 +76,7 @@ services:
     ports:
       - "15432:5432"
     volumes:
-      - ./pg_data:/var/lib/postgresql/data
+      - ./pg_data:/var/lib/postgresql/data:z
 networks:
   default:
     external:


### PR DESCRIPTION
## Link(s) to Jira
- 

## Description of Intent of Change(s)
I have not been able to successfully hit endpoints when running the service through docker containers: 
```
docker-compose up --build 
http://127.0.0.1:9080/api/rbac/v1/roles/
```
would cause the following error: 
```
is the server running locally and acceptingconnections on unix domain socket "/var/run/postgresql/.s.pgsql.5432"?
```

I think its because [these](https://github.com/RedHatInsights/insights-rbac/blob/master/rbac/rbac/database.py#L49-L50) variables were not being passed in to the docker container (passing them in resolved the issue for me) 
## Local Testing
Bring up the services via docker-compose: 
```
docker-compose up --build
```
Then run migrations & hit an endpoint on the server: 
http://127.0.0.1:9080/api/rbac/v1/roles/ - notice that it returns correctly 

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
