### PR TITLE
update example value for cross account requests in open api spec

### DIFF
--- a/docs/source/specs/openapi.json
+++ b/docs/source/specs/openapi.json
@@ -3718,7 +3718,7 @@
             "type": "array",
             "items": {
               "type": "string",
-              "example": "Role Name"
+              "example": "Role Display Name"
             }
           }
         }
@@ -3742,7 +3742,7 @@
             "type": "array",
             "items": {
               "type": "string",
-              "example": "Role Name"
+              "example": "Role Display Name"
             }
           }
         }
@@ -3761,7 +3761,7 @@
             "type": "array",
             "items": {
               "type": "string",
-              "example": "Role Name"
+              "example": "Role Display Name"
             }
           },
           "status": {


### PR DESCRIPTION
`POST + PUT + PATCH /cross_account_requests` endpoints uses role display name in the json payloads (and if the role doesn't have a `display_name` then rbac [populates](https://github.com/RedHatInsights/insights-rbac/blob/5a71008586d0ef495dfbdcd98aea39589e762190/rbac/management/role/model.py#L62-L66) the `name` property