### PR TITLE
Add Worker Alerts when Redis Cache is not Working 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -85,7 +85,8 @@ COPY . .
 # create the rbac user
 RUN \
     adduser rbac -u ${USER_ID} -g 0 && \
-    chmod ug+rw ${APP_ROOT} ${APP_HOME} ${APP_HOME}/static /tmp
+    chmod ug+rw ${APP_ROOT} ${APP_HOME} ${APP_HOME}/static && \
+    chmod ug+rwx /tmp
 USER rbac
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -86,7 +86,7 @@ COPY . .
 RUN \
     adduser rbac -u ${USER_ID} -g 0 && \
     chmod ug+rw ${APP_ROOT} ${APP_HOME} ${APP_HOME}/static && \
-    chmod ug+rwx /tmp
+    chmod -R 777 /tmp
 USER rbac
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -85,8 +85,7 @@ COPY . .
 # create the rbac user
 RUN \
     adduser rbac -u ${USER_ID} -g 0 && \
-    chmod ug+rw ${APP_ROOT} ${APP_HOME} ${APP_HOME}/static && \
-    chmod -R 777 /tmp
+    chmod ug+rw ${APP_ROOT} ${APP_HOME} ${APP_HOME}/static /tmp
 USER rbac
 
 
@@ -96,8 +95,8 @@ RUN \
     # This `app.log` file is created during the `collectstatic` step. We need to
     # remove it else the random OCP user will not be able to access it. This file
     # will be recreated by the Pod when the application starts.
-    rm ${APP_HOME}/app.log
-
+    rm ${APP_HOME}/app.log && \
+    rm /tmp/counter* 
 EXPOSE 8080
 
 # GIT_COMMIT is added during build in `build_deploy.sh`

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -22,7 +22,7 @@ curl -s $CICD_URL/bootstrap.sh > .cicd_bootstrap.sh && source .cicd_bootstrap.sh
 source $CICD_ROOT/build.sh
 
 # Run the unit tests with an ephemeral db
-#source $APP_ROOT/unit_test.sh
+source $APP_ROOT/unit_test.sh
 
 # Deploy rbac to an ephemeral namespace for testing
 source $CICD_ROOT/deploy_ephemeral_env.sh

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -22,7 +22,7 @@ curl -s $CICD_URL/bootstrap.sh > .cicd_bootstrap.sh && source .cicd_bootstrap.sh
 source $CICD_ROOT/build.sh
 
 # Run the unit tests with an ephemeral db
-source $APP_ROOT/unit_test.sh
+#source $APP_ROOT/unit_test.sh
 
 # Deploy rbac to an ephemeral namespace for testing
 source $CICD_ROOT/deploy_ephemeral_env.sh

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -22,7 +22,7 @@ curl -s $CICD_URL/bootstrap.sh > .cicd_bootstrap.sh && source .cicd_bootstrap.sh
 source $CICD_ROOT/build.sh
 
 # Run the unit tests with an ephemeral db
-# source $APP_ROOT/unit_test.sh
+source $APP_ROOT/unit_test.sh
 
 # Deploy rbac to an ephemeral namespace for testing
 source $CICD_ROOT/deploy_ephemeral_env.sh

--- a/rbac/management/cache.py
+++ b/rbac/management/cache.py
@@ -10,6 +10,8 @@ from prometheus_client import Counter
 from redis import BlockingConnectionPool, exceptions
 from redis.client import Redis
 
+from rbac.settings import ACCESS_CACHE_ENABLED
+
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 _connection_pool = BlockingConnectionPool(**settings.REDIS_CACHE_CONNECTION_PARAMS)  # should match gunicorn.threads
 
@@ -25,7 +27,7 @@ class BasicCache:
     def __init__(self):
         """Init the class."""
         self._connection = None
-        self.use_caching = False
+        self.use_caching = ACCESS_CACHE_ENABLED
 
     @property
     def connection(self):

--- a/rbac/management/cache.py
+++ b/rbac/management/cache.py
@@ -10,8 +10,6 @@ from prometheus_client import Counter
 from redis import BlockingConnectionPool, exceptions
 from redis.client import Redis
 
-from rbac.settings import ACCESS_CACHE_ENABLED
-
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 _connection_pool = BlockingConnectionPool(**settings.REDIS_CACHE_CONNECTION_PARAMS)  # should match gunicorn.threads
 
@@ -27,7 +25,7 @@ class BasicCache:
     def __init__(self):
         """Init the class."""
         self._connection = None
-        self.use_caching = ACCESS_CACHE_ENABLED
+        self.use_caching = True
 
     @property
     def connection(self):
@@ -51,7 +49,7 @@ class BasicCache:
     def disable_caching(self):
         """Disable caching and increment prometheus metric that redis caching is disabled."""
         self.use_caching = False
-        logger.info("redis Cache Disabled")
+        logger.info("Redis Cache Disabled")
         redis_disable_cache_get_total.inc()
         return self.use_caching
 

--- a/rbac/management/cache.py
+++ b/rbac/management/cache.py
@@ -44,14 +44,14 @@ class BasicCache:
     def enable_caching(self):
         """Enable caching and incremements prometheus metric that redis caching is enabled."""
         self.use_caching = True
-        logger.info("Cache Enabled")
+        logger.info("Redis Cache Enabled")
         redis_enable_cache_get_total.inc()
         return self.use_caching
 
     def disable_caching(self):
-        """Disable caching and incrememnt prometheus metric that redis caching is disabled."""
+        """Disable caching and increment prometheus metric that redis caching is disabled."""
         self.use_caching = False
-        logger.info("Cache Disabled")
+        logger.info("redis Cache Disabled")
         redis_disable_cache_get_total.inc()
         return self.use_caching
 

--- a/rbac/management/cache.py
+++ b/rbac/management/cache.py
@@ -6,11 +6,17 @@ import logging
 import pickle
 
 from django.conf import settings
+from prometheus_client import Counter
 from redis import BlockingConnectionPool, exceptions
 from redis.client import Redis
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 _connection_pool = BlockingConnectionPool(**settings.REDIS_CACHE_CONNECTION_PARAMS)  # should match gunicorn.threads
+
+redis_enable_cache_get_total = Counter("redis_enable_cache_get_total", "Total amount of use_caching is true")
+redis_disable_cache_get_total = Counter(
+    "redis_disable_cache_get_total", "Total amount of times cache has been disabled"
+)
 
 
 class BasicCache:
@@ -19,6 +25,7 @@ class BasicCache:
     def __init__(self):
         """Init the class."""
         self._connection = None
+        self.use_caching = False
 
     @property
     def connection(self):
@@ -31,6 +38,36 @@ class BasicCache:
                 self._connection = None
                 raise
         return self._connection
+
+    def enable_caching(self):
+        """Enable caching and incremements prometheus metric that redis caching is enabled."""
+        self.use_caching = True
+        logger.info("Cache Enabled")
+        redis_enable_cache_get_total.inc()
+        return self.use_caching
+
+    def disable_caching(self):
+        """Disable caching and incrememnt prometheus metric that redis caching is disabled."""
+        self.use_caching = False
+        logger.info("Cache Disabled")
+        redis_disable_cache_get_total.inc()
+        return self.use_caching
+
+    def redis_health_check(self):
+        """Check whether redis cache is reachable. If it is not reachable, then disable caching."""
+        self._connection = Redis(connection_pool=_connection_pool, ssl=settings.REDIS_SSL)
+        try:
+            response = self._connection.ping()
+            if response:
+                logger.info("Redis cache is reachable.")
+                self.enable_caching()
+                return True
+            else:
+                logger.info("Redis cache is not reachable.")
+                self.disable_caching()
+                return False
+        except Exception as e:
+            logger.exception("Error:", e)
 
     @contextlib.contextmanager
     def delete_handler(self, err_msg):
@@ -47,7 +84,14 @@ class BasicCache:
     def get_cached(self, key, error_message):
         """Get cached object from redis, throw error if there is any."""
         try:
-            return self.get_from_redis(key)
+            if self.redis_health_check() is True:
+                if self.use_caching:
+                    return self.get_from_redis(key)
+            else:
+                # Retrieve data directly
+                logger.info("Not Retrieving Data from Redis Cache")
+                self.disable_caching()
+                pass
         except exceptions.RedisError:
             logger.exception(error_message)
         return None

--- a/rbac/management/health/__init__.py
+++ b/rbac/management/health/__init__.py
@@ -1,0 +1,25 @@
+#
+# Copyright 2019 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""RBAC project module."""
+
+from __future__ import absolute_import, unicode_literals
+
+# This will make sure the app is always imported when
+# Django starts so that shared_task will use this app.
+from rbac.celery import app as celery_app
+
+__all__ = ("celery_app",)

--- a/rbac/management/health/healthcheck.py
+++ b/rbac/management/health/healthcheck.py
@@ -29,4 +29,4 @@ def redis_health():
     time.sleep(10)
 
     redis_cache = BasicCache()
-    redis_cache.redis_health_check(redis_cache)
+    redis_cache.redis_health_check()

--- a/rbac/management/health/healthcheck.py
+++ b/rbac/management/health/healthcheck.py
@@ -1,0 +1,32 @@
+#
+# Copyright 2019 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""Celery Task for Redis Health Check."""
+
+import logging
+import time
+
+from management.cache import BasicCache
+
+logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
+
+
+def redis_health():
+    """Check health of redis cache."""
+    time.sleep(10)
+
+    redis_cache = BasicCache()
+    redis_cache.redis_health_check(redis_cache)

--- a/rbac/management/tasks.py
+++ b/rbac/management/tasks.py
@@ -19,6 +19,7 @@ from __future__ import absolute_import, unicode_literals
 
 from celery import shared_task
 from django.core.management import call_command
+from management.health.healthcheck import redis_health
 from management.principal.cleaner import clean_tenants_principals
 
 
@@ -56,3 +57,9 @@ def run_sync_schemas_in_worker(kwargs):
 def run_ocm_performance_in_worker():
     """Celery task to run ocm performance tests."""
     call_command("ocm_performance")
+
+
+@shared_task
+def run_redis_cache_health():
+    """Celery task to check health of redis cache."""
+    redis_health()

--- a/rbac/rbac/celery.py
+++ b/rbac/rbac/celery.py
@@ -44,6 +44,11 @@ app.conf.beat_schedule = {
         "schedule": crontab(minute=0, hour=0),
         "args": [],
     },  # noqa: E231, E501
+    "schedule-redis-check": {
+        "task": "management.tasks.run_redis_cache_health",
+        "schedule": 30,
+        "args": [],
+    },
 }
 
 # Load task modules from all registered Django app configs.

--- a/rbac/rbac/middleware.py
+++ b/rbac/rbac/middleware.py
@@ -71,7 +71,7 @@ def catch_integrity_error(func):
 
 def is_no_auth(request):
     """Check condition for needing to authenticate the user."""
-    no_auth_list = ["status", "metrics", "openapi.json"]
+    no_auth_list = ["status", "metrics", "openapi.json", "health"]
     no_auth = any(no_auth_path in request.path for no_auth_path in no_auth_list)
     return no_auth
 

--- a/tests/rbac/test_cache.py
+++ b/tests/rbac/test_cache.py
@@ -15,7 +15,6 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 """Test the caching system."""
-import os
 import pickle
 from unittest import skipIf
 from unittest.mock import call, patch

--- a/tests/rbac/test_cache.py
+++ b/tests/rbac/test_cache.py
@@ -21,6 +21,7 @@ from unittest.mock import call, patch
 
 from django.conf import settings
 from django.test import TestCase
+from management.cache import BasicCache
 from management.cache import TenantCache
 from management.models import Access, Group, Permission, Policy, Principal, ResourceDefinition, Role
 
@@ -259,7 +260,8 @@ class TenantCacheTest(TestCase):
         super().tearDownClass()
 
     @patch("management.cache.TenantCache.connection")
-    def test_tenant_cache_functions_success(self, redis_connection):
+    @patch("management.cache.BasicCache.redis_health_check")
+    def test_tenant_cache_functions_success(self, redis_health_check, redis_connection):
         tenant_name = self.tenant.tenant_name
         tenant_org_id = self.tenant.org_id
         if settings.AUTHENTICATE_WITH_ORG_ID:
@@ -274,11 +276,13 @@ class TenantCacheTest(TestCase):
         self.assertTrue(call().__enter__().set(key, dump_content) in redis_connection.pipeline.mock_calls)
 
         redis_connection.get.return_value = dump_content
+        redis_health_check.return_value = True
         # Get tenant from cache
         if settings.AUTHENTICATE_WITH_ORG_ID:
             tenant = tenant_cache.get_tenant(tenant_org_id)
         else:
             tenant = tenant_cache.get_tenant(tenant_name)
+        redis_health_check.assert_called_once()
         redis_connection.get.assert_called_once_with(key)
         self.assertEqual(tenant, self.tenant)
 


### PR DESCRIPTION
## Link(s) to Jira
- [RHCLOUD-25588](https://issues.redhat.com/browse/RHCLOUD-25588)

## Description of Intent of Change(s)
The what, why and how.
If the cache cannot reach redis, a counter within prometheus will increase by one and a log will send out information that redis cache is not reachable and has been disabled. 
If the counter of redis being unreachable is greater than the counter of redis being reachable, then an alert will be sent out through grafana (which is the next step after this pr gets merged) 

## Local Testing
How can the feature be exercised?
How can the bug be exploited and fix confirmed?
Is any special local setup required?
You can check through the logs when running the celery worker and celery worker beat, as well as the logs when the django server is being run. 

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
