### PR TITLE
Remove unnecessary testdata

### DIFF
--- a/tests/management/role/test_view.py
+++ b/tests/management/role/test_view.py
@@ -831,23 +831,7 @@ class RoleViewsetTests(IdentityRequest):
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
-    @patch(
-        "management.principal.proxy.PrincipalProxy.request_filtered_principals",
-        return_value={
-            "status_code": 200,
-            "data": [
-                {
-                    "org_id": "100001",
-                    "is_org_admin": True,
-                    "is_internal": False,
-                    "id": 52567473,
-                    "username": "test_user",
-                    "account_number": "1111111",
-                    "is_active": True,
-                }
-            ],
-        },
-    )
+    @patch("management.principal.proxy.PrincipalProxy.request_filtered_principals")
     def test_list_role_with_additional_fields_username_success(self, mock_request):
         """Test that we can read a list of roles and add fields for username."""
         field_1 = "groups_in_count"
@@ -856,9 +840,24 @@ class RoleViewsetTests(IdentityRequest):
         new_display_fields.add(field_1)
         new_display_fields.add(field_2)
 
-        url = "{}?add_fields={},{}&username={}".format(URL, field_1, field_2, self.test_principal.username)
+        mock_request.return_value = {
+            "status_code": 200,
+            "data": [
+                {
+                    "org_id": "100001",
+                    "is_org_admin": True,
+                    "is_internal": False,
+                    "id": 52567473,
+                    "username": self.principal.username,
+                    "account_number": "1111111",
+                    "is_active": True,
+                }
+            ],
+        }
+
+        url = "{}?add_fields={},{}&username={}".format(URL, field_1, field_2, self.principal.username)
         client = APIClient()
-        response = client.get(url, **self.test_headers)
+        response = client.get(url, **self.headers)
 
         self.assertEqual(len(response.data.get("data")), 4)
 

--- a/tests/management/role/test_view.py
+++ b/tests/management/role/test_view.py
@@ -23,7 +23,6 @@ from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APIClient
 
-from api.models import Tenant
 from management.cache import TenantCache
 from management.models import (
     Group,
@@ -86,53 +85,6 @@ class RoleViewsetTests(IdentityRequest):
             "external_role_id",
             "external_tenant",
         }
-
-        self.test_tenant = Tenant(tenant_name="acct1111111", account_id="1111111", org_id="100001", ready=True)
-        self.test_tenant.save()
-        self.test_principal = Principal(username="test_user", tenant=self.test_tenant)
-        self.test_principal.save()
-
-        user_data = {"username": "test_user", "email": "test@gmail.com"}
-        request_context = self._create_request_context(
-            {"account_id": "1111111", "tenant_name": "acct1111111", "org_id": "100001"}, user_data, is_org_admin=True
-        )
-        request = request_context["request"]
-        self.test_headers = request.META
-
-        self.test_policy = Policy.objects.create(name="policyA", tenant=self.test_tenant)
-        self.test_group = Group(name="groupA", description="groupA description", tenant=self.test_tenant)
-        self.test_group.save()
-        self.test_group.principals.add(self.test_principal)
-        self.test_group.policies.add(self.test_policy)
-        self.test_group.save()
-
-        self.test_policy_two = Policy.objects.create(name="policyB", tenant=self.test_tenant)
-        self.test_group_two = Group(name="groupB", description="groupB description", tenant=self.test_tenant)
-        self.test_group_two.save()
-        self.test_group_two.principals.add(self.test_principal)
-        self.test_group_two.policies.add(self.test_policy_two)
-        self.test_group_two.save()
-
-        self.test_adminRole = Role(**admin_def_role_config, tenant=self.test_tenant)
-        self.test_adminRole.save()
-
-        self.test_platformAdminRole = Role(**platform_admin_def_role_config, tenant=self.test_tenant)
-        self.test_platformAdminRole.save()
-
-        self.test_sysRole = Role(**sys_role_config, tenant=self.test_tenant)
-        self.test_sysRole.save()
-
-        self.test_defRole = Role(**def_role_config, tenant=self.test_tenant)
-        self.test_defRole.save()
-        self.test_defRole.save()
-
-        self.test_policy.roles.add(
-            self.test_defRole, self.test_sysRole, self.test_adminRole, self.test_platformAdminRole
-        )
-        self.test_policy.save()
-
-        self.test_policy_two.roles.add(self.test_platformAdminRole)
-        self.test_policy_two.save()
 
         self.principal = Principal(username=self.user_data["username"], tenant=self.tenant)
         self.principal.save()


### PR DESCRIPTION
this PR can me merged after https://github.com/RedHatInsights/insights-rbac/pull/938

## Description of Intent of Change(s):
in the class `RoleViewsetTests` I found we create set of test data around tenant `self.test_tenant`
for this tenant we create principal `self.test_principal`, header `self.test_header`, groups `self.test_group` and `self.test_group_two` and roles, policies and so on (everything with pattern `self.test_XXX`)

test data is created in the `setUp()` method and is used ONLY for 1 test (from 65 in this class) => `test_list_role_with_additional_fields_username_success()` 

so I changed this test to use the already existing test data (used by rest of tests) and removed the not needed tests data

bonus: faster tests (on my machine 5 - 6 seconds)

## Local testing:
- without the change remove all test data and run tests via `tox` and check that only 1 test is affected
- with the change just run tests via `tox` 