### PR TITLE
Openapi spec for Relation API

### DIFF
--- a/docs/source/specs/relations-openapi.yml
+++ b/docs/source/specs/relations-openapi.yml
@@ -60,6 +60,96 @@ paths:
       responses:
         '201':
           description: '{}'
+  /groups/{uuid}/roles/relationships/:
+    post:
+      tags:
+        - Group
+      summary: Add a role to a group in the tenant
+      operationId: addRoleToGroup
+      parameters:
+        - name: uuid
+          in: path
+          description: TODO
+          required: true
+          schema:
+            type: string
+            format: uuid
+      description: |
+        Example of request body from platform RBAC API
+        ```
+          {
+            "roles": [
+              "94846f2f-cced-474f-b7f3-47e2ec51dd11"
+            ]
+          }
+        ```
+        
+        Schema in SpiceDB
+        ```
+        ```
+
+        Example of relations in SpiceDB creation (in zed format)
+        ```
+        ```
+      requestBody:
+        content:
+            application/json:
+                schema:
+                    $ref: '#/components/schemas/api.rebac.v1.CreateRelationshipsRequest'
+                examples:
+                  addPrincipalToGroupExample:
+                    $ref: '#/components/examples/AddRoleToGroupExample'
+      responses:
+        '200':
+          description: '{}'
+  /roles/relationships/:
+    post:
+      tags:
+        - Group
+      summary: Add a role to a group in the tenant
+      operationId: createRole
+      description: |
+        Example of request body from platform RBAC API
+        ```
+          {
+            "name": "RoleA",
+            "display_name": "ARoleName",
+            "description": "A description of RoleA",
+            "access": [
+              {
+                "permission": "cost-management:*:read",
+                "resourceDefinitions": [
+                  {
+                    "attributeFilter": {
+                      "key": "cost-management.aws.account",
+                      "operation": "equal",
+                      "value": "123456"
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ```
+        
+        Schema in SpiceDB
+        ```
+        ```
+
+        Example of relations in SpiceDB creation (in zed format)
+        ```
+        ```
+      requestBody:
+        content:
+            application/json:
+                schema:
+                    $ref: '#/components/schemas/api.rebac.v1.CreateRelationshipsRequest'
+                examples:
+                  addPrincipalToGroupExample:
+                    $ref: '#/components/examples/CreateRoleExample'
+      responses:
+        '200':
+          description: '{}'
 components:
   schemas:
     api.rebac.v1.CreateRelationshipsRequest:
@@ -98,6 +188,32 @@ components:
   examples:
     AddPrincipalToGroupExample:
       summary: An example of adding principal to group
+      value:
+        touch: true
+        relationships:
+          - object:
+              type: group
+              id: 9aca5b38-07b1-4873-aaae-d02c94c05673
+            relation: member
+            subject:
+              object:
+                type: user
+                id: user_dev
+    AddRoleToGroupExample:
+      summary: TODO - needs to updated - An example of adding role to group
+      value:
+        touch: true
+        relationships:
+          - object:
+              type: group
+              id: 9aca5b38-07b1-4873-aaae-d02c94c05673
+            relation: member
+            subject:
+              object:
+                type: user
+                id: user_dev
+    CreateRoleExample:
+      summary: TODO - needs to updated - An example of adding role to group
       value:
         touch: true
         relationships:

--- a/docs/source/specs/relations-openapi.yml
+++ b/docs/source/specs/relations-openapi.yml
@@ -1,0 +1,111 @@
+openapi: 3.0.0
+info:
+  description: Mapping from Relation API for Role Based Access Control API
+  version: 1.0.0
+  title: Role Based Access Control
+  license:
+    name: AGPL-3.0
+    url: https://opensource.org/licenses/AGPL-3.0
+tags:
+  - name: Group
+    description: Operations about groups
+paths:
+  /groups/{uuid}/principals/relationships:
+    post:
+      tags:
+        - Group
+      summary: Add a principal to a group in the tenant
+      operationId: addPrincipalToGroup
+      parameters:
+        - name: uuid
+          in: path
+          description: '`uuid` is populated `relationships.object.id` request body'
+          required: true
+          schema:
+            type: string
+            format: uuid
+      description: |
+        Example of request body from platform RBAC API
+        ```
+        {
+          "principals": [
+            {
+              "username": "user_dev"
+            }
+          ]
+        }
+        ```
+        
+        Schema in SpiceDB
+        ```
+          definition user {}
+          
+          definition group {
+              relation member: user | group#member
+          }
+        ```
+
+        Example of relations in SpiceDB creation (in zed format)
+        ```
+          zed relationship read group:9aca5b38-07b1-4873-aaae-d02c94c05673 group:9aca5b38-07b1-4873-aaae-d02c94c05673 member user_dev
+        ```
+      requestBody:
+        content:
+            application/json:
+                schema:
+                    $ref: '#/components/schemas/api.rebac.v1.CreateRelationshipsRequest'
+                examples:
+                  addPrincipalToGroupExample:
+                    $ref: '#/components/examples/AddPrincipalToGroupExample'
+      responses:
+        '201':
+          description: '{}'
+components:
+  schemas:
+    api.rebac.v1.CreateRelationshipsRequest:
+        type: object
+        properties:
+            touch:
+                type: boolean
+                description: 'true means that request will not error if any of the user-group assignments has already been created. Could also be false for the opposite semantics: i.e. to fail if any of the relationships already exist.'
+            relationships:
+                type: array
+                items:
+                    $ref: '#/components/schemas/api.rebac.v1.Relationship'
+    api.rebac.v1.Relationship:
+        type: object
+        properties:
+            object:
+                $ref: '#/components/schemas/api.rebac.v1.ObjectReference'
+            relation:
+                type: string
+            subject:
+                $ref: '#/components/schemas/api.rebac.v1.SubjectReference'
+    api.rebac.v1.SubjectReference:
+        type: object
+        properties:
+            relation:
+                type: string
+            object:
+                $ref: '#/components/schemas/api.rebac.v1.ObjectReference'
+    api.rebac.v1.ObjectReference:
+        type: object
+        properties:
+            type:
+                type: string
+            id:
+                type: string
+  examples:
+    AddPrincipalToGroupExample:
+      summary: An example of adding principal to group
+      value:
+        touch: true
+        relationships:
+          - object:
+              type: group
+              id: 9aca5b38-07b1-4873-aaae-d02c94c05673
+            relation: member
+            subject:
+              object:
+                type: user
+                id: user_dev


### PR DESCRIPTION
This is copy of rbac openapi in yaml - intent is to rewrite this spec with Relation API endpoint with example - which could be used in mapping RBAC to Relation API


NOTES:
- request in path section is in form  of path is `<rbac_endpoint_path>/<relation_endpoint_path>`
 where <relation_endpoint_path> is same(relationships) in most cases - this is way how to know which endpoint is mapped.
example:
/groups/{uuid}/principals/relationships
- if there is parameter in path like {uuid} it would be helpful where this parameter is presented in relation API response body
- in description description section we can state:
   -  Example of request body from platform RBAC API
   -  Schema in SpiceDB
   - Example of relations in SpiceDB creation (in zed format)
