### PR TITLE
RHCLOUD-29641 | RHCLOUD-29668 | RHCLOUD-29631 | feature: users should see service account group info

### DIFF
--- a/rbac/management/principal/it_service.py
+++ b/rbac/management/principal/it_service.py
@@ -18,7 +18,7 @@
 import logging
 import time
 import uuid
-from typing import Tuple
+from typing import Optional, Tuple, Union
 
 import requests
 from django.conf import settings
@@ -83,7 +83,7 @@ class ITService:
         self.it_url = f"{self.protocol}://{self.host}:{self.port}{self.base_path}{IT_PATH_GET_SERVICE_ACCOUNTS}"
 
     @it_request_all_service_accounts_time_tracking.time()
-    def request_service_accounts(self, bearer_token: str, client_ids: list[str] = None) -> list[dict]:
+    def request_service_accounts(self, bearer_token: str, client_ids: Optional[list[str]] = None) -> list[dict]:
         """Request the service accounts for a tenant and returns the entire list that IT has."""
         # We cannot talk to IT if we don't have a bearer token.
         if not bearer_token:
@@ -98,7 +98,7 @@ class ITService:
 
             # If the offset is zero, that means that we need to call the service at least once to get the first
             # service accounts. If it equals the limit, that means that there are more pages to fetch.
-            parameters = {"first": offset, "max": limit}
+            parameters: dict[str, Union[int, list[str]]] = {"first": offset, "max": limit}
             # If we were given client IDs to filter the collection with, do it!
             if client_ids:
                 parameters["clientId"] = client_ids

--- a/rbac/management/principal/it_service.py
+++ b/rbac/management/principal/it_service.py
@@ -73,6 +73,16 @@ def limit_offset_validation(offset, limit):
 class ITService:
     """A class to handle interactions with the IT service."""
 
+    # Instance variable for the class.
+    _instance = None
+
+    def __new__(cls, *args, **kwargs):
+        """Create a single instance of the class."""
+        if cls._instance is None:
+            cls._instance = super().__new__(cls, *args, **kwargs)
+
+        return cls._instance
+
     def __init__(self):
         """Establish IT connection information."""
         self.host = settings.IT_SERVICE_HOST

--- a/rbac/management/principal/it_service.py
+++ b/rbac/management/principal/it_service.py
@@ -17,6 +17,7 @@
 """Class to manage interactions with the IT service accounts service."""
 import logging
 import time
+import uuid
 from typing import Tuple
 
 import requests
@@ -79,17 +80,16 @@ class ITService:
         self.port = settings.IT_SERVICE_PORT
         self.protocol = settings.IT_SERVICE_PROTOCOL_SCHEME
         self.it_request_timeout = settings.IT_SERVICE_TIMEOUT_SECONDS
+        self.it_url = f"{self.protocol}://{self.host}:{self.port}{self.base_path}{IT_PATH_GET_SERVICE_ACCOUNTS}"
 
     @it_request_all_service_accounts_time_tracking.time()
-    def request_service_accounts(self, bearer_token: str) -> list[dict]:
+    def request_service_accounts(self, bearer_token: str, client_ids: list[str] = None) -> list[dict]:
         """Request the service accounts for a tenant and returns the entire list that IT has."""
         # We cannot talk to IT if we don't have a bearer token.
         if not bearer_token:
             raise MissingAuthorizationError()
 
         received_service_accounts: list[dict] = []
-        # Prepare the URL to fetch the service accounts.
-        url = f"{self.protocol}://{self.host}:{self.port}{self.base_path}{IT_PATH_GET_SERVICE_ACCOUNTS}"
 
         # Attempt fetching all the service accounts for the tenant.
         try:
@@ -98,11 +98,16 @@ class ITService:
 
             # If the offset is zero, that means that we need to call the service at least once to get the first
             # service accounts. If it equals the limit, that means that there are more pages to fetch.
+            parameters = {"first": offset, "max": limit}
+            # If we were given client IDs to filter the collection with, do it!
+            if client_ids:
+                parameters["clientId"] = client_ids
+
             while offset == 0 or offset == limit:
                 response = requests.get(
-                    url=url,
+                    url=self.it_url,
                     headers={"Authorization": f"Bearer {bearer_token}"},
-                    params={"first": offset, "max": limit},
+                    params=parameters,
                     timeout=self.it_request_timeout,
                 )
 
@@ -134,7 +139,7 @@ class ITService:
         except requests.exceptions.ConnectionError as exception:
             LOGGER.error(
                 "Unable to connect to IT to fetch the service accounts. Attempted URL %s with error: %s",
-                url,
+                self.it_url,
                 exception,
             )
 
@@ -146,7 +151,7 @@ class ITService:
         except requests.exceptions.Timeout as exception:
             LOGGER.error(
                 "The connection to IT timed out when trying to fetch service accounts. Attempted URL %s with error: %s",
-                url,
+                self.it_url,
                 exception,
             )
 
@@ -159,6 +164,49 @@ class ITService:
             service_accounts.append(self._transform_incoming_payload(incoming_service_account))
 
         return service_accounts
+
+    def is_service_account_valid_by_client_id(self, user: User, service_account_client_id: str) -> bool:
+        """Check if the specified service account is valid."""
+        if settings.IT_BYPASS_IT_CALLS:
+            return False
+
+        return self._is_service_account_valid(user=user, client_id=service_account_client_id)
+
+    def is_service_account_valid_by_username(self, user: User, service_account_username: str) -> bool:
+        """Check if the specified service account is valid."""
+        # The usernames for the service accounts usually come in the form "service-account-${CLIENT_ID}". We don't need
+        # the prefix of the username to query IT, since they only accept client IDs to filter collections.
+        if settings.IT_BYPASS_IT_CALLS:
+            return True
+
+        if self.is_username_service_account(service_account_username):
+            client_id = service_account_username.replace("service-account-", "")
+        else:
+            client_id = service_account_username
+
+        return self._is_service_account_valid(user=user, client_id=client_id)
+
+    def _is_service_account_valid(self, user: User, client_id: str) -> bool:
+        """Check if the provided client ID can be found in the tenant's organization by calling IT."""
+        if settings.IT_BYPASS_IT_CALLS:
+            return True
+        else:
+            service_accounts: list[dict] = self.request_service_accounts(
+                bearer_token=user.bearer_token,
+                client_ids=[client_id],
+            )
+
+            if len(service_accounts) == 0:
+                return False
+            elif len(service_accounts) == 1:
+                sa = service_accounts[0]
+                return client_id == sa.get("clientId")
+            else:
+                LOGGER.error(
+                    f'unexpected number of service accounts received from IT. Wanted one with client ID "{client_id}",'
+                    f" got {len(service_accounts)}: {service_accounts}"
+                )
+                return False
 
     def get_service_accounts(self, user: User, options: dict = {}) -> Tuple[list[dict], int]:
         """Request and returns the service accounts for the given tenant."""
@@ -319,6 +367,29 @@ class ITService:
             return filtered_service_accounts
         else:
             return service_accounts
+
+    @staticmethod
+    def is_username_service_account(username: str) -> bool:
+        """Check if the given username belongs to a service account."""
+        return username.startswith("service-account-")
+
+    @staticmethod
+    def extract_client_id_service_account_username(username: str) -> uuid.UUID:
+        """Extract the client ID from the service account's username."""
+        # If it has the "service-account" prefix, we just need to strip it and return the rest of the username, which
+        # contains the client ID. Else, we have just received the client ID.
+        try:
+            if ITService.is_username_service_account(username=username):
+                return uuid.UUID(username.replace("service-account-", ""))
+            else:
+                return uuid.UUID(username)
+        except ValueError:
+            raise serializers.ValidationError(
+                {
+                    "detail": "unable to extract the client ID from the service account's username because the"
+                    " provided UUID is invalid"
+                }
+            )
 
     def _transform_incoming_payload(self, service_account_from_it_service: dict) -> dict:
         """Transform the incoming service account from IT into a dict which fits our response structure."""

--- a/rbac/management/querysets.py
+++ b/rbac/management/querysets.py
@@ -183,7 +183,7 @@ def get_role_queryset(request) -> QuerySet:
                 is_org_admin = request.user.admin
             else:
                 # Service accounts were agreed not to be considered organization administrators.
-                if request.user.is_service_account:
+                if ITService.is_username_service_account(username=username):
                     is_org_admin = False
                 else:
                     is_org_admin = get_admin_from_proxy(username, request)
@@ -258,7 +258,7 @@ def get_access_queryset(request: Request) -> QuerySet:
         is_org_admin = request.user.admin
     else:
         # Service accounts were agreed not to be considered organization administrators.
-        if request.user.is_service_account:
+        if ITService.is_username_service_account(username=username):
             is_org_admin = False
         else:
             is_org_admin = get_admin_from_proxy(username, request)
@@ -301,7 +301,7 @@ def _filter_admin_default(request: Request, queryset: QuerySet):
         is_org_admin = request.user.admin
     else:
         # Service accounts were agreed not to be considered organization administrators.
-        if request.user.is_service_account:
+        if ITService.is_username_service_account(username=username):
             is_org_admin = False
         else:
             is_org_admin = get_admin_from_proxy(username, request)

--- a/rbac/management/utils.py
+++ b/rbac/management/utils.py
@@ -104,7 +104,6 @@ def get_principal(
             else:
                 verify_principal_with_proxy(username, request, verify_principal=verify_principal)
 
-        # In the case that the user that made the request was a service account, store it accordingly in the database.
         if ITService.is_username_service_account(username=username):
             client_id: uuid.UUID = ITService.extract_client_id_service_account_username(username)
 

--- a/rbac/management/utils.py
+++ b/rbac/management/utils.py
@@ -17,6 +17,7 @@
 """Helper utilities for management module."""
 import json
 import os
+import uuid
 from uuid import UUID
 
 from django.conf import settings
@@ -25,11 +26,12 @@ from django.core.handlers.wsgi import WSGIRequest
 from django.utils.translation import gettext as _
 from management.models import Access, Group, Policy, Principal, Role
 from management.permissions.principal_access import PrincipalAccessPermission
+from management.principal.it_service import ITService
 from management.principal.proxy import PrincipalProxy
 from rest_framework import serializers, status
+from rest_framework.request import Request
 
-from api.models import CrossAccountRequest, Tenant, User
-
+from api.models import CrossAccountRequest, Tenant
 
 USERNAME_KEY = "username"
 APPLICATION_KEY = "application"
@@ -66,24 +68,48 @@ def get_principal_from_request(request):
     return get_principal(username, request, verify_principal=bool(qs_user), from_query=from_query)
 
 
-def get_principal(username, request, verify_principal=True, from_query=False):
+def get_principal(
+    username: str, request: Request, verify_principal: bool = True, from_query: bool = False
+) -> Principal:
     """Get principals from username."""
     # First check if principal exist on our side,
     # if not call BOP to check if user exist in the account.
-    tenant = request.tenant
+    tenant: Tenant = request.tenant
     try:
-        # If the username was provided through a query we must verify if it is an org admin from the BOP
+        # If the username was provided through a query we must verify if it exists in the corresponding services first.
         if from_query:
-            verify_principal_with_proxy(username, request, verify_principal=verify_principal)
+            if ITService.is_username_service_account(username=username):
+                it_service = ITService()
+                if not it_service.is_service_account_valid_by_username(
+                    user=request.user, service_account_username=username
+                ):
+                    raise serializers.ValidationError(
+                        {"detail": f"No data found for service account with username '{username}'"}
+                    )
+            else:
+                verify_principal_with_proxy(username, request, verify_principal=verify_principal)
         principal = Principal.objects.get(username__iexact=username, tenant=tenant)
     except Principal.DoesNotExist:
-        verify_principal_with_proxy(username, request, verify_principal=verify_principal)
+        # If the "from query" parameter was specified, the username was validated above, so there is no need to
+        # validate it again.
+        if not from_query:
+            if ITService.is_username_service_account(username):
+                it_service = ITService()
+                if not it_service.is_service_account_valid_by_username(
+                    user=request.user, service_account_username=username
+                ):
+                    raise serializers.ValidationError(
+                        {"detail": f"No data found for service account with username '{username}'"}
+                    )
+            else:
+                verify_principal_with_proxy(username, request, verify_principal=verify_principal)
 
         # In the case that the user that made the request was a service account, store it accordingly in the database.
-        user: User = request.user
-        if user and user.is_service_account:
+        if ITService.is_username_service_account(username=username):
+            client_id: uuid.UUID = ITService.extract_client_id_service_account_username(username)
+
             principal, _ = Principal.objects.get_or_create(
-                username=user.username, tenant=tenant, type=SERVICE_ACCOUNT_KEY, service_account_id=user.client_id
+                username=username, tenant=tenant, type=SERVICE_ACCOUNT_KEY, service_account_id=client_id
             )
         else:
             # Avoid possible race condition if the user was created while checking BOP

--- a/tests/management/principal/test_it_service.py
+++ b/tests/management/principal/test_it_service.py
@@ -1,0 +1,181 @@
+#
+# Copyright 2024 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""Test the principal model."""
+import uuid
+
+from django.conf import settings
+
+from management.principal.it_service import ITService
+from rest_framework import serializers
+from tests.identity_request import IdentityRequest
+from unittest import mock
+
+from api.models import User
+
+
+class ITServiceTests(IdentityRequest):
+    """Test the IT service class"""
+
+    def setUp(self):
+        self.it_service = ITService()
+
+    @mock.patch("management.principal.it_service.ITService._is_service_account_valid")
+    def test_is_service_account_valid_by_username_client_id(self, _is_service_account_valid: mock.Mock):
+        """Test that the function under test calls the underlying function with the unmodified client ID."""
+        client_uuid = str(uuid.uuid4())
+        user = User()
+
+        self.it_service.is_service_account_valid_by_username(user=user, service_account_username=client_uuid)
+
+        _is_service_account_valid.assert_called_with(user=user, client_id=client_uuid)
+
+    @mock.patch("management.principal.it_service.ITService._is_service_account_valid")
+    def test_is_service_account_valid_by_username_full(self, _is_service_account_valid: mock.Mock):
+        """Test that the function under test calls the underlying function by stripping the service account prefix."""
+        client_uuid = uuid.uuid4()
+        username = f"service-account-{client_uuid}"
+        user = User()
+
+        self.it_service.is_service_account_valid_by_username(user=user, service_account_username=username)
+
+        _is_service_account_valid.assert_called_with(user=user, client_id=str(client_uuid))
+
+    @mock.patch("management.principal.it_service.ITService.request_service_accounts")
+    def test_is_service_account_valid_bypass_it_calls(self, _):
+        """Test that the function under test assumes service accounts to always be valid when bypassing IT calls."""
+        original_bypass_it_calls_value = settings.IT_BYPASS_IT_CALLS
+        try:
+            settings.IT_BYPASS_IT_CALLS = True
+
+            self.assertEqual(
+                True,
+                self.it_service._is_service_account_valid(user=User(), client_id="mocked-cid"),
+                "when IT calls are bypassed, a service account should always be validated as if it existed",
+            )
+        finally:
+            settings.IT_BYPASS_IT_CALLS = original_bypass_it_calls_value
+
+    @mock.patch("management.principal.it_service.ITService.request_service_accounts")
+    def test_is_service_account_valid_zero_results_from_it(self, request_service_accounts: mock.Mock):
+        """Test that the function under test treats an empty result from IT as an invalid service account."""
+        request_service_accounts.return_value = []
+        user = User()
+        user.bearer_token = "mocked-bt"
+
+        self.assertEqual(
+            False,
+            self.it_service._is_service_account_valid(user=user, client_id="mocked-cid"),
+            "when IT returns an empty array for the given client ID, the service account should be considered invalid",
+        )
+
+    @mock.patch("management.principal.it_service.ITService.request_service_accounts")
+    def test_is_service_account_valid_one_matching_result_from_it(self, request_service_accounts: mock.Mock):
+        """Test that the function under test positively validates the given service account if IT responds with that service account."""
+        client_id = "client-id-123"
+        request_service_accounts.return_value = [{"clientId": client_id}]
+        user = User()
+        user.bearer_token = "mocked-bt"
+
+        self.assertEqual(
+            True,
+            self.it_service._is_service_account_valid(user=user, client_id=client_id),
+            "when IT returns the requested service account via the client ID, the function under test should return True",
+        )
+
+    @mock.patch("management.principal.it_service.ITService.request_service_accounts")
+    def test_is_service_account_valid_not_matching_result_from_it(self, request_service_accounts: mock.Mock):
+        """Test that the function under test does not validate the given service account if IT does not return a response with a proper service account."""
+        client_id = "client-id-123"
+        request_service_accounts.return_value = [{"clientId": "different-client-id"}]
+        user = User()
+        user.bearer_token = "mocked-bt"
+
+        self.assertEqual(
+            False,
+            self.it_service._is_service_account_valid(user=user, client_id=client_id),
+            "when IT returns a service account which doesn't match the provided client ID, the function under test should return False",
+        )
+
+    @mock.patch("management.principal.it_service.ITService.request_service_accounts")
+    def test_is_service_account_valid_multiple_results_from_it(self, request_service_accounts: mock.Mock):
+        """Test that the function under retunrs False when IT returns multiple service accounts for a single client ID."""
+        request_service_accounts.return_value = [{}, {}]
+        user = User()
+        user.bearer_token = "mocked-bt"
+
+        self.assertEqual(
+            False,
+            self.it_service._is_service_account_valid(user=user, client_id="mocked_cid"),
+            "when IT returns more service accounts than the ones requested, the function under test should return False",
+        )
+
+    def test_username_is_service_account(self) -> None:
+        """Test that the username is correctly identified as a service account."""
+        username = f"service-account-{uuid.uuid4()}"
+        self.assertEqual(
+            ITService.is_username_service_account(username),
+            True,
+            f"the given username '{username}' should have been identified as a service account username",
+        )
+
+    def test_username_is_not_service_account(self) -> None:
+        """Test that the provided usernames are correctly identified as not service accounts."""
+        usernames: list[str] = [
+            "foo",
+            "bar",
+            f"serivce-account-{uuid.uuid4()}",
+            f"service-acount-{uuid.uuid4()}",
+            str(uuid.uuid4()),
+        ]
+
+        for username in usernames:
+            self.assertEqual(
+                ITService.is_username_service_account(username),
+                False,
+                f"the given username '{username}' should have not been identified as a service account username",
+            )
+
+    def test_extract_client_id_service_account_username(self) -> None:
+        """Test that the client ID is correctly extracted from the service account's username"""
+        client_id = uuid.uuid4()
+
+        # Call the function under test with just the client ID. It should return it as is.
+        self.assertEqual(
+            client_id,
+            ITService.extract_client_id_service_account_username(username=str(client_id)),
+            "the client ID should be returned when it is passed to the function under test",
+        )
+
+        # Call the function under test with the whole prefix, and check that the client ID is correctly identified.
+        self.assertEqual(
+            client_id,
+            ITService.extract_client_id_service_account_username(username=f"service-account-{client_id}"),
+            "the client ID was not correctly extracted from a full username",
+        )
+
+        # Call the function under test with an invalid username which contains a bad formed UUID.
+        try:
+            ITService.extract_client_id_service_account_username(username="abcde")
+            self.fail(
+                "when providing an invalid UUID as the client ID to be extracted, the function under test should raise an error"
+            )
+        except serializers.ValidationError as ve:
+            self.assertEqual(
+                "unable to extract the client ID from the service account's username because the provided UUID is invalid",
+                str(ve.detail.get("detail")),
+                "unexpected error message when providing an invalid UUID as the client ID",
+            )

--- a/tests/management/principal/test_it_service.py
+++ b/tests/management/principal/test_it_service.py
@@ -33,6 +33,23 @@ class ITServiceTests(IdentityRequest):
     def setUp(self):
         self.it_service = ITService()
 
+    def test_it_service_singleton(self):
+        """Test that the IT Service class only gets instantiated once."""
+        class_instances = [
+            ITService(),
+            ITService(),
+            ITService(),
+            ITService(),
+            ITService(),
+        ]
+
+        for instance in class_instances:
+            self.assertEqual(
+                self.it_service,
+                instance,
+                "no new instances of the IT service class should have been created since it is supposed to be a singleton",
+            )
+
     @mock.patch("management.principal.it_service.ITService._is_service_account_valid")
     def test_is_service_account_valid_by_username_client_id(self, _is_service_account_valid: mock.Mock):
         """Test that the function under test calls the underlying function with the unmodified client ID."""


### PR DESCRIPTION
## Link(s) to Jira
- [[RHCLOUD-29631]](https://issues.redhat.com/browse/RHCLOUD-29631)
- [[RHCLOUD-29641]](https://issues.redhat.com/browse/RHCLOUD-29641)
- [[RHCLOUD-29668]](https://issues.redhat.com/browse/RHCLOUD-29668)

## Dependencies
- https://github.com/RedHatInsights/insights-rbac/pull/1021

## Description of Intent of Change(s)
Enables listing the group information about service accounts, when the "username" query parameter is used in the "groups" endpoint.

## Local Testing
### How can the feature be exercised?
Right now it is not possible to list them in stage. To reproduce it:

1. Create a service account and add it to a group.
2. Send a `GET /groups/?username=<service-account-username>` request.

You will obtain a 404 instead of a response with the groups that service accounts belongs to.

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [x] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
