### PR TITLE
[RHCLOUD-27004] adding platform security github workflow

### DIFF
--- a/.github/workflows/platfrom-security-workflow.yml
+++ b/.github/workflows/platfrom-security-workflow.yml
@@ -1,0 +1,27 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+# This workflow checks out code, builds an image, performs a container image
+# vulnerability scan with Anchore's Grype tool, and generates an
+# SBOM via Anchore's Syft tool
+
+# For more information on Anchore's container image scanning tool Grype, see
+# https://github.com/anchore/grype
+
+# For more information about the Anchore SBOM tool, Syft, see
+# https://github.com/anchore/syft
+
+name: ConsoleDot Platform Security Scan
+
+on:
+  push:
+    branches: [ "main", "master", "security-compliance" ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ "main", "master", "security-compliance" ]
+
+jobs:
+  PlatSec-Security-Workflow:
+    uses: RedHatInsights/platform-security-gh-workflow/.github/workflows/platsec-security-scan-reusable-workflow.yml@master


### PR DESCRIPTION
This PR is to add the **Platform Security Github Workflow** to the repo.

The Platform Security Github Workflow will to provide container security scanning anytime a Pull-Request is opened or merged.

Platform Security GH Workflow repo: https://github.com/RedHatInsights/platform-security-gh-workflow
Confluence docs: https://docs.engineering.redhat.com/display/PLATFORMAM/Platform+Security+GitHub+Workflow

[RHCLOUD-27004](https://issues.redhat.com/browse/RHCLOUD-27004) PlatA&M | Onboard Repos to the PlatSec Github Workflow