### PR TITLE
RHCLOUD-27878 | fix: order by is wrongly specified

### DIFF
--- a/rbac/management/principal/it_service.py
+++ b/rbac/management/principal/it_service.py
@@ -224,8 +224,13 @@ class ITService:
         group_service_account_principals = group.principals.filter(type=TYPE_SERVICE_ACCOUNT)
 
         # Apply the specified query pamareters for the collection. Begin with the sort order.
-        order_by = options.get("sort_order")
-        if order_by:
+        sort_order = options.get("sort_order")
+        if sort_order:
+            if sort_order == "asc":
+                order_by = "username"
+            else:
+                order_by = "-username"
+
             group_service_account_principals = group_service_account_principals.order_by(order_by)
 
         # Check if we should filter the service accounts by the username that the user specified.


### PR DESCRIPTION
## Link(s) to Jira
- [RHCLOUD-27878](https://issues.redhat.com/browse/RHCLOUD-27878)

## Description of Intent of Change(s)
The order by query parameter is required to be specified as "username" or "-username" in the view, and then gets converted to an internal "sort order" option with the "asc" or "desc" values. However, in order to apply those to the username field the service accounts' code needs to reconvert those "asc" and "desc" values to the "username" and "-username" values that Django understands.


## Local Testing
### How can the bug be exploited and fix confirmed?
In stage, try sending a `GET /api/rbac/v1/groups/d70d0ca7-ee83-4f0e-b792-cb2bc46ef70d/principals/?principal_type=service-account&order_by=username` request. The service returns a 500 error instead of the expected payload.

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
