### PR TITLE
[RHCLOUD-26054] Improve logging for principals in group changes 

### DIFF
--- a/rbac/management/group/model.py
+++ b/rbac/management/group/model.py
@@ -140,8 +140,8 @@ def principal_group_change_sync_handler(
 
     if action in ["pre_remove", "post_remove"] and isinstance(instance, Group):
         if instance.tenant is not None:
-            org_id = instance.tenant.org_id if hasattr(instance.tenant, 'org_id') else None
-            account_id = instance.tenant.account_id if hasattr(instance.tenant, 'account_id') else None
+            org_id = instance.tenant.org_id if hasattr(instance.tenant, "org_id") else None
+            account_id = instance.tenant.account_id if hasattr(instance.tenant, "account_id") else None
             logger.info("Action %s for group: %s, OrgId: %s, AcctId: %s", action, instance.name, org_id, account_id)
 
     if action in ["post_add", "pre_remove", "pre_clear"]:

--- a/rbac/management/group/model.py
+++ b/rbac/management/group/model.py
@@ -137,6 +137,13 @@ def principal_group_change_sync_handler(
 ):
     """Signal handler to inform external services of Group membership changes."""
     logger.info("Handling signal for group %s membership change - informing sync topic", instance)
+
+    if action in ["pre_remove", "post_remove"] and isinstance(instance, Group):
+        if instance.tenant is not None:
+            org_id = instance.tenant.org_id if hasattr(instance.tenant, 'org_id') else None
+            account_id = instance.tenant.account_id if hasattr(instance.tenant, 'account_id') else None
+            logger.info("Action %s for group: %s, OrgId: %s, AcctId: %s", action, instance.name, org_id, account_id)
+
     if action in ["post_add", "pre_remove", "pre_clear"]:
         if isinstance(instance, Group):
             sync_handlers.send_sync_message(

--- a/rbac/management/group/view.py
+++ b/rbac/management/group/view.py
@@ -19,10 +19,10 @@
 import logging
 
 from django.conf import settings
+from django.db import transaction
 from django.db.models.aggregates import Count
 from django.utils.translation import gettext as _
 from django_filters import rest_framework as filters
-from django.db import transaction
 from management.filters import CommonFilters
 from management.group.definer import add_roles, remove_roles, set_system_flag_before_update
 from management.group.model import Group
@@ -378,7 +378,6 @@ class GroupViewSet(
 
     def remove_principals(self, group, principals, account=None, org_id=None):
         """Process list of principals and remove them from the group."""
-
         req_id = getattr(self.request, "req_id", None)
         logger.info(f"[Request_id:{req_id}] remove_principals for group {group.name} for org id {org_id} started...")
 
@@ -388,9 +387,7 @@ class GroupViewSet(
             tenant = Tenant.objects.get(tenant_name=f"acct{account}")
 
         valid_principals = Principal.objects.filter(group=group, tenant=tenant, username__in=principals)
-        valid_usernames = valid_principals.values_list(
-            "username", flat=True
-        )
+        valid_usernames = valid_principals.values_list("username", flat=True)
         usernames_diff = set(principals) - set(valid_usernames)
         if usernames_diff:
             if settings.AUTHENTICATE_WITH_ORG_ID:
@@ -412,7 +409,7 @@ class GroupViewSet(
             for principal in valid_principals:
                 group.principals.remove(principal)
 
-        logger.info(f"[Request_id:{req_id}] Principals {valid_usernames} removed from group {group.name} for org id {org_id}.")
+        logger.info(f"[Request_id:{req_id}] {valid_usernames} removed from group {group.name} for org id {org_id}.")
         for username in principals:
             group_principal_change_notification_handler(self.request.user, group, username, "removed")
         return group


### PR DESCRIPTION
- Change a way for principal membership in groups and add request id to remove principal method logs
   - Reason for that changing a way is that `delete` method did not invoke [handler method for signal handler](https://github.com/RedHatInsights/insights-rbac/blob/master/rbac/management/group/model.py#L164) for membership changes. It is working with remove method - (I am aware about performance degradation - but this is not often operation)
- Improve logging in signal hander for membership changes

## Link(s) to Jira
- https://issues.redhat.com/browse/RHCLOUD-26054?src=confmacro



