### PR TITLE
[RHCLOUD-27277] Change type of value in ResourceDefinitionFilter component of openapi spec

### DIFF
--- a/docs/source/specs/openapi.json
+++ b/docs/source/specs/openapi.json
@@ -3725,8 +3725,32 @@
             ]
           },
           "value": {
-            "type": "string",
-            "example": "123456"
+            "oneOf": [
+              {
+                "type": "string",
+                "example": "123456"
+              },
+              {
+                "type": "null",
+                "example": null
+              },
+              {
+                "type": "array",
+                "items": {
+                  "oneOf": [
+                    {
+                      "type": "string",
+                      "example": "value1"
+                    },
+                    {
+                      "type": "null",
+                      "example": null
+                    }
+                  ]
+                },
+                "example": ["value1", null, "value2"]
+              }
+            ]
           }
         }
       },

--- a/docs/source/specs/openapi.json
+++ b/docs/source/specs/openapi.json
@@ -3728,11 +3728,8 @@
             "oneOf": [
               {
                 "type": "string",
-                "example": "123456"
-              },
-              {
-                "type": "null",
-                "example": null
+                "example": "123456",
+                "nullable": true
               },
               {
                 "type": "array",
@@ -3741,14 +3738,11 @@
                     {
                       "type": "string",
                       "example": "value1"
-                    },
-                    {
-                      "type": "null",
-                      "example": null
                     }
                   ]
                 },
-                "example": ["value1", null, "value2"]
+                "example": ["value1", "value2"],
+                "nullable": true
               }
             ]
           }


### PR DESCRIPTION
Change is from type `string` to one of:
`string`
`null`
**array**: elements are one of:
`string`
`null`

### Links
https://issues.redhat.com/browse/RHCLOUD-27277
