### PR TITLE
move the queryset pagination after principals check in BOP - to calculate the count properly

### DIFF
--- a/tests/internal/integration/test_integration_views.py
+++ b/tests/internal/integration/test_integration_views.py
@@ -290,7 +290,16 @@ class IntegrationViewsTests(IdentityRequest):
                     "username": "user_a",
                     "account_number": "1111111",
                     "is_active": True,
-                }
+                },
+                {
+                    "org_id": "100001",
+                    "is_org_admin": False,
+                    "is_internal": False,
+                    "id": 52567474,
+                    "username": "user_admin",
+                    "account_number": "1111111",
+                    "is_active": True,
+                },
             ],
         },
     )


### PR DESCRIPTION
before this change we ran the removed code only because we need the list of usernames
but we can get the usernames directly from `principals_from_params`
when this variable doesnt contains any principal, it returns the empty list `[]` and that is what we need
so for this case we just get list of usernames and then validate it via BOP

this code set the `count` value
`self.paginate_queryset(resp.get("data"))`