### PR TITLE
[RHCLOUD-27072] Add 'format' task to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,9 @@ html:
 lint:
 	tox -elint
 
+format:
+	black -t py39 -l 119 rbac tests
+
 reinitdb:
 	make start-db
 	make reset-db

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ Please use \`make <target>' where <target> is one of:
   help                     show this message
   html                     create html documentation for the project
   lint                     run linting against the project
+  format                   format linting errors found by lint task
 
 --- Commands using local services ---
   create-test-db-file      create a Postgres DB dump file for RBAC


### PR DESCRIPTION
## Link(s) to Jira
[RHCLOUD-27072](https://issues.redhat.com/browse/RHCLOUD-27072)

## Description of Intent of Change(s)
Adding the "format" task to makefile allows us to auto format files if that `make lint`  shows as needing to be reformatted

## Test Locally
1. Change a file that would cause the lint to show a file needs to be reformatted
2. Run `make format`
3. run `make lint`
Should see it has corrected the formatting and the error/warning goes away.