### PR TITLE
[RHCLOUD-24682] Remove principal from group (= remove relation between principal and group in the management_group_principal table)

### DIFF
--- a/docs/source/specs/openapi.json
+++ b/docs/source/specs/openapi.json
@@ -1318,7 +1318,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/ErrorNotFound"
                 }
               }
             }

--- a/rbac/management/group/view.py
+++ b/rbac/management/group/view.py
@@ -390,7 +390,7 @@ class GroupViewSet(
                         "errors": [
                             {
                                 "detail": f"User '{username}' not found in the group '{group.name}'.",
-                                "status": "404",
+                                "status": status.HTTP_404_NOT_FOUND,
                                 "source": "principals",
                             }
                         ],

--- a/tests/management/group/test_view.py
+++ b/tests/management/group/test_view.py
@@ -956,7 +956,7 @@ class GroupViewsetTests(IdentityRequest):
         response = client.delete(url, format="json", **self.headers)
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
-        err_message = f"User '{invalid_username}' not found in the group '{self.group.name}'."
+        err_message = f"User(s) {{'{invalid_username}'}} not found in the group '{self.group.name}'."
         self.assertEqual(str(response.data.get("errors")[0].get("detail")), err_message)
 
     @patch(

--- a/tests/management/group/test_view.py
+++ b/tests/management/group/test_view.py
@@ -948,6 +948,17 @@ class GroupViewsetTests(IdentityRequest):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(str(response.data.get("errors")[0].get("detail")), f"{invalid_uuid} is not a valid UUID.")
 
+    def test_remove_group_principals_invalid_username(self):
+        """Test that removing a principal returns an error for invalid username."""
+        invalid_username = "invalid_3098408"
+        url = reverse("group-principals", kwargs={"uuid": self.group.uuid}) + f"?usernames={invalid_username}"
+        client = APIClient()
+        response = client.delete(url, format="json", **self.headers)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+        err_message = f"User '{invalid_username}' not found in the group '{self.group.name}'."
+        self.assertEqual(str(response.data.get("errors")[0].get("detail")), err_message)
+
     @patch(
         "management.principal.proxy.PrincipalProxy.request_filtered_principals",
         return_value={

--- a/tests/management/group/test_view.py
+++ b/tests/management/group/test_view.py
@@ -937,13 +937,16 @@ class GroupViewsetTests(IdentityRequest):
         client = APIClient()
         response = client.delete(url, format="json", **self.headers)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(str(response.data.get("errors")[0].get("detail")), "Query parameter usernames is required.")
 
     def test_remove_group_principals_invalid_guid(self):
         """Test that removing a principal returns an error when GUID is invalid."""
-        url = reverse("group-principals", kwargs={"uuid": "invalid"})
+        invalid_uuid = "invalid"
+        url = reverse("group-principals", kwargs={"uuid": invalid_uuid})
         client = APIClient()
         response = client.delete(url, format="json", **self.headers)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(str(response.data.get("errors")[0].get("detail")), f"{invalid_uuid} is not a valid UUID.")
 
     @patch(
         "management.principal.proxy.PrincipalProxy.request_filtered_principals",


### PR DESCRIPTION
## Link(s) to Jira
- [RHCLOUD-24682](https://issues.redhat.com/browse/RHCLOUD-24682)

## Description of Intent of Change(s)
when we try to delete not existing principal from a group
we get 500 Internal Server Error because there is [referenced variable before assignment](https://github.com/RedHatInsights/insights-rbac/blob/4c72d551c81ca69f7bfc6d8a82bb90dbc46ff0c6/rbac/management/group/view.py#L388)
+
in this case we should return 404


## Local Testing
`DELETE api/rbac/v1/groups/{{uuid}}/principals/?usernames=not-valid-username`

