### PR TITLE
Update to docker-up & docker-down targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -257,6 +257,7 @@ oc-up-all: oc-up oc-create-rbac
 oc-up-db: oc-up oc-create-db
 
 docker-up:
+	@docker network ls --format '{{.Name}}' |grep -q  rbac-network > /dev/null 2>&1 && echo "" || docker network create rbac-network
 	docker-compose up --build -d
 
 docker-logs:
@@ -269,6 +270,7 @@ docker-test-all:
 	docker-compose -f rbac-test.yml up --build
 
 docker-down:
-	docker-compose down
+	@docker ps --format '{{.Names}}' |grep -q  rbac >/dev/null 2>&1 && docker-compose down || echo ""
+	@docker network ls --format '{{.Name}}' |grep -q  rbac-network > /dev/null 2>&1 && \docker network rm rbac-network > /dev/null 2>&1 || echo ""
 
 .PHONY: docs


### PR DESCRIPTION
## Link(s) to Jira
[RHCLOUD-26956](https://issues.redhat.com/browse/RHCLOUD-26956)

## Description of Intent of Change(s)
Update to docker-up and docker-down targets so that it will be idempotent and also handle setup and tear down of the rbac-network on both

## Local Testing
1.  Cleanup first
2. pipenv install --dev 
3. pipenv shell
4. run `make docker-up`
     - Check docker containers are running (`docker ps --format '{{.Names}}' |grep -q  rbac`)
     - Check docker network is setup (`docker network ls --format '{{.Name}}' |grep -q  rbac-network`)
5. run `make docker-up` again (should just run with no errors)
6. run `make docker-down`
     - Check docker containers are NOT running (`docker ps --format '{{.Names}}' |grep -q  rbac`)
     - Check docker network is NOT setup (`docker network ls --format '{{.Name}}' |grep -q  rbac-network`)
 7. run `make docker-down` (should run with no errors)