### PR TITLE
Remove extra service defining

### DIFF
--- a/deploy/rbac-clowdapp.yml
+++ b/deploy/rbac-clowdapp.yml
@@ -3195,21 +3195,6 @@ objects:
     principal-proxy-ssl-verify: RmFsc2U=
     sentry-dsn: ''
   type: Opaque
-- apiVersion: v1
-  kind: Service
-  metadata:
-    name: rbac
-    labels:
-      app: rbac
-      pod: rbac-service
-  spec:
-    ports:
-    - port: 8080
-      protocol: TCP
-      targetPort: 8000
-      name: weblegacy
-    selector:
-      pod: rbac-service
 
 parameters:
 - description: Image name


### PR DESCRIPTION
The clowder will manage and create service for the application. This extra definition of service is causing issues for front container to locate correct rbac service in emph cluster.

## Link(s) to Jira
- https://issues.redhat.com/browse/RHCLOUD-30267

## Description of Intent of Change(s)
The what, why and how.
Remove extra definition of service.
The clowder will create service automatically, this service is not used anywhere

## Local Testing
Will do some ephemeral tests

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
