### PR TITLE
[WIP][RHCLOUD-30665] moved logic for limit and offset out of it_service class to fix the calculation of 'count' in the response

### DIFF
--- a/rbac/management/principal/view.py
+++ b/rbac/management/principal/view.py
@@ -205,6 +205,9 @@ class PrincipalView(APIView):
                     },
                 )
 
+            service_accounts_count = len(service_accounts)
+            service_accounts = service_accounts[offset : offset + limit]
+
             # Adapt the response object to reuse the code below.
             resp = {"status_code": status.HTTP_200_OK, "data": service_accounts}
         else:
@@ -214,14 +217,16 @@ class PrincipalView(APIView):
         response_data = {}
         if status_code == status.HTTP_200_OK:
             data = resp.get("data", [])
-            if isinstance(data, dict):
+            if principal_type == "service-account":
+                count = service_accounts_count
+            elif isinstance(data, dict):
                 count = data.get("userCount")
                 data = data.get("users")
             elif isinstance(data, list):
                 count = len(data)
             else:
                 count = None
-            response_data["meta"] = {"count": count}
+            response_data["meta"] = {"count": count, "limit": limit, "offset": offset}
             response_data["links"] = {
                 "first": f"{path}?limit={limit}&offset=0{usernames_filter}",
                 "next": f"{path}?limit={limit}&offset={offset + limit}{usernames_filter}",


### PR DESCRIPTION
## Link(s) to Jira
- https://issues.redhat.com/browse/RHCLOUD-30665

## Description of Intent of Change(s)
with previous logic the "count" for the response was not correctly calculated and that caused that "links" were not created correctly and this led to the UI issues with pagination

this PR move the limit+offset logic to the `it_service.py` file because first we need to calculate "count" and then filter the service account for the page

## Local Testing
check acceptance criteria in the JIRA ticket but generally you can test this like this
send request to the `GET principals/` or GET `groups/{uuid}/principals/` endpoint and filter only service accounts, try different combination of limit and offset and check:

- values of count, limit, offset are set correctly
- links are created correctly
- returned data contains correct service account