### PR TITLE
[RHCLOUD-31875] Update the group permissions

### DIFF
--- a/rbac/management/permissions/group_access.py
+++ b/rbac/management/permissions/group_access.py
@@ -38,11 +38,12 @@ class GroupAccessPermission(permissions.BasePermission):
             group_read = request.user.access.get("group", {}).get("read", [])
             if group_read:
                 return True
-            username = request.query_params.get("username")
-            if username:
-                return username == request.user.username
-            if not username and is_scope_principal(request):
-                return True
+            if view.basename == "group" and view.action == "list":
+                username = request.query_params.get("username")
+                if username:
+                    return username == request.user.username
+                if not username and is_scope_principal(request):
+                    return True
         else:
             group_write = request.user.access.get("group", {}).get("write", [])
 

--- a/rbac/management/permissions/utils.py
+++ b/rbac/management/permissions/utils.py
@@ -29,6 +29,4 @@ def is_scope_principal(request):
         return False
 
     scope = request.query_params.get(SCOPE_KEY, ORG_ID_SCOPE)
-    if scope != PRINCIPAL_SCOPE:
-        return False
-    return True
+    return scope == PRINCIPAL_SCOPE

--- a/tests/management/permissions/test_group_access.py
+++ b/tests/management/permissions/test_group_access.py
@@ -115,8 +115,12 @@ class GroupAccessPermissionTest(TestCase):
         identity_header = {"decoded": {"identity": {"user": {"username": "test_user"}}}}
         user = Mock(spec=User, admin=False, access=access, username="test_user")
         req = Mock(user=user, method="GET", query_params={"username": "test_user"})
+
         accessPerm = GroupAccessPermission()
-        result = accessPerm.has_permission(request=req, view=self.mocked_view)
+        mocked_view = Mock()
+        mocked_view.basename = "group"
+        mocked_view.action = "list"
+        result = accessPerm.has_permission(request=req, view=mocked_view)
         self.assertTrue(result)
 
     def test_no_perm_not_admin_get_others_groups(self):


### PR DESCRIPTION
## Link(s) to Jira
- [RHCLOUD-31875](https://issues.redhat.com/browse/RHCLOUD-31875)

## Description of Intent of Change(s)
the non admin (non org admin and non rbac admin) user can retrieve the group detail via `GET /groups/{uuid}/?scope=principal`
but only org admin or rbac admin can do that
the `scope` query param is not valid param for this endpoint and should be ignored

**how to reproduce it:**
1. find or create new user based principal (non org admin, non rbac admin)
2. create new group (without roles) and add the user from (1) into this group
3. with the user from step (1) in the identity header send the `GET /groups/{uuid}/` request with the group uuid created in the previous step (2) -> expected 403 response
4. with the user from step (1) in the identity header send the request with principal scope `GET /groups/{uuid}/?scope=principal` with the group uuid created in the step (2) -> expected 403 response but you get 200 response with group details

403 Response example
```
{
    "errors": [
        {
            "detail": "You do not have permission to perform this action.",
            "source": "detail",
            "status": "403"
        }
    ]
}
```

the issue exists and should be fixed for the service account base principal too

**the broader context:**
the non org admin and non rbac admin have an access to Group APIs only to list groups the principal belongs in
- with `scope` query param with principal value - `GET /groups/?scope=principal `
- with `usename` query param when the username is principal's own username - `GET /groups/?username=<value> `

## Local Testing
How can the feature be exercised?
How can the bug be exploited and fix confirmed?
Is any special local setup required?
