### PR TITLE
fix log message in the group view remove_service_accounts()

### DIFF
--- a/rbac/management/group/view.py
+++ b/rbac/management/group/view.py
@@ -1089,7 +1089,7 @@ class GroupViewSet(
         request_id = getattr(self.request, "req_id", None)
         logger.info(
             f"[Request_id: {request_id}] remove_service_accounts({service_accounts}),"
-            "Group:{group.name},OrgId:{org_id},Acct:{account_name}"
+            f"Group:{group.name},OrgId:{org_id},Acct:{user.account}"
         )
 
         # Fetch the tenant from the database.


### PR DESCRIPTION
to make a linter happy we split the log message into 2 lines but forgot to add the "f" label before the second line

that causes the values in the curly braces are not replaced as expected and our logs look like this

```
[2024-08-03 23:22:49,891] INFO: [Request_id: a95f26ea5363487096e420fc7c1555c0] 
remove_service_accounts(['service-account-95491c9e-43e8-4dc4-aac4-eb0eb45b8afa']),
Group:{group.name},OrgId:{org_id},Acct:{account_name}
```

check in the [Kibana](https://kibana.apps.crcp01ue1.o9m8.p1.openshiftapps.com/app/kibana#/discover?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-24h,to:now))&_a=(columns:!(_source),filters:!(),index:'43c5fed0-d5ce-11ea-b58c-a7c95afd7a5d',interval:auto,query:(language:kuery,query:'@message:%22*%20remove_service_accounts%22'),sort:!()))