### PR TITLE
RHCLOUD-30838 | refactor: move the token validation to the middleware

### DIFF
--- a/rbac/api/models.py
+++ b/rbac/api/models.py
@@ -72,6 +72,6 @@ class User:
     is_active = True
     org_id = None
     # Service account properties.
-    bearer_token: str = None
+    bearer_token: str = ""
     client_id: str = ""
     is_service_account: bool = False

--- a/rbac/api/models.py
+++ b/rbac/api/models.py
@@ -72,5 +72,6 @@ class User:
     is_active = True
     org_id = None
     # Service account properties.
+    bearer_token: str = None
     client_id: str = ""
     is_service_account: bool = False

--- a/rbac/management/group/view.py
+++ b/rbac/management/group/view.py
@@ -685,7 +685,7 @@ class GroupViewSet(
                 options[SERVICE_ACCOUNT_DESCRIPTION_KEY] = request.query_params.get(SERVICE_ACCOUNT_DESCRIPTION_KEY)
                 options[SERVICE_ACCOUNT_NAME_KEY] = request.query_params.get(SERVICE_ACCOUNT_NAME_KEY)
 
-                # Get the principal username option parameter and the limit and offset parameters too.
+                # Get the "principal username" parameter.
                 options[PRINCIPAL_USERNAME_KEY] = request.query_params.get(PRINCIPAL_USERNAME_KEY)
 
                 # Fetch the group's service accounts.

--- a/rbac/management/principal/it_service.py
+++ b/rbac/management/principal/it_service.py
@@ -155,12 +155,12 @@ class ITService:
 
         return service_accounts
 
-    def get_service_accounts(self, user: User, bearer_token: str, options: dict = {}) -> Tuple[list[dict], int]:
+    def get_service_accounts(self, user: User, options: dict = {}) -> Tuple[list[dict], int]:
         """Request and returns the service accounts for the given tenant."""
         # We might want to bypass calls to the IT service on ephemeral or test environments.
         it_service_accounts: list[dict] = []
         if not settings.IT_BYPASS_IT_CALLS:
-            it_service_accounts = self.request_service_accounts(bearer_token=bearer_token)
+            it_service_accounts = self.request_service_accounts(bearer_token=user.bearer_token)
 
         # Get the service accounts from the database. The weird filter is to fetch the service accounts depending on
         # the account number or the organization ID the user gave.
@@ -238,12 +238,12 @@ class ITService:
 
         return service_accounts, count
 
-    def get_service_accounts_group(self, group: Group, bearer_token: str, options: dict = {}) -> list[dict]:
+    def get_service_accounts_group(self, group: Group, user: User, options: dict = {}) -> list[dict]:
         """Get the service accounts for the given group."""
         # We might want to bypass calls to the IT service on ephemeral or test environments.
         it_service_accounts: list[dict] = []
         if not settings.IT_BYPASS_IT_CALLS:
-            it_service_accounts = self.request_service_accounts(bearer_token=bearer_token)
+            it_service_accounts = self.request_service_accounts(bearer_token=user.bearer_token)
 
         # Fetch the service accounts from the group.
         group_service_account_principals = group.principals.filter(type=TYPE_SERVICE_ACCOUNT)

--- a/rbac/rbac/middleware.py
+++ b/rbac/rbac/middleware.py
@@ -27,6 +27,8 @@ from django.db import IntegrityError
 from django.http import Http404, HttpResponse, QueryDict
 from django.urls import resolve
 from django.utils.deprecation import MiddlewareMixin
+from management.authorization.token_validator import ITSSOTokenValidator, InvalidTokenError, MissingAuthorizationError
+from management.authorization.token_validator import UnableMeetPrerequisitesError
 from management.cache import TenantCache
 from management.models import Principal
 from management.utils import APPLICATION_KEY, access_for_principal, validate_psk
@@ -232,6 +234,12 @@ class IdentityHeaderMiddleware(MiddlewareMixin):
                 user.user_id = None
                 user.system = False
 
+                # The requests made by service accounts are expected to come with an Authorization header which
+                # contains a Bearer token. Therefore, we will attempt to extract it and validate it, and also store it
+                # in case we need to use it to contact IT with it.
+                token_validator = ITSSOTokenValidator()
+                user.bearer_token = token_validator.validate_token(request=request)
+
             # If we did not get the user information or service account information from the "x-rh-identity" header,
             # then the request is directly unauthorized.
             if not user_info and not service_account:
@@ -287,6 +295,52 @@ class IdentityHeaderMiddleware(MiddlewareMixin):
                         logger.error("Cross account request permission denied. Requester is not internal user.")
                         return HttpResponseUnauthorizedRequest()
                     user.username = f"{user.account}-{user.user_id}"
+        except InvalidTokenError:
+            return HttpResponse(
+                content=json.dumps(
+                    {
+                        "errors": [
+                            {
+                                "detail": "Invalid token provided.",
+                                "status": str(status.HTTP_401_UNAUTHORIZED),
+                            }
+                        ]
+                    }
+                ),
+                content_type="application/json",
+                status=status.HTTP_401_UNAUTHORIZED,
+            )
+        except MissingAuthorizationError:
+            return HttpResponse(
+                content=json.dumps(
+                    {
+                        "errors": [
+                            {
+                                "detail": "A Bearer token in an authorization header is required when contacting RBAC"
+                                " with a service account.",
+                                "status": str(status.HTTP_401_UNAUTHORIZED),
+                            }
+                        ]
+                    }
+                ),
+                content_type="application/json",
+                status=status.HTTP_401_UNAUTHORIZED,
+            )
+        except UnableMeetPrerequisitesError:
+            return HttpResponse(
+                content=json.dumps(
+                    {
+                        "errors": [
+                            {
+                                "detail": "Unable to validate the provided token.",
+                                "status": str(status.HTTP_500_INTERNAL_SERVER_ERROR),
+                            }
+                        ]
+                    }
+                ),
+                content_type="application/json",
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )
         except (KeyError, TypeError, JSONDecodeError):
             request_psk = request.META.get(RH_RBAC_PSK)
             account = request.META.get(RH_RBAC_ACCOUNT)

--- a/tests/identity_request.py
+++ b/tests/identity_request.py
@@ -123,7 +123,7 @@ class IdentityRequest(TestCase):
                 "user_id": "1111111",
             }
 
-        if service_account_data is not None:
+        if service_account_data:
             identity["identity"]["service_account"] = {
                 "client_id": service_account_data.get("client_id"),
                 "username": service_account_data.get("username"),
@@ -137,6 +137,6 @@ class IdentityRequest(TestCase):
             if user_data:
                 identity["identity"]["type"] = "User"
             else:
-                identity["identity"]["type"] = "Service account"
+                identity["identity"]["type"] = "ServiceAccount"
 
         return identity

--- a/tests/management/principal/test_view.py
+++ b/tests/management/principal/test_view.py
@@ -827,19 +827,6 @@ class PrincipalViewsetTests(IdentityRequest):
 
         cross_account_principal.delete()
 
-    def test_fetch_service_accounts(self):
-        """Test fetching service accounts while not providing a token
-
-        Test that when the user request the service accounts without an authorization token, an unauthorized response
-        is returned
-        """
-
-        url = f'{reverse("principals")}?type=service-account'
-        client = APIClient()
-        response: Response = client.get(url, **self.headers)
-
-        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
-
     @override_settings(IT_BYPASS_TOKEN_VALIDATION=True)
     @patch("management.principal.it_service.ITService.request_service_accounts")
     def test_read_principal_service_account_list_success(self, mock_request):

--- a/tests/rbac/test_middleware.py
+++ b/tests/rbac/test_middleware.py
@@ -16,7 +16,9 @@
 #
 """Test the project middleware."""
 import collections
+import json
 import os
+from unittest import mock
 from unittest.mock import Mock
 from django.conf import settings
 from django.http import QueryDict
@@ -31,6 +33,7 @@ from api.models import Tenant, User
 from api.serializers import create_tenant_name
 from tests.identity_request import IdentityRequest
 from rbac.middleware import HttpResponseUnauthorizedRequest, IdentityHeaderMiddleware
+from management.authorization.token_validator import UnableMeetPrerequisitesError
 from management.models import Access, Group, Permission, Principal, Policy, ResourceDefinition, Role
 
 
@@ -341,6 +344,201 @@ class IdentityHeaderMiddlewareTest(IdentityRequest):
             request.GET = test_case
 
             self.assertEqual(middleware.should_load_user_permissions(request, user), False)
+
+    def test_service_account_with_no_authorization_header(self):
+        """Test that a 401 is returned when a service account with no authorization header contacts RBAC."""
+        # Prepare the mocked service account data.
+        service_account_data = self._create_service_account_data()
+        customer = self._create_customer_data()
+
+        # Prepare the mocked request.
+        request_context = self._create_request_context(
+            customer_data=customer, user_data=None, service_account_data=service_account_data
+        )
+        mock_request = request_context["request"]
+        mock_request.path = "/api/v1/access/"
+        middleware = IdentityHeaderMiddleware(get_response=IdentityHeaderMiddleware.process_request)
+
+        # Set the authorization header to an empty one to test that a missing authorization exception is raised.
+        mock_request.headers = {"Authorization": None}
+
+        # Call the middleware under test.
+        result = middleware.process_request(mock_request)
+
+        # Assert that the content type header has the correct value.
+        self.assertEqual(
+            "application/json", result.headers.get("Content-Type"), "the content type header has the incorrect value"
+        )
+
+        # Assert that the status code is the expected one.
+        self.assertEqual(
+            status.HTTP_401_UNAUTHORIZED,
+            result.status_code,
+            "unexpected status code received when the authorization header is missing",
+        )
+
+        # Assert that the contents of the body are the expected ones.
+        content = json.loads(result.content.decode("utf-8"))
+        errors = content["errors"]
+        if not errors:
+            self.fail('expected an "errors" array in the received response\'s body, but it was not found')
+
+        if len(errors) != 1:
+            self.fail(f'expected a single error in the "errors" array, {len(errors)} errors received')
+
+        error = errors[0]
+        error_detail = error.get("detail")
+
+        if not error_detail:
+            self.fail("the error detail is missing from the error object")
+
+        self.assertEqual(
+            error_detail,
+            "A Bearer token in an authorization header is required when contacting RBAC with a service account.",
+            "unexpected error detail received in the response",
+        )
+
+        error_status = error.get("status")
+
+        if not error_status:
+            self.fail("the error object is missing the status code")
+
+        self.assertEqual(
+            str(status.HTTP_401_UNAUTHORIZED),
+            error_status,
+            "unexpected status code received in the body of the response",
+        )
+
+    @mock.patch("management.authorization.token_validator.ITSSOTokenValidator._get_json_web_keyset")
+    def test_service_account_unable_validate_token(self, _get_json_web_keyset: Mock):
+        """Test 500 response for a service account request when unable to meet prerequisites to validate the token."""
+        # Prepare the mocked service account data.
+        service_account_data = self._create_service_account_data()
+        customer = self._create_customer_data()
+
+        # Prepare the mocked request.
+        request_context = self._create_request_context(
+            customer_data=customer, user_data=None, service_account_data=service_account_data
+        )
+        mock_request = request_context["request"]
+        mock_request.path = "/api/v1/access/"
+        middleware = IdentityHeaderMiddleware(get_response=IdentityHeaderMiddleware.process_request)
+
+        # Set a non-empty authorization header.
+        mock_request.headers = {"Authorization": "invalid-bearer-token"}
+        # Pretend that we are not able to contact IT in order to fetch the required key set to validate the token.
+        _get_json_web_keyset.side_effect = UnableMeetPrerequisitesError()
+
+        # Call the middleware under test.
+        result = middleware.process_request(mock_request)
+
+        # Assert that the content type header has the correct value.
+        self.assertEqual(
+            "application/json", result.headers.get("Content-Type"), "the content type header has the incorrect value"
+        )
+
+        # Assert that the status code is the expected one.
+        self.assertEqual(
+            status.HTTP_500_INTERNAL_SERVER_ERROR,
+            result.status_code,
+            "unexpected status code received when we are unable to meet the prerequisites to validate the token",
+        )
+
+        # Assert that the contents of the body are the expected ones.
+        content = json.loads(result.content.decode("utf-8"))
+        errors = content["errors"]
+        if not errors:
+            self.fail('expected an "errors" array in the received response\'s body, but it was not found')
+
+        if len(errors) != 1:
+            self.fail(f'expected a single error in the "errors" array, {len(errors)} errors received')
+
+        error = errors[0]
+        error_detail = error.get("detail")
+
+        if not error_detail:
+            self.fail("the error detail is missing from the error object")
+
+        self.assertEqual(
+            error_detail, "Unable to validate the provided token.", "unexpected error detail received in the response"
+        )
+
+        error_status = error.get("status")
+
+        if not error_status:
+            self.fail("the error object is missing the status code")
+
+        self.assertEqual(
+            str(status.HTTP_500_INTERNAL_SERVER_ERROR),
+            error_status,
+            "unexpected status code received in the body of the response",
+        )
+
+    @mock.patch("management.authorization.token_validator.ITSSOTokenValidator._get_json_web_keyset")
+    @mock.patch("management.authorization.token_validator.jwt.decode")
+    def test_service_account_with_invalid_bearer_token(self, decode: Mock, _get_json_web_keyset: Mock):
+        """Test 401 response for a service account request with an invalid bearer token."""
+        # Prepare the mocked service account data.
+        service_account_data = self._create_service_account_data()
+        customer = self._create_customer_data()
+
+        # Prepare the mocked request.
+        request_context = self._create_request_context(
+            customer_data=customer, user_data=None, service_account_data=service_account_data
+        )
+        mock_request = request_context["request"]
+        mock_request.path = "/api/v1/access/"
+        middleware = IdentityHeaderMiddleware(get_response=IdentityHeaderMiddleware.process_request)
+
+        # Set a non-empty authorization header.
+        mock_request.headers = {"Authorization": "invalid-bearer-token"}
+        # The token validator should avoid calling IT for the test.
+        _get_json_web_keyset.return_value = "invalid-return-value"
+        # Make the "decode" function raise any exception to test that it gets properly handled.
+        decode.side_effect = ValueError("invalid value")
+
+        # Call the middleware under test.
+        result = middleware.process_request(mock_request)
+
+        # Assert that the content type header has the correct value.
+        self.assertEqual(
+            "application/json", result.headers.get("Content-Type"), "the content type header has the incorrect value"
+        )
+
+        # Assert that the status code is the expected one.
+        self.assertEqual(
+            status.HTTP_401_UNAUTHORIZED,
+            result.status_code,
+            "unexpected status code received when the bearer token is invalid",
+        )
+
+        # Assert that the contents of the body are the expected ones.
+        content = json.loads(result.content.decode("utf-8"))
+        errors = content["errors"]
+        if not errors:
+            self.fail('expected an "errors" array in the received response\'s body, but it was not found')
+
+        if len(errors) != 1:
+            self.fail(f'expected a single error in the "errors" array, {len(errors)} errors received')
+
+        error = errors[0]
+        error_detail = error.get("detail")
+
+        if not error_detail:
+            self.fail("the error detail is missing from the error object")
+
+        self.assertEqual(error_detail, "Invalid token provided.", "unexpected error detail received in the response")
+
+        error_status = error.get("status")
+
+        if not error_status:
+            self.fail("the error object is missing the status code")
+
+        self.assertEqual(
+            str(status.HTTP_401_UNAUTHORIZED),
+            error_status,
+            "unexpected status code received in the body of the response",
+        )
 
 
 class ServiceToService(IdentityRequest):


### PR DESCRIPTION
## Link(s) to Jira
- [[RHCLOUD-30838]](https://issues.redhat.com/browse/RHCLOUD-30838)

## Description of Intent of Change(s)
Instead of validating the token that comes in the requests made by the service accounts in every view, it makes more sense to validate it when we are building our internal user object, and to leave it there for easy access for the rest of the code.

## Local Testing
How can the feature be exercised?
How can the bug be exploited and fix confirmed?
Is any special local setup required?

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [x] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
