### PR TITLE
refactor: removed redundant initialization of variable res_list

### DIFF
--- a/rbac/rbac/middleware.py
+++ b/rbac/rbac/middleware.py
@@ -153,7 +153,6 @@ class IdentityHeaderMiddleware(MiddlewareMixin):
             for access_item in access_list:  # pylint: disable=too-many-nested-blocks
                 resource_type = access_item.permission.resource_type
                 operation = access_item.permission.verb
-                res_list = []
                 if operation == "*":
                     operation = "write"
                 res_list = ["*"]


### PR DESCRIPTION
the variable `res_list` is initialised few rows below so the first initialisation is not needed