### PR TITLE
[RHCLOUD-29513] open api spec - added base urls for prod/stage/local

### DIFF
--- a/docs/source/specs/openapi.json
+++ b/docs/source/specs/openapi.json
@@ -2848,9 +2848,36 @@
   },
   "servers": [
     {
-      "url": "/api/rbac/v1"
+      "url": "https://console.redhat.com/{basePath}",
+      "description": "Production Server",
+      "variables": {
+        "basePath": {
+          "default": "api/rbac/v1"
+        }
+      }
+    },
+    {
+      "url": "https://console.stage.redhat.com/{basePath}",
+      "description": "Staging Server",
+      "variables": {
+        "basePath": {
+          "default": "api/rbac/v1"
+        }
+      }
+    },
+    {
+      "url": "http://localhost:{port}/{basePath}",
+      "description": "Development Server",
+      "variables": {
+        "port": {
+          "default": "8000"
+        },
+        "basePath": {
+          "default": "api/rbac/v1"
+        }
+      }
     }
-  ],
+  ],  
   "components": {
     "parameters": {
       "QueryOffset": {


### PR DESCRIPTION
The Open API spec for RBAC in the API Catalog and Documentation Red Hat Developer pages ([link](https://developers.redhat.com/api-catalog/api/rbac)) doesn't contain full url for production, stage and local environment. This causes the url in the black panel is not correct.

![image](https://github.com/RedHatInsights/insights-rbac/assets/89980168/dca2c599-9993-46dc-990c-6e3ce697bdf1)

This PR fixes it.