### PR TITLE
Support SSL when connecting to redis

### DIFF
--- a/rbac/management/cache.py
+++ b/rbac/management/cache.py
@@ -24,7 +24,7 @@ class BasicCache:
     def connection(self):
         """Get Redis connection from the pool."""
         if not self._connection:
-            self._connection = Redis(connection_pool=_connection_pool)
+            self._connection = Redis(connection_pool=_connection_pool, ssl=settings.REDIS_SSL)
             try:
                 self._connection.ping()
             except exceptions.RedisError:


### PR DESCRIPTION
## Link(s) to Jira
- https://osd-jira.redhat-osd.local:8443/browse/FRH-23715

## Description of Intent of Change(s)
This PR is to support connecting to redis over SSL when a password is specified. The way to get ssl working with a connection pool is kind of weird in the sense of you have to specify `redis.SSLConnection` as the class - but the celery just needs `rediss://` at the beginning of the URL. 

The docs are non-existent for this, and this is where I found out how to get the parameters right: https://github.com/redis/redis-py/issues/780

## Local Testing
How can the feature be exercised?
How can the bug be exploited and fix confirmed?
Is any special local setup required?

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
