### PR TITLE
RHCLOUD-27878 | fix: unintended "principal_username" filter applied to query

### DIFF
--- a/rbac/management/group/view.py
+++ b/rbac/management/group/view.py
@@ -761,8 +761,12 @@ class GroupViewSet(
                         },
                     )
 
-                # Get the principal username option parameter and the limit and offset parameters too.
-                options[PRINCIPAL_USERNAME_KEY] = request.query_params.get(PRINCIPAL_USERNAME_KEY)
+                # Get the principal username option parameter and the limit and offset parameters too. Sometimes the UI
+                # sends "false" as the "principal username" query parameter. In that case we assume no filtering was
+                # intended to be done.
+                principal_username = request.query_params.get(PRINCIPAL_USERNAME_KEY)
+                if principal_username and principal_username != "false":
+                    options[PRINCIPAL_USERNAME_KEY] = principal_username
                 options["limit"] = int(request.query_params.get("limit", StandardResultsSetPagination.default_limit))
                 options["offset"] = int(request.query_params.get("offset", 0))
 


### PR DESCRIPTION
## Link(s) to Jira
- [[RHCLOUD]](https://issues.redhat.com/browse/RHCLOUD-27878)

## Description of Intent of Change(s)
Sometimes the UI seems to send "false" when the principal username filter doesn't want to be applied, which makes the query to actually try to filter by the "false" username.

## Local Testing
How can the feature be exercised?
How can the bug be exploited and fix confirmed?
Is any special local setup required?

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
