### PR TITLE
[RHCLOUD-30665] fix logic for the 'count' calculation - needed for the response

### DIFF
--- a/rbac/management/group/view.py
+++ b/rbac/management/group/view.py
@@ -44,7 +44,7 @@ from management.permissions import GroupAccessPermission
 from management.principal.it_service import ITService
 from management.principal.model import Principal
 from management.principal.proxy import PrincipalProxy
-from management.principal.serializer import PrincipalSerializer
+from management.principal.serializer import PrincipalSerializer, ServiceAccountSerializer
 from management.principal.view import ADMIN_ONLY_KEY, USERNAME_ONLY_KEY, VALID_BOOLEAN_VALUE
 from management.querysets import get_group_queryset, get_role_queryset
 from management.role.view import RoleViewSet
@@ -54,7 +54,6 @@ from rest_framework.decorators import action
 from rest_framework.filters import OrderingFilter
 from rest_framework.response import Response
 
-from api.common.pagination import StandardResultsSetPagination
 from api.models import Tenant, User
 from .insufficient_privileges import InsufficientPrivilegesError
 from .service_account_not_found_error import ServiceAccountNotFoundError
@@ -773,8 +772,6 @@ class GroupViewSet(
 
                 # Get the principal username option parameter and the limit and offset parameters too.
                 options[PRINCIPAL_USERNAME_KEY] = request.query_params.get(PRINCIPAL_USERNAME_KEY)
-                options["limit"] = int(request.query_params.get("limit", StandardResultsSetPagination.default_limit))
-                options["offset"] = int(request.query_params.get("offset", 0))
 
                 # Fetch the group's service accounts.
                 it_service = ITService()
@@ -798,9 +795,9 @@ class GroupViewSet(
 
                 # Prettify the output payload and return it.
                 page = self.paginate_queryset(service_accounts)
-                serializer = PrincipalSerializer(page, many=True)
+                serializer = ServiceAccountSerializer(page, many=True)
 
-                return self.get_paginated_response(service_accounts)
+                return self.get_paginated_response(serializer.data)
 
             principals_from_params = self.filtered_principals(group, request)
             page = self.paginate_queryset(principals_from_params)

--- a/rbac/management/principal/it_service.py
+++ b/rbac/management/principal/it_service.py
@@ -149,7 +149,7 @@ class ITService:
 
         return service_accounts
 
-    def get_service_accounts(self, user: User, bearer_token: str, options: dict = {}) -> list[dict]:
+    def get_service_accounts(self, user: User, bearer_token: str, options: dict = {}) -> (list[dict], int):
         """Request and returns the service accounts for the given tenant."""
         # We might want to bypass calls to the IT service on ephemeral or test environments.
         it_service_accounts: list[dict] = []
@@ -208,6 +208,7 @@ class ITService:
         limit = options.get("limit")
         limit_offset_validation(offset, limit)
 
+        count = len(service_account_principals)
         service_account_principals = service_account_principals[offset : offset + limit]
 
         # If we are in an ephemeral or test environment, we will take all the service accounts of the user that are
@@ -229,7 +230,7 @@ class ITService:
             service_account_principals=sap_dict, it_service_accounts=it_service_accounts, options=options
         )
 
-        return service_accounts
+        return service_accounts, count
 
     def get_service_accounts_group(self, group: Group, bearer_token: str, options: dict = {}) -> list[dict]:
         """Get the service accounts for the given group."""
@@ -257,14 +258,6 @@ class ITService:
             group_service_account_principals = group_service_account_principals.filter(
                 username__contains=principal_username
             )
-
-        # Get the limit and the offset. We always have default values for these, so it is safe to simply fetch them.
-        offset = options.get("offset")
-        limit = options.get("limit")
-        limit_offset_validation(offset, limit)
-
-        # Filter the service accounts with the offset and the limit.
-        group_service_account_principals = group_service_account_principals[offset : offset + limit]
 
         # If we are in an ephemeral or test environment, we will take all the service accounts of the user that are
         # stored in the database and generate a mocked response for them, simulating that IT has the corresponding

--- a/rbac/management/principal/serializer.py
+++ b/rbac/management/principal/serializer.py
@@ -69,3 +69,20 @@ class PrincipalInputSerializer(serializers.Serializer):
         """Metadata for the serializer."""
 
         fields = ("username", "clientID", "type")
+
+
+class ServiceAccountSerializer(serializers.Serializer):
+    """Serializer for Service Account."""
+
+    clientID = serializers.UUIDField()
+    name = serializers.CharField()
+    description = serializers.CharField()
+    owner = serializers.CharField()
+    time_created = serializers.IntegerField()
+    type = serializers.CharField()
+    username = serializers.CharField()
+
+    class Meta:
+        """Metadata for the serializer."""
+
+        fields = "__all__"

--- a/rbac/management/principal/view.py
+++ b/rbac/management/principal/view.py
@@ -188,7 +188,7 @@ class PrincipalView(APIView):
             # Fetch the service accounts from IT.
             try:
                 it_service = ITService()
-                service_accounts = it_service.get_service_accounts(
+                service_accounts, sa_count = it_service.get_service_accounts(
                     user=user, bearer_token=bearer_token, options=options
                 )
             except (requests.exceptions.ConnectionError, UnexpectedStatusCodeFromITError):
@@ -214,7 +214,9 @@ class PrincipalView(APIView):
         response_data = {}
         if status_code == status.HTTP_200_OK:
             data = resp.get("data", [])
-            if isinstance(data, dict):
+            if principal_type == "service-account":
+                count = sa_count
+            elif isinstance(data, dict):
                 count = data.get("userCount")
                 data = data.get("users")
             elif isinstance(data, list):

--- a/tests/management/principal/test_view.py
+++ b/tests/management/principal/test_view.py
@@ -836,3 +836,152 @@ class PrincipalViewsetTests(IdentityRequest):
         response: Response = client.get(url, **self.headers)
 
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    @override_settings(IT_BYPASS_TOKEN_VALIDATION=True)
+    @patch("management.principal.it_service.ITService.request_service_accounts")
+    def test_read_principal_service_account_list_success(self, mock_request):
+        """Test that we can read a list of service accounts."""
+        # Create SA in the database
+        sa_client_id = "b6636c60-a31d-013c-b93d-6aa2427b506c"
+        sa_username = "service_account-" + sa_client_id
+
+        Principal.objects.create(
+            username=sa_username,
+            tenant=self.tenant,
+            type="service-account",
+            service_account_id=sa_client_id,
+        )
+
+        mock_request.return_value = [
+            {
+                "clientID": sa_client_id,
+                "name": "service_account_name",
+                "description": "Service Account description",
+                "owner": "jsmith",
+                "username": sa_username,
+                "time_created": 1706784741,
+                "type": "service-account",
+            }
+        ]
+
+        url = f"{reverse('principals')}?type=service-account"
+        client = APIClient()
+        response = client.get(url, **self.headers)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIsInstance(response.data.get("data"), list)
+        self.assertEqual(int(response.data.get("meta").get("count")), 1)
+        self.assertEqual(len(response.data.get("data")), 1)
+
+        sa = response.data.get("data")[0]
+        self.assertCountEqual(
+            list(sa.keys()),
+            ["clientID", "name", "description", "owner", "time_created", "type", "username"],
+        )
+        self.assertEqual(sa.get("clientID"), sa_client_id)
+        self.assertEqual(sa.get("name"), "service_account_name")
+        self.assertEqual(sa.get("description"), "Service Account description")
+        self.assertEqual(sa.get("owner"), "jsmith")
+        self.assertEqual(sa.get("type"), "service-account")
+        self.assertEqual(sa.get("username"), sa_username)
+
+    @override_settings(IT_BYPASS_TOKEN_VALIDATION=True)
+    @patch("management.principal.it_service.ITService.request_service_accounts")
+    def test_read_principal_service_account_list_empty_response(self, mock_request):
+        """Test that empty response is returned when tenant doesn't have a service account in RBAC database."""
+
+        sa_client_id = "026f5290-a3d3-013c-b93f-6aa2427b506c"
+        mock_request.return_value = [
+            {
+                "clientID": sa_client_id,
+                "name": "service_account_name",
+                "description": "Service Account description",
+                "owner": "jsmith",
+                "username": "service_account-" + sa_client_id,
+                "time_created": 1706784741,
+                "type": "service-account",
+            }
+        ]
+
+        url = f"{reverse('principals')}?type=service-account"
+        client = APIClient()
+        response = client.get(url, **self.headers)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIsInstance(response.data.get("data"), list)
+        self.assertEqual(int(response.data.get("meta").get("count")), 0)
+        self.assertEqual(len(response.data.get("data")), 0)
+
+    @override_settings(IT_BYPASS_TOKEN_VALIDATION=True)
+    @patch("management.principal.it_service.ITService.request_service_accounts")
+    def test_read_principal_service_account_valid_limit_offset(self, mock_request):
+        """Test that we can read a list of service accounts according to the given limit and offset."""
+        # Create 3 SA in the database
+        sa_client_ids = [
+            "b6636c60-a31d-013c-b93d-6aa2427b506c",
+            "69a116a0-a3d4-013c-b940-6aa2427b506c",
+            "6f3c2700-a3d4-013c-b941-6aa2427b506c",
+        ]
+        for uuid in sa_client_ids:
+            Principal.objects.create(
+                username="service_account-" + uuid,
+                tenant=self.tenant,
+                type="service-account",
+                service_account_id=uuid,
+            )
+
+        # create a return value for the mock
+        mocked_values = []
+        for uuid in sa_client_ids:
+            mocked_values.append(
+                {
+                    "clientID": uuid,
+                    "name": f"service_account_name_{uuid.split('-')[0]}",
+                    "description": f"Service Account description {uuid.split('-')[0]}",
+                    "owner": "jsmith",
+                    "username": "service_account-" + uuid,
+                    "time_created": 1706784741,
+                    "type": "service-account",
+                }
+            )
+
+        mock_request.return_value = mocked_values
+
+        # without limit and offset the default values are used
+        # limit=10, offset=0
+        url = f"{reverse('principals')}?type=service-account"
+        client = APIClient()
+        response = client.get(url, **self.headers)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(int(response.data.get("meta").get("count")), 3)
+        self.assertEqual(len(response.data.get("data")), 3)
+
+        # set custom limit and offset
+        test_values = [(1, 1), (2, 2), (5, 5)]
+        for limit, offset in test_values:
+            url = f"{reverse('principals')}?type=service-account&limit={limit}&offset={offset}"
+            client = APIClient()
+            response = client.get(url, **self.headers)
+
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            self.assertEqual(int(response.data.get("meta").get("count")), 3)
+            # for limit=1, offset=1, count=3 is the result min(1, max(0, 2)) = 1
+            # for limit=2, offset=2, count=3 is the result min(2, max(0, 1)) = 1
+            # for limit=5, offset=5, count=3 is the result min(5, max(0, -2)) = 0
+            self.assertEqual(len(response.data.get("data")), min(limit, max(0, 3 - offset)))
+
+    @override_settings(IT_BYPASS_TOKEN_VALIDATION=True)
+    @patch("management.principal.it_service.ITService.request_service_accounts", return_value=None)
+    def test_read_principal_service_account_invalid_limit_offset(self, mock_request):
+        """Test that 400 is returned for negative limit and offset."""
+        test_values = [(-1, 1), (2, -2)]
+        expected_message = "Values for limit and offset must be positive numbers."
+
+        for limit, offset in test_values:
+            url = f"{reverse('principals')}?type=service-account&limit={limit}&offset={offset}"
+            client = APIClient()
+            response = client.get(url, **self.headers)
+            err = response.json()["errors"][0]
+            self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+            self.assertEqual(err["detail"], expected_message)


### PR DESCRIPTION
this is second version of https://github.com/RedHatInsights/insights-rbac/pull/1010 (in the end only one version will be merged)

## Link(s) to Jira
- https://issues.redhat.com/browse/RHCLOUD-30665

## Description of Intent of Change(s)
with previous logic the "count" for the response was not correctly calculated and that caused that "links" were not created correctly and this led to the UI issues with pagination

this PR adds a new return value for the "count" to the IT Service class methods used for Service Accounts

## Local Testing
check acceptance criteria in the JIRA ticket but generally you can test this like this
send request to the `GET principals/` or GET `groups/{uuid}/principals/` endpoint and filter only service accounts, try different combination of limit and offset and check:

- values of count, limit, offset are set correctly
- links are created correctly
- returned data contains correct service account