### PR TITLE
[RHCLOUD-31315] limit the 'principalCount' value to user based principals only

### DIFF
--- a/rbac/management/group/view.py
+++ b/rbac/management/group/view.py
@@ -24,6 +24,7 @@ import requests
 from django.conf import settings
 from django.db import connection
 from django.db import transaction
+from django.db.models import Q
 from django.db.models.aggregates import Count
 from django.utils.translation import gettext as _
 from django_filters import rest_framework as filters
@@ -160,7 +161,8 @@ class GroupViewSet(
     """
 
     queryset = Group.objects.annotate(
-        principalCount=Count("principals", distinct=True), policyCount=Count("policies", distinct=True)
+        principalCount=Count("principals", filter=Q(principals__type="user"), distinct=True),
+        policyCount=Count("policies", distinct=True),
     )
     permission_classes = (GroupAccessPermission,)
     lookup_field = "uuid"

--- a/rbac/management/querysets.py
+++ b/rbac/management/querysets.py
@@ -16,7 +16,7 @@
 #
 """Queryset helpers for management module."""
 from django.conf import settings
-from django.db.models import QuerySet
+from django.db.models import Q, QuerySet
 from django.db.models.aggregates import Count
 from django.urls import reverse
 from django.utils.translation import gettext as _
@@ -60,7 +60,8 @@ PRINCIPAL_QUERYSET_MAP = {
 def get_annotated_groups():
     """Return an annotated set of groups for the tenant."""
     return Group.objects.annotate(
-        principalCount=Count("principals", distinct=True), policyCount=Count("policies", distinct=True)
+        principalCount=Count("principals", filter=Q(principals__type="user"), distinct=True),
+        policyCount=Count("policies", distinct=True),
     )
 
 


### PR DESCRIPTION
JIRA: [RHCLOUD-31315](https://issues.redhat.com/browse/RHCLOUD-31315)

for Service Accounts feature we split the principals into 2 groups:
- user based principals
- service account based principals

to following this pattern when we want to list all principals, we have to use 2 requests

example:
- list all user based principals `GET api/rbac/v1/principals/ `
- list all service account based principals `GET api/rbac/v1/principals/?type=service-account`

------------

there are another endpoints where we have to implement this attitude
`GET api/rbac/v1/groups/` returns list of groups in the tenant, the group object contains field `principalCount` and value is calculated as count of all (user based and service account based) principals in the group
=> this needs to be changed as ** the number of only user based principals**

similar for `PUT api/rbac/v1/groups/{uuid}`

-------------
**how to test:**
- create new rbac group
- add 1 user based principal into this group
- add 1 service account based principal into this group
- list all groups `GET api/rbac/v1/groups/` and check the value of the `principalCount` for your group

now: principalCount = 2
expected: principalCount = 1