### PR TITLE
Add external source id to principals

### DIFF
--- a/rbac/management/principal/proxy.py
+++ b/rbac/management/principal/proxy.py
@@ -122,6 +122,7 @@ class PrincipalProxy:  # pylint: disable=too-few-public-methods
             "last_name": item.get("last_name"),
             "is_active": item.get("is_active"),
             "is_org_admin": item.get("is_org_admin"),
+            "external_source_id": item.get("id"),
         }
 
         if return_id:

--- a/tests/management/principal/test_proxy.py
+++ b/tests/management/principal/test_proxy.py
@@ -65,6 +65,7 @@ def mocked_requests_get_200_json(*args, **kwargs):  # pylint: disable=unused-arg
         "last_name": "user1",
         "is_active": "true",
         "is_org_admin": "true",
+        "id": "3",
     }
     json_response = [user]
     return MockResponse(json_response, status.HTTP_200_OK)
@@ -79,6 +80,7 @@ def mocked_requests_get_200_json_count(*args, **kwargs):  # pylint: disable=unus
         "last_name": "user1",
         "is_active": "true",
         "is_org_admin": "true",
+        "id": "1",
     }
     user2 = {
         "username": "test_user2",
@@ -87,6 +89,7 @@ def mocked_requests_get_200_json_count(*args, **kwargs):  # pylint: disable=unus
         "last_name": "user2",
         "is_active": "true",
         "is_org_admin": "false",
+        "id": "2",
     }
     json_response = {"userCount": 2, "users": [user1, user2]}
     return MockResponse(json_response, status.HTTP_200_OK)
@@ -168,6 +171,7 @@ class PrincipalProxyTest(TestCase):
             "last_name": "user1",
             "is_active": "true",
             "is_org_admin": "true",
+            "external_source_id": "3",
         }
         expected = {"data": [user], "status_code": 200}
         self.assertEqual(expected, result)
@@ -185,6 +189,7 @@ class PrincipalProxyTest(TestCase):
             "last_name": "user1",
             "is_active": "true",
             "is_org_admin": "true",
+            "external_source_id": "1",
         }
         user2 = {
             "username": "test_user2",
@@ -193,6 +198,7 @@ class PrincipalProxyTest(TestCase):
             "last_name": "user2",
             "is_active": "true",
             "is_org_admin": "false",
+            "external_source_id": "2",
         }
         expected = {"data": {"userCount": 2, "users": [user1, user2]}, "status_code": 200}
         self.assertEqual(expected, result)


### PR DESCRIPTION
This returns `external_source_id` as part of a `/principals/` GET request, in order
to tie user records back to the external source of truth.

These IDs should be populated by bop/mbop regardless of the source of truth in
a given environment and is already part of the API spec for bop.

We may want to include a source name mapping at some point as well, but since this
is environment specific, it should be implicit knowledge from whoever is consuming
and requiring this new field.