### PR TITLE
[RHCLOUD-31133] Service Account filter by username fix

### DIFF
--- a/rbac/management/principal/it_service.py
+++ b/rbac/management/principal/it_service.py
@@ -331,10 +331,12 @@ class ITService:
             group_service_account_principals = group_service_account_principals.order_by(order_by)
 
         # Check if we should filter the service accounts by the username that the user specified.
+        # In this case we want to ignore the prefix "service-account-" in the SA username and
+        # filter records only by SA client ID (uuid).
         principal_username = options.get("principal_username")
         if principal_username:
             group_service_account_principals = group_service_account_principals.filter(
-                username__contains=principal_username
+                service_account_id__contains=principal_username
             )
 
         # If we are in an ephemeral or test environment, we will take all the service accounts of the user that are

--- a/tests/management/principal/test_it_service.py
+++ b/tests/management/principal/test_it_service.py
@@ -955,7 +955,7 @@ class ITServiceTests(IdentityRequest):
 
         # Set up the options for the function. The username is trimmed and set, to check that the "contains" condition
         # works as expected.
-        options = {"principal_username": sa_principals_should_be_in_group[0].username[:-10]}
+        options = {"principal_username": sa_principals_should_be_in_group[0].username[:-10].strip("service-account-")}
 
         # Call the function under test.
         result = self.it_service.get_service_accounts_group(group=group_a, user=user, options=options)


### PR DESCRIPTION
## Link(s) to Jira
- [RHCLOUD-31133](https://issues.redhat.com/browse/RHCLOUD-31133)

## Description of Intent of Change(s)
- the UI needs to filter SA by client ID, the RBAC backend doesn't support this 
- because the value of service account username = prefix `service-account-` + client ID and RBAC backend supports filtering by username we decided to ignore the prefix `service-account-` for service accounts filtering by username (= with query param `principal_username` in the request)

## Local Testing
create a group with 2 service account based principals
- one SA contains character "a" in the uuid (e.g. `07f2420a-424e-4c2f-a52f-0fe160097d7e`)
- second SA doesn't contain character "a" in the uuid (e.g. `e78dc6b2-5930-4649-999f-266f4b926f3e`)
try to filter service accounts by username = "a" and only SA with "a" in the client ID should occurred in the response
```
http://localhost:8000/api/rbac/v1/groups/{{group-uuid}}/principals/?principal_type=service-account&principal_username=a
```

(because we ignore the `service-account-` prefix, the "a" found in this prefix is ignored)
