### PR TITLE
added tearDown() method under RoleViewsetTests class to tear down all created tests objects

### DIFF
--- a/tests/management/role/test_view.py
+++ b/tests/management/role/test_view.py
@@ -24,6 +24,7 @@ from rest_framework import status
 from rest_framework.test import APIClient
 
 from api.models import User, Tenant
+from management.cache import TenantCache
 from management.models import (
     Group,
     Permission,
@@ -185,6 +186,22 @@ class RoleViewsetTests(IdentityRequest):
 
         self.access3 = Access.objects.create(permission=self.permission2, role=self.sysRole, tenant=self.tenant)
         Permission.objects.create(permission="cost-management:*:*", tenant=self.tenant)
+
+    def tearDown(self):
+        """Tear down role viewset tests."""
+        Group.objects.all().delete()
+        Principal.objects.all().delete()
+        Role.objects.all().delete()
+        Policy.objects.all().delete()
+        Permission.objects.all().delete()
+        Access.objects.all().delete()
+        ExtTenant.objects.all().delete()
+        ExtRoleRelation.objects.all().delete()
+
+        # we need to delete old test_tenant's that may exist in cache
+        test_tenant_org_id = "100001"
+        cached_tenants = TenantCache()
+        cached_tenants.delete_tenant(test_tenant_org_id)
 
     def create_role(self, role_name, role_display="", in_access_data=None):
         """Create a role."""


### PR DESCRIPTION
this will fix the issue when you want to add new test with `self.test_principal` and the `setUp()` method tries to add this principal under tenant with `org_id="100001"` but Tenant exists in the cache

how to test this:
find test `test_list_role_with_additional_fields_username_success` and make a copy under different test name and you find out that test is not passing even the test is same  