### PR TITLE
 RHCLOUD-28261 | feature: return stubs for the service accounts

### DIFF
--- a/docs/source/specs/openapi.json
+++ b/docs/source/specs/openapi.json
@@ -644,6 +644,19 @@
                 false
               ]
             }
+          },
+          {
+            "in": "query",
+            "name": "type",
+            "required": false,
+            "description": "Parameter for selecting the type of principal to be returned.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "service-account",
+                "user"
+              ]
+            }
           }
         ],
         "responses": {
@@ -1237,6 +1250,19 @@
               "enum": [
                 true,
                 false
+              ]
+            }
+          },
+          {
+            "in": "query",
+            "name": "principal_type",
+            "required": false,
+            "description": "Parameter for selecting the type of principal to be returned.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "service-account",
+                "user"
               ]
             }
           }

--- a/rbac/management/group/view.py
+++ b/rbac/management/group/view.py
@@ -57,12 +57,14 @@ USERNAMES_KEY = "usernames"
 ROLES_KEY = "roles"
 EXCLUDE_KEY = "exclude"
 ORDERING_PARAM = "order_by"
+PRINCIPAL_TYPE_KEY = "principal_type"
 VALID_ROLE_ORDER_FIELDS = list(RoleViewSet.ordering_fields)
 ROLE_DISCRIMINATOR_KEY = "role_discriminator"
 VALID_EXCLUDE_VALUES = ["true", "false"]
 VALID_GROUP_ROLE_FILTERS = ["role_name", "role_description", "role_display_name", "role_system"]
 VALID_GROUP_PRINCIPAL_FILTERS = ["principal_username"]
 VALID_PRINCIPAL_ORDER_FIELDS = ["username"]
+VALID_PRINCIPAL_TYPE_VALUE = ["service-account", "user"]
 VALID_ROLE_ROLE_DISCRIMINATOR = ["all", "any"]
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
@@ -428,6 +430,8 @@ class GroupViewSet(
         @apiHeader {String} token User authorization token
 
         @apiParam (Path) {String} id Group unique identifier
+        @apiParam (Query) {String} principal_type Parameter for selecting the type of principal to be returned (either
+                                                  "service-account" or "user").
 
         @apiSuccess {String} uuid Group unique identifier
         @apiSuccess {String} name Group name
@@ -540,6 +544,16 @@ class GroupViewSet(
                     request.query_params, USERNAME_ONLY_KEY, VALID_BOOLEAN_VALUE, "false"
                 ),
             }
+
+            # Attempt validating and obtaining the "principal type" query
+            # parameter. For now, having "service-account" as the "principal
+            # type" returns a stub.
+            principalType = validate_and_get_key(
+                request.query_params, PRINCIPAL_TYPE_KEY, VALID_PRINCIPAL_TYPE_VALUE, required=False
+            )
+
+            if principalType == "service-account":
+                return self.user_service_accounts_response()
 
             admin_only = validate_and_get_key(request.query_params, ADMIN_ONLY_KEY, VALID_BOOLEAN_VALUE, False, False)
             if admin_only == "true":
@@ -745,3 +759,26 @@ class GroupViewSet(
         # Exclude the roles in the group
         roles_for_group = group.roles().values("uuid")
         return roles.exclude(uuid__in=roles_for_group)
+
+    def user_service_accounts_response(self):
+        """Return a stubbed user or service account response.
+
+        Returns a dictionary with a mocked empty array response, in order to use
+        the structure as the returning values when a "user" or "service-account"
+        principal types are specified as query parameters. For more information
+        check https://issues.redhat.com/browse/RHCLOUD-28261.
+        """
+        return Response(
+            data={
+                "meta": {"count": 0, "limit": 0, "offset": 0},
+                "links": {
+                    "first": "",
+                    "next": "",
+                    "previous": "",
+                    "last": "",
+                },
+                "data": [],
+                "status": status.HTTP_200_OK,
+            },
+            status=status.HTTP_200_OK,
+        )


### PR DESCRIPTION
## Link(s) to Jira
-  [[RHCLOUD-28261]](https://issues.redhat.com/browse/RHCLOUD-28261)

## Description of Intent of Change(s)
The UI team is blocked because RBAC still doesn't fully support the service accounts. Even though the ADR is nearly finished, the sooner we can let the UI team consume the endpoints with the service accounts the better.

They have told us that it is not required to return real data, so that is why we are returning static stubs instead. Once the ADR is finished, we will remove them.

The default behavior is to honor old query parameters, that is why they have precedence over the rest.

## Local Testing
### How can the feature be exercised?
The affected endpoints are:
- `/principals/`
- `/groups/{uuid}/principals/`

You can append the following query parameters to the endpoints:

- `GET /principals/?type=user`
- `GET /principals/?type=service-account`

- `GET /groups/{uuid}/principals/?type=user`
- `GET /groups/{uuid}/principals/?type=service-account`

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
