### PR TITLE
[POC] Fixes for workspace move endpoint

### DIFF
--- a/rbac/management/role/permissions/openshift.json
+++ b/rbac/management/role/permissions/openshift.json
@@ -1,7 +1,7 @@
 {
-  "openshift": [
+  "cluster": [
     {
-      "verb": "cluster"
+      "verb": "read"
     }
   ]
 }

--- a/workspaces.http
+++ b/workspaces.http
@@ -151,23 +151,8 @@ POST http://localhost:8080/api/rbac/v1/roles/
   "description": "Openshift openshiftA Access for IBM",
   "access": [
     {
-      "permission": "ibm:openshift:cluster",
-      "resourceDefinitions": [
-         {
-             "attributeFilter": {
-                 "key": "id",
-                 "operation": "equal",
-                 "value": "39c8cecd-e595-46fb-8908-13365d59d5e8"
-             }
-         },
-         {
-             "attributeFilter": {
-                 "key": "id",
-                 "operation": "equal",
-                 "value": "XXXXXXXXXXX"
-             }
-         }
-      ]
+      "permission": "openshift:cluster:read",
+      "resourceDefinitions": []
     }
   ]
 }


### PR DESCRIPTION
- This makes to work move endpoint with empty resource definition.

```
### Move this Asset from Workspace X to Workspace Y
### Move those Asset from Workspace X to Workspace Y - Line 13
### Let's move service permission from root workspace to sub workspace
### http://localhost:8080/api/rbac/v1/workspace/<source_workspace>/move/<target_workspace>
POST http://localhost:8080/api/rbac/v1/workspaces/d4c0077b-a9f2-4239-a960-79db8195aafc/move/8113321f-a203-4b1e-a8e9-66711b3e2d8e/

{
  "access": [
    {
      "permission": "openshift:cluster:read",
      "resourceDefinitions": []
    }
  ]
}

```

- this also seeds permission `openshift:cluster:read`
