### PR TITLE
[RHCLOUD-26991] Fix for warning in docker-compose network setup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,5 +79,5 @@ services:
       - ./pg_data:/var/lib/postgresql/data:z
 networks:
   default:
-    external:
-      name: rbac-network
+    name: rbac-network
+    external: true


### PR DESCRIPTION
## Link(s) to Jira
- [RHCLOUD-26991](https://issues.redhat.com/browse/RHCLOUD-26991)

## Description of Intent of Change(s)
Fix the warning that is being deisplayed when running `make docker-up`

## Local Testing
Prior to this change you will see the following
```
> make docker-up
\e]0;Making insights-rbac708570eb27866b01f8bd9767f746e3fc9b4e2a36cb24767e2772f2ab948680c4
docker-compose up --build -d
WARN[0000] network default: network.external.name is deprecated in favor of network.name 
```

After the change you do not see the warning
