### PR TITLE
[RHCLOUD-32067] List groups principal scope

### DIFF
--- a/rbac/management/querysets.py
+++ b/rbac/management/querysets.py
@@ -96,13 +96,15 @@ def get_group_queryset(request, args=None, kwargs=None):
 
 def _gather_group_querysets(request, args, kwargs):
     """Decide which groups to provide for request."""
+    username = request.query_params.get("username")
+
     if settings.AUTHENTICATE_WITH_ORG_ID:
         scope = request.query_params.get(SCOPE_KEY, ORG_ID_SCOPE)
-        if scope != ORG_ID_SCOPE:
+        if scope != ORG_ID_SCOPE and not username:
             return get_object_principal_queryset(request, scope, Group)
     else:
         scope = request.query_params.get(SCOPE_KEY, ACCOUNT_SCOPE)
-        if scope != ACCOUNT_SCOPE:
+        if scope != ACCOUNT_SCOPE and not username:
             return get_object_principal_queryset(request, scope, Group)
 
     public_tenant = Tenant.objects.get(tenant_name="public")
@@ -110,7 +112,6 @@ def _gather_group_querysets(request, args, kwargs):
         tenant=request.tenant
     ) or Group.platform_default_set().filter(tenant=public_tenant)
 
-    username = request.query_params.get("username")
     exclude_username = request.query_params.get("exclude_username")
 
     if username and exclude_username:

--- a/tests/management/group/test_view.py
+++ b/tests/management/group/test_view.py
@@ -4734,17 +4734,11 @@ class GroupViewNonAdminTests(IdentityRequest):
 
         # Adding the 'scope' param doesn't affect the response because the 'scope' param is ignored
         # when query contains the 'username' param
-        for scope in ("org_id", "principal"):
+        for scope in ("org_id", "principal", "foo"):
             url_with_scope = url + f"&scope={scope}"
             response = client.get(url_with_scope, format="json", **self.headers_user_based_principal)
             self.assertEqual(response.status_code, status.HTTP_200_OK)
             self.assertEqual(len(response.data.get("data")), 1)
-
-        # For invalid 'scope' param the 400 response is returned
-        url_with_scope = url + "&scope=foo"
-        response = client.get(url_with_scope, format="json", **self.headers_user_based_principal)
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEqual(response.data.get("errors")[0].get("detail"), self.invalid_value_for_scope_query_param)
 
     @patch(
         "management.principal.proxy.PrincipalProxy.request_filtered_principals",


### PR DESCRIPTION
## Link(s) to Jira
- [RHCLOUD-32067](https://issues.redhat.com/browse/RHCLOUD-32067)

## Description of Intent of Change(s)
when query params `scope=principal` and `username=<same-username-as-in-header>` are used in one request GET /groups/, the response is 403 but 200 is expected

## Local Testing
send request with non admin user in header (non org admin, non rbac admin)
`GET /groups/?scope=principal&username<same-username-as-your-user-in-header>`
now the response is 403
after fix 200 + all principal's groups are listed in response

this should work for
- user based non admin principal
- service account based non admin principal

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
