### PR TITLE
Add group chrome kafka message

### DIFF
--- a/deploy/rbac-clowdapp.yml
+++ b/deploy/rbac-clowdapp.yml
@@ -23,6 +23,9 @@ objects:
     - topicName: ${EXTERNAL_SYNC_TOPIC}
       partitions: 1
       replicas: 3
+    - topicName: ${EXTERNAL_CHROME_TOPIC}
+      partitions: 1
+      replicas: 3
     deployments:
     - name: worker-service
       minReplicas: ${{MIN_WORKER_REPLICAS}}
@@ -186,6 +189,8 @@ objects:
             value: ${NOTIFICATIONS_TOPIC}
           - name: EXTERNAL_SYNC_TOPIC
             value: ${EXTERNAL_SYNC_TOPIC}
+          - name: EXTERNAL_CHROME_TOPIC
+            value: ${EXTERNAL_CHROME_TOPIC}
           - name: MIGRATE_AND_SEED_ON_INIT
             value: ${WORKER_MIGRATE_AND_SEED_ON_INIT}
 
@@ -451,6 +456,8 @@ objects:
             value: ${KAFKA_ENABLED}
           - name: EXTERNAL_SYNC_TOPIC
             value: ${EXTERNAL_SYNC_TOPIC}
+          - name: EXTERNAL_CHROME_TOPIC
+            value: ${EXTERNAL_CHROME_TOPIC}
           - name: MIGRATE_AND_SEED_ON_INIT
             value: ${SERVICE_MIGRATE_AND_SEED_ON_INIT}
           - name: USE_CLOWDER_CA_FOR_BOP
@@ -3345,6 +3352,8 @@ parameters:
   value: 'False'
 - name: EXTERNAL_SYNC_TOPIC
   value: 'platform.rbac.sync'
+- name: EXTERNAL_CHROME_TOPIC
+  value: 'platform.chrome.sync'
 - name: SERVICE_MIGRATE_AND_SEED_ON_INIT
   value: 'True'
 - name: WORKER_MIGRATE_AND_SEED_ON_INIT

--- a/rbac/internal/integration/chrome_handlers.py
+++ b/rbac/internal/integration/chrome_handlers.py
@@ -1,0 +1,53 @@
+#
+# Copyright 2019 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+"""Notification handlers of object change."""
+import json
+import logging
+import os
+from uuid import uuid4
+
+from core.kafka import RBACProducer
+from django.conf import settings
+from django.utils import timezone
+
+logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
+chrome_producer = RBACProducer()
+chrome_topic = settings.EXTERNAL_CHROME_TOPIC
+
+with open(os.path.join(settings.BASE_DIR, "internal", "integration", "chrome_message_template.json")) as template:
+    message_template = json.load(template)
+
+
+def build_chrome_message(event_type, uuid, org_id):
+    """Create message based on template."""
+    message = message_template
+    message["id"] = str(uuid4())
+    message["time"] = timezone.now().isoformat()
+    message["data"]["organizations"] = [org_id]
+    message["data"]["payload"]["entityType"] = "rbac.group"
+    message["data"]["payload"]["entityId"] = str(uuid)
+    message["data"]["payload"]["eventType"] = event_type
+    return message
+
+
+def send_chrome_message(event_type, uuid, org_id):
+    """Build and send chrome message."""
+    if not settings.AUTHENTICATE_WITH_ORG_ID:
+        return
+    chrome_message = build_chrome_message(event_type, uuid, org_id)
+    chrome_producer.send_kafka_message(chrome_topic, chrome_message)

--- a/rbac/internal/integration/chrome_message_template.json
+++ b/rbac/internal/integration/chrome_message_template.json
@@ -1,0 +1,17 @@
+{
+    "specversion": "1.0.2",
+    "type": "data.invalidation",
+    "source": "/rbac/v1/status/",
+    "id": "",
+    "time": "",
+    "datacontenttype": "application/json",
+    "data":{
+        "broadcast": false,
+        "organizations": [],
+        "payload": {
+            "entityType": "rbac.group",
+            "entityId": "",
+            "eventType": ""
+        }
+    }
+}

--- a/rbac/rbac/settings.py
+++ b/rbac/rbac/settings.py
@@ -385,6 +385,7 @@ NOTIFICATIONS_RH_ENABLED = ENVIRONMENT.get_value("NOTIFICATIONS_RH_ENABLED", def
 NOTIFICATIONS_TOPIC = ENVIRONMENT.get_value("NOTIFICATIONS_TOPIC", default=None)
 
 EXTERNAL_SYNC_TOPIC = ENVIRONMENT.get_value("EXTERNAL_SYNC_TOPIC", default=None)
+EXTERNAL_CHROME_TOPIC = ENVIRONMENT.get_value("EXTERNAL_CHROME_TOPIC", default=None)
 
 # if we don't enable KAFKA we can't use the notifications
 if not KAFKA_ENABLED:
@@ -426,6 +427,10 @@ if KAFKA_ENABLED:
     clowder_sync_topic = KafkaTopics.get(EXTERNAL_SYNC_TOPIC)
     if clowder_sync_topic:
         EXTERNAL_SYNC_TOPIC = clowder_sync_topic.name
+
+    clowder_chrome_topic = KafkaTopics.get(EXTERNAL_CHROME_TOPIC)
+    if clowder_chrome_topic:
+        EXTERNAL_CHROME_TOPIC = clowder_chrome_topic.name
 
 # BOP TLS settings
 if ENVIRONMENT.bool("CLOWDER_ENABLED", default=False) and ENVIRONMENT.bool("USE_CLOWDER_CA_FOR_BOP", default=False):

--- a/tox.ini
+++ b/tox.ini
@@ -31,6 +31,7 @@ setenv =
   AUTHENTICATE_WITH_ORG_ID=True
   NOTIFICATIONS_TOPIC=platform.notifications.ingress
   EXTERNAL_SYNC_TOPIC=platform.rbac.sync
+  EXTERNAL_CHROME_TOPIC=platform.chrome
   MOCK_KAFKA=True
   KAFKA_ENABLED=True
 deps =


### PR DESCRIPTION
We need to send kafka message when 
group is created/updated/deleted.

format of message is cloud event, example of sent message to `platform.chrome` topic:

```
{
  "specversion": "1.0.2",
  "type": "data.invalidation",
  "source": "/rbac/v1/status/",
  "id": "480e9e77-f71b-41ee-8d21-11c117afc6d9",
  "time": "2023-07-04T13:05:06.345064+00:00",
  "datacontenttype": "application/json",
  "data": {
    "broadcast": false,
    "organizations": [
      "11111"
    ],
    "payload": {
      "entityType": "rbac.group",
      "entityId": "be5242af-eabe-4925-b176-b45cc251d7df",
      "eventType": "create"
    }
  }
}
```




This is experimental effort - tests are not included for now.

