### PR TITLE
Change the port back to 8080

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -97,7 +97,7 @@ RUN \
     # will be recreated by the Pod when the application starts.
     rm ${APP_HOME}/app.log
 
-EXPOSE 8000
+EXPOSE 8080
 
 # GIT_COMMIT is added during build in `build_deploy.sh`
 # Set this at the end to leverage build caching

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,9 @@ services:
         - DATABASE_NAME=postgres
         - POSTGRES_SQL_SERVICE_HOST=db
         - POSTGRES_SQL_SERVICE_PORT=5432
+        - DATABASE_HOST=db
+        - DATABASE_PORT=5432
+        - API_PATH_PREFIX=/api/rbac
         - DATABASE_USER=postgres
         - DATABASE_PASSWORD=postgres
         - DJANGO_LOG_HANDLERS=console,ecs
@@ -24,7 +27,7 @@ services:
         - REDIS_HOST=${REDIS_HOST-rbac_redis}
       privileged: true
       ports:
-          - 9080:8000
+          - 9080:8080
       volumes:
         - '.:/rbac/'
       links:
@@ -73,7 +76,7 @@ services:
     ports:
       - "15432:5432"
     volumes:
-      - ./pg_data:/var/lib/postgresql/data
+      - ./pg_data:/var/lib/postgresql/data:z
 networks:
   default:
     external:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,9 +14,6 @@ services:
         - DATABASE_NAME=postgres
         - POSTGRES_SQL_SERVICE_HOST=db
         - POSTGRES_SQL_SERVICE_PORT=5432
-        - DATABASE_HOST=db
-        - DATABASE_PORT=5432
-        - API_PATH_PREFIX=/api/rbac
         - DATABASE_USER=postgres
         - DATABASE_PASSWORD=postgres
         - DJANGO_LOG_HANDLERS=console,ecs
@@ -76,7 +73,7 @@ services:
     ports:
       - "15432:5432"
     volumes:
-      - ./pg_data:/var/lib/postgresql/data:z
+      - ./pg_data:/var/lib/postgresql/data
 networks:
   default:
     external:

--- a/rbac/gunicorn.py
+++ b/rbac/gunicorn.py
@@ -4,7 +4,7 @@ import os
 
 from rbac.env import ENVIRONMENT
 
-CLOWDER_PORT = "8000"
+CLOWDER_PORT = "8080"
 if ENVIRONMENT.bool("CLOWDER_ENABLED", default=False):
     from app_common_python import LoadedConfig
 


### PR DESCRIPTION
## Link(s) to Jira
- 

## Description of Intent of Change(s)
Other teams that run docker locally expect the port that is exposed to be 8080 not 8000

## Local Testing
How can the feature be exercised? 
How can the bug be exploited and fix confirmed?
Is any special local setup required?

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
