### PR TITLE
RBAC pr-check simplification

### DIFF
--- a/Dockerfile-pr-check
+++ b/Dockerfile-pr-check
@@ -1,20 +1,11 @@
 FROM registry.access.redhat.com/ubi8/python-39:latest
 WORKDIR $APP_ROOT
 USER root
-COPY Pipfile .
-COPY Pipfile.lock .
-COPY tox.ini .
-COPY mypy.ini .
-COPY requirements.txt .
-COPY Makefile .
 
 # install related pip dependencies
 ENV PIP_DEFAULT_TIMEOUT=100
 RUN pip install --upgrade pip
-RUN pip install pipenv
 RUN pip install tox
-RUN pipenv install --deploy && \
-    pipenv --clear
 
 #copy the src files
 COPY . .

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -29,5 +29,5 @@ source $CICD_ROOT/deploy_ephemeral_env.sh
 # Run smoke tests with ClowdJobInvocation
 source $CICD_ROOT/cji_smoke_test.sh
 
-#Run the new image for the unit_tests and run the unit tests
+# Run the new image for the unit_tests and run the unit tests
 source $APP_ROOT/unit_test.sh


### PR DESCRIPTION
we dont need to install all dependencies because the `tox` will create own virtual environment and install everything is needed https://github.com/RedHatInsights/insights-rbac/blob/281ad3a730f588eeeee6af891df67ba5003d09ba/tox.ini#L40

**how to test:**
pr-check is running successfully with unit tests + linters + mypy check