### PR TITLE
add '/openapi.json' endpoint into internal open api spec

### DIFF
--- a/rbac/internal/specs/openapi.json
+++ b/rbac/internal/specs/openapi.json
@@ -1037,6 +1037,28 @@
           }
         }
       }
+    },
+    "/openapi.json": {
+      "get": {
+        "tags": [
+          "Other operations"
+        ],
+        "summary": "Get API document in JSON format",
+        "description": "Get document for Internal Integrations API for Role Based Access Control.",
+        "operationId": "openapi",
+        "responses": {
+          "200": {
+            "description": "The API document for Internal RBAC endpoints.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "servers": [


### PR DESCRIPTION
we provide the internal endpoint /openapi.json but we don't have it in internal open api spec

test:
run RBAC locally and send request
```
GET http://localhost:8000/_private/api/v1/openapi.json
```
with internal user in `x-rh-identity` (`"type":"Associate"`)