### PR TITLE
upgraded base image for rbac to use ubi8 minimal 8.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8 AS base
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9 AS base
 
 USER root
 


### PR DESCRIPTION
this will fix the Platform Security Grype check