### PR TITLE
RHCLOUD-27878 | fix: endelss IT service account fetching loop

### DIFF
--- a/rbac/management/principal/it_service.py
+++ b/rbac/management/principal/it_service.py
@@ -95,8 +95,11 @@ class ITService:
                 # Extract the body contents.
                 body_contents = response.json()
 
-                # Recalculate the offset to decide whether to get more service accounts or not.
+                # Recalculate the offset to decide whether to get more service accounts or not. If the offset is zero,
+                # it means that there were no service accounts in IT for the tenant.
                 offset = offset + len(body_contents)
+                if offset == 0:
+                    break
 
                 # Merge the previously received service accounts with the new ones.
                 received_service_accounts = received_service_accounts + body_contents


### PR DESCRIPTION
## Link(s) to Jira
- [[RHCLOUD-27878]](https://issues.redhat.com/browse/RHCLOUD-27878)

## Description of Intent of Change(s)
When the tenant doesn't have any service accounts, the loop simply keeps on going because the offset keeps being zero.

## Local Testing
### How can the bug be exploited and fix confirmed?
- In stage, send a GET request to `'https://console.stage.redhat.com/api/rbac/v1/principals/?type=service-account'` with an `Authorization: Bearer <token>` header. The token can be taken by opening the network tab of your browser, logging in to ConsoleDot and then filtering the requests by "token". You'll be able to grab the bearer token from the response to that call.

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
