### PR TITLE
[RHCLOUD-23970] add the system query param in the internal open api spec for the principals' groups endpoint

### DIFF
--- a/rbac/internal/specs/openapi.json
+++ b/rbac/internal/specs/openapi.json
@@ -490,6 +490,15 @@
                 "modified"
               ]
             }
+          },
+          {
+            "name": "system",
+            "in": "query",
+            "required": false,
+            "description": "Parameter for filtering resource by system flag.",
+            "schema": {
+              "type": "boolean"
+            }
           }
         ],
         "responses": {


### PR DESCRIPTION
## Link(s) to Jira
- [RHCLOUD-23970](https://issues.redhat.com/browse/RHCLOUD-23970)

## Description of Intent of Change(s)
internal endpoint: `GET /integrations/tenant/<orgId>/principal/<username>/groups/ `
the `system` parameter is already working for this endpoint, we need just to update the internal openapi spec
