### PR TITLE
[RHCLOUD-30108] all principals can list the system roles under a tenant

### DIFF
--- a/rbac/management/permissions/role_access.py
+++ b/rbac/management/permissions/role_access.py
@@ -31,6 +31,9 @@ class RoleAccessPermission(permissions.BasePermission):
         if request.user.admin:
             return True
         if request.method in permissions.SAFE_METHODS:
+            system_param = request.query_params.get("system")
+            if system_param and system_param.lower() == "true":
+                return True
             if is_scope_principal(request):
                 return True
             role_read = request.user.access.get("role", {}).get("read", [])

--- a/rbac/management/querysets.py
+++ b/rbac/management/querysets.py
@@ -205,6 +205,9 @@ def get_role_queryset(request) -> QuerySet:
         return base_query
     if request.user.admin:
         return base_query
+    system_param = request.query_params.get("system")
+    if system_param and system_param.lower() == "true":
+        return base_query
     access = user_has_perm(request, "role")
     if access == "All":
         return base_query

--- a/tests/management/role/test_view.py
+++ b/tests/management/role/test_view.py
@@ -1670,3 +1670,43 @@ class RoleViewNonAdminTests(IdentityRequest):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         expected_count = self.system_roles_count + 1
         self.assertEqual(len(response.data.get("data")), expected_count)
+
+    def test_list_roles_without_User_Access_Admin_system_false_fail(self):
+        """
+        Test that principal without 'User Access administrator' role cannot read a list of roles
+        with '?system=false' in the request.
+        """
+        client = APIClient()
+        url = reverse("role-list") + "?system=false"
+
+        response = client.get(url, **self.headers_user_based_principal)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.data.get("errors")[0].get("detail"), self.no_permission_err_message)
+
+        response = client.get(url, **self.headers_service_account_principal)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.data.get("errors")[0].get("detail"), self.no_permission_err_message)
+
+        # Org Admin can list the roles
+        response = client.get(url, **self.headers_org_admin)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data.get("data")), self.non_system_roles_count)
+
+    def test_list_roles_with_User_Access_Admin_system_false_success(self):
+        """
+        Test that principal with 'User Access administrator' role can read a list of roles
+        with '?system=false' in the request.
+        """
+        # Create a group with 'User Access administrator' role and add principals we use in headers
+        group_with_UA_admin = self._create_group_with_user_access_admin_role(self.tenant)
+        group_with_UA_admin.principals.add(self.user_based_principal, self.service_account_principal)
+        client = APIClient()
+        url = reverse("role-list") + "?system=false"
+
+        response = client.get(url, **self.headers_user_based_principal)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data.get("data")), self.non_system_roles_count)
+
+        response = client.get(url, **self.headers_service_account_principal)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data.get("data")), self.non_system_roles_count)

--- a/tests/management/role/test_view.py
+++ b/tests/management/role/test_view.py
@@ -1591,3 +1591,45 @@ class RoleViewNonAdminTests(IdentityRequest):
         )
         policy_for_rbac_admin_group.roles.add(user_access_administrator_role)
         return rbac_admin_group
+
+    def test_list_roles_without_User_Access_Admin_fail(self):
+        """
+        Test that principal without 'User Access administrator' role cannot read a list of roles.
+        """
+        client = APIClient()
+        url = reverse("role-list")
+
+        response = client.get(url, **self.headers_user_based_principal)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.data.get("errors")[0].get("detail"), self.no_permission_err_message)
+
+        response = client.get(url, **self.headers_service_account_principal)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.data.get("errors")[0].get("detail"), self.no_permission_err_message)
+
+        # Org Admin can list the roles
+        response = client.get(url, **self.headers_org_admin)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        expected_count = self.system_roles_count + self.non_system_roles_count
+        self.assertEqual(len(response.data.get("data")), expected_count)
+
+    def test_list_roles_with_User_Access_Admin_success(self):
+        """
+        Test that principal with 'User Access administrator' role can read a list of roles.
+        """
+        # Create a group with 'User Access administrator' role and add principals we use in headers
+        group_with_UA_admin = self._create_group_with_user_access_admin_role(self.tenant)
+        group_with_UA_admin.principals.add(self.user_based_principal, self.service_account_principal)
+
+        client = APIClient()
+        url = reverse("role-list")
+
+        response = client.get(url, **self.headers_user_based_principal)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        expected_count = self.system_roles_count + self.non_system_roles_count + 1
+        self.assertEqual(len(response.data.get("data")), expected_count)
+
+        response = client.get(url, **self.headers_service_account_principal)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        expected_count = self.system_roles_count + self.non_system_roles_count + 1
+        self.assertEqual(len(response.data.get("data")), expected_count)

--- a/tests/management/role/test_view.py
+++ b/tests/management/role/test_view.py
@@ -1561,3 +1561,33 @@ class RoleViewNonAdminTests(IdentityRequest):
         test_tenant_org_id = "100001"
         cached_tenants = TenantCache()
         cached_tenants.delete_tenant(test_tenant_org_id)
+
+    @staticmethod
+    def _create_group_with_user_access_admin_role(tenant):
+        """Create a group with a 'User Access administrator' role."""
+        # Create a group with 'User Access administrator' role
+        rbac_admin_permission = Permission.objects.create(
+            application="rbac", permission="rbac:*:*", resource_type="*", verb="*", tenant=tenant
+        )
+        user_access_administrator_role = Role.objects.create(
+            admin_default=True,
+            description="User Access administrator role description",
+            display_name="User Access administrator",
+            platform_default=False,
+            system=True,
+            tenant=tenant,
+        )
+        Access.objects.create(permission=rbac_admin_permission, role=user_access_administrator_role, tenant=tenant)
+        rbac_admin_group = Group.objects.create(
+            admin_default=False,
+            description="A group with the 'User Access administrator' role",
+            name="rbac_admin_group",
+            platform_default=False,
+            system=False,
+            tenant=tenant,
+        )
+        policy_for_rbac_admin_group = Policy.objects.create(
+            group=rbac_admin_group, name="Policy for rbac_admin_group", system=True, tenant=tenant
+        )
+        policy_for_rbac_admin_group.roles.add(user_access_administrator_role)
+        return rbac_admin_group


### PR DESCRIPTION
## Link(s) to Jira
- [RHCLOUD-31592](https://issues.redhat.com/browse/RHCLOUD-31592)
- [RHCLOUD-30108](https://issues.redhat.com/browse/RHCLOUD-30108)

## Description of Intent of Change(s)
we found that behaviour in [RHCLOUD-30108](https://issues.redhat.com/browse/RHCLOUD-30108) is caused because the `/roles/` endpoint is called with the `?system=true` query param and this action requires to be org admin or RBAC admin (= user with the 'User Access administrator' role) ... after discussion we decided that all users should have an access to the system roles (defined in the [rbac-config](https://github.com/RedHatInsights/rbac-config) repo)

## Local Testing
send the request to the `roles` endpoint with or without `system` query param
```
GET /api/rbac/v1/roles/
GET /api/rbac/v1/roles/?system=true
GET /api/rbac/v1/roles/?system=false
```
you need to be an org admin or user with 'User Access administrator' role to list roles under a tenant
or 
with `?system=true` query param all users can list roles under a tenant
(detailed AC Checklist here [RHCLOUD-31592](https://issues.redhat.com/browse/RHCLOUD-31592))

