### PR TITLE
[RHCLOUD-22552] Add ability to set  'GUNICORN_THREAD_LIMIT' as an env variable

### DIFF
--- a/deploy/rbac-clowdapp.yml
+++ b/deploy/rbac-clowdapp.yml
@@ -450,6 +450,8 @@ objects:
             value: ${NOTIFICATIONS_ENABLED}
           - name: GUNICORN_WORKER_MULTIPLIER
             value: ${GUNICORN_WORKER_MULTIPLIER}
+          - name: GUNICORN_THREAD_LIMIT
+            value: ${GUNICORN_THREAD_LIMIT}
           - name: NOTIFICATIONS_TOPIC
             value: ${NOTIFICATIONS_TOPIC}
           - name: KAFKA_ENABLED
@@ -3345,6 +3347,8 @@ parameters:
   value: '8892'
 - name: GUNICORN_WORKER_MULTIPLIER
   value: '2'
+- name: GUNICORN_THREAD_LIMIT
+  value: '10'
 - name: NOTIFICATIONS_TOPIC
   value: 'platform.notifications.ingress'
 - description: Enable kafka

--- a/rbac/gunicorn.py
+++ b/rbac/gunicorn.py
@@ -14,5 +14,5 @@ bind = f"0.0.0.0:{CLOWDER_PORT}"
 
 cpu_resources = int(os.environ.get("POD_CPU_LIMIT", multiprocessing.cpu_count()))
 workers = cpu_resources * int(os.environ.get("GUNICORN_WORKER_MULTIPLIER", 2))
-threads = 10
+threads = int(os.environ.get("GUNICORN_THREAD_LIMIT", 10))
 limit_request_field_size = 16380


### PR DESCRIPTION
## Link(s) to Jira
[RHCLOUD-22552](https://issues.redhat.com/browse/RHCLOUD-22552)

This PR give the ability to set the `GUNICORN_THREAD_LIMIT` as an env variable. This will default to 10 if not provided.

Example:
    GUNICORN_THREAD_LIMIT=10
    
## Tested in ephemeral env (views env view of the service pod)

**Value sert to `2`:**
![Screenshot 2023-07-27 at 2 22 17 PM](https://github.com/RedHatInsights/insights-rbac/assets/57504257/63b07c0e-e0d9-4bbb-8c8f-e9cfd219d573)

**Value set to `30`:**
![Screenshot 2023-07-27 at 2 26 45 PM](https://github.com/RedHatInsights/insights-rbac/assets/57504257/9ae19636-10bc-4ea2-8b1b-2b516e3a23d2)

