### PR TITLE
RHCLOUD-27878 | fix: unmanaged 500 errors due to incorrect labels

### DIFF
--- a/rbac/management/principal/it_service.py
+++ b/rbac/management/principal/it_service.py
@@ -44,8 +44,14 @@ it_request_all_service_accounts_time_tracking = Histogram(
 
 it_request_status_count = Counter(
     "it_request_status_total",
-    "Number of requests from IT to BOP and resulting status",
+    "Number of requests from RBAC to IT's SSO and resulting status",
     ["method", "status"],
+)
+
+it_request_error = Counter(
+    "it_request_error",
+    "Number of requests from RBAC to IT's SSO that failed and the reason why they failed",
+    ["error"],
 )
 
 
@@ -82,6 +88,10 @@ class ITService:
                     timeout=self.it_request_timeout,
                 )
 
+                # Save the metrics for the successful call. Successful does not mean that we received an OK response,
+                # but that we were able to reach IT's SSO instead and get a response from them.
+                it_request_status_count.labels(method=requests.get.__name__.upper(), status=response.status_code)
+
                 if not status.is_success(response.status_code):
                     LOGGER.error(
                         "Unexpected status code '%s' received from IT when fetching service accounts. "
@@ -111,7 +121,7 @@ class ITService:
             )
 
             # Increment the error count.
-            it_request_status_count.labels(method=requests.get.__name__.upper(), status=response.status_code).inc()
+            it_request_error.labels(error="connection-error").inc()
 
             # Raise the exception again to return a proper response to the client
             raise exception
@@ -123,7 +133,7 @@ class ITService:
             )
 
             # Increment the error count.
-            it_request_status_count.labels(method=requests.get.__name__.upper(), error="timeout").inc()
+            it_request_error.labels(error="timeout").inc()
 
         # Transform the incoming payload into our model's service accounts.
         service_accounts: list[dict] = []


### PR DESCRIPTION
## Link(s) to Jira
- [[RHCLOUD-27878]](https://issues.redhat.com/browse/RHCLOUD-27878)

## Description of Intent of Change(s)
The defined labels for the counters and the labels used on the IT service class did not match, and that caused an unhandled 500 error that would make RBAC error incorrectly.

## Local Testing
### How can the bug be exploited and fix confirmed?
Set up RBAC locally, set the `IT_SERVICE_TIMEOUT_SECONDS` environment variable to 1 second, and replace the `url` variable on the `ITService#request_service_accounts` method with a `url = https://httpstat.us/200?sleep=50000`, run RBAC and then send a request to `GET /groups/{uuid}/principals/?type=service-accounts`

You will see that the request times out and that RBAC throws unhandled exceptions.

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
