### PR TITLE
Remove specific Django version from readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -52,7 +52,7 @@ If deploying with Openshift seems overly complex you can try an alternate local 
 Configuration
 ^^^^^^^^^^^^^
 
-This project is developed using the Django 4.1.7 web framework. Many configuration settings can be read in from a `.env` file. An example file `.env.example` is provided in the repository. To use the defaults simply ::
+This project is developed using the Django web framework. Many configuration settings can be read in from a `.env` file. An example file `.env.example` is provided in the repository. To use the defaults simply ::
 
     cp .env.example .env
 


### PR DESCRIPTION
we update dependencies all the time, I believe we dont need to change the readme every time when we upgrade Django framework