### PR TITLE
[RHCLOUD-19598] added min 3 replicas exception for DVO checks for rbac scheduler and worker

### DIFF
--- a/deploy/rbac-clowdapp.yml
+++ b/deploy/rbac-clowdapp.yml
@@ -26,6 +26,9 @@ objects:
     deployments:
     - name: worker-service
       minReplicas: ${{MIN_WORKER_REPLICAS}}
+      metadata:
+        annotations:
+          ignore-check.kube-linter.io/minimum-three-replicas: "dont need 3 replicas - runs background processes from turnpike/weekly tasks"
       podSpec:
         image: ${IMAGE}:${IMAGE_TAG}
         initContainers:
@@ -188,6 +191,9 @@ objects:
 
     - name: scheduler-service
       minReplicas: ${{MIN_SCHEDULER_REPLICAS}}
+      metadata:
+        annotations:
+          ignore-check.kube-linter.io/minimum-three-replicas: "dont need 3 replicas - keeps the cron scheduled for the weekly tasks"
       podSpec:
         image: ${IMAGE}:${IMAGE_TAG}
         command:


### PR DESCRIPTION
to solve FIRING tickets (minimum three replicas DVO) we need to set an exception for rbac worker and scheduler


- [RHCLOUD-19598 [FIRING:2] deployment_validation_operator_minimum_three_replicas rbac crcp01ue1 deployment-validation-operator-metrics deployment-validation-operator](https://issues.redhat.com/browse/RHCLOUD-19598)
- [RHCLOUD-19512 [FIRING:2] deployment_validation_operator_minimum_three_replicas rbac crcs02ue1 deployment-validation-operator-metrics deployment-validation-operator](https://issues.redhat.com/browse/RHCLOUD-19512)