### PR TITLE
RHCLOUD-30375 | feature: filter service accounts by their description and name

### DIFF
--- a/docs/source/specs/openapi.json
+++ b/docs/source/specs/openapi.json
@@ -1265,6 +1265,24 @@
                 "user"
               ]
             }
+          },
+          {
+            "in": "query",
+            "name": "service_account_description",
+            "required": false,
+            "description": "Parameter for filtering the service accounts by their description.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "service_account_name",
+            "required": false,
+            "description": "Parameter for filtering the service accounts by their name.",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {

--- a/rbac/management/group/view.py
+++ b/rbac/management/group/view.py
@@ -70,6 +70,8 @@ PRINCIPAL_TYPE_KEY = "principal_type"
 PRINCIPAL_USERNAME_KEY = "principal_username"
 VALID_ROLE_ORDER_FIELDS = list(RoleViewSet.ordering_fields)
 ROLE_DISCRIMINATOR_KEY = "role_discriminator"
+SERVICE_ACCOUNT_DESCRIPTION_KEY = "service_account_description"
+SERVICE_ACCOUNT_NAME_KEY = "service_account_name"
 SERVICE_ACCOUNT_USERNAME_FORMAT = "service-account-{clientID}"
 TYPE_SERVICE_ACCOUNT = "service-account"
 VALID_EXCLUDE_VALUES = ["true", "false"]
@@ -770,7 +772,10 @@ class GroupViewSet(
                         },
                     )
 
-                # Get the principal username option parameter and the limit and offset parameters too.
+                # Get the service account's description and name filters, and the principal's username filter too.
+                # Finally, get the limit and offset parameters.
+                options[SERVICE_ACCOUNT_DESCRIPTION_KEY] = request.query_params.get(SERVICE_ACCOUNT_DESCRIPTION_KEY)
+                options[SERVICE_ACCOUNT_NAME_KEY] = request.query_params.get(SERVICE_ACCOUNT_NAME_KEY)
                 options[PRINCIPAL_USERNAME_KEY] = request.query_params.get(PRINCIPAL_USERNAME_KEY)
 
                 # Fetch the group's service accounts.


### PR DESCRIPTION
## Link(s) to Jira
- [[RHCLOUD-30375]](https://issues.redhat.com/browse/RHCLOUD-30375)

## Description of Intent of Change(s)
In order to provide a better user experience, we need to be able to return filtered results for service accounts by filtering them by their descriptions and/or their names.

## Local Testing
How can the feature be exercised?
How can the bug be exploited and fix confirmed?
Is any special local setup required?

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
