### PR TITLE
RHCLOUD-30387 | fix: cleanup job removes service accounts

### DIFF
--- a/rbac/management/principal/cleaner.py
+++ b/rbac/management/principal/cleaner.py
@@ -34,7 +34,7 @@ proxy = PrincipalProxy()  # pylint: disable=invalid-name
 def clean_tenant_principals(tenant):
     """Check if all the principals in the tenant exist, remove non-existent principals."""
     removed_principals = []
-    principals = list(Principal.objects.filter(tenant=tenant))
+    principals = list(Principal.objects.filter(type="user").filter(tenant=tenant))
     if settings.AUTHENTICATE_WITH_ORG_ID:
         tenant_id = tenant.org_id
     else:


### PR DESCRIPTION
## Link(s) to Jira
- [[RHCLOUD-30387]](https://issues.redhat.com/browse/RHCLOUD-30387)

## Description of Intent of Change(s)
The clean up job for a tenant's principals was also cleaning up service accounts. The change modifies the job so that it only picks up user accounts when attempting to clean up RBAC's database.

## Local Testing
How can the feature be exercised?
How can the bug be exploited and fix confirmed?
Is any special local setup required?

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [x] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
