### PR TITLE
[RHCLOUD-21260] Add admin_only parameter support for groups/:UID/principals 

### DIFF
--- a/docs/source/specs/openapi.json
+++ b/docs/source/specs/openapi.json
@@ -1187,6 +1187,20 @@
             }
           },
           {
+            "name": "admin_only",
+            "in": "query",
+            "description": "Get only admin users within an account.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "true",
+                "false"
+              ],
+              "default": "false"
+            }
+          },
+          {
             "name": "principal_username",
             "in": "query",
             "required": false,

--- a/rbac/management/group/view.py
+++ b/rbac/management/group/view.py
@@ -41,7 +41,7 @@ from management.permissions import GroupAccessPermission
 from management.principal.model import Principal
 from management.principal.proxy import PrincipalProxy
 from management.principal.serializer import PrincipalSerializer
-from management.principal.view import USERNAME_ONLY_KEY, VALID_BOOLEAN_VALUE
+from management.principal.view import ADMIN_ONLY_KEY, USERNAME_ONLY_KEY, VALID_BOOLEAN_VALUE
 from management.querysets import get_group_queryset, get_role_queryset
 from management.role.view import RoleViewSet
 from management.utils import validate_and_get_key, validate_group_name, validate_uuid
@@ -533,6 +533,11 @@ class GroupViewSet(
                     request.query_params, USERNAME_ONLY_KEY, VALID_BOOLEAN_VALUE, "false"
                 ),
             }
+
+            admin_only = validate_and_get_key(request.query_params, ADMIN_ONLY_KEY, VALID_BOOLEAN_VALUE, False, False)
+            if admin_only == "true":
+                options[ADMIN_ONLY_KEY] = True
+
             if settings.AUTHENTICATE_WITH_ORG_ID:
                 resp = proxy.request_filtered_principals(username_list, org_id=org_id, options=options)
             else:


### PR DESCRIPTION
## Depends on
- [x] https://github.com/RedHatInsights/backoffice-proxy/pull/108

## Link(s) to Jira
- https://issues.redhat.com/browse/RHCLOUD-21260

## Description of Intent of Change(s)
This adds support for admin_only parameter for API endpoint:

```
api/rbac/v1/groups/:UID/principals
```

This was not possible before because this request depends on backoffice proxy. 
It was not possible because RBAC uses call to BOP to validate principals in this request. 

This validation did not support **admin_only** parameter - so support for **admin_only** parameter needed to be added in BOP: https://github.com/RedHatInsights/backoffice-proxy/pull/108


## Local Testing
IF https://github.com/RedHatInsights/backoffice-proxy/pull/108 is not merged we need to run backoffice proxy locally with this PR.

- run rbac
- call request:
preparation:

Prepare data so such request will return you org_admin and non admins:
```
api/rbac/v1/groups/adaad94e-d888-4469-8ed7-160d53f88159/principals/
```


```
"data": [
    {
      "username": "lpichler99",
      "email": "lpichler@redhat.com",
      "first_name": "Libor",
      "last_name": null,
      "is_active": true,
      "is_org_admin": true
    },
    {
      "username": "lpichler98a",
      "email": "lpichler@redhat.com",
      "first_name": "Og",
      "last_name": null,
      "is_active": true,
      "is_org_admin": false
    }
  ]
}
```

With this change when you call 

```
api/rbac/v1/groups/adaad94e-d888-4469-8ed7-160d53f88159/principals/?admin_only=true
```

response should be:
```
"data": [
    {
      "username": "lpichler99",
      "email": "lpichler@redhat.com",
      "first_name": "Libor",
      "last_name": null,
      "is_active": true,
      "is_org_admin": true
    }
  ]
}
```

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
