### PR TITLE
removed example for 'usernames' query param

### DIFF
--- a/docs/source/specs/openapi.json
+++ b/docs/source/specs/openapi.json
@@ -565,8 +565,7 @@
             "description": "Comma separated usernames of principals to get. If match_criteria is specified, only the first username will be picked up for search.",
             "required": false,
             "schema": {
-              "type": "string",
-              "example": "userA,userB"
+              "type": "string"
             }
           },
           {


### PR DESCRIPTION
**this PR is draft for open api spec improvements**

open api spec updates
- removed schema's example for `usernames` query param -> this value was used as default value in the swagger si it always had to be manually removed (=annoying)