### PR TITLE
[RHCLOUD-27353] Add ability to run Grype scanning tool in dev environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,7 @@ Please use \`make <target>' where <target> is one of:
   docker-shell              run django and db containers with shell access to server (for pdb)
   docker-logs               connect to console logs for all services
   docker-test-all           run unittests
+  docker-grype				Run security checks on the project image(s)
 
 --- Commands using an OpenShift Cluster ---
   oc-clean                 stop openshift cluster & remove local config data
@@ -259,6 +260,14 @@ oc-up:
 oc-up-all: oc-up oc-create-rbac
 
 oc-up-db: oc-up oc-create-db
+
+docker-grype:
+	@docker-compose build >/dev/null 2>&1
+	@echo ""
+	@docker run --rm \
+		--volume /var/run/docker.sock:/var/run/docker.sock \
+		--name Grype anchore/grype:latest \
+		insights-rbac-rbac-server --only-fixed
 
 docker-up:
 	@docker network ls --format '{{.Name}}' |grep -q  rbac-network > /dev/null 2>&1 && echo "" || docker network create rbac-network

--- a/Makefile
+++ b/Makefile
@@ -263,11 +263,12 @@ oc-up-db: oc-up oc-create-db
 
 docker-grype:
 	@docker-compose build >/dev/null 2>&1
+
 	@echo ""
 	@docker run --rm \
 		--volume /var/run/docker.sock:/var/run/docker.sock \
 		--name Grype anchore/grype:latest \
-		insights-rbac-rbac-server --only-fixed
+		$$(docker images --format '{{.Repository}}' |grep rbac-server) --only-fixed
 
 docker-up:
 	@docker network ls --format '{{.Name}}' |grep -q  rbac-network > /dev/null 2>&1 && echo "" || docker network create rbac-network


### PR DESCRIPTION
## Link(s) to Jira
[RHCLOUD-27353](https://issues.redhat.com/browse/RHCLOUD-27353)

## Description of Intent of Change(s)
Add ability to run Grype scanning tool in dev environment. 

## Local Testing
```
> make docker-grype
\e]0;Making insights-rbac
NAME        INSTALLED  FIXED-IN    TYPE    VULNERABILITY        SEVERITY 
Django      4.1.7      4.1.10      python  GHSA-jh3w-4vvf-mjgr  High      
Django      4.1.7      4.1.9       python  GHSA-r3xc-prgr-mg9p  Critical  
certifi     2023.5.7   2023.07.22  python  GHSA-xqr8-7jwr-rhp7  Low       
certifi     2023.7.22  2023.07.22  python  GHSA-xqr8-7jwr-rhp7  Low       
pip         9.0.3      19.2        python  GHSA-gpvv-69j7-gwj8  High      
pip         9.0.3      21.1        python  GHSA-5xp3-jfq3-5q8x  Medium    
requests    2.28.2     2.31.0      python  GHSA-j8r2-6x86-q33q  Medium    
setuptools  39.2.0     65.5.1      python  GHSA-r9hx-vwmv-q579  High      
sqlparse    0.4.3      0.4.4       python  GHSA-rrm6-wvj7-cwh2  Medium
ired?
```

