### PR TITLE
[RHCLOUD-31333] pagination fix for 'groups/{uuid}/principals' endpoint

### DIFF
--- a/rbac/management/group/view.py
+++ b/rbac/management/group/view.py
@@ -823,8 +823,8 @@ class GroupViewSet(
             if isinstance(resp, dict) and "errors" in resp:
                 return Response(status=resp.get("status_code"), data=resp.get("errors"))
 
-            self.paginate_queryset(resp.get("data"))
-            response = self.get_paginated_response(resp.get("data"))
+            page = self.paginate_queryset(resp.get("data"))
+            response = self.get_paginated_response(page)
         else:
             self.protect_system_groups("remove principals")
 


### PR DESCRIPTION
JIRA [RHCLOUD-31333](https://issues.redhat.com/browse/RHCLOUD-31333)

this will fix the pagination for `api/rbac/v1/groups/{group-uuid}/principals/`
and for internal endpoint `api/v1/integrations/tenant/{org_id}/groups/{group-uuid}/principals/`

now:
pagination is not working = all principals are returned and limit and offset are ignored

expected:
pagination is working according given limit and offset