### PR TITLE
[RHCLOUD-27368] Fix for container names in dev env

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ version: '3'
 
 services:
   rbac-server:
+      container_name: rbac_server
       build:
           context: .
           dockerfile: Dockerfile
@@ -78,6 +79,7 @@ services:
       - "6379:6379"
 
   db:
+    container_name: rbac_db
     image: postgres:14.5
     environment:
     - POSTGRES_DB=postgres


### PR DESCRIPTION
## Link(s) to Jira
[RHCLOUD-27368](https://issues.redhat.com/browse/RHCLOUD-27368)

## Description of Intent of Change(s)
Updates container names in dev env

## Local Testing
**BEFORE:**
```
 > docker ps
CONTAINER ID   IMAGE                          COMMAND                  CREATED         STATUS         PORTS                     NAMES
42f38cf8132d   insights-rbac-rbac-server      "./scripts/entrypoin…"   6 minutes ago   Up 6 minutes   0.0.0.0:9080->8080/tcp    insights-rbac-rbac-server-1
9b83eb54f999   insights-rbac-rbac-scheduler   "celery --broker=red…"   6 minutes ago   Up 6 minutes   8080/tcp                  rbac_scheduler
f86e0e61f3e2   insights-rbac-rbac-worker      "celery --broker=red…"   6 minutes ago   Up 6 minutes   8080/tcp                  rbac_worker
2832f1acc187   postgres:14.5                  "docker-entrypoint.s…"   6 minutes ago   Up 6 minutes   0.0.0.0:15432->5432/tcp   insights-rbac-db-1
442449f30c6b   redis:5.0.4                    "docker-entrypoint.s…"   6 minutes ago   Up 6 minutes   0.0.0.0:6379->6379/tcp    rbac_redis
```

**AFTER:**
```
> docker ps
CONTAINER ID   IMAGE                          COMMAND                  CREATED         STATUS         PORTS                     NAMES
ff234c885343   insights-rbac-rbac-server      "./scripts/entrypoin…"   5 seconds ago   Up 3 seconds   0.0.0.0:9080->8080/tcp    rbac_server
4cc697be3c66   insights-rbac-rbac-scheduler   "celery --broker=red…"   5 seconds ago   Up 3 seconds   8080/tcp                  rbac_scheduler
3c02cd7b63df   insights-rbac-rbac-worker      "celery --broker=red…"   5 seconds ago   Up 3 seconds   8080/tcp                  rbac_worker
83f6be964496   postgres:14.5                  "docker-entrypoint.s…"   5 seconds ago   Up 4 seconds   0.0.0.0:15432->5432/tcp   rbac_db
2014c3ddd94b   redis:5.0.4                    "docker-entrypoint.s…"   5 seconds ago   Up 4 seconds   0.0.0.0:6379->6379/tcp    rbac_redis

```
