### PR TITLE
[RHCLOUD-31297] fix for '_generate_error_data_payload_response' and missing 'basename' attribute

### DIFF
--- a/rbac/api/common/exception_handler.py
+++ b/rbac/api/common/exception_handler.py
@@ -74,7 +74,7 @@ def _generate_error_data_payload_response(detail: str, context, http_status_code
 
     # Some exceptions might be raised from places that are not views.
     view = context.get("view")
-    if view:
+    if view and hasattr(view, "basename"):
         data["errors"][0]["source"] = view.basename
 
     return data

--- a/tests/api/common/test_exception_handler.py
+++ b/tests/api/common/test_exception_handler.py
@@ -207,10 +207,38 @@ class ExceptionHandlerTest(TestCase):
 
         self.assertEqual(detail, only_error.get("detail"), f"unexpected detail message in the payload: {result}")
 
+        self.assertEqual(mocked_view.basename, only_error.get("source"), f"unexpected source in the payload: {result}")
+
         self.assertEqual(
-            mocked_view.basename, only_error.get("source"), f"unexpected detail message in the payload: {result}"
+            str(http_status_code), only_error.get("status"), f"unexpected status code in the payload: {result}"
         )
 
+    def test_generate_error_data_payload_without_view_basename(self):
+        """
+        Tests that the function under test generates the data payload correctly
+        when a view is passed in the context without basename attribute."""
+        # Prepare a payload with a view in the context without "basename" attribute.
+        detail = "some error message"
+        context = {"view": []}
+        http_status_code = status.HTTP_200_OK
+
+        # Call the function under test.
+        result = _generate_error_data_payload_response(
+            detail=detail, context=context, http_status_code=http_status_code
+        )
+
+        # Assert that the correct structure is returned.
+        errors = result.get("errors")
+        if not errors:
+            self.fail(f"the errors array was not present in the payload: {result}")
+
+        if len(errors) != 1:
+            self.fail(f"only one error was expected in the payload: {result}")
+
+        only_error = errors[0]
+
+        self.assertEqual(detail, only_error.get("detail"), f"unexpected detail message in the payload: {result}")
+        self.assertIsNone(only_error.get("source"), f"unexpected 'source' in the payload: {result}")
         self.assertEqual(
             str(http_status_code), only_error.get("status"), f"unexpected status code in the payload: {result}"
         )


### PR DESCRIPTION
as discussed on Slack [here](https://redhat-internal.slack.com/archives/C023NSG08N7/p1709537652285719?thread_ts=1709279193.467249&cid=C023NSG08N7)

we need to check if `basename` attribute is present to get 401 instead of 500

**how to test locally:**
enable the token validation in .env file
```
IT_BYPASS_TOKEN_VALIDATION=False
IT_SERVICE_PROTOCOL_SCHEME=https
IT_SERVICE_HOST=sso.stage.redhat.com
IT_SERVICE_PORT=443
```
send `GET /api/rbac/v1/principals/?type=service-account` request with invalid Bearer Token
now you get `500 Internal Server Error`
```
<!doctype html>
<html lang="en">

<head>
    <title>Server Error (500)</title>
</head>

<body>
    <h1>Server Error (500)</h1>
    <p></p>
</body>

</html>
```


after change you will get **401 Unauthorized**
```
{
    "errors": [
        {
            "detail": "Invalid token provided.",
            "status": "401"
        }
    ]
}
```
