### PR TITLE
Add command urls and shell to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,6 +114,9 @@ run-migrations:
 shell:
 	DJANGO_READ_DOT_ENV_FILE=True $(PYTHON) $(PYDIR)/manage.py shell
 
+urls:
+	DJANGO_READ_DOT_ENV_FILE=True $(PYTHON) $(PYDIR)/manage.py show_urls
+
 create-test-db-file: run-migrations
 	sleep 1
 	DJANGO_READ_DOT_ENV_FILE=True $(PYTHON) $(PYDIR)/manage.py runserver > /dev/null 2>&1 &

--- a/Makefile
+++ b/Makefile
@@ -111,6 +111,9 @@ make-migrations:
 run-migrations:
 	DJANGO_READ_DOT_ENV_FILE=True $(PYTHON) $(PYDIR)/manage.py migrate
 
+shell:
+	DJANGO_READ_DOT_ENV_FILE=True $(PYTHON) $(PYDIR)/manage.py shell
+
 create-test-db-file: run-migrations
 	sleep 1
 	DJANGO_READ_DOT_ENV_FILE=True $(PYTHON) $(PYDIR)/manage.py runserver > /dev/null 2>&1 &


### PR DESCRIPTION
- Added Django shell command to Makefile

Added Django shell command to Makefile
The updated Makefile now provides a convenient way to
launch the Django shell, streamlining development processes.

Example:
```
make shell
Type "help", "copyright", "credits" or "license" for more information.
(InteractiveConsole)
>>> from management.role.model import Role
>>> Role.objects.count()
23
```

- Added 'show_urls' command to Makefile

Added 'show_urls' command to Makefile
The Makefile now includes a command to conveniently display all
the URLs of the Django application, aiding in development and debugging.

Example:
```
make urls

/_private/api/cars/expire/	internal.views.car_expiry
/_private/api/migrations/progress/	internal.views.migration_progress
/_private/api/migrations/run/	internal.views.run_migrations
/_private/api/seeds/run/	internal.views.run_seeds
...

```

