### PR TITLE
set cpu and memory resources for the worker init container

### DIFF
--- a/deploy/rbac-clowdapp.yml
+++ b/deploy/rbac-clowdapp.yml
@@ -42,6 +42,13 @@ objects:
             command:
               - sh
               - /opt/rbac/deploy/init-container-setup.sh
+            resources:
+              limits:
+                cpu: ${INIT_WORKER_CPU_LIMIT}
+                memory: ${INIT_WORKER_MEMORY_LIMIT}
+              requests:
+                cpu: ${INIT_WORKER_CPU_REQUEST}
+                memory: ${INIT_WORKER_MEMORY_REQUEST}
         command:
           - /bin/bash
           - '-c'
@@ -765,6 +772,22 @@ parameters:
   displayName: Memory Limit
   name: CELERY_WORKER_MEMORY_LIMIT
   value: 512Mi
+- description: Initial amount of CPU the init worker container will request.
+  displayName: RBAC worker init container CPU Resource Request
+  name: INIT_WORKER_CPU_REQUEST
+  value: 500m
+- description: Maximum amount of CPU the init worker container can use.
+  displayName: RBAC worker init container CPU Resource Limit
+  name: INIT_WORKER_CPU_LIMIT
+  value: 2000m
+- description: Initial amount of memory the init worker container will request.
+  displayName: RBAC worker init container Memory Resource Request
+  name: INIT_WORKER_MEMORY_REQUEST
+  value: 512Mi
+- description: Maximum amount of memory the init worker container can use.
+  displayName: RBAC worker init container Memory Resource Limit
+  name: INIT_WORKER_MEMORY_LIMIT
+  value: 3Gi
 - displayName: Django Debug
   name: DJANGO_DEBUG
   value: 'False'


### PR DESCRIPTION
the rbac worker init container runs migrations and seeding jobs that are very cpu and memory intensive so we want to set resources separately for init container and for the worker container itself

![image](https://github.com/user-attachments/assets/35505c30-c8cd-4ebe-b08b-a3c0b4b0643b)
https://grafana.stage.devshift.net/d/HXbU7G1Iz/aandm-resources-health?orgId=1&from=1721143635069&to=1721145097089&var-Datasource=crcp01ue1-prometheus