### PR TITLE
[RHCLOUD-21356] - fix for adding in query by user status

### DIFF
--- a/docs/source/specs/openapi.json
+++ b/docs/source/specs/openapi.json
@@ -2491,6 +2491,21 @@
             }
           },
           {
+            "name": "status",
+            "in": "query",
+            "description": "Set the status of users to get back.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "enabled",
+                "disabled",
+                "all"
+              ],
+              "default": "enabled"
+            }
+          },
+          {
             "$ref": "#/components/parameters/QueryLimit"
           },
           {

--- a/rbac/management/utils.py
+++ b/rbac/management/utils.py
@@ -89,12 +89,13 @@ def verify_principal_with_proxy(username, request, verify_principal=True):
     """Verify username through the BOP."""
     account = request.user.account
     org_id = request.user.org_id
+    query_options={"status": request.query_params.get("status")}
     proxy = PrincipalProxy()
     if verify_principal:
         if settings.AUTHENTICATE_WITH_ORG_ID:
-            resp = proxy.request_filtered_principals([username], org_id=org_id)
+            resp = proxy.request_filtered_principals([username], org_id=org_id, options = query_options)
         else:
-            resp = proxy.request_filtered_principals([username], account)
+            resp = proxy.request_filtered_principals([username], account, options = query_options)
 
         if isinstance(resp, dict) and "errors" in resp:
             raise Exception("Dependency error: request to get users from dependent service failed.")

--- a/rbac/management/utils.py
+++ b/rbac/management/utils.py
@@ -193,7 +193,7 @@ def filter_queryset_by_tenant(queryset, tenant):
 
 
 def validate_and_get_key(params, query_key, valid_values, default_value=None, required=True):
-    """Validate the key."""
+    """Validate and return the key."""
     value = params.get(query_key, default_value)
     if not value:
         if required:
@@ -209,6 +209,17 @@ def validate_and_get_key(params, query_key, valid_values, default_value=None, re
         )
         raise serializers.ValidationError({key: _(message)})
     return value.lower()
+
+
+def validate_key(params, query_key, valid_values, default_value=None, required=True):
+    """Validate a key and do not return the value."""
+    value = params.get(query_key, default_value)
+    if value.lower() not in valid_values:
+        key = "detail"
+        message = "{} query parameter value '{}' is invalid. {} are valid inputs.".format(
+            query_key, value, valid_values
+        )
+        raise serializers.ValidationError({key: _(message)})
 
 
 def validate_uuid(uuid, key="UUID Validation"):

--- a/rbac/management/utils.py
+++ b/rbac/management/utils.py
@@ -89,13 +89,12 @@ def verify_principal_with_proxy(username, request, verify_principal=True):
     """Verify username through the BOP."""
     account = request.user.account
     org_id = request.user.org_id
-    query_options={"status": request.query_params.get("status")}
     proxy = PrincipalProxy()
     if verify_principal:
         if settings.AUTHENTICATE_WITH_ORG_ID:
-            resp = proxy.request_filtered_principals([username], org_id=org_id, options = query_options)
+            resp = proxy.request_filtered_principals([username], org_id=org_id, options = request.query_params)
         else:
-            resp = proxy.request_filtered_principals([username], account, options = query_options)
+            resp = proxy.request_filtered_principals([username], account, options = request.query_params)
 
         if isinstance(resp, dict) and "errors" in resp:
             raise Exception("Dependency error: request to get users from dependent service failed.")

--- a/rbac/management/utils.py
+++ b/rbac/management/utils.py
@@ -92,9 +92,9 @@ def verify_principal_with_proxy(username, request, verify_principal=True):
     proxy = PrincipalProxy()
     if verify_principal:
         if settings.AUTHENTICATE_WITH_ORG_ID:
-            resp = proxy.request_filtered_principals([username], org_id=org_id, options = request.query_params)
+            resp = proxy.request_filtered_principals([username], org_id=org_id, options=request.query_params)
         else:
-            resp = proxy.request_filtered_principals([username], account, options = request.query_params)
+            resp = proxy.request_filtered_principals([username], account, options=request.query_params)
 
         if isinstance(resp, dict) and "errors" in resp:
             raise Exception("Dependency error: request to get users from dependent service failed.")


### PR DESCRIPTION
## Link(s) to Jira
- [RHCLOUD-25689](https://issues.redhat.com/browse/RHCLOUD-25689)
- Linked to first PR for this Jira ticket: [First PR](https://github.com/RedHatInsights/insights-rbac/pull/886)

## Description of Intent of Change(s)
- This adds the parameter to the endpoint so that status does not always default to enabled

## Local Testing
- Testing will need to be set up with stage data for this PR. If you need any help do not hesitate to ping me =)
- Grab a user from stage preferable an inactive user so `status=disabled`. Can do this with the following BOP endpoint:
`/v1/accounts/{accountNumber}/users`
- Now that we have selected our user we can test the access endpoint:
      - `{{baseUrl}}/access/?application={application name ex: rbac}&username={username}`
      - This should return the following since the default status is `enabled` and we have an inactive user
      
     ```
    "errors": [
      {
          "detail": "No data found for principal with username '{username}'",
          "source": "detail",
          "status": "400"
      }
  ]
  ```
     -  `{{baseUrl}}/access/?application={application name ex: rbac}&username={username}$status=disabled`
     -  This should return data for this users permissions since we are passing in the correct status
     ```
     "data": [
        {
            "resourceDefinitions": [],
            "permission": "rbac:principal:read"
        }
    ]
     ```
     - `{{baseUrl}}/access/?application={application name ex: rbac}&username={username}$status=all`
     - This should return the same as the above endpoint since all includes both inactive and active users.
- hit this url: `{{baseUrl}}/access/?application={application name ex: rbac}&username={username}$status=falsestatus`
      - If passing in a none existing status `ex: falsestatus` the following response should be returned:
```
{
    "errors": [
        {
            "detail": "status query parameter value 'falsestatus' is invalid. ['enabled', 'disabled', 'all'] are valid inputs.",
            "source": "detail",
            "status": "400"
        }
    ]
}
```
- Check docs as there should now also be a parameter query filter option for the access endpoint 

## Checklist
- [x] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [x] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
