### PR TITLE
RHCLOUD-29786 | fix: access endpoint returning data for new service accounts

### DIFF
--- a/rbac/management/utils.py
+++ b/rbac/management/utils.py
@@ -137,19 +137,24 @@ def access_for_roles(roles, param_applications):
     return set(access)
 
 
-def groups_for_principal(principal, tenant, **kwargs):
+def groups_for_principal(principal: Principal, tenant, **kwargs):
     """Gathers all groups for a principal, including the default."""
     if principal.cross_account:
         return set()
     assigned_group_set = principal.group.all()
     public_tenant = Tenant.objects.get(tenant_name="public")
-    platform_default_group_set = Group.platform_default_set().filter(
-        tenant=tenant
-    ) or Group.platform_default_set().filter(tenant=public_tenant)
+    platform_default_group_set = Group.platform_default_set().filter(tenant=tenant)
 
-    admin_default_group_set = Group.admin_default_set().filter(tenant=tenant) or Group.admin_default_set().filter(
-        tenant=public_tenant
-    )
+    # Service accounts should not get any access details related to the default groups.
+    if not platform_default_group_set and principal.type == "user":
+        platform_default_group_set = Group.platform_default_set().filter(tenant=public_tenant)
+
+    admin_default_group_set = Group.admin_default_set().filter(tenant=tenant)
+
+    # Same as above, the default admin group should only be fetched for the users.
+    if not admin_default_group_set and principal.type == "user":
+        Group.admin_default_set().filter(tenant=public_tenant)
+
     prefetch_lookups = kwargs.get("prefetch_lookups_for_groups")
 
     if prefetch_lookups:


### PR DESCRIPTION
## Link(s) to Jira
[[RHCLOUD-29786]](https://issues.redhat.com/browse/RHCLOUD-29786)

## Description of Intent of Change(s)
When using a fresh service account to send requests to the access endpoint, some data was getting returned from the default access groups. However, service accounts can't be associated with those default groups, so it does not make any sense for us to be returning data from those.

## Local Testing
### How can the bug be exploited and fix confirmed?
1. Create a service account.
2. Get a service account token.
3. Send a request to the /access endpoint with `curl --proxy http://squid.redhat.com:3128/ -sSH "Authorization:Bearer ${access_token}" "https://console.redhat.com/api/rbac/v1/access/?application=remediations"`

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
