### PR TITLE
RHCLOUD-27878 | fix: missing query parameter to remove service accounts

### DIFF
--- a/docs/source/specs/openapi.json
+++ b/docs/source/specs/openapi.json
@@ -1327,7 +1327,14 @@
             "name": "usernames",
             "in": "query",
             "description": "A comma separated list of usernames for principals to remove from the group",
-            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "service-accounts",
+            "in": "query",
+            "description": "A comma separated list of usernames for service accounts to remove from the group",
             "schema": {
               "type": "string"
             }


### PR DESCRIPTION
## Link(s) to Jira
- [[RHCLOUD-27878]](https://issues.redhat.com/RHCLOUD-27878)

## Description of Intent of Change(s)
The UI team has let us know that the service accounts query parameter is missing from the OpenAPI spec, which causes, obviously, the API client generators to not generate it.

Therefore, there is no way for them to remove the service accounts because the query parameter is not available to them.

## Local Testing
How can the feature be exercised?
How can the bug be exploited and fix confirmed?
Is any special local setup required?

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
