### PR TITLE
[RHCLOUD-5481] Optional trailing slashes 

### DIFF
--- a/rbac/api/cross_access/view.py
+++ b/rbac/api/cross_access/view.py
@@ -16,6 +16,8 @@
 #
 
 """View for cross access request."""
+import re
+
 from django.conf import settings
 from django.db.models import Q
 from django.utils import timezone
@@ -123,7 +125,7 @@ class CrossAccountRequestViewSet(
 
     def get_serializer_class(self):
         """Get serializer based on route."""
-        if self.request.path.endswith("cross-account-requests/") and self.request.method == "GET":
+        if re.match(".*/cross-account-requests/?$", self.request.path) and self.request.method == "GET":
             return CrossAccountRequestSerializer
         return CrossAccountRequestDetailSerializer
 

--- a/rbac/api/urls.py
+++ b/rbac/api/urls.py
@@ -16,16 +16,17 @@
 """Describes the urls and patterns for the API application."""
 from django.conf.urls import include
 from django.urls import re_path
-from rest_framework.routers import DefaultRouter
+from management.urls import OptionalSlashRouter
 
 from api.views import CrossAccountRequestViewSet, openapi, status
 
-ROUTER = DefaultRouter()
+
+ROUTER = OptionalSlashRouter()
 ROUTER.register(r"cross-account-requests", CrossAccountRequestViewSet, basename="cross")
 
 # pylint: disable=invalid-name
 urlpatterns = [
-    re_path(r"^status/$", status, name="server-status"),
+    re_path(r"^status/?$", status, name="server-status"),
     re_path(r"^openapi.json", openapi, name="openapi"),
     re_path(r"^", include(ROUTER.urls)),
 ]

--- a/rbac/management/group/view.py
+++ b/rbac/management/group/view.py
@@ -17,6 +17,7 @@
 
 """View for group management."""
 import logging
+import re
 
 from django.conf import settings
 from django.db.models.aggregates import Count
@@ -163,7 +164,7 @@ class GroupViewSet(
             return GroupRoleSerializerIn
         if self.request.method in ("POST", "PUT"):
             return GroupInputSerializer
-        if self.request.path.endswith("groups/") and self.request.method == "GET":
+        if re.match(".*/groups/?$", self.request.path) and self.request.method == "GET":
             return GroupInputSerializer
         return GroupSerializer
 

--- a/rbac/management/role/view.py
+++ b/rbac/management/role/view.py
@@ -134,9 +134,9 @@ class RoleViewSet(
 
     def get_serializer_class(self):
         """Get serializer class based on route."""
-        if self.request.path.endswith("roles/") and self.request.method == "GET":
+        if self.request.method == "GET" and re.match(".*/roles/?$", self.request.path):
             return RoleDynamicSerializer
-        if self.request.method == "PATCH" and re.match(".*/roles/.*/$", self.request.path):
+        if self.request.method == "PATCH" and re.match(".*/roles/.*/?$", self.request.path):
             return RolePatchSerializer
         return RoleSerializer
 

--- a/rbac/management/urls.py
+++ b/rbac/management/urls.py
@@ -20,7 +20,16 @@ from management.views import AccessView, GroupViewSet, PermissionViewSet, Policy
 from rest_framework.routers import DefaultRouter
 
 
-ROUTER = DefaultRouter()
+class OptionalSlashRouter(DefaultRouter):
+    """Custom Router that set optional trailing slash."""
+
+    def __init__(self, *args, **kwargs):
+        """Make all trailing slashes optional in the URLs used by the view sets."""
+        super().__init__(*args, **kwargs)
+        self.trailing_slash = "/?"
+
+
+ROUTER = OptionalSlashRouter()
 ROUTER.register(r"groups", GroupViewSet)
 ROUTER.register(r"roles", RoleViewSet)
 ROUTER.register(r"policies", PolicyViewSet)
@@ -28,7 +37,7 @@ ROUTER.register(r"permissions", PermissionViewSet)
 
 # pylint: disable=invalid-name
 urlpatterns = [
-    re_path(r"^principals/$", PrincipalView.as_view(), name="principals"),
-    re_path(r"^access/$", AccessView.as_view(), name="access"),
+    re_path(r"^principals/?$", PrincipalView.as_view(), name="principals"),
+    re_path(r"^access/?$", AccessView.as_view(), name="access"),
     re_path(r"^", include(ROUTER.urls)),
 ]

--- a/rbac/rbac/middleware.py
+++ b/rbac/rbac/middleware.py
@@ -19,6 +19,7 @@
 import binascii
 import json
 import logging
+import re
 from json.decoder import JSONDecodeError
 
 from django.conf import settings
@@ -221,7 +222,7 @@ class IdentityHeaderMiddleware(MiddlewareMixin):
                 return HttpResponse(json.dumps(payload), content_type="application/json", status=400)
 
             if settings.AUTHENTICATE_WITH_ORG_ID:
-                if not user.admin and not (request.path.endswith("/access/") and request.method == "GET"):
+                if not user.admin and not (re.match(".*/access/?$", request.path) and request.method == "GET"):
                     try:
                         tenant = Tenant.objects.filter(org_id=user.org_id).get()
                     except Tenant.DoesNotExist:
@@ -230,7 +231,7 @@ class IdentityHeaderMiddleware(MiddlewareMixin):
 
                     user.access = IdentityHeaderMiddleware._get_access_for_user(user.username, tenant)
             else:
-                if not user.admin and not (request.path.endswith("/access/") and request.method == "GET"):
+                if not user.admin and not (re.match(".*/access/?$", request.path) and request.method == "GET"):
                     try:
                         tenant_name = create_tenant_name(user.account)
                         tenant = Tenant.objects.filter(tenant_name=tenant_name).get()

--- a/tests/api/cross_access/test_view.py
+++ b/tests/api/cross_access/test_view.py
@@ -343,7 +343,7 @@ class CrossAccountRequestViewTests(IdentityRequest):
     def test_retrieve_request_query_by_account_success(self, mock_request):
         """Test retrieve of cross account request based on account number of identity."""
         client = APIClient()
-        response = client.get(f"{URL_LIST}{self.request_1.request_id}/", **self.headers)
+        response = client.get(f"{URL_LIST}/{self.request_1.request_id}/", **self.headers)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get("email"), "test_user@email.com")
@@ -353,14 +353,14 @@ class CrossAccountRequestViewTests(IdentityRequest):
     def test_retrieve_request_query_by_account_fail_if_request_in_another_account(self):
         """Test retrieve cross account request based on account number of identity would fail for non org admin."""
         client = APIClient()
-        response = client.get(f"{URL_LIST}{self.request_3.request_id}/", **self.headers)
+        response = client.get(f"{URL_LIST}/{self.request_3.request_id}/", **self.headers)
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_retrieve_request_query_by_account_fail_if_not_admin(self):
         """Test retrieve cross account request based on account number of identity would fail for non org admin."""
         client = APIClient()
-        response = client.get(f"{URL_LIST}{self.request_1.request_id}/", **self.associate_non_admin_request.META)
+        response = client.get(f"{URL_LIST}/{self.request_1.request_id}/", **self.associate_non_admin_request.META)
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
         self.assertEqual(response.data["errors"][0]["detail"].code, "permission_denied")
@@ -369,7 +369,7 @@ class CrossAccountRequestViewTests(IdentityRequest):
         """Test retrieve cross account request based on user id of identity."""
         client = APIClient()
         response = client.get(
-            f"{URL_LIST}{self.request_1.request_id}/?query_by=user_id", **self.associate_non_admin_request.META
+            f"{URL_LIST}/{self.request_1.request_id}/?query_by=user_id", **self.associate_non_admin_request.META
         )
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -382,7 +382,7 @@ class CrossAccountRequestViewTests(IdentityRequest):
         """Test retrieve cross account request based on user id of identity would fail for non associate."""
         client = APIClient()
         response = client.get(
-            f"{URL_LIST}{self.request_2.request_id}/?query_by=user_id", **self.associate_non_admin_request.META
+            f"{URL_LIST}/{self.request_2.request_id}/?query_by=user_id", **self.associate_non_admin_request.META
         )
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
@@ -390,7 +390,7 @@ class CrossAccountRequestViewTests(IdentityRequest):
     def test_retrieve_request_query_by_user_id_fail_if_not_associate(self):
         """Test retrieve cross account request based on user id of identity would fail for non associate."""
         client = APIClient()
-        response = client.get(f"{URL_LIST}{self.request_1.request_id}/?query_by=user_id", **self.headers)
+        response = client.get(f"{URL_LIST}/{self.request_1.request_id}/?query_by=user_id", **self.headers)
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
         self.assertEqual(response.data["errors"][0]["detail"].code, "permission_denied")
@@ -876,7 +876,7 @@ class CrossAccountRequestViewTests(IdentityRequest):
     def test_list_requests_query_by_org_id_success(self, mock_request):
         """Test that cross account request stores org_id."""
         client = APIClient()
-        response = client.get(f"{URL_LIST}{self.request_2.request_id}/", **self.headers)
+        response = client.get(f"{URL_LIST}/{self.request_2.request_id}/", **self.headers)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get("email"), "test_user@email.com")


### PR DESCRIPTION
## Link(s) to Jira
- [RHCLOUD-5481](https://issues.redhat.com/browse/RHCLOUD-5481)

## Description of Intent of Change(s)
**CURRENT STATE:** 
endpoints  contain trailing slash 
without trailing slash we get response with error in the html format (status 404)

example of request without trailing slash:
```
POST api/rbac/v1/groups
{
  "name": "Group_name_2",
  "description": "A description of Group"
}
```

response:
```
Status 404 Not Found

<!doctype html>
<html lang="en">
<head>
    <title>Not Found</title>
</head>
<body>
    <h1>Not Found</h1>
    <p>The requested resource was not found on this server.</p>
</body>
</html>
```

this current state is affected by:
- Django settings `APPEND_SLASH = False` ([docs here](https://docs.djangoproject.com/en/4.1/ref/settings/#append-slash))
- `rest_framework.routers.DefaultRouter()`  as our router ([docs here](https://www.django-rest-framework.org/api-guide/routers/#defaultrouter)) with default value `trailing_slash=True`
- using trailing slash in `urlpatterns` for endpoints that are not registered in `DefaultRouter()` - e.g. api/rbac/v1/principals/

Django settings can be found [here](https://github.com/RedHatInsights/insights-rbac/blob/4c72d551c81ca69f7bfc6d8a82bb90dbc46ff0c6/rbac/rbac/settings.py#L305). `DefaultRouter()` and `urlpatterns` for example [here](https://github.com/RedHatInsights/insights-rbac/blob/4c72d551c81ca69f7bfc6d8a82bb90dbc46ff0c6/rbac/management/urls.py#L23-L33).

**ANALYSIS:**
We cannot change Django settings `APPEND_SLASH` to `True` because then if the request does not match the pattern, the request is redirected to the same url with trailing slash, but this redirecting causes the data submitted in a POST request to be lost (and redirected request is send as GET).

We can change the parameter `trailing_slash to False`
```
ROUTER = DefaultRouter(trailing_slash=False)
```
then the endpoints registered in `DefaultRouter()` are working without trailing slash and we can have our api that works without trailing slashes 
(in this case we need to do appropriate change for endpoints that are not registered in `DefaultRouter()`)

We can have api that accepts both options - so it won't matter if the endpoint contains trailing slash or not and both options will return the same result.
But I believe it is fine to have an api with all its endpoints end with a slash or not end with a slash -> so there is no need to support both options.

So my recommendation is to not change anything. All our endpoints now contain trailing slash (and it is also stated this way in our openapi spec).

However, if we want, we can set our API to accept both variants by defining a custom router as captured in this PR. Please note that this is only a draft and the PR does not contain the necessary changes for internal endpoints.

## Local Testing
just test that endpoints are working correctly with and without trailing slash

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?