### PR TITLE
removed not used variable

### DIFF
--- a/rbac/management/group/view.py
+++ b/rbac/management/group/view.py
@@ -609,7 +609,6 @@ class GroupViewSet(
 
             # Process the service accounts and add them to the group.
             if len(service_accounts) > 0:
-                bearer_token: str = None
                 try:
                     # Attempt validating the JWT token.
                     token_validator = ITSSOTokenValidator()
@@ -725,7 +724,6 @@ class GroupViewSet(
 
             # Make sure we return early for service accounts.
             if principalType == "service-account":
-                bearer_token: str = None
                 try:
                     # Attempt validating the JWT token.
                     token_validator = ITSSOTokenValidator()

--- a/rbac/management/principal/view.py
+++ b/rbac/management/principal/view.py
@@ -131,7 +131,6 @@ class PrincipalView(APIView):
 
         # Get either service accounts or user principals, depending on what the user specified.
         if principal_type == "service-account":
-            bearer_token: str = None
             try:
                 # Attempt validating the JWT token.
                 token_validator = ITSSOTokenValidator()


### PR DESCRIPTION
`bearer_token` var is created in the `try` block and because `except` blocks end with `return` statement, there is not needed to initialize it twice (once above `try` block and once inside it)