### PR TITLE
Fix calling params if not set

### DIFF
--- a/rbac/internal/views.py
+++ b/rbac/internal/views.py
@@ -473,6 +473,14 @@ def ocm_performance(request):
     return HttpResponse('Invalid method, only "POST" is allowed.', status=405)
 
 
+def get_param_list(request, param_name):
+    """Get a list of params from a request."""
+    params = request.GET.get(param_name, [])
+    if params:
+        params = params.split(",")
+    return params
+
+
 def role_migration(request):
     """View method for running role migrations from V1 to V2 spiceDB schema.
 
@@ -481,9 +489,10 @@ def role_migration(request):
     if request.method != "POST":
         return HttpResponse('Invalid method, only "POST" is allowed.', status=405)
     logger.info("Running V1 Role migration.")
+
     args = {
-        "exclude_apps": request.GET.get("exclude_apps", "").split(","),
-        "orgs": request.GET.get("orgs", "").split(","),
+        "exclude_apps": get_param_list(request, "exclude_apps"),
+        "orgs": get_param_list(request, "orgs"),
     }
     migrate_roles_in_worker.delay(args)
     return HttpResponse("Role migration from V1 to V2 are running in a background worker.", status=202)

--- a/tests/internal/test_views.py
+++ b/tests/internal/test_views.py
@@ -479,3 +479,16 @@ class InternalViewsetTests(IdentityRequest):
             response.content.decode(),
             "Role migration from V1 to V2 are running in a background worker.",
         )
+
+        # Without params
+        migration_mock.reset_mock()
+        response = self.client.post(
+            f"/_private/api/utils/role_migration/",
+            **self.request.META,
+        )
+        migration_mock.assert_called_once_with({"exclude_apps": [], "orgs": []})
+        self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
+        self.assertEqual(
+            response.content.decode(),
+            "Role migration from V1 to V2 are running in a background worker.",
+        )


### PR DESCRIPTION
If the param, e.g. orgs, is not set, the the params will be [""], which will cause the job not finding any tenants since checking orgs empty would fail and tenants = tenants.filter(org_id__in=orgs) will be run

## Link(s) to Jira
-

## Description of Intent of Change(s)
The what, why and how.

## Local Testing
How can the feature be exercised?
How can the bug be exploited and fix confirmed?
Is any special local setup required?

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
