### PR TITLE
RHCLOUD-31077 | fix: unable to add service accounts to groups

### DIFF
--- a/rbac/api/common/exception_handler.py
+++ b/rbac/api/common/exception_handler.py
@@ -19,6 +19,7 @@
 import copy
 
 from django.db import IntegrityError
+from management.authorization.missing_authorization import MissingAuthorizationError
 from rest_framework import status
 from rest_framework.views import Response, exception_handler
 
@@ -82,4 +83,21 @@ def custom_exception_handler(exc, context):
             },  # noqa: E231
             status=status.HTTP_400_BAD_REQUEST,
         )
+    elif isinstance(exc, MissingAuthorizationError):
+        source_view = context.get("view")
+        response = Response(
+            data={
+                "errors": [
+                    {
+                        "detail": "A Bearer token in an authorization header is required when"
+                        " performing service account operations.",
+                        "source": source_view.basename,
+                        "status": str(status.HTTP_401_UNAUTHORIZED),
+                    }
+                ]
+            },
+            content_type="application/json",
+            status=status.HTTP_401_UNAUTHORIZED,
+        )
+
     return response

--- a/rbac/management/principal/it_service.py
+++ b/rbac/management/principal/it_service.py
@@ -22,6 +22,7 @@ from typing import Tuple
 import requests
 from django.conf import settings
 from django.db.models import Q
+from management.authorization.missing_authorization import MissingAuthorizationError
 from management.models import Group, Principal
 from prometheus_client import Counter, Histogram
 from rest_framework import serializers, status
@@ -82,6 +83,10 @@ class ITService:
     @it_request_all_service_accounts_time_tracking.time()
     def request_service_accounts(self, bearer_token: str) -> list[dict]:
         """Request the service accounts for a tenant and returns the entire list that IT has."""
+        # We cannot talk to IT if we don't have a bearer token.
+        if not bearer_token:
+            raise MissingAuthorizationError()
+
         received_service_accounts: list[dict] = []
         # Prepare the URL to fetch the service accounts.
         url = f"{self.protocol}://{self.host}:{self.port}{self.base_path}{IT_PATH_GET_SERVICE_ACCOUNTS}"

--- a/rbac/management/utils.py
+++ b/rbac/management/utils.py
@@ -21,6 +21,7 @@ from uuid import UUID
 
 from django.conf import settings
 from django.core.exceptions import PermissionDenied
+from django.core.handlers.wsgi import WSGIRequest
 from django.utils.translation import gettext as _
 from management.models import Access, Group, Policy, Principal, Role
 from management.permissions.principal_access import PrincipalAccessPermission
@@ -319,3 +320,13 @@ def get_admin_from_proxy(username, request):
 
     is_org_admin = bop_resp.get("data")[index]["is_org_admin"]
     return is_org_admin
+
+
+def request_has_bearer_authentication_header(request: WSGIRequest) -> bool:
+    """Check if the incoming request has an authorization header, of the bearer type."""
+    authorization_header_contents: str = request.headers.get("Authorization")
+
+    if authorization_header_contents:
+        return authorization_header_contents.startswith("Bearer")
+    else:
+        return False

--- a/tests/identity_request.py
+++ b/tests/identity_request.py
@@ -99,6 +99,7 @@ class IdentityRequest(TestCase):
         json_identity = json_dumps(identity)
         mock_header = b64encode(json_identity.encode("utf-8"))
         request = Mock()
+        request.headers = {RH_IDENTITY_HEADER: mock_header}
         request.META = {RH_IDENTITY_HEADER: mock_header}
         request.scope = {}
         request_context = {"request": request}

--- a/tests/management/test_utils.py
+++ b/tests/management/test_utils.py
@@ -26,6 +26,7 @@ from management.utils import (
     roles_for_principal,
     account_id_for_tenant,
     get_principal,
+    request_has_bearer_authentication_header,
 )
 from tests.identity_request import IdentityRequest
 from unittest import mock
@@ -179,3 +180,30 @@ class UtilsTests(IdentityRequest):
         self.assertEqual(created_service_account.service_account_id, str(user.client_id))
         self.assertEqual(created_service_account.type, "service-account")
         self.assertEqual(created_service_account.username, user.username)
+
+    def test_request_has_bearer_authorization_header(self):
+        """Test that the function under test is able to identify when the request has a Bearer authorization header."""
+        request = mock.Mock()
+        request.headers = {}
+
+        self.assertEqual(
+            False,
+            request_has_bearer_authentication_header(request=request),
+            "the function under test should return 'False' when the request has no authorization header",
+        )
+
+        request.headers = {"Authorization": "unexpected non-bearer value"}
+
+        self.assertEqual(
+            False,
+            request_has_bearer_authentication_header(request=request),
+            "the function under test should return 'False' when the request has no Bearer authorization contents",
+        )
+
+        request.headers = {"Authorization": "Bearer mocked-value"}
+
+        self.assertEqual(
+            True,
+            request_has_bearer_authentication_header(request=request),
+            "the function under test should return 'True' when the request has a Bearer authorization header",
+        )


### PR DESCRIPTION
## Link(s) to Jira
- [[RHCLOUD-31077]](https://issues.redhat.com/browse/RHCLOUD-31077)

## Description of Intent of Change(s)
Due to the recent refactoring changes which moved the token validation to the middleware, only requests coming from service accounts were getting their token validated and then assigned to the "User" internal object.

This caused that the bearer token coming from the requests of any other user would not be added to the "User" object, which in turn caused the IT Service to start sending empty bearer tokens to IT.

Finally, IT responded with 401 Unauthorized errors because of the missing bearer tokens.

## Local Testing
### How can the bug be exploited and fix confirmed?
- As an organization administrator, send a request with a bearer token to any of the RBAC endpoints that work with service accounts. You will receive 500 errors instead of the regular service account responses.

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [x] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
