### PR TITLE
replaced deprecated 'assertEquals' alias for 'assertEqual' method

### DIFF
--- a/tests/management/role/test_view.py
+++ b/tests/management/role/test_view.py
@@ -693,23 +693,23 @@ class RoleViewsetTests(IdentityRequest):
         # create a role
         role_name = "groupsInRole"
         created_role = self.create_role("groupsInRole")
-        self.assertEquals(created_role.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(created_role.status_code, status.HTTP_201_CREATED)
         role_uuid = created_role.data.get("uuid")
 
         # create a group
         group_name = "groupsInGroup"
         created_group = self.create_group(group_name)
-        self.assertEquals(created_group.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(created_group.status_code, status.HTTP_201_CREATED)
         group_uuid = created_group.data.get("uuid")
 
         # create a policy to link the 2
         policy_name = "groupsInPolicy"
         created_policy = self.create_policy(policy_name, group_uuid, [role_uuid])
-        self.assertEquals(created_policy.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(created_policy.status_code, status.HTTP_201_CREATED)
 
         # add user principal to the created group
         principal_response = self.add_principal_to_group(group_uuid, self.user_data["username"])
-        self.assertEquals(principal_response.status_code, status.HTTP_200_OK, principal_response)
+        self.assertEqual(principal_response.status_code, status.HTTP_200_OK, principal_response)
 
         # hit /roles?groups_in, group should appear in groups_in
         field_1 = "groups_in_count"
@@ -740,14 +740,14 @@ class RoleViewsetTests(IdentityRequest):
         # make sure created role exists in result set and has correct values
         created_role = next((iterRole for iterRole in response_data if iterRole["name"] == role_name), None)
         self.assertIsNotNone(created_role)
-        self.assertEquals(created_role["groups_in_count"], 1)
-        self.assertEquals(created_role["groups_in"][0]["name"], group_name)
+        self.assertEqual(created_role["groups_in_count"], 1)
+        self.assertEqual(created_role["groups_in"][0]["name"], group_name)
 
         # make sure a default role exists in result set and has correct values
         default_role = next((iterRole for iterRole in response_data if iterRole["name"] == self.defRole.name), None)
         self.assertIsNotNone(default_role)
-        self.assertEquals(default_role["groups_in_count"], 1)
-        self.assertEquals(default_role["groups_in"][0]["name"], self.group.name)
+        self.assertEqual(default_role["groups_in_count"], 1)
+        self.assertEqual(default_role["groups_in"][0]["name"], self.group.name)
 
     def test_list_role_with_groups_in_fields_for_admin_scope_success(self):
         """Test that we can read a list of roles and the groups_in fields is set correctly for a admin scoped request."""
@@ -779,14 +779,14 @@ class RoleViewsetTests(IdentityRequest):
         # make sure a default role exists in result set and has correct values
         default_role = next((iterRole for iterRole in response_data if iterRole["name"] == self.defRole.name), None)
         self.assertIsNotNone(default_role)
-        self.assertEquals(default_role["groups_in_count"], 1)
-        self.assertEquals(default_role["groups_in"][0]["name"], self.group.name)
+        self.assertEqual(default_role["groups_in_count"], 1)
+        self.assertEqual(default_role["groups_in"][0]["name"], self.group.name)
 
         # make sure an admin role exists in result set and has correct values
         admin_role = next((iterRole for iterRole in response_data if iterRole["name"] == self.adminRole.name), None)
         self.assertIsNotNone(admin_role)
-        self.assertEquals(admin_role["groups_in_count"], 1)
-        self.assertEquals(admin_role["groups_in"][0]["name"], self.group.name)
+        self.assertEqual(admin_role["groups_in_count"], 1)
+        self.assertEqual(admin_role["groups_in"][0]["name"], self.group.name)
 
     def test_list_role_with_username_forbidden_to_nonadmin(self):
         """Test that non admin can not read a list of roles for username."""

--- a/tests/management/test_querysets.py
+++ b/tests/management/test_querysets.py
@@ -87,7 +87,7 @@ class QuerySetTest(TestCase):
         user = Mock(spec=User, admin=True)
         req = Mock(user=user, tenant=self.tenant, query_params={})
         queryset = get_group_queryset(req)
-        self.assertEquals(queryset.count(), 5)
+        self.assertEqual(queryset.count(), 5)
 
     @patch(
         "management.principal.proxy.PrincipalProxy.request_filtered_principals",
@@ -115,7 +115,7 @@ class QuerySetTest(TestCase):
         user = Mock(spec=User, admin=True, account="00001", username="test_user")
         req = Mock(user=user, tenant=self.tenant, query_params={"username": "test_user"})
         queryset = get_group_queryset(req)
-        self.assertEquals(queryset.count(), 1)
+        self.assertEqual(queryset.count(), 1)
 
     @patch(
         "management.principal.proxy.PrincipalProxy.request_filtered_principals",
@@ -149,7 +149,7 @@ class QuerySetTest(TestCase):
             path=reverse("group-list"),
         )
         queryset = get_group_queryset(req)
-        self.assertEquals(queryset.count(), 1)
+        self.assertEqual(queryset.count(), 1)
 
     @patch(
         "management.principal.proxy.PrincipalProxy.request_filtered_principals",
@@ -178,7 +178,7 @@ class QuerySetTest(TestCase):
         user = Mock(spec=User, admin=False, account="00001", username="test_user")
         req = Mock(user=user, method="GET", tenant=self.tenant, query_params={"username": "test_user2"})
         queryset = get_group_queryset(req)
-        self.assertEquals(queryset.count(), 0)
+        self.assertEqual(queryset.count(), 0)
 
     @patch(
         "management.principal.proxy.PrincipalProxy.request_filtered_principals",
@@ -205,7 +205,7 @@ class QuerySetTest(TestCase):
         user = Mock(spec=User, admin=True, account="00001", username="test_user")
         req = Mock(user=user, tenant=self.tenant, query_params={"username": "test_user"})
         queryset = get_group_queryset(req)
-        self.assertEquals(queryset.count(), 1)
+        self.assertEqual(queryset.count(), 1)
 
     @patch(
         "management.principal.proxy.PrincipalProxy.request_filtered_principals",
@@ -231,7 +231,7 @@ class QuerySetTest(TestCase):
         user = Mock(spec=User, admin=False, account="00001", username="test_user")
         req = Mock(user=user, tenant=self.tenant, query_params={"username": "test_user"})
         queryset = get_group_queryset(req)
-        self.assertEquals(queryset.count(), 0)
+        self.assertEqual(queryset.count(), 0)
 
     @patch(
         "management.principal.proxy.PrincipalProxy.request_filtered_principals",
@@ -259,7 +259,7 @@ class QuerySetTest(TestCase):
         user = Mock(spec=User, admin=False, account="00001", username="test_user")
         req = Mock(user=user, tenant=self.tenant, query_params={"username": "test_user"})
         queryset = get_group_queryset(req)
-        self.assertEquals(queryset.count(), 1)
+        self.assertEqual(queryset.count(), 1)
 
     @patch(
         "management.principal.proxy.PrincipalProxy.request_filtered_principals",
@@ -288,7 +288,7 @@ class QuerySetTest(TestCase):
         user = Mock(spec=User, admin=False, account="00001", username="test_user", access=access)
         req = Mock(user=user, tenant=self.tenant, query_params={"username": "test_user"})
         queryset = get_group_queryset(req)
-        self.assertEquals(queryset.count(), 0)
+        self.assertEqual(queryset.count(), 0)
 
     @patch(
         "management.principal.proxy.PrincipalProxy.request_filtered_principals",
@@ -321,7 +321,7 @@ class QuerySetTest(TestCase):
         default_group.principals.add(principal)
 
         # Check that 7 groups are created
-        self.assertEquals(Group.objects.count(), 7)
+        self.assertEqual(Group.objects.count(), 7)
 
         user = Mock(spec=User, admin=False, account="00001", username="test_user")
         req = Mock(
@@ -336,7 +336,7 @@ class QuerySetTest(TestCase):
         # Check that principal can be added into 4 groups
         # (excluded 2 groups where the principal is already a member
         # and excluded default groups where cannot be added manually)
-        self.assertEquals(queryset.count(), 4)
+        self.assertEqual(queryset.count(), 4)
 
     def test_get_role_queryset_admin(self):
         """Test get_role_queryset as an admin."""
@@ -344,7 +344,7 @@ class QuerySetTest(TestCase):
         user = Mock(spec=User, admin=True)
         req = Mock(user=user, tenant=self.tenant, query_params={})
         queryset = get_role_queryset(req)
-        self.assertEquals(queryset.count(), 5)
+        self.assertEqual(queryset.count(), 5)
         self.assertIsNotNone(queryset.last().accessCount)
 
     @patch(
@@ -440,8 +440,8 @@ class QuerySetTest(TestCase):
         user = Mock(spec=User, admin=False, username="test_user", access={})
         req = Mock(user=user, tenant=self.tenant, method="GET", query_params={"username": "test_user2"})
         queryset = get_role_queryset(req)
-        self.assertEquals(list(queryset), [])
-        self.assertEquals(queryset.count(), 0)
+        self.assertEqual(list(queryset), [])
+        self.assertEqual(queryset.count(), 0)
 
     @patch(
         "management.principal.proxy.PrincipalProxy.request_filtered_principals",
@@ -468,8 +468,8 @@ class QuerySetTest(TestCase):
         req = Mock(user=user, method="GET", tenant=self.tenant, query_params={"username": "test_user2"})
         queryset = get_role_queryset(req)
         role = queryset.last()
-        self.assertEquals(list(queryset), [roles.first()])
-        self.assertEquals(queryset.count(), 1)
+        self.assertEqual(list(queryset), [roles.first()])
+        self.assertEqual(queryset.count(), 1)
         self.assertTrue(hasattr(role, "accessCount"))
         self.assertTrue(hasattr(role, "policyCount"))
 
@@ -503,8 +503,8 @@ class QuerySetTest(TestCase):
         )
         queryset = get_role_queryset(req)
         role = queryset.last()
-        self.assertEquals(list(queryset), [roles.first()])
-        self.assertEquals(queryset.count(), 1)
+        self.assertEqual(list(queryset), [roles.first()])
+        self.assertEqual(queryset.count(), 1)
         self.assertTrue(hasattr(role, "accessCount"))
         self.assertTrue(hasattr(role, "policyCount"))
 
@@ -531,8 +531,8 @@ class QuerySetTest(TestCase):
         user = Mock(spec=User, admin=True, account="00001", username="admin")
         req = Mock(user=user, method="GET", tenant=self.tenant, query_params={"username": "test_user2"})
         queryset = get_role_queryset(req)
-        self.assertEquals(list(queryset), [roles.first()])
-        self.assertEquals(queryset.count(), 1)
+        self.assertEqual(list(queryset), [roles.first()])
+        self.assertEqual(queryset.count(), 1)
 
     def test_get_role_queryset_get_all(self):
         """Test get_role_queryset as a user with all access."""
@@ -541,7 +541,7 @@ class QuerySetTest(TestCase):
         user = Mock(spec=User, admin=False, access=access)
         req = Mock(user=user, method="GET", tenant=self.tenant, query_params={})
         queryset = get_role_queryset(req)
-        self.assertEquals(queryset.count(), 5)
+        self.assertEqual(queryset.count(), 5)
 
     def test_get_role_queryset_get_some(self):
         """Test get_role_queryset as a user with one role access."""
@@ -550,7 +550,7 @@ class QuerySetTest(TestCase):
         user = Mock(spec=User, admin=False, access=access)
         req = Mock(user=user, method="GET", tenant=self.tenant, query_params={})
         queryset = get_role_queryset(req)
-        self.assertEquals(queryset.count(), 1)
+        self.assertEqual(queryset.count(), 1)
 
     def test_get_role_queryset_get_none(self):
         """Test get_role_queryset as a user with no access."""
@@ -559,7 +559,7 @@ class QuerySetTest(TestCase):
         user = Mock(spec=User, admin=False, access=access)
         req = Mock(user=user, method="GET", tenant=self.tenant, query_params={})
         queryset = get_role_queryset(req)
-        self.assertEquals(queryset.count(), 0)
+        self.assertEqual(queryset.count(), 0)
 
     def test_get_role_queryset_post_all(self):
         """Test get_role_queryset as a user with all access."""
@@ -568,7 +568,7 @@ class QuerySetTest(TestCase):
         user = Mock(spec=User, admin=False, access=access)
         req = Mock(user=user, method="PUT", tenant=self.tenant, query_params={})
         queryset = get_role_queryset(req)
-        self.assertEquals(queryset.count(), 5)
+        self.assertEqual(queryset.count(), 5)
 
     def test_get_role_queryset_put_some(self):
         """Test get_role_queryset as a user with one role access."""
@@ -577,7 +577,7 @@ class QuerySetTest(TestCase):
         user = Mock(spec=User, admin=False, access=access)
         req = Mock(user=user, method="PUT", tenant=self.tenant, query_params={})
         queryset = get_role_queryset(req)
-        self.assertEquals(queryset.count(), 1)
+        self.assertEqual(queryset.count(), 1)
 
     def test_get_role_queryset_put_none(self):
         """Test get_role_queryset as a user with no access."""
@@ -586,7 +586,7 @@ class QuerySetTest(TestCase):
         user = Mock(spec=User, admin=False, access=access)
         req = Mock(user=user, method="PUT", tenant=self.tenant, query_params={})
         queryset = get_role_queryset(req)
-        self.assertEquals(queryset.count(), 0)
+        self.assertEqual(queryset.count(), 0)
 
     def test_get_policy_queryset_admin(self):
         """Test get_policy_queryset as an admin."""
@@ -594,7 +594,7 @@ class QuerySetTest(TestCase):
         user = Mock(spec=User, admin=True)
         req = Mock(user=user, tenant=self.tenant, query_params={})
         queryset = get_policy_queryset(req)
-        self.assertEquals(queryset.count(), 5)
+        self.assertEqual(queryset.count(), 5)
 
     def test_get_policy_queryset_get_all(self):
         """Test get_policy_queryset as a user with all access."""
@@ -603,7 +603,7 @@ class QuerySetTest(TestCase):
         user = Mock(spec=User, admin=False, access=access)
         req = Mock(user=user, method="GET", tenant=self.tenant, query_params={})
         queryset = get_policy_queryset(req)
-        self.assertEquals(queryset.count(), 5)
+        self.assertEqual(queryset.count(), 5)
 
     def test_get_policy_queryset_get_some(self):
         """Test get_policy_queryset as a user with one role access."""
@@ -612,7 +612,7 @@ class QuerySetTest(TestCase):
         user = Mock(spec=User, admin=False, access=access)
         req = Mock(user=user, method="GET", tenant=self.tenant, query_params={})
         queryset = get_policy_queryset(req)
-        self.assertEquals(queryset.count(), 1)
+        self.assertEqual(queryset.count(), 1)
 
     def test_get_policy_queryset_get_none(self):
         """Test get_policy_queryset as a user with no access."""
@@ -621,7 +621,7 @@ class QuerySetTest(TestCase):
         user = Mock(spec=User, admin=False, access=access)
         req = Mock(user=user, method="GET", tenant=self.tenant, query_params={})
         queryset = get_policy_queryset(req)
-        self.assertEquals(queryset.count(), 0)
+        self.assertEqual(queryset.count(), 0)
 
     def test_get_policy_queryset_post_all(self):
         """Test get_policy_queryset as a user with all access."""
@@ -630,7 +630,7 @@ class QuerySetTest(TestCase):
         user = Mock(spec=User, admin=False, access=access)
         req = Mock(user=user, method="PUT", tenant=self.tenant, query_params={})
         queryset = get_policy_queryset(req)
-        self.assertEquals(queryset.count(), 5)
+        self.assertEqual(queryset.count(), 5)
 
     def test_get_policy_queryset_put_some(self):
         """Test get_policy_queryset as a user with one role access."""
@@ -639,7 +639,7 @@ class QuerySetTest(TestCase):
         user = Mock(spec=User, admin=False, access=access)
         req = Mock(user=user, method="PUT", tenant=self.tenant, query_params={})
         queryset = get_policy_queryset(req)
-        self.assertEquals(queryset.count(), 1)
+        self.assertEqual(queryset.count(), 1)
 
     def test_get_policy_queryset_put_none(self):
         """Test get_policy_queryset as a user with no access."""
@@ -648,7 +648,7 @@ class QuerySetTest(TestCase):
         user = Mock(spec=User, admin=False, access=access)
         req = Mock(user=user, method="PUT", tenant=self.tenant, query_params={})
         queryset = get_policy_queryset(req)
-        self.assertEquals(queryset.count(), 0)
+        self.assertEqual(queryset.count(), 0)
 
     def test_get_policy_queryset_scope_put_none(self):
         """Test get_policy_queryset for a principal scope with put."""
@@ -657,7 +657,7 @@ class QuerySetTest(TestCase):
         user = Mock(spec=User, admin=False, access=access)
         req = Mock(user=user, method="PUT", tenant=self.tenant, query_params={SCOPE_KEY: PRINCIPAL_SCOPE})
         queryset = get_policy_queryset(req)
-        self.assertEquals(queryset.count(), 0)
+        self.assertEqual(queryset.count(), 0)
 
     def test_get_policy_queryset_bad_scope(self):
         """Test get_policy_queryset with a bad scope."""
@@ -682,7 +682,7 @@ class QuerySetTest(TestCase):
         req.META = encoded_req.META
 
         queryset = get_access_queryset(req)
-        self.assertEquals(queryset.count(), 1)
+        self.assertEqual(queryset.count(), 1)
 
     def test_get_access_queryset_non_org_admin(self):
         """Test get_access_queryset with a non 'org admin' user"""
@@ -698,7 +698,7 @@ class QuerySetTest(TestCase):
         req.META = encoded_req.META
 
         queryset = get_access_queryset(req)
-        self.assertEquals(queryset.count(), 0)
+        self.assertEqual(queryset.count(), 0)
 
     @patch(
         "management.principal.proxy.PrincipalProxy.request_filtered_principals",
@@ -734,7 +734,7 @@ class QuerySetTest(TestCase):
         req.META = encoded_req.META
 
         queryset = get_access_queryset(req)
-        self.assertEquals(queryset.count(), 0)
+        self.assertEqual(queryset.count(), 0)
 
     def _setup_group_for_org_admin_tests(self):
         role = Role.objects.create(name="role_admin_default", tenant=self.tenant)


### PR DESCRIPTION
https://docs.python.org/3.9/library/unittest.html#deprecated-aliases