### PR TITLE
RHCLOUD-30299 | feature: return if service accounts are in group

### DIFF
--- a/docs/source/specs/openapi.json
+++ b/docs/source/specs/openapi.json
@@ -1277,7 +1277,7 @@
             "in": "query",
             "name": "service_account_client_ids",
             "required": false,
-            "description": "By specifying a list of client IDs with this query parameter, RBAC will return an object with the specified client ID and it's matching boolean value to flag whether the client ID is present in the group or not",
+            "description": "By specifying a list of client IDs with this query parameter, RBAC will return an object with the specified client ID and it's matching boolean value to flag whether the client ID is present in the group or not. This query parameter cannot be used along with any other query parameter.",
             "schema": {
               "type": "array",
               "items": {
@@ -1316,6 +1316,9 @@
                     },
                     {
                       "$ref": "#/components/schemas/ServiceAccountPagination"
+                    },
+                    {
+                      "$ref": "#/components/schemas/ServiceAccountInGroupResponse"
                     }
                   ]
                 }
@@ -3380,6 +3383,30 @@
             }
           }
         ]
+      },
+      "ServiceAccountInGroupResponse": {
+        "properties": {
+          "meta": {
+            "$ref": "#/components/schemas/PaginationMeta"
+          },
+          "links": {
+            "description": "The links object for this particular response will be empty, since there is no pagination available for the query parameter",
+            "type": "object",
+            "example": {}
+          },
+          "data": {
+            "description": "Object which indicates whether the given service account UUIDs in the query parameter are present in the specified group or not",
+            "type": "object",
+            "additionalProperties": {
+              "description": "The response is a map of the form \"UUID\": (true|false)",
+              "type": "boolean"
+            },
+            "example": {
+              "dd946f24-cfda-11ee-acb6-7b2702ff4dc8": true,
+              "3e728bb0-b167-013c-c455-6aa2427b506c": false
+            }
+          }
+        }
       },
       "Group": {
         "required": [

--- a/docs/source/specs/openapi.json
+++ b/docs/source/specs/openapi.json
@@ -1275,6 +1275,18 @@
           },
           {
             "in": "query",
+            "name": "service_account_client_ids",
+            "required": false,
+            "description": "By specifying a list of client IDs with this query parameter, RBAC will return an object with the specified client ID and it's matching boolean value to flag whether the client ID is present in the group or not",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "in": "query",
             "name": "service_account_description",
             "required": false,
             "description": "Parameter for filtering the service accounts by their description.",

--- a/rbac/management/group/view.py
+++ b/rbac/management/group/view.py
@@ -17,7 +17,8 @@
 
 """View for group management."""
 import logging
-from typing import Iterable
+from typing import Iterable, Optional
+from uuid import UUID
 
 import requests
 from django.conf import settings
@@ -70,6 +71,7 @@ PRINCIPAL_TYPE_KEY = "principal_type"
 PRINCIPAL_USERNAME_KEY = "principal_username"
 VALID_ROLE_ORDER_FIELDS = list(RoleViewSet.ordering_fields)
 ROLE_DISCRIMINATOR_KEY = "role_discriminator"
+SERVICE_ACCOUNT_CLIENT_IDS_KEY = "service_account_client_ids"
 SERVICE_ACCOUNT_DESCRIPTION_KEY = "service_account_description"
 SERVICE_ACCOUNT_NAME_KEY = "service_account_name"
 SERVICE_ACCOUNT_USERNAME_FORMAT = "service-account-{clientID}"
@@ -500,7 +502,7 @@ class GroupViewSet(
         return group
 
     @action(detail=True, methods=["get", "post", "delete"])
-    def principals(self, request: Request, uuid=None):
+    def principals(self, request: Request, uuid: Optional[UUID] = None):
         """Get, add or remove principals from a group."""
         """
         @api {get} /api/v1/groups/:uuid/principals/    Get principals for a group
@@ -713,6 +715,78 @@ class GroupViewSet(
                 serializer = ServiceAccountSerializer(page, many=True)
 
                 return self.get_paginated_response(serializer.data)
+
+            if SERVICE_ACCOUNT_CLIENT_IDS_KEY in request.query_params:
+                # This query parameter is incompatible with any other query parameter, because it changes the
+                # payload that gets returned.
+                if len(request.query_params) > 1:
+                    return Response(
+                        status=status.HTTP_400_BAD_REQUEST,
+                        data={
+                            "errors": [
+                                {
+                                    "detail": f"The '{SERVICE_ACCOUNT_CLIENT_IDS_KEY}' parameter is incompatible with"
+                                    f" any other query parameter. Please, use it alone",
+                                    "source": "groups",
+                                    "status": str(status.HTTP_400_BAD_REQUEST),
+                                }
+                            ]
+                        },
+                    )
+                else:
+                    # Check that the specified query parameter is not empty.
+                    service_account_client_ids_raw = request.query_params.get(SERVICE_ACCOUNT_CLIENT_IDS_KEY).strip()
+                    if not service_account_client_ids_raw:
+                        return Response(
+                            status=status.HTTP_400_BAD_REQUEST,
+                            data={
+                                "errors": [
+                                    {
+                                        "detail": "Not a single client ID was specified for the client IDs filter",
+                                        "source": "groups",
+                                        "status": str(status.HTTP_400_BAD_REQUEST),
+                                    }
+                                ]
+                            },
+                        )
+
+                    # Turn the received and comma separated client IDs into a manageable set.
+                    received_client_ids: set[str] = set(service_account_client_ids_raw.split(","))
+
+                    processed_client_ids: set[UUID] = set()
+                    for rci in received_client_ids:
+                        try:
+                            processed_client_ids.add(UUID(str(rci)))
+                        except ValueError:
+                            return Response(
+                                status=status.HTTP_400_BAD_REQUEST,
+                                data={
+                                    "errors": [
+                                        {
+                                            "detail": f"The specified client ID '{rci}' is not a valid UUID",
+                                            "source": "groups",
+                                            "status": str(status.HTTP_400_BAD_REQUEST),
+                                        }
+                                    ]
+                                },
+                            )
+
+                    # Generate the report of which of the tenant's service accounts are in a group, and which
+                    # ones are available to be added to the given group.
+                    it_service = ITService()
+                    result: dict = it_service.generate_service_accounts_report_in_group(
+                        group=group, client_ids=processed_client_ids
+                    )
+
+                    # Prettify the output payload and return it.
+                    return Response(
+                        status=status.HTTP_200_OK,
+                        data={
+                            "meta": {"count": len(result)},
+                            "links": {},
+                            "data": result,
+                        },
+                    )
 
             principals_from_params = self.filtered_principals(group, request)
             page = self.paginate_queryset(principals_from_params)

--- a/rbac/management/group/view.py
+++ b/rbac/management/group/view.py
@@ -693,10 +693,10 @@ class GroupViewSet(
                 # Turn the received and comma separated client IDs into a manageable set.
                 received_client_ids: set[str] = set(service_account_client_ids_raw.split(","))
 
-                processed_client_ids: set[UUID] = set()
+                # Validate that the provided strings are actually UUIDs.
                 for rci in received_client_ids:
                     try:
-                        processed_client_ids.add(UUID(str(rci)))
+                        UUID(rci)
                     except ValueError:
                         return Response(
                             status=status.HTTP_400_BAD_REQUEST,
@@ -715,7 +715,7 @@ class GroupViewSet(
                 # ones are available to be added to the given group.
                 it_service = ITService()
                 result: dict = it_service.generate_service_accounts_report_in_group(
-                    group=group, client_ids=processed_client_ids
+                    group=group, client_ids=received_client_ids
                 )
 
                 # Prettify the output payload and return it.

--- a/rbac/management/principal/it_service.py
+++ b/rbac/management/principal/it_service.py
@@ -19,7 +19,6 @@ import logging
 import time
 import uuid
 from typing import Optional, Tuple, Union
-from uuid import UUID
 
 import requests
 from django.conf import settings
@@ -403,7 +402,7 @@ class ITService:
                 }
             )
 
-    def generate_service_accounts_report_in_group(self, group: Group, client_ids: set[UUID]) -> dict[str, bool]:
+    def generate_service_accounts_report_in_group(self, group: Group, client_ids: set[str]) -> dict[str, bool]:
         """Check if the given service accounts are in the specified group."""
         # Fetch the service accounts from the group.
         group_service_account_principals = (
@@ -414,10 +413,8 @@ class ITService:
 
         # Mark the specified client IDs as "present or missing" from the result set.
         result: dict[str, bool] = {}
-        for rci_uuid in client_ids:
-            rci = str(rci_uuid)
-
-            result[rci] = rci in group_service_account_principals
+        for incoming_client_id in client_ids:
+            result[incoming_client_id] = incoming_client_id in group_service_account_principals
 
         return result
 

--- a/rbac/management/principal/it_service.py
+++ b/rbac/management/principal/it_service.py
@@ -412,7 +412,7 @@ class ITService:
             .filter(service_account_id__in=client_ids)
         )
 
-        # Mark the specified client IDs as "present or missing" from the result set.ç
+        # Mark the specified client IDs as "present or missing" from the result set.
         result: dict[str, bool] = {}
         for rci_uuid in client_ids:
             rci = str(rci_uuid)

--- a/rbac/management/principal/it_service.py
+++ b/rbac/management/principal/it_service.py
@@ -406,8 +406,10 @@ class ITService:
     def generate_service_accounts_report_in_group(self, group: Group, client_ids: set[UUID]) -> dict[str, bool]:
         """Check if the given service accounts are in the specified group."""
         # Fetch the service accounts from the group.
-        group_service_account_principals = group.principals.values_list("service_account_id", flat=True).filter(
-            type=TYPE_SERVICE_ACCOUNT
+        group_service_account_principals = (
+            group.principals.values_list("service_account_id", flat=True)
+            .filter(type=TYPE_SERVICE_ACCOUNT)
+            .filter(service_account_id__in=client_ids)
         )
 
         # Mark the specified client IDs as "present or missing" from the result set.ç

--- a/tests/management/principal/test_it_service.py
+++ b/tests/management/principal/test_it_service.py
@@ -263,17 +263,17 @@ class ITServiceTests(IdentityRequest):
             request_client_ids_str.add(str(rci))
 
         # Assert that all the service accounts were flagged as not present in the group.
-        for key, value in result.items():
+        for client_id, is_present_in_group in result.items():
             # Make sure the specified client IDs are in the set.
             self.assertEqual(
                 True,
-                key in request_client_ids_str,
+                client_id in request_client_ids_str,
                 "expected to find the specified client ID from the request in the returning result",
             )
             # Make sure they are all set to "false" since there shouldn't be any of those client IDs in the group.
             self.assertEqual(
                 False,
-                value,
+                is_present_in_group,
                 "the client ID should have not been found in the group, since the group had no service accounts",
             )
 
@@ -322,7 +322,7 @@ class ITServiceTests(IdentityRequest):
         # below.
         group_service_accounts_set = {str(sa_1.service_account_id), str(sa_2.service_account_id)}
 
-        # For this test, we don't associate any service accounts to it.
+        # Create a group and associate principals to it.
         group = Group(name="it-service-group", platform_default=False, system=False, tenant=self.tenant)
         group.save()
         # Add the principal accounts to make sure that we are only working with service accounts. If we weren't, these
@@ -444,7 +444,7 @@ class ITServiceTests(IdentityRequest):
             str(sa_5.service_account_id),
         }
 
-        # For this test, we don't associate any service accounts to it.
+        # Create a group and associate principals to it.
         group = Group(name="it-service-group", platform_default=False, system=False, tenant=self.tenant)
         group.save()
         # Add the principal accounts to make sure that we are only working with service accounts. If we weren't, these
@@ -488,20 +488,20 @@ class ITServiceTests(IdentityRequest):
             request_client_ids_str.add(str(rci))
 
         # Assert that all the results are flagged as being part of the group.
-        for key, value in result.items():
+        for client_id, is_present_in_group in result.items():
             self.assertEqual(
                 True,
-                key in request_client_ids_str,
+                client_id in request_client_ids_str,
                 "expected to find the specified client ID from the request in the returning result",
             )
             self.assertEqual(
                 True,
-                key in group_service_accounts_set,
+                client_id in group_service_accounts_set,
                 "expected to find the client ID from the result set in the service accounts' group set",
             )
             # Make sure they are all set to "true" since all the specified client IDs should be in the group.
             self.assertEqual(
                 True,
-                value,
+                is_present_in_group,
                 "the client ID should have been found in the group, since the group had all the service accounts added to it",
             )

--- a/tests/management/principal/test_it_service.py
+++ b/tests/management/principal/test_it_service.py
@@ -238,10 +238,10 @@ class ITServiceTests(IdentityRequest):
         group.save()
 
         # Simulate that a few client IDs were specified in the request.
-        request_client_ids = set[uuid.UUID]()
-        request_client_ids.add(uuid.uuid4())
-        request_client_ids.add(uuid.uuid4())
-        request_client_ids.add(uuid.uuid4())
+        request_client_ids = set[str]()
+        request_client_ids.add(str(uuid.uuid4()))
+        request_client_ids.add(str(uuid.uuid4()))
+        request_client_ids.add(str(uuid.uuid4()))
 
         # Call the function under test.
         result: dict[str, bool] = self.it_service.generate_service_accounts_report_in_group(
@@ -250,17 +250,12 @@ class ITServiceTests(IdentityRequest):
         # Assert that only the specified client IDs are present in the result.
         self.assertEqual(3, len(result))
 
-        # Transform the UUIDs to strings to match the generated result and be able to create assertions.
-        request_client_ids_str: set[str] = set()
-        for rci in request_client_ids:
-            request_client_ids_str.add(str(rci))
-
         # Assert that all the service accounts were flagged as not present in the group.
         for client_id, is_present_in_group in result.items():
             # Make sure the specified client IDs are in the set.
             self.assertEqual(
                 True,
-                client_id in request_client_ids_str,
+                client_id in request_client_ids,
                 "expected to find the specified client ID from the request in the returning result",
             )
             # Make sure they are all set to "false" since there shouldn't be any of those client IDs in the group.
@@ -348,14 +343,15 @@ class ITServiceTests(IdentityRequest):
         }
 
         # Add all the UUIDs to a set to pass it to the function under test.
-        request_client_ids = set[uuid.UUID]()
-        request_client_ids.add(not_in_group)
-        request_client_ids.add(not_in_group_2)
-        request_client_ids.add(not_in_group_3)
+        request_client_ids = set[str]()
+        request_client_ids.add(str(not_in_group))
+        request_client_ids.add(str(not_in_group_2))
+        request_client_ids.add(str(not_in_group_3))
+
         # Specify the service accounts' UUIDs here too, because the function under test should flag them as present in
         # the group.
-        request_client_ids.add(client_uuid_1)
-        request_client_ids.add(client_uuid_2)
+        request_client_ids.add(str(client_uuid_1))
+        request_client_ids.add(str(client_uuid_2))
 
         # Call the function under test.
         result: dict[str, bool] = self.it_service.generate_service_accounts_report_in_group(
@@ -364,11 +360,6 @@ class ITServiceTests(IdentityRequest):
 
         # Assert that all the specified client IDs are present in the result.
         self.assertEqual(5, len(result))
-
-        # Transform the UUIDs to strings to match the generated result and be able to create assertions.
-        request_client_ids_str: set[str] = set()
-        for rci in request_client_ids:
-            request_client_ids_str.add(str(rci))
 
         # Assert that the mixed matches are identified correctly.
         for client_id, is_it_present_in_group in result.items():
@@ -456,12 +447,12 @@ class ITServiceTests(IdentityRequest):
         group.save()
 
         # Simulate that a few client IDs were specified in the request.
-        request_client_ids = set[uuid.UUID]()
-        request_client_ids.add(client_uuid_1)
-        request_client_ids.add(client_uuid_2)
-        request_client_ids.add(client_uuid_3)
-        request_client_ids.add(client_uuid_4)
-        request_client_ids.add(client_uuid_5)
+        request_client_ids = set[str]()
+        request_client_ids.add(str(client_uuid_1))
+        request_client_ids.add(str(client_uuid_2))
+        request_client_ids.add(str(client_uuid_3))
+        request_client_ids.add(str(client_uuid_4))
+        request_client_ids.add(str(client_uuid_5))
 
         # Call the function under test.
         result: dict[str, bool] = self.it_service.generate_service_accounts_report_in_group(
@@ -471,16 +462,11 @@ class ITServiceTests(IdentityRequest):
         # Assert that all the specified client IDs are present in the result.
         self.assertEqual(5, len(result))
 
-        # Transform the UUIDs to strings to match the generated result and be able to create assertions.
-        request_client_ids_str: set[str] = set()
-        for rci in request_client_ids:
-            request_client_ids_str.add(str(rci))
-
         # Assert that all the results are flagged as being part of the group.
         for client_id, is_present_in_group in result.items():
             self.assertEqual(
                 True,
-                client_id in request_client_ids_str,
+                client_id in request_client_ids,
                 "expected to find the specified client ID from the request in the returning result",
             )
             self.assertEqual(

--- a/tests/management/principal/test_it_service.py
+++ b/tests/management/principal/test_it_service.py
@@ -370,20 +370,25 @@ class ITServiceTests(IdentityRequest):
             request_client_ids_str.add(str(rci))
 
         # Assert that the mixed matches are identified correctly.
-        for key, value in result.items():
+        for client_id, is_it_present_in_group in result.items():
             # If the value is "true" it should be present in the service accounts' result set from above. Else, it
             # means that the specified client IDs were not part of the group, and that they should have been flagged
             # as such.
-            if value:
+            if is_it_present_in_group:
                 self.assertEqual(
                     True,
-                    key in group_service_accounts_set,
+                    client_id in group_service_accounts_set,
                     "a client ID which was not part of the group was incorrectly flagged as if it was",
                 )
             else:
                 self.assertEqual(
+                    False,
+                    is_it_present_in_group,
+                    "a client ID which was part of the group was incorrectly flagged as if it wasn't",
+                )
+                self.assertEqual(
                     True,
-                    key in request_client_ids_str,
+                    client_id in request_client_ids_str,
                     "a client ID which was part of the group was incorrectly flagged as if it wasn't",
                 )
 

--- a/tests/management/principal/test_it_service.py
+++ b/tests/management/principal/test_it_service.py
@@ -338,9 +338,21 @@ class ITServiceTests(IdentityRequest):
 
         # Simulate that a few client IDs were specified in the request.
         request_client_ids = set[uuid.UUID]()
-        request_client_ids.add(uuid.uuid4())
-        request_client_ids.add(uuid.uuid4())
-        request_client_ids.add(uuid.uuid4())
+        not_in_group = uuid.uuid4()
+        not_in_group_2 = uuid.uuid4()
+        not_in_group_3 = uuid.uuid4()
+
+        request_client_ids.add(not_in_group)
+        request_client_ids.add(not_in_group_2)
+        request_client_ids.add(not_in_group_3)
+
+        # Also, create a set with the service accounts that will NOT go in the group to make it easier to assert that
+        # the results flag them as such.
+        service_accounts_not_in_group_set = {
+            str(not_in_group),
+            str(not_in_group_2),
+            str(not_in_group_3),
+        }
 
         # Specify the service accounts' UUIDs here too, because the function under test should flag them as present in
         # the group.
@@ -373,13 +385,8 @@ class ITServiceTests(IdentityRequest):
                 )
             else:
                 self.assertEqual(
-                    False,
-                    is_it_present_in_group,
-                    "a client ID which was part of the group was incorrectly flagged as if it wasn't",
-                )
-                self.assertEqual(
                     True,
-                    client_id in request_client_ids_str,
+                    client_id in service_accounts_not_in_group_set,
                     "a client ID which was part of the group was incorrectly flagged as if it wasn't",
                 )
 

--- a/tests/management/principal/test_it_service.py
+++ b/tests/management/principal/test_it_service.py
@@ -242,13 +242,9 @@ class ITServiceTests(IdentityRequest):
 
         # Simulate that a few client IDs were specified in the request.
         request_client_ids = set[uuid.UUID]()
-        specified_client_uuid_1 = uuid.uuid4()
-        specified_client_uuid_2 = uuid.uuid4()
-        specified_client_uuid_3 = uuid.uuid4()
-
-        request_client_ids.add(specified_client_uuid_1)
-        request_client_ids.add(specified_client_uuid_2)
-        request_client_ids.add(specified_client_uuid_3)
+        request_client_ids.add(uuid.uuid4())
+        request_client_ids.add(uuid.uuid4())
+        request_client_ids.add(uuid.uuid4())
 
         # Call the function under test.
         result: dict[str, bool] = self.it_service.generate_service_accounts_report_in_group(
@@ -342,19 +338,14 @@ class ITServiceTests(IdentityRequest):
 
         # Simulate that a few client IDs were specified in the request.
         request_client_ids = set[uuid.UUID]()
-        specified_client_uuid_1 = uuid.uuid4()
-        specified_client_uuid_2 = uuid.uuid4()
-        specified_client_uuid_3 = uuid.uuid4()
+        request_client_ids.add(uuid.uuid4())
+        request_client_ids.add(uuid.uuid4())
+        request_client_ids.add(uuid.uuid4())
+
         # Specify the service accounts' UUIDs here too, because the function under test should flag them as present in
         # the group.
-        specified_client_uuid_4 = client_uuid_1
-        specified_client_uuid_5 = client_uuid_2
-
-        request_client_ids.add(specified_client_uuid_1)
-        request_client_ids.add(specified_client_uuid_2)
-        request_client_ids.add(specified_client_uuid_3)
-        request_client_ids.add(specified_client_uuid_4)
-        request_client_ids.add(specified_client_uuid_5)
+        request_client_ids.add(client_uuid_1)
+        request_client_ids.add(client_uuid_2)
 
         # Call the function under test.
         result: dict[str, bool] = self.it_service.generate_service_accounts_report_in_group(
@@ -461,18 +452,12 @@ class ITServiceTests(IdentityRequest):
         group.save()
 
         # Simulate that a few client IDs were specified in the request.
-        request_client_ids = set[str]()
-        specified_client_uuid_1 = client_uuid_1
-        specified_client_uuid_2 = client_uuid_2
-        specified_client_uuid_3 = client_uuid_3
-        specified_client_uuid_4 = client_uuid_4
-        specified_client_uuid_5 = client_uuid_5
-
-        request_client_ids.add(specified_client_uuid_1)
-        request_client_ids.add(specified_client_uuid_2)
-        request_client_ids.add(specified_client_uuid_3)
-        request_client_ids.add(specified_client_uuid_4)
-        request_client_ids.add(specified_client_uuid_5)
+        request_client_ids = set[uuid.UUID]()
+        request_client_ids.add(client_uuid_1)
+        request_client_ids.add(client_uuid_2)
+        request_client_ids.add(client_uuid_3)
+        request_client_ids.add(client_uuid_4)
+        request_client_ids.add(client_uuid_5)
 
         # Call the function under test.
         result: dict[str, bool] = self.it_service.generate_service_accounts_report_in_group(


### PR DESCRIPTION
## Link(s) to Jira
- [[RHCLOUD-30299]](https://issues.redhat.com/browse/RHCLOUD-30299)

## Description of Intent of Change(s)
The UI needs a way to discern which service accounts are already present in the group, so that they can show them as either enabled or disabled when presenting them to the user.

## Local Testing
### How can the feature be exercised?
1. Create a new group.
2. Add some service accounts to it —or not—.
3. Send a `GET /groups/{uuid}/principals/?service_account_client_ids=<clientID>,<clientID>,<clientID>` request.

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [x] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
