### PR TITLE
replaced deprecated 'warn' method

### DIFF
--- a/rbac/management/principal/cleaner.py
+++ b/rbac/management/principal/cleaner.py
@@ -59,7 +59,7 @@ def clean_tenant_principals(tenant):
             principal.delete()
             logger.info("Username %s not found for tenant %s, principal removed.", principal.username, tenant_id)
         else:
-            logger.warn(
+            logger.warning(
                 "Unknown status %d when checking username %s" " for tenant %s, no change needed.",
                 status_code,
                 principal.username,


### PR DESCRIPTION
`warn` method is obsolete and identical with `warning` method
https://docs.python.org/3.9/library/logging.html#logging.Logger.warning
