### PR TITLE
RHCLOUD-30035 | feature: tests for the "get_principal" method

### DIFF
--- a/rbac/management/utils.py
+++ b/rbac/management/utils.py
@@ -84,11 +84,11 @@ def get_principal(username, request, verify_principal=True, from_query=False):
             principal = Principal.objects.get_or_create(
                 username=user.username, tenant=tenant, type=SERVICE_ACCOUNT_KEY, service_account_id=user.client_id
             )
-
-        # Avoid possible race condition if the user was created while checking BOP
-        principal, created = Principal.objects.get_or_create(
-            username=username, tenant=tenant
-        )  # pylint: disable=unused-variable
+        else:
+            # Avoid possible race condition if the user was created while checking BOP
+            principal = Principal.objects.get_or_create(
+                username=username, tenant=tenant
+            )  # pylint: disable=unused-variable
 
     return principal
 

--- a/rbac/management/utils.py
+++ b/rbac/management/utils.py
@@ -81,12 +81,12 @@ def get_principal(username, request, verify_principal=True, from_query=False):
         # In the case that the user that made the request was a service account, store it accordingly in the database.
         user: User = request.user
         if user and user.is_service_account:
-            principal = Principal.objects.get_or_create(
+            principal, _ = Principal.objects.get_or_create(
                 username=user.username, tenant=tenant, type=SERVICE_ACCOUNT_KEY, service_account_id=user.client_id
             )
         else:
             # Avoid possible race condition if the user was created while checking BOP
-            principal = Principal.objects.get_or_create(
+            principal, _ = Principal.objects.get_or_create(
                 username=username, tenant=tenant
             )  # pylint: disable=unused-variable
 

--- a/tests/management/test_utils.py
+++ b/tests/management/test_utils.py
@@ -138,7 +138,7 @@ class UtilsTests(IdentityRequest):
     @mock.patch("management.utils.verify_principal_with_proxy")
     def test_get_principal_created(self, mocked):
         """Test that when a user principal does not exist in the database, it gets created."""
-        # Build a non existent service account.
+        # Build a non existent user principal.
         user = User()
         user.username = "abcde"
 

--- a/tests/management/test_utils.py
+++ b/tests/management/test_utils.py
@@ -15,16 +15,20 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 """Test the utils module."""
-from api.models import Tenant
-from management.models import Group, Permission, Principal, Policy, Role, Access
+import uuid
+
+from api.models import Tenant, User
+from management.models import Access, Group, Permission, Principal, Policy, Role
 from management.utils import (
     access_for_principal,
     groups_for_principal,
     policies_for_principal,
     roles_for_principal,
     account_id_for_tenant,
+    get_principal,
 )
 from tests.identity_request import IdentityRequest
+from unittest import mock
 
 
 class UtilsTests(IdentityRequest):
@@ -130,3 +134,48 @@ class UtilsTests(IdentityRequest):
         """Test that we get the expected account number from a tenant name."""
         tenant = Tenant.objects.create(tenant_name="acct1234")
         self.assertEqual(account_id_for_tenant(tenant), "1234")
+
+    @mock.patch("management.utils.verify_principal_with_proxy")
+    def test_get_principal_created(self, mocked):
+        """Test that when a user principal does not exist in the database, it gets created."""
+        # Build a non existent service account.
+        user = User()
+        user.username = "abcde"
+
+        request = mock.Mock()
+        request.user = user
+        request.tenant = self.tenant
+        request.query_params = {}
+
+        # Attempt to fetch the service account principal from the database. Since it does not exist, it should create
+        # one.
+        get_principal(username=user.username, request=request)
+
+        # Assert that the service account was properly created in the database.
+        created_service_account = Principal.objects.get(username=user.username)
+        self.assertEqual(created_service_account.type, "user")
+        self.assertEqual(created_service_account.username, user.username)
+
+    @mock.patch("management.utils.verify_principal_with_proxy")
+    def test_get_principal_service_account_created(self, mocked):
+        """Test that when a service account principal does not exist in the database, it gets created."""
+        # Build a non existent service account.
+        user = User()
+        user.client_id = uuid.uuid4()
+        user.is_service_account = True
+        user.username = "abcde"
+
+        request = mock.Mock()
+        request.user = user
+        request.tenant = self.tenant
+        request.query_params = {}
+
+        # Attempt to fetch the service account principal from the database. Since it does not exist, it should create
+        # one.
+        get_principal(username=user.username, request=request)
+
+        # Assert that the service account was properly created in the database.
+        created_service_account = Principal.objects.get(username=user.username)
+        self.assertEqual(created_service_account.service_account_id, str(user.client_id))
+        self.assertEqual(created_service_account.type, "service-account")
+        self.assertEqual(created_service_account.username, user.username)


### PR DESCRIPTION
## Link(s) to Jira
- [[RHCLOUD-30035]](https://issues.redhat.com/browse/RHCLOUD-30035)

## Description of Intent of Change(s)
Adds tests for the "get_principal" method, to make sure that it creates the user and service account principals when they're not present in the database.

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [x] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
