### PR TITLE
Update security compliance tag naming convention.

### DIFF
--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -4,7 +4,7 @@ IMAGE="quay.io/cloudservices/rbac"
 IMAGE_TAG=$(git rev-parse --short=7 HEAD)
 GIT_COMMIT=$(git rev-parse --short HEAD)
 SMOKE_TEST_TAG="latest"
-SECURITY_COMPLIANCE_TAG="sc-$(date +%Y%m%d)"
+SECURITY_COMPLIANCE_TAG="sc-$(date +%Y%m%d)-$(git rev-parse --short=7 HEAD)"
 
 if [[ -z "$QUAY_USER" || -z "$QUAY_TOKEN" ]]; then
     echo "QUAY_USER and QUAY_TOKEN must be set"


### PR DESCRIPTION
### Overview
This PR updates the `Security-Compliance Tag` Naming Convention within the `build_deploy.sh` to make it easier to identify the Git Commit the image is based on.

### Example:
OLD: `sc-20230920`
NEW: `sc-20230920-94234ce`