### PR TITLE
RHCLOUD-30376 Service accounts removal from a group

### DIFF
--- a/docs/source/specs/openapi.json
+++ b/docs/source/specs/openapi.json
@@ -1378,7 +1378,7 @@
           {
             "name": "service-accounts",
             "in": "query",
-            "description": "A comma separated list of usernames for service accounts to remove from the group",
+            "description": "A comma separated list of client IDs for service accounts to remove from the group",
             "schema": {
               "type": "string"
             }

--- a/tests/management/group/test_view.py
+++ b/tests/management/group/test_view.py
@@ -3065,7 +3065,7 @@ class GroupViewNonAdminTests(IdentityRequest):
 
         # Generate the URL for removing the principals from the regular group.
         group_principals_url = reverse("group-principals", kwargs={"uuid": regular_group.uuid})
-        group_principals_url = f"{group_principals_url}?service-accounts={service_account_principal_to_delete.username}&usernames={user_principal_to_remove.username}"
+        group_principals_url = f"{group_principals_url}?service-accounts={service_account_principal_to_delete.service_account_id}&usernames={user_principal_to_remove.username}"
         api_client = APIClient()
 
         # Make sure that before calling the endpoint the group has the two principals.
@@ -3355,7 +3355,7 @@ class GroupViewNonAdminTests(IdentityRequest):
 
         # Generate the URL for removing the principals from the regular group.
         group_principals_url = reverse("group-principals", kwargs={"uuid": regular_group.uuid})
-        group_principals_url = f"{group_principals_url}?service-accounts={service_account_principal_to_delete.username}&usernames={user_principal_to_remove.username}"
+        group_principals_url = f"{group_principals_url}?service-accounts={service_account_principal_to_delete.service_account_id}&usernames={user_principal_to_remove.username}"
         api_client = APIClient()
 
         # Make sure that before calling the endpoint the group has the two principals.
@@ -4090,7 +4090,7 @@ class GroupViewNonAdminTests(IdentityRequest):
 
         url = (
             reverse("group-principals", kwargs={"uuid": test_group.uuid})
-            + f"?service-accounts={sa_principal.username}"
+            + f"?service-accounts={sa_principal.service_account_id}"
         )
         client = APIClient()
 
@@ -4160,7 +4160,7 @@ class GroupViewNonAdminTests(IdentityRequest):
 
         url = (
             reverse("group-principals", kwargs={"uuid": test_group.uuid})
-            + f"?service-accounts={sa_principal.username}"
+            + f"?service-accounts={sa_principal.service_account_id}"
         )
         client = APIClient()
 
@@ -4252,7 +4252,7 @@ class GroupViewNonAdminTests(IdentityRequest):
 
         url = (
             reverse("group-principals", kwargs={"uuid": test_group.uuid})
-            + f"?service-accounts={sa_principal.username}"
+            + f"?service-accounts={sa_principal.service_account_id}"
         )
         client = APIClient()
 


### PR DESCRIPTION
## Link(s) to Jira
- [RHCLOUD-30376](https://issues.redhat.com/browse/RHCLOUD-30376)
- [RHCLOUD-32030](https://issues.redhat.com/browse/RHCLOUD-32030)

## Description of Intent of Change(s)
we can remove the service account from a group with `DELETE /groups/<uuid>/principals/?service-accounts=<sa_list> `
where `uuid` is group id and `sa_list` is comma separated list of service account usernames

the service account username is created as prefix `service-account-` + `client_id` but this prefix is something RBAC manages internally so we can simplify the service account removal and use the service account id to identify the SAs we want to remove

**ACs:**
- we are able to remove the service account from the group and we use the service account id as identification in the query

## Local Testing
if we want to remove the service account with client id  `0bba10f8-7ae0-4148-a29f-592c9992caa0` from a group with uuid `1916e7e3-8320-4791-bbd6-b9bf80548c37 `
the request will look like this `DELETE /groups/1916e7e3-8320-4791-bbd6-b9bf80548c37/principals/?service-account=0bba10f8-7ae0-4148-a29f-592c9992caa0 `