### PR TITLE
[RHCLOUD-25689] - Fix groups and counts for admin and platform roles

### DIFF
--- a/rbac/management/role/definitions/inventory_local_test.json
+++ b/rbac/management/role/definitions/inventory_local_test.json
@@ -1,0 +1,20 @@
+{
+    "roles": [
+      {
+        "name": "Inventory Hosts Administrator",
+        "description": "Be able to read and edit Inventory Hosts data.",
+        "system": true,
+        "platform_default": true,
+        "admin_default": true,
+        "version": 3,
+        "access": [
+          {
+            "permission": "inventory:hosts:write"
+          },
+          {
+            "permission": "inventory:hosts:read"
+          }
+        ]
+      }
+    ]
+  }

--- a/rbac/management/role/definitions/inventory_local_test.json
+++ b/rbac/management/role/definitions/inventory_local_test.json
@@ -1,8 +1,8 @@
 {
     "roles": [
       {
-        "name": "Inventory Hosts Administrator",
-        "description": "Be able to read and edit Inventory Hosts data.",
+        "name": "Inventory Hosts Administrator Local Test",
+        "description": "Be able to read and edit Inventory Hosts data. Just for local testing.",
         "system": true,
         "platform_default": true,
         "admin_default": true,

--- a/rbac/management/role/permissions/inventory_local_test.json
+++ b/rbac/management/role/permissions/inventory_local_test.json
@@ -1,0 +1,32 @@
+{
+    "*": [
+        {
+            "verb": "read"
+        },
+        {
+            "verb": "*"
+        }
+    ],
+    "hosts": [
+        {
+            "verb": "read"
+        },
+        {
+            "verb": "write"
+        },
+        {
+            "verb": "*"
+        }
+    ],
+    "groups": [
+        {
+            "verb": "read"
+        },
+        {
+            "verb": "write"
+        },
+        {
+            "verb": "*"
+        }
+    ]
+}

--- a/rbac/management/role/serializer.py
+++ b/rbac/management/role/serializer.py
@@ -345,9 +345,14 @@ def obtain_groups_in(obj, request):
     qs = (
         assigned_groups
         | (
-            Group.platform_default_set().filter(tenant=request.tenant).filter(policies__in=policy_ids)
-            or Group.platform_default_set().filter(tenant=public_tenant).filter(policies__in=policy_ids)
-            | Group.admin_default_set().filter(tenant=public_tenant).filter(policies__in=policy_ids)
+            (
+                Group.platform_default_set().filter(tenant=request.tenant).filter(policies__in=policy_ids)
+                or Group.platform_default_set().filter(tenant=public_tenant).filter(policies__in=policy_ids)
+            )
+            | (
+                Group.admin_default_set().filter(tenant=request.tenant).filter(policies__in=policy_ids)
+                or Group.admin_default_set().filter(tenant=public_tenant).filter(policies__in=policy_ids)
+            )
         )
     ).distinct()
 

--- a/rbac/management/role/serializer.py
+++ b/rbac/management/role/serializer.py
@@ -347,7 +347,7 @@ def obtain_groups_in(obj, request):
         | (
             Group.platform_default_set().filter(tenant=request.tenant).filter(policies__in=policy_ids)
             or Group.platform_default_set().filter(tenant=public_tenant).filter(policies__in=policy_ids)
-            or Group.admin_default_set().filter(tenant=public_tenant).filter(policies__in=policy_ids)
+            | Group.admin_default_set().filter(tenant=public_tenant).filter(policies__in=policy_ids)
         )
     ).distinct()
 

--- a/rbac/management/role/serializer.py
+++ b/rbac/management/role/serializer.py
@@ -342,19 +342,14 @@ def obtain_groups_in(obj, request):
         assigned_groups = filter_queryset_by_tenant(Group.objects.filter(policies__in=policy_ids), request.tenant)
 
     public_tenant = Tenant.objects.get(tenant_name="public")
-    qs = (
-        assigned_groups
-        | (
-            (
-                Group.platform_default_set().filter(tenant=request.tenant).filter(policies__in=policy_ids)
-                or Group.platform_default_set().filter(tenant=public_tenant).filter(policies__in=policy_ids)
-            )
-            | (
-                Group.admin_default_set().filter(tenant=request.tenant).filter(policies__in=policy_ids)
-                or Group.admin_default_set().filter(tenant=public_tenant).filter(policies__in=policy_ids)
-            )
-        )
-    ).distinct()
+    platform_default_groups = Group.platform_default_set().filter(tenant=request.tenant).filter(
+        policies__in=policy_ids
+    ) or Group.platform_default_set().filter(tenant=public_tenant).filter(policies__in=policy_ids)
+    admin_default_groups = Group.admin_default_set().filter(tenant=request.tenant).filter(
+        policies__in=policy_ids
+    ) or Group.admin_default_set().filter(tenant=public_tenant).filter(policies__in=policy_ids)
+
+    qs = (assigned_groups | platform_default_groups | admin_default_groups).distinct()
 
     return qs
 

--- a/tests/management/role/test_view.py
+++ b/tests/management/role/test_view.py
@@ -120,7 +120,7 @@ class RoleViewsetTests(IdentityRequest):
         self.test_adminRole = Role(**admin_def_role_config, tenant=self.test_tenant)
         self.test_adminRole.save()
 
-        self.test_platformAdminRole = Role(**platform_admin_def_role_config, tenant = self.test_tenant)
+        self.test_platformAdminRole = Role(**platform_admin_def_role_config, tenant=self.test_tenant)
         self.test_platformAdminRole.save()
 
         self.test_sysRole = Role(**sys_role_config, tenant=self.test_tenant)
@@ -130,7 +130,9 @@ class RoleViewsetTests(IdentityRequest):
         self.test_defRole.save()
         self.test_defRole.save()
 
-        self.test_policy.roles.add(self.test_defRole, self.test_sysRole, self.test_adminRole, self.test_platformAdminRole)
+        self.test_policy.roles.add(
+            self.test_defRole, self.test_sysRole, self.test_adminRole, self.test_platformAdminRole
+        )
         self.test_policy.save()
 
         self.test_policy_two.roles.add(self.test_platformAdminRole)


### PR DESCRIPTION
## Link(s) to Jira
- [RHCLOUD-25689](https://issues.redhat.com/browse/RHCLOUD-25689)

## Description of Intent of Change(s)
- Fixes the grouping query for the admin and platform default groups in the role serializer. Original query used the python or operator which will take the first value. Changing the check to use the `|` operator for query objects to perform a union check on platform or admin. 

## Local Testing
1. Start up the build 
2. Seed the data: `ACCESS_CACHE_CONNECT_SIGNALS=False MAX_SEED_THREADS=2 ./rbac/manage.py seeds --roles --permissions --groups`
3. Hit the following Get endpoint `/api/rbac/v1/roles/?display_name=Inventory Hosts Administrator&scope=account&order_by=display_name&add_fields=groups_in_count%2Cgroups_in`
4. This should return the following information:
- Note that the groups in should have both default and default admin access, and the groups in count should be 2.
```
"data": [
        {
            "uuid": "221ab349-6808-4f2b-b5e4-38ded62c281c",
            "name": "Inventory Hosts Administrator",
            "display_name": "Inventory Hosts Administrator",
            "description": "Be able to read and edit Inventory Hosts data.",
            "created": "2023-07-10T15:54:45.601068Z",
            "modified": "2023-07-10T15:54:45.601237Z",
            "policyCount": 2,
            "groups_in": [
                {
                    "name": "Default access",
                    "uuid": "5572df00-134b-4db4-93c4-6375d7db21cd",
                    "description": "This group contains the roles that all users inherit by default. Adding or removing roles in this group will affect permissions for all users in your organization."
                },
                {
                    "name": "Default admin access",
                    "uuid": "fa466287-a03d-48b9-93d0-e520136a75b1",
                    "description": "This group contains the roles that all org admin users inherit by default. Adding or removing roles in this group will affect permissions for all org admin users in your org."
                }
            ],
            "groups_in_count": 2,
            "accessCount": 2,
            "applications": [
                "inventory"
            ],
            "system": true,
            "platform_default": true,
            "admin_default": true,
            "external_role_id": null,
            "external_tenant": null
        }
    ]
```
5. Run unit tests: `tox`

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [x] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
