### PR TITLE
RHCLOUD-29631: Forcing the Bearer Token validation for request access from a Service Account

### DIFF
--- a/rbac/management/principal/it_service.py
+++ b/rbac/management/principal/it_service.py
@@ -211,7 +211,7 @@ class ITService:
                 return False
             elif len(service_accounts) == 1:
                 sa = service_accounts[0]
-                return client_id == sa.get("clientId")
+                return client_id == sa.get("clientID")
             else:
                 LOGGER.error(
                     f'unexpected number of service accounts received from IT. Wanted one with client ID "{client_id}",'

--- a/tests/management/principal/test_it_service.py
+++ b/tests/management/principal/test_it_service.py
@@ -104,7 +104,7 @@ class ITServiceTests(IdentityRequest):
     def test_is_service_account_valid_one_matching_result_from_it(self, request_service_accounts: mock.Mock):
         """Test that the function under test positively validates the given service account if IT responds with that service account."""
         client_id = "client-id-123"
-        request_service_accounts.return_value = [{"clientId": client_id}]
+        request_service_accounts.return_value = [{"clientID": client_id}]
         user = User()
         user.bearer_token = "mocked-bt"
 
@@ -118,7 +118,7 @@ class ITServiceTests(IdentityRequest):
     def test_is_service_account_valid_not_matching_result_from_it(self, request_service_accounts: mock.Mock):
         """Test that the function under test does not validate the given service account if IT does not return a response with a proper service account."""
         client_id = "client-id-123"
-        request_service_accounts.return_value = [{"clientId": "different-client-id"}]
+        request_service_accounts.return_value = [{"clientID": "different-client-id"}]
         user = User()
         user.bearer_token = "mocked-bt"
 

--- a/tests/management/test_utils.py
+++ b/tests/management/test_utils.py
@@ -161,9 +161,12 @@ class UtilsTests(IdentityRequest):
         self.assertEqual(created_service_account.type, "user")
         self.assertEqual(created_service_account.username, user.username)
 
+    @mock.patch("management.authorization.token_validator.ITSSOTokenValidator.validate_token")
     @mock.patch("management.principal.it_service.ITService.is_service_account_valid_by_username")
     @mock.patch("management.utils.verify_principal_with_proxy")
-    def test_get_principal_service_account_created(self, mocked: Mock, is_service_account_valid_by_username: Mock):
+    def test_get_principal_service_account_created(
+        self, mocked: Mock, is_service_account_valid_by_username: Mock, validate_token: Mock
+    ):
         """Test that when a service account principal does not exist in the database, it gets created."""
         # Build a non-existent service account.
         user = User()
@@ -202,6 +205,9 @@ class UtilsTests(IdentityRequest):
                 username=username, tenant=self.tenant, type=SERVICE_ACCOUNT_KEY, service_account_id=client_id
             )
 
+            # Simulate that a bearer token was given, and that it was correctly validated.
+            validate_token.return_value = "mocked-bearer-token"
+
             # Simulate that the IT service says the service account's username is valid.
             is_service_account_valid_by_username.return_value = True
 
@@ -221,18 +227,18 @@ class UtilsTests(IdentityRequest):
                 "the service account principal we created and the returned principal should be the same",
             )
 
+    @mock.patch("management.authorization.token_validator.ITSSOTokenValidator.validate_token")
     @mock.patch("management.principal.it_service.ITService.is_service_account_valid_by_username")
     def test_get_principal_from_query_service_account_not_validated_validation_error(
-        self, is_service_account_valid_by_username: Mock
+        self, is_service_account_valid_by_username: Mock, validate_token: Mock
     ):
         """Test that when the service account username cannot be validated, a validation error is raised"""
         # Create a service account principal in the database, which will be fetched by the function under test.
         client_id = uuid.uuid4()
         username = f"service-account-{client_id}"
 
-        created_principal = Principal.objects.create(
-            username=username, tenant=self.tenant, type=SERVICE_ACCOUNT_KEY, service_account_id=client_id
-        )
+        # Simulate that a bearer token was given, and that it was correctly validated.
+        validate_token.return_value = "mocked-bearer-token"
 
         # Simulate that the IT service says the service account's username is valid.
         is_service_account_valid_by_username.return_value = False
@@ -256,9 +262,10 @@ class UtilsTests(IdentityRequest):
         # Assert that the validation function gets called once.
         is_service_account_valid_by_username.assert_called_with(user=request.user, service_account_username=username)
 
+    @mock.patch("management.authorization.token_validator.ITSSOTokenValidator.validate_token")
     @mock.patch("management.principal.it_service.ITService.is_service_account_valid_by_username")
     def test_get_principal_from_query_service_account_validated_principal_exists(
-        self, is_service_account_valid_by_username: Mock
+        self, is_service_account_valid_by_username: Mock, validate_token: Mock
     ):
         """Test that when specifying the "from query" parameter the service account is validated"""
         # Create a service account principal in the database, which will be fetched by the function under test.
@@ -268,6 +275,9 @@ class UtilsTests(IdentityRequest):
         created_principal = Principal.objects.create(
             username=username, tenant=self.tenant, type=SERVICE_ACCOUNT_KEY, service_account_id=client_id
         )
+
+        # Simulate that a bearer token was given, and that it was correctly validated.
+        validate_token.return_value = "mocked-bearer-token"
 
         # Simulate that the IT service says the service account's username is valid.
         is_service_account_valid_by_username.return_value = True
@@ -290,14 +300,18 @@ class UtilsTests(IdentityRequest):
             "the service account principal we created and the returned principal should be the same",
         )
 
+    @mock.patch("management.authorization.token_validator.ITSSOTokenValidator.validate_token")
     @mock.patch("management.principal.it_service.ITService.is_service_account_valid_by_username")
     def test_get_principal_from_query_service_account_validated_principal_not_exists(
-        self, is_service_account_valid_by_username: Mock
+        self, is_service_account_valid_by_username: Mock, validate_token: Mock
     ):
         """Test that when specifying the "from query" parameter the service account is validated just once"""
         # Create a service account principal in the database, which will be fetched by the function under test.
         client_id = uuid.uuid4()
         username = f"service-account-{client_id}"
+
+        # Simulate that a bearer token was given, and that it was correctly validated.
+        validate_token.return_value = "mocked-bearer-token"
 
         # Simulate that the IT service says the service account's username is valid.
         is_service_account_valid_by_username.return_value = True
@@ -347,14 +361,18 @@ class UtilsTests(IdentityRequest):
             "the client ID of the created service account principal does not match the one given to the function under test",
         )
 
+    @mock.patch("management.authorization.token_validator.ITSSOTokenValidator.validate_token")
     @mock.patch("management.principal.it_service.ITService.is_service_account_valid_by_username")
     def test_get_principal_service_account_validated_principal_not_exists(
-        self, is_service_account_valid_by_username: Mock
+        self, is_service_account_valid_by_username: Mock, validate_token: Mock
     ):
         """Test that when the "from query" parameter is missing the service account is validated just once"""
         # Create a service account principal in the database, which will be fetched by the function under test.
         client_id = uuid.uuid4()
         username = f"service-account-{client_id}"
+
+        # Simulate that a bearer token was given, and that it was correctly validated.
+        validate_token.return_value = "mocked-bearer-token"
 
         # Simulate that the IT service says the service account's username is valid.
         is_service_account_valid_by_username.return_value = True


### PR DESCRIPTION

## Link(s) to Jira
- https://issues.redhat.com/browse/RHCLOUD-29631

## Description of Intent of Change(s)
Forcing the Bearer Token validation for request access from a Service Account

## Local Testing
How can the feature be exercised?
How can the bug be exploited and fix confirmed?
Is any special local setup required?

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
