### PR TITLE
Send an unique rh-message-id for each notification

### DIFF
--- a/rbac/management/notifications/notification_handlers.py
+++ b/rbac/management/notifications/notification_handlers.py
@@ -32,7 +32,6 @@ from api.models import Tenant
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 noto_producer = RBACProducer()
 noto_topic = settings.NOTIFICATIONS_TOPIC
-noto_headers = [("rh-message-id", str(uuid4()).encode("utf-8"))]
 with open(os.path.join(settings.BASE_DIR, "management", "notifications", "message_template.json")) as template:
     message_template = json.load(template)
 
@@ -52,6 +51,7 @@ def build_notifications_message(event_type, payload, account_id=None, org_id=Non
 def notify(event_type, payload, account_id=None, org_id=None):
     """Actually send notifications message."""
     noto_message = build_notifications_message(event_type, payload, account_id, org_id)
+    noto_headers = [("rh-message-id", str(uuid4()).encode("utf-8"))]
     noto_producer.send_kafka_message(noto_topic, noto_message, noto_headers)
 
 


### PR DESCRIPTION

## Link(s) to Jira
-

## Description of Intent of Change(s)
Notifications expects `rh-message-id` to be unique per each message/app. 

This changes the header to be created right before sending the notification to allow to get a new id on each notification.

Notifications will drop messages with repeated ids as it expect these to be already processed.

## Local Testing

Send multiple notifications and verify kafka messages. Each one should have an unique id.

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
