### PR TITLE
Use role name to remove selective role

### DIFF
--- a/rbac/internal/specs/openapi.json
+++ b/rbac/internal/specs/openapi.json
@@ -884,6 +884,104 @@
           }
         }
       }
+    },
+    "/api/utils/roles/": {
+      "delete": {
+        "tags": [
+          "Role"
+        ],
+        "summary": "Delete Red Hat managed role",
+        "description": "Specify a role name to delete a Red Hat managed role.",
+        "operationId": "DeleteRole",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "query",
+            "required": true,
+            "description": "Name of the role to delete.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Role deleted"
+          },
+          "400": {
+            "description": "Bad Input"
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/utils/permission/": {
+      "delete": {
+        "tags": [
+          "Permission"
+        ],
+        "summary": "Delete permission",
+        "description": "Specify a permission to delete a permission.",
+        "operationId": "DeletePermission",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "query",
+            "required": true,
+            "description": "Name of the permission to delete.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Permission deleted"
+          },
+          "400": {
+            "description": "Bad Input"
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "servers": [

--- a/rbac/internal/urls.py
+++ b/rbac/internal/urls.py
@@ -76,7 +76,7 @@ urlpatterns = [
     path("api/utils/invalid_default_admin_groups/", views.invalid_default_admin_groups),
     path("api/utils/ocm_performance/", views.ocm_performance),
     path("api/utils/get_org_admin/<int:org_or_account>/", views.get_org_admin),
-    path("api/utils/roles/<uuid:role_uuid>/", views.role_removal),
+    path("api/utils/role/", views.role_removal),
     path("api/utils/permission/", views.permission_removal),
 ]
 


### PR DESCRIPTION
It is hard to query uuid for the role. So use name is a better choice. Since the role name is unique for each tenant, the seeded role name is unique since they are all in public tenant.

## Link(s) to Jira
- https://issues.redhat.com/browse/RHCLOUD-27278

## Description of Intent of Change(s)
The what, why and how.
It is hard to know the uuid of the role.

## Local Testing
How can the feature be exercised?
How can the bug be exploited and fix confirmed?
Is any special local setup required?
Local unit tests

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
