### PR TITLE
Modify docker compose file to work with podman

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.9'
-
 services:
   rbac-server:
       container_name: rbac_server

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,8 +42,6 @@ services:
           - 9080:8080
       volumes:
         - '.:/rbac/'
-      links:
-        - db
       depends_on:
         db:
           condition: service_healthy
@@ -65,8 +63,6 @@ services:
       working_dir: /opt/rbac/rbac
       entrypoint: ['celery', '--broker=redis://redis:6379/0', '-A', 'rbac.celery', 'worker', '--loglevel=INFO']
       privileged: true
-      links:
-          - redis
       depends_on:
         redis:
           condition: service_healthy
@@ -84,8 +80,6 @@ services:
       working_dir: /opt/rbac/rbac
       entrypoint: ['celery', '--broker=redis://redis:6379/0', '-A', 'rbac.celery', 'beat', '--loglevel=INFO']
       privileged: true
-      links:
-          - redis
       depends_on:
         redis:
           condition: service_healthy
@@ -113,10 +107,11 @@ services:
     - POSTGRES_DB=postgres
     - POSTGRES_USER=postgres
     - POSTGRES_PASSWORD=postgres
+    - PGDATA=/var/lib/postgresql/data/pgdata
     ports:
       - "15432:5432"
     volumes:
-      - ./pg_data:/var/lib/postgresql/data:z
+      - pg_data:/var/lib/postgresql/data
     healthcheck:
       test: [ "CMD-SHELL", "pg_isready -U postgres" ]
       interval: 5s
@@ -130,6 +125,9 @@ services:
     depends_on:
       rbac-server:
         condition: service_healthy
+
+volumes:
+  pg_data:
 
 networks:
   default:


### PR DESCRIPTION
## Link(s) to Jira
- This is what I did to be able to run the following and have it work: 

```
podman compose up --build 
```

## Description of Intent of Change(s)
Since we are moving to podman - our compose file was incompatible. Please make sure these changes work for you 

## Local Testing
How can the feature be exercised?
How can the bug be exploited and fix confirmed?
Is any special local setup required?

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
