### PR TITLE
RBAC Grafana dashboard - update unit for 'Requests duration 99 % quantile'

### DIFF
--- a/dashboards/grafana-dashboard-insights-rbac-operations.configmap.yaml
+++ b/dashboards/grafana-dashboard-insights-rbac-operations.configmap.yaml
@@ -2870,7 +2870,6 @@ data:
                       "mode": "off"
                     }
                   },
-                  "decimals": 3,
                   "mappings": [],
                   "min": 0,
                   "thresholds": {
@@ -2886,7 +2885,7 @@ data:
                       }
                     ]
                   },
-                  "unit": "ms"
+                  "unit": "s"
                 },
                 "overrides": []
               },
@@ -3906,7 +3905,7 @@ data:
       "timezone": "",
       "title": "Operations - Rbac w/CPU",
       "uid": "TjP_nMWMk",
-      "version": 8,
+      "version": 9,
       "weekStart": ""
     }
 kind: ConfigMap


### PR DESCRIPTION
before
![image](https://github.com/RedHatInsights/insights-rbac/assets/89980168/3cc1f3e7-bc95-4a6c-95d2-a95a3a3a9c6e)
