### PR TITLE
refactor(dev): update postgresql-rds image tag

### DIFF
--- a/unit_test.sh
+++ b/unit_test.sh
@@ -14,7 +14,7 @@ docker run -d \
     -e POSTGRESQL_USER=root \
     -e POSTGRESQL_PASSWORD=root \
     -e POSTGRESQL_DATABASE=rbac \
-    quay.io/cloudservices/postgresql-rds:14-1
+    quay.io/cloudservices/postgresql-rds:14
 
 PORT=$(docker inspect $DB_CONTAINER | grep HostPort | sort | uniq | grep -o [0-9]*)
 echo "DB Listening on Port: ${PORT}"


### PR DESCRIPTION

## Link(s) to Jira
-

## Description of Intent of Change(s)
postgresql-rds "-1" images are being deprecated; moving to postgresql-rds:14 instead

## Local Testing
How can the feature be exercised?
How can the bug be exploited and fix confirmed?
Is any special local setup required?

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
