### PR TITLE
[RHCLOUD-27185] upgraded base image for rbac to use ubi8 minimal 8.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.7-1049 AS base
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8 AS base
 
 USER root
 


### PR DESCRIPTION
On UBI 8.7 using `microdnf --nodocs -y` upgrade will pull python 3.6
location of that command: https://github.com/RedHatInsights/insights-rbac/blob/security-compliance/Dockerfile#L41 
In UBI 8.8 that command does not pull the vulnerable python 3.6 packages