### PR TITLE
RHCLOUD-29641: Validate Service Account usernames before requests

### DIFF
--- a/rbac/management/principal/it_service.py
+++ b/rbac/management/principal/it_service.py
@@ -35,6 +35,7 @@ from .unexpected_status_code_from_it import UnexpectedStatusCodeFromITError
 LOGGER = logging.getLogger(__name__)
 SERVICE_ACCOUNT_CLIENT_IDS_KEY = "service_account_client_ids"
 TYPE_SERVICE_ACCOUNT = "service-account"
+KEY_SERVICE_ACCOUNT = "service-account-"
 
 # IT path to fetch the service accounts.
 IT_PATH_GET_SERVICE_ACCOUNTS = "/service_accounts/v1"
@@ -191,7 +192,7 @@ class ITService:
             return True
 
         if self.is_username_service_account(service_account_username):
-            client_id = service_account_username.replace("service-account-", "")
+            client_id = service_account_username.replace(KEY_SERVICE_ACCOUNT, "")
         else:
             client_id = service_account_username
 
@@ -376,25 +377,32 @@ class ITService:
     @staticmethod
     def is_username_service_account(username: str) -> bool:
         """Check if the given username belongs to a service account."""
-        return username.startswith("service-account-")
+        starts_with = username.startswith(KEY_SERVICE_ACCOUNT)
+
+        # Validate the UUID for the ClientID reference
+        if starts_with:
+            try:
+                if username.count(KEY_SERVICE_ACCOUNT) != 1:
+                    raise ValueError
+
+                uuid.UUID(username.replace(KEY_SERVICE_ACCOUNT, ""))
+            except ValueError:
+                raise serializers.ValidationError({"detail": "Invalid format for a Service Account username"})
+
+        return starts_with
 
     @staticmethod
     def extract_client_id_service_account_username(username: str) -> uuid.UUID:
         """Extract the client ID from the service account's username."""
         # If it has the "service-account" prefix, we just need to strip it and return the rest of the username, which
         # contains the client ID. Else, we have just received the client ID.
-        try:
-            if ITService.is_username_service_account(username=username):
-                return uuid.UUID(username.replace("service-account-", ""))
-            else:
+        if ITService.is_username_service_account(username=username):
+            return uuid.UUID(username.replace(KEY_SERVICE_ACCOUNT, ""))
+        else:
+            try:
                 return uuid.UUID(username)
-        except ValueError:
-            raise serializers.ValidationError(
-                {
-                    "detail": "unable to extract the client ID from the service account's username because the"
-                    " provided UUID is invalid"
-                }
-            )
+            except ValueError:
+                raise serializers.ValidationError({"detail": "Invalid ClientId for a Service Account username"})
 
     def generate_service_accounts_report_in_group(self, group: Group, client_ids: set[str]) -> dict[str, bool]:
         """Check if the given service accounts are in the specified group."""

--- a/tests/management/principal/test_it_service.py
+++ b/tests/management/principal/test_it_service.py
@@ -239,15 +239,28 @@ class ITServiceTests(IdentityRequest):
             "the client ID was not correctly extracted from a full username",
         )
 
-        # Call the function under test with an invalid username which contains a bad formed UUID.
+        # Call the function under test with a username without client ID (UUID).
         try:
-            ITService.extract_client_id_service_account_username(username="abcde")
+            self.assertFalse(ITService.extract_client_id_service_account_username(username="abcde"))
             self.fail(
                 "when providing an invalid UUID as the client ID to be extracted, the function under test should raise an error"
             )
         except serializers.ValidationError as ve:
             self.assertEqual(
-                "unable to extract the client ID from the service account's username because the provided UUID is invalid",
+                "Invalid ClientId for a Service Account username",
+                str(ve.detail.get("detail")),
+                "unexpected error message when providing an invalid UUID as the client ID",
+            )
+
+        # Call the function under test with an invalid username which contains a bad formed UUID.
+        try:
+            ITService.extract_client_id_service_account_username(username="service-account-xxxxx")
+            self.fail(
+                "when providing an invalid UUID as the client ID to be extracted, the function under test should raise an error"
+            )
+        except serializers.ValidationError as ve:
+            self.assertEqual(
+                "Invalid format for a Service Account username",
                 str(ve.detail.get("detail")),
                 "unexpected error message when providing an invalid UUID as the client ID",
             )


### PR DESCRIPTION
## Link(s) to Jira
- RHCLOUD-29641

## Description of Intent of Change(s)
Validate Service Account usernames before requests

## Local Testing
How can the feature be exercised?
How can the bug be exploited and fix confirmed?
Is any special local setup required?

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
