### PR TITLE
[RHCLOUD-28571] remove catalog app from ROLE_CREATE_ALLOW_LIST

### DIFF
--- a/deploy/rbac-clowdapp.yml
+++ b/deploy/rbac-clowdapp.yml
@@ -727,7 +727,7 @@ parameters:
   value: 'False'
 - description: Application allow list for role creation in RBAC
   name: ROLE_CREATE_ALLOW_LIST
-  value: cost-management,remediations,inventory,drift,policies,advisor,catalog,approval,vulnerability,compliance,automation-analytics,notifications,patch,integrations,ros,staleness,config-manager,idmsvc
+  value: cost-management,remediations,inventory,drift,policies,advisor,approval,vulnerability,compliance,automation-analytics,notifications,patch,integrations,ros,staleness,config-manager,idmsvc
 - description: Timestamp expiration allowance on destructive actions through the internal RBAC API
   name: RBAC_DESTRUCTIVE_API_ENABLED_UNTIL
   value: ''


### PR DESCRIPTION
[RHCLOUD-28571](https://issues.redhat.com/browse/RHCLOUD-28571)

because we are removing `catalog` roles and permissions from RBAC, we need to update the `ROLE_CREATE_ALLOW_LIST` variable