### PR TITLE
Add new notification event type for TAM access

### DIFF
--- a/rbac/api/cross_access/serializer.py
+++ b/rbac/api/cross_access/serializer.py
@@ -18,6 +18,7 @@
 """Serializer for CrossAccountRequest."""
 from django.db import transaction
 from management.models import Role
+from management.notifications.notification_handlers import cross_account_access_handler
 from management.permission.serializer import PermissionSerializer
 from rest_framework import serializers
 
@@ -110,6 +111,7 @@ class CrossAccountRequestDetailSerializer(serializers.ModelSerializer):
         role_data = validated_data.pop("roles")
         display_names = [role["display_name"] for role in role_data]
         request = CrossAccountRequest.objects.create(**validated_data)
+        cross_account_access_handler(request, self.context["user"])
 
         roles = Role.objects.filter(display_name__in=display_names)
         for role in roles:

--- a/rbac/api/cross_access/view.py
+++ b/rbac/api/cross_access/view.py
@@ -127,6 +127,12 @@ class CrossAccountRequestViewSet(
             return CrossAccountRequestSerializer
         return CrossAccountRequestDetailSerializer
 
+    def get_serializer_context(self):
+        """Get serializer context."""
+        context = super().get_serializer_context()
+        context["user"] = self.request.user
+        return context
+
     def create(self, request, *args, **kwargs):
         """Create cross account requests for associate."""
         self.validate_and_format_input(request.data)


### PR DESCRIPTION
## Link(s) to Jira
- https://issues.redhat.com/browse/RHCLOUD-25247

## Description of Intent of Change(s)
The what, why and how.
Emit new event type when TAM access request is created.

## Local Testing
Unit tests. Will check in stage once deployed and this get merged: https://github.com/RedHatInsights/notifications-backend/pull/2419

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [x] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
