### PR TITLE
Service Accounts principals/ endpoint - fix for "count"

### DIFF
--- a/rbac/management/principal/it_service.py
+++ b/rbac/management/principal/it_service.py
@@ -202,15 +202,6 @@ class ITService:
         else:
             service_account_principals = service_account_principals.order_by("-username")
 
-        # We always set a default offset and a limit if the user doesn't specify them, so it is safe to simply put the
-        # two parameters in the query to slice it.
-        offset = options.get("offset")
-        limit = options.get("limit")
-        limit_offset_validation(offset, limit)
-
-        count = len(service_account_principals)
-        service_account_principals = service_account_principals[offset : offset + limit]
-
         # If we are in an ephemeral or test environment, we will take all the service accounts of the user that are
         # stored in the database and generate a mocked response for them, simulating that IT has the corresponding
         # service account to complement the information.
@@ -229,6 +220,15 @@ class ITService:
         service_accounts: [dict] = self._merge_principals_it_service_accounts(
             service_account_principals=sap_dict, it_service_accounts=it_service_accounts, options=options
         )
+
+        # We always set a default offset and a limit if the user doesn't specify them, so it is safe to simply put the
+        # two parameters in the query to slice it.
+        offset = options.get("offset")
+        limit = options.get("limit")
+        limit_offset_validation(offset, limit)
+
+        count = len(service_accounts)
+        service_accounts = service_accounts[offset : offset + limit]  # type: ignore
 
         return service_accounts, count
 

--- a/rbac/management/principal/view.py
+++ b/rbac/management/principal/view.py
@@ -222,7 +222,7 @@ class PrincipalView(APIView):
                 count = len(data)
             else:
                 count = None
-            response_data["meta"] = {"count": count}
+            response_data["meta"] = {"count": count, "limit": limit, "offset": offset}
             response_data["links"] = {
                 "first": f"{path}?limit={limit}&offset=0{usernames_filter}",
                 "next": f"{path}?limit={limit}&offset={offset + limit}{usernames_filter}",

--- a/rbac/management/principal/view.py
+++ b/rbac/management/principal/view.py
@@ -105,6 +105,8 @@ class PrincipalView(APIView):
         try:
             limit = int(query_params.get("limit", default_limit))
             offset = int(query_params.get("offset", 0))
+            if limit < 0 or offset < 0:
+                raise ValueError
             options["limit"] = limit
             options["offset"] = offset
             options["sort_order"] = validate_and_get_key(query_params, SORTORDER_KEY, VALID_SORTORDER_VALUE, "asc")


### PR DESCRIPTION
## Link(s) to Jira
- fix for comment in the [RHCLOUD-30665](https://issues.redhat.com/browse/RHCLOUD-30665)

## Description of Intent of Change(s)
it looks like the count is not calculate correctly because after it the data are filtered so we have to move the logic for it in the end of the function

and

added fields "limit" and "offset" into response of principals/ endpoint