### PR TITLE
RHCLOUD-27878 | fix: limit and offset filters make RBAC return a 500

### DIFF
--- a/rbac/management/group/view.py
+++ b/rbac/management/group/view.py
@@ -763,8 +763,8 @@ class GroupViewSet(
 
                 # Get the principal username option parameter and the limit and offset parameters too.
                 options[PRINCIPAL_USERNAME_KEY] = request.query_params.get(PRINCIPAL_USERNAME_KEY)
-                options["limit"] = request.query_params.get("limit", StandardResultsSetPagination.default_limit)
-                options["offset"] = request.query_params.get("offset", 0)
+                options["limit"] = int(request.query_params.get("limit", StandardResultsSetPagination.default_limit))
+                options["offset"] = int(request.query_params.get("offset", 0))
 
                 # Fetch the group's service accounts.
                 it_service = ITService()


### PR DESCRIPTION
## Link(s) to Jira
- [[RHCLOUD-27878]](https://issues.redhat.com/browse/RHCLOUD-27878)

## Description of Intent of Change(s)
The incoming query parameters are strings by default, and since I wasn't casting them, Django was complaining that it could not apply the offset and the limit correctly for being of incompatible types.

## Local Testing
### How can the bug be exploited and fix confirmed?
In stage, try to open the RBAC group page and you'll see a 500. If you try to send the same request to the current RBAC application, it returns a 500, and the console shows the following error: `TypeError: '<' not supported between instances of 'str' and 'int`.

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
