### PR TITLE
refactor: removed not used method _create_customer()

### DIFF
--- a/tests/api/cross_access/test_view.py
+++ b/tests/api/cross_access/test_view.py
@@ -47,7 +47,7 @@ class CrossAccountRequestViewTests(IdentityRequest):
         self.account = self.customer_data["account_id"]
         self.org_id = self.customer_data["org_id"]
         self.associate_non_admin_request_context = self._create_request_context(
-            self.customer_data, self.user_data, create_customer=False, is_org_admin=False, is_internal=True
+            self.customer_data, self.user_data, is_org_admin=False, is_internal=True
         )
         self.associate_non_admin_request = self.associate_non_admin_request_context["request"]
 
@@ -57,13 +57,13 @@ class CrossAccountRequestViewTests(IdentityRequest):
         self.not_anemic_customer_data["account_id"] = self.not_anemic_account
         self.not_anemic_customer_data["tenant_name"] = f"acct{self.not_anemic_account}"
         self.associate_not_anemic_request_context = self._create_request_context(
-            self.not_anemic_customer_data, self.user_data, create_customer=False, is_org_admin=False, is_internal=True
+            self.not_anemic_customer_data, self.user_data, is_org_admin=False, is_internal=True
         )
         self.associate_not_anemic_request = self.associate_not_anemic_request_context["request"]
         self.not_anemic_headers = self.associate_not_anemic_request_context["request"].META
 
         self.associate_admin_request_context = self._create_request_context(
-            self.customer_data, self.user_data, create_customer=False, is_org_admin=True, is_internal=True
+            self.customer_data, self.user_data, is_org_admin=True, is_internal=True
         )
         self.associate_admin_request = self.associate_admin_request_context["request"]
 

--- a/tests/identity_request.py
+++ b/tests/identity_request.py
@@ -71,30 +71,10 @@ class IdentityRequest(TestCase):
         return user_data
 
     @classmethod
-    def _create_customer(cls, account, create_tenant=False, org_id=None):
-        """Create a customer.
-
-        Args:
-            account (str): The account identifier
-
-        Returns:
-            (Customer) The created customer
-
-        """
-        tenant_name = create_tenant_name(account)
-        tenant = None
-        if create_tenant:
-            tenant = Tenant(tenant_name=tenant_name, account_id=account, org_id=org_id)
-            tenant.save()
-        return tenant
-
-    @classmethod
     def _create_request_context(
         cls,
         customer_data,
         user_data,
-        create_customer=True,
-        create_tenant=False,
         is_org_admin=True,
         is_internal=False,
         cross_account=False,
@@ -103,8 +83,6 @@ class IdentityRequest(TestCase):
         customer = customer_data
         account = customer.get("account_id")
         org_id = customer.get("org_id", None)
-        if create_customer:
-            cls.customer = cls._create_customer(account, create_tenant=create_tenant, org_id=org_id)
 
         identity = cls._build_identity(user_data, account, org_id, is_org_admin, is_internal)
         if cross_account:

--- a/tests/internal/integration/test_integration_views.py
+++ b/tests/internal/integration/test_integration_views.py
@@ -36,9 +36,7 @@ class IntegrationViewsTests(IdentityRequest):
         super().setUp()
         self.client = APIClient()
         self.customer = self.customer_data
-        self.internal_request_context = self._create_request_context(
-            self.customer, self.user_data, create_customer=False, is_internal=True, create_tenant=False
-        )
+        self.internal_request_context = self._create_request_context(self.customer, self.user_data, is_internal=True)
 
         self.request = self.internal_request_context["request"]
         user = User()
@@ -129,9 +127,7 @@ class IntegrationViewsTests(IdentityRequest):
 
     def test_groups_invalid_account(self):
         """Test that a /tenant/<id>/groups/?username= request from an external account fails."""
-        external_request_context = self._create_request_context(
-            self.customer, self.user_data, create_customer=False, is_internal=False, create_tenant=False
-        )
+        external_request_context = self._create_request_context(self.customer, self.user_data, is_internal=False)
         request = external_request_context["request"]
         response = self.client.get(
             f"/_private/api/v1/integrations/tenant/{self.tenant.org_id}/groups/?username=user_a",
@@ -198,9 +194,7 @@ class IntegrationViewsTests(IdentityRequest):
 
     def test_groups_for_principal_invalid_account(self):
         """Test that a /tenant/<id>/principal/<username>groups/ request from an external account fails."""
-        external_request_context = self._create_request_context(
-            self.customer, self.user_data, create_customer=False, is_internal=False, create_tenant=False
-        )
+        external_request_context = self._create_request_context(self.customer, self.user_data, is_internal=False)
         request = external_request_context["request"]
         response = self.client.get(
             f"/_private/api/v1/integrations/tenant/{self.tenant.org_id}/principal/user_a/groups/",
@@ -274,9 +268,7 @@ class IntegrationViewsTests(IdentityRequest):
     def test_roles_from_group_invalid_account(self):
         """Test that a /tenant/<id>/groups/<uuid>/roles/ request from an external account fails."""
         group_all_uuid = Group.objects.get(name="Group All").uuid
-        external_request_context = self._create_request_context(
-            self.customer, self.user_data, create_customer=False, is_internal=False, create_tenant=False
-        )
+        external_request_context = self._create_request_context(self.customer, self.user_data, is_internal=False)
         request = external_request_context["request"]
         response = self.client.get(
             f"/_private/api/v1/integrations/tenant/{self.tenant.org_id}/groups/{group_all_uuid}/roles/",
@@ -341,9 +333,7 @@ class IntegrationViewsTests(IdentityRequest):
     def test_roles_for_group_principal_invalid_account(self):
         """Test that a valid request to /tenant/<id>/principal/user_admin/groups/<uuid>/roles/ from an external account fails."""
         group_all_uuid = Group.objects.get(name="Group All").uuid
-        external_request_context = self._create_request_context(
-            self.customer, self.user_data, create_customer=False, is_internal=False, create_tenant=False
-        )
+        external_request_context = self._create_request_context(self.customer, self.user_data, is_internal=False)
         request = external_request_context["request"]
         response = self.client.get(
             f"/_private/api/v1/integrations/tenant/{self.tenant.org_id}/principal/user_admin/groups/{group_all_uuid}/roles/",

--- a/tests/internal/test_views.py
+++ b/tests/internal/test_views.py
@@ -44,9 +44,7 @@ class InternalViewsetTests(IdentityRequest):
         super().setUp()
         self.client = APIClient()
         self.customer = self.customer_data
-        self.internal_request_context = self._create_request_context(
-            self.customer, self.user_data, create_customer=False, is_internal=True, create_tenant=False
-        )
+        self.internal_request_context = self._create_request_context(self.customer, self.user_data, is_internal=True)
 
         self.request = self.internal_request_context["request"]
         user = User()

--- a/tests/management/role/test_view.py
+++ b/tests/management/role/test_view.py
@@ -968,7 +968,7 @@ class RoleViewsetTests(IdentityRequest):
         """Test that non admin can not read a list of roles for username."""
         # Setup non admin request
         non_admin_request_context = self._create_request_context(
-            self.customer_data, self.user_data, create_customer=False, is_org_admin=False
+            self.customer_data, self.user_data, is_org_admin=False
         )
         non_admin_request = non_admin_request_context["request"]
 

--- a/tests/rbac/test_middleware.py
+++ b/tests/rbac/test_middleware.py
@@ -96,7 +96,7 @@ class RbacTenantMiddlewareTest(IdentityRequest):
         self.customer = self._create_customer_data()
         self.tenant_name = create_tenant_name(self.customer["account_id"])
         self.org_id = self.customer["org_id"]
-        self.request_context = self._create_request_context(self.customer, self.user_data, create_customer=False)
+        self.request_context = self._create_request_context(self.customer, self.user_data)
         self.request = self.request_context["request"]
         self.request.path = "/api/v1/providers/"
         user = User()
@@ -117,7 +117,7 @@ class RbacTenantMiddlewareTest(IdentityRequest):
 
     def test_get_tenant_with_no_user(self):
         """Test that a 401 is returned."""
-        request_context = self._create_request_context(self.customer, None, create_customer=False)
+        request_context = self._create_request_context(self.customer, None)
         mock_request = request_context["request"]
         mock_request.path = "/api/v1/providers/"
         middleware = IdentityHeaderMiddleware(get_response=IdentityHeaderMiddleware.process_request)
@@ -129,7 +129,7 @@ class RbacTenantMiddlewareTest(IdentityRequest):
         user_data = self._create_user_data()
         customer = self._create_customer_data()
         customer["org_id"] = "45321"
-        request_context = self._create_request_context(customer, user_data, create_customer=True)
+        request_context = self._create_request_context(customer, user_data)
         request = request_context["request"]
         request.path = "/api/v1/providers/"
         request.META["QUERY_STRING"] = ""
@@ -154,7 +154,7 @@ class IdentityHeaderMiddlewareTest(IdentityRequest):
         self.customer = self._create_customer_data()
         self.tenant_name = create_tenant_name(self.customer["account_id"])
         self.org_id = self.customer["org_id"]
-        self.request_context = self._create_request_context(self.customer, self.user_data, create_customer=False)
+        self.request_context = self._create_request_context(self.customer, self.user_data)
         self.request = self.request_context["request"]
         self.request.path = "/api/v1/providers/"
         self.request.META["QUERY_STRING"] = ""
@@ -171,7 +171,7 @@ class IdentityHeaderMiddlewareTest(IdentityRequest):
         middleware = IdentityHeaderMiddleware(get_response=IdentityHeaderMiddleware.process_request)
         # User without redhat email will fail.
         request_context = self._create_request_context(
-            self.customer, self.user_data, create_customer=False, cross_account=True, is_internal=True
+            self.customer, self.user_data, cross_account=True, is_internal=True
         )
         mock_request = request_context["request"]
         mock_request.path = "/api/v1/providers/"
@@ -181,9 +181,7 @@ class IdentityHeaderMiddlewareTest(IdentityRequest):
 
         # User with is_internal equal to False will fail.
         self.user_data["email"] = "test@redhat.com"
-        request_context = self._create_request_context(
-            self.customer, self.user_data, create_customer=False, cross_account=True
-        )
+        request_context = self._create_request_context(self.customer, self.user_data, cross_account=True)
         mock_request = request_context["request"]
         mock_request.path = "/api/v1/providers/"
 
@@ -193,7 +191,7 @@ class IdentityHeaderMiddlewareTest(IdentityRequest):
         # Success pass if user is internal and with redhat email
         self.user_data["email"] = "test@redhat.com"
         request_context = self._create_request_context(
-            self.customer, self.user_data, create_customer=False, cross_account=True, is_internal=True
+            self.customer, self.user_data, cross_account=True, is_internal=True
         )
         mock_request = request_context["request"]
         mock_request.path = "/api/v1/providers/"
@@ -227,7 +225,7 @@ class IdentityHeaderMiddlewareTest(IdentityRequest):
         customer = self._create_customer_data()
         account_id = customer["account_id"]
         del customer["account_id"]
-        request_context = self._create_request_context(customer, self.user_data, create_customer=False)
+        request_context = self._create_request_context(customer, self.user_data)
         mock_request = request_context["request"]
         mock_request.path = "/api/v1/providers/"
         middleware = IdentityHeaderMiddleware(get_response=IdentityHeaderMiddleware.process_request)
@@ -260,7 +258,7 @@ class IdentityHeaderMiddlewareTest(IdentityRequest):
 
         user_data = self._create_user_data()
         customer = self._create_customer_data()
-        request_context = self._create_request_context(customer, user_data, create_customer=False)
+        request_context = self._create_request_context(customer, user_data)
         request = request_context["request"]
         request.path = "/api/v1/providers/"
         request.META["QUERY_STRING"] = ""
@@ -356,9 +354,7 @@ class InternalIdentityHeaderMiddleware(IdentityRequest):
         super().setUp()
         self.user_data = self._create_user_data()
         self.customer = self._create_customer_data()
-        self.internal_request_context = self._create_request_context(
-            self.customer, self.user_data, create_customer=False, is_internal=True
-        )
+        self.internal_request_context = self._create_request_context(self.customer, self.user_data, is_internal=True)
 
     def test_internal_user_can_access_private_api(self):
         request = self.internal_request_context["request"]


### PR DESCRIPTION
## Description of Intent of Change(s)
this PR removes method `_create_customer()` from `IdentityRequest` class from file `/insights-rbac/tests/identity_request.py`

I noticed that another method `_create_request_context()` in the same class uses this method like this:
```
        if create_customer:
            cls.customer = cls._create_customer(account, create_tenant=create_tenant, org_id=org_id)
```
but `cls.customer` is not used anymore

and the method `_create_customer()` itself is doing something only when param `create_tenant=True`, but default value is `False` + there is not a single occurrence of this function being used with parameter `create_tenant=True`


## Local Testing
just run tests via tox
`$ tox -r`