### PR TITLE
[RHCLOUD-33738] Group principals username only

### DIFF
--- a/tests/management/group/test_view.py
+++ b/tests/management/group/test_view.py
@@ -140,7 +140,7 @@ class GroupViewsetTests(IdentityRequest):
         self.service_accounts = []
         for uuid in self.sa_client_ids:
             principal = Principal(
-                username="service_account-" + uuid,
+                username="service-account-" + uuid,
                 tenant=self.tenant,
                 type="service-account",
                 service_account_id=uuid,

--- a/tests/management/group/test_view.py
+++ b/tests/management/group/test_view.py
@@ -2158,6 +2158,28 @@ class GroupViewsetTests(IdentityRequest):
                 self.assertEqual(sa.get("type"), "service-account")
                 self.assertEqual(sa.get("username"), mock_sa["username"])
 
+    def test_get_group_service_account_username_only_success(self):
+        """
+        Test that getting the service account usernames from a group returns successfully
+        with 'username_only' query parameter.
+        """
+        # We expected only usernames from RBAC database
+        expected_usernames = [f"service-account-{sa}" for sa in self.sa_client_ids]
+
+        sa_type_param = "principal_type=service-account"
+        username_only_param = "username_only=true"
+        url = f"{reverse('group-principals', kwargs={'uuid': self.group.uuid})}?{sa_type_param}&{username_only_param}"
+        client = APIClient()
+        response = client.get(url, **self.headers)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIsInstance(response.data.get("data"), list)
+        self.assertEqual(int(response.data.get("meta").get("count")), 3)
+        self.assertEqual(len(response.data.get("data")), 3)
+
+        for sa in response.data.get("data"):
+            self.assertIn(sa["username"], expected_usernames)
+
     @override_settings(IT_BYPASS_TOKEN_VALIDATION=True)
     @patch("management.principal.it_service.ITService.request_service_accounts")
     def test_get_group_service_account_empty_response(self, mock_request):

--- a/tests/management/principal/test_it_service.py
+++ b/tests/management/principal/test_it_service.py
@@ -935,6 +935,36 @@ class ITServiceTests(IdentityRequest):
             created_database_sa_principals=sa_principals_should_be_in_group, function_result=result
         )
 
+    def test_get_service_accounts_group_username_only(self):
+        """
+        Test the function returns the list of service account usernames with query
+        parameter username_only='true'.
+        """
+        group_a, _ = self._create_two_rbac_groups_with_service_accounts()
+        expected_usernames = [sa.username for sa in group_a.principals.all()]
+
+        user = User()
+        user.account = self.tenant.account_id
+        user.org_id = self.tenant.org_id
+
+        # Call the function under test.
+        options = {"username_only": "true"}
+        result = self.it_service.get_service_accounts_group(group=group_a, user=user, options=options)
+
+        self.assertEqual(
+            2,
+            len(result),
+            "only two service accounts were added to the group, and a different number of them is present",
+        )
+
+        for item in result:
+            self.assertIn(
+                item["username"],
+                expected_usernames,
+                f'the service account with username \'{item["username"]}\' is not present in the list of expected '
+                f"usernames '{expected_usernames}'",
+            )
+
     @mock.patch("management.principal.it_service.ITService.request_service_accounts")
     def test_get_service_accounts_group_filter_by_username(self, request_service_accounts: mock.Mock):
         """Test the function under test returns the filtered service accounts by username from the given group"""

--- a/tests/management/principal/test_it_service.py
+++ b/tests/management/principal/test_it_service.py
@@ -683,7 +683,10 @@ class ITServiceTests(IdentityRequest):
 
     @mock.patch("management.principal.it_service.ITService.request_service_accounts")
     def test_is_service_account_valid_multiple_results_from_it(self, request_service_accounts: mock.Mock):
-        """Test that the function under retunrs False when IT returns multiple service accounts for a single client ID."""
+        """
+        Test that the function under test returns False
+        when IT returns multiple service accounts for a single client ID.
+        """
         request_service_accounts.return_value = [{}, {}]
         user = User()
         user.bearer_token = "mocked-bt"
@@ -1221,7 +1224,9 @@ class ITServiceTests(IdentityRequest):
             )
 
     def test_generate_service_accounts_report_in_group_mixed_results(self):
-        """Test that the function under test is able to correctly flag the sevice accounts when there are mixed results"""
+        """
+        Test that the function under test is able to correctly flag the service accounts when there are mixed results
+        """
         # Create a group and associate principals to it.
         group = Group(name="it-service-group", platform_default=False, system=False, tenant=self.tenant)
         group.save()


### PR DESCRIPTION
## Link(s) to Jira
- [RHCLOUD-33738](https://issues.redhat.com/browse/RHCLOUD-33738)

## Description of Intent of Change(s)
we support the `username_only` parameter for the endpoint `GET /groups/{uuid}/principals/?username_only=true` to return only usernames for principals (in that case the call to IT is skipped)

and we should support the same for the service account based principals
`GET /groups/{uuid}/principals/?principal_type=service-account&username_only=true`

so in this case the call to IT will be skipped and we will return only service account usernames from RBAC database

## Local Testing
create a group with at least 1 service account
send the request `GET /groups/{uuid}/principals/?principal_type=service-account`
check the response contains whole service account object

then send the request `GET /groups/{uuid}/principals/?principal_type=service-account&username_only=true`
check the response contains only usernames
