### PR TITLE
Deduplicate access permissions list returned to clients

### DIFF
--- a/rbac/management/access/view.py
+++ b/rbac/management/access/view.py
@@ -23,10 +23,10 @@ from management.querysets import get_access_queryset
 from management.role.serializer import AccessSerializer
 from management.utils import (
     APPLICATION_KEY,
+    deduplicate_access_queryset,
     get_principal_from_request,
     validate_and_get_key,
     validate_limit_and_offset,
-    deduplicate_access_queryset,
 )
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response

--- a/rbac/management/access/view.py
+++ b/rbac/management/access/view.py
@@ -121,7 +121,9 @@ class AccessView(APIView):
         access_policy = cache.get_policy(principal.uuid, sub_key)
         if access_policy is None:
             queryset = self.get_queryset(ordering)
-            access_policy = self.serializer_class(queryset, many=True).data
+            access_policy = self.serializer_class(
+                deduplicate_access_queryset(queryset), many=True
+            ).data
             cache.save_policy(principal.uuid, sub_key, access_policy)
 
         page = self.paginate_queryset(access_policy)

--- a/rbac/management/access/view.py
+++ b/rbac/management/access/view.py
@@ -26,6 +26,7 @@ from management.utils import (
     get_principal_from_request,
     validate_and_get_key,
     validate_limit_and_offset,
+    deduplicate_access_queryset,
 )
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response

--- a/rbac/management/permission/model.py
+++ b/rbac/management/permission/model.py
@@ -31,6 +31,20 @@ class Permission(TenantAwareModel):
     description = models.TextField(default="")
     permissions = models.ManyToManyField("self", symmetrical=False, related_name="requiring_permissions")
 
+    def __eq__(self, other):
+        return self.permission == other.permission
+
+    def __contains__(self, other):
+        # Note that the sense of 'contains' is opposite to the sense of 'in':
+        # A is in B if B contains A.
+        if self.permission == other.permission:
+            return True
+        if not (self.application == other.application or self.application == '*'):
+            return False
+        if not (self.resource_type == other.resource_type or self.resource_type == '*'):
+            return False
+        return (self.verb == other.verb or self.verb == '*' or (other.verb == 'read' and self.verb == 'write'))
+
     def save(self, *args, **kwargs):
         """Populate the application, resource_type and verb field before saving."""
         context = self.permission.split(":")


### PR DESCRIPTION
It is useful for clients to handle the simplest list of permissions objects, for performance reasons.  It reduces the data transferred to the client application, and it reduces the possibility that a client will misinterpret some part of the data.  It also reduces the amount of data RBAC stores in its cache, thus saving space and time.

This implements a basic process to deduplicate the list of permissions objects returned to the client.  It does two basic optimisations:

1. Two exactly matching permissions - e.g. 'app:\*:read' and 'app:\*:read'
   - are combined.  Their resourceDefinitions are appended without attempting to interpret them.
2. The '\*' verb implies all other verbs.  Therefore 'app:\*:read' will be ignored in favour of 'app:\*:\*'.  Ignored permissions have their resourceDefinitions thrown away because they are superseded.

Further optimisations may be possible but may be app-dependent and we should tread with caution here.

A basic test is included, but probably not yet working.

## Checklist
- [N/A] if API spec changes are required, is the spec updated?
- [N/A] are there any pre/post merge actions required? if so, document here.
- [Y] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [N] does this require migration changes?
  - [N] if yes, are they backwards compatible?
- [Y] is there known, direct impact to dependent teams/components?
  - [X] if yes, how will this be handled?
    They may celebrate.

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [Y] Input Validation
- [Y] Output Encoding
- [Y] Authentication and Password Management
- [Y] Session Management
- [Y] Access Control
- [Y] Cryptographic Practices
- [Y] Error Handling and Logging
- [Y] Data Protection
- [Y] Communication Security
- [Y] System Configuration
- [Y] Database Security
- [Y] File Management
- [Y] Memory Management
- [Y] General Coding Practices
