### PR TITLE
RHCLOUD-35015: Bring mapping reads within locked transaction to prevent out of order replication

### DIFF
--- a/rbac/internal/views.py
+++ b/rbac/internal/views.py
@@ -480,7 +480,7 @@ def get_param_list(request, param_name):
 def data_migration(request):
     """View method for running migrations from V1 to V2 spiceDB schema.
 
-    POST /_private/api/utils/data_migration/?exclude_apps=cost_management,rbac&orgs=id_1,id_2&write_db=True
+    POST /_private/api/utils/data_migration/?exclude_apps=cost_management,rbac&orgs=id_1,id_2&write_relationships=True
     """
     if request.method != "POST":
         return HttpResponse('Invalid method, only "POST" is allowed.', status=405)
@@ -489,7 +489,7 @@ def data_migration(request):
     args = {
         "exclude_apps": get_param_list(request, "exclude_apps"),
         "orgs": get_param_list(request, "orgs"),
-        "write_db": request.GET.get("write_db", "False") == "True",
+        "write_relationships": request.GET.get("write_relationships", "False") == "True",
     }
     migrate_data_in_worker.delay(args)
     return HttpResponse("Data migration from V1 to V2 are running in a background worker.", status=202)

--- a/rbac/management/management/commands/migrate_relations.py
+++ b/rbac/management/management/commands/migrate_relations.py
@@ -24,7 +24,7 @@ class Command(BaseCommand):
         kwargs = {
             "exclude_apps": options["exclude_apps"],
             "orgs": options["org_list"],
-            "write_db": options["write_to_db"],
+            "write_relationships": options["write_relationships"],
         }
         migrate_data(**kwargs)
         logger.info("*** Migration completed. ***\n")

--- a/rbac/management/role/relation_api_dual_write_handler.py
+++ b/rbac/management/role/relation_api_dual_write_handler.py
@@ -124,6 +124,9 @@ class RelationApiDualWriteHandler:
 
             self.role_relations = relations
 
+            if self.binding_mapping is None:
+                self.binding_mapping = BindingMapping.objects.create(role=self.role)
+
             self.binding_mapping.mappings = mappings
             self.binding_mapping.save()
 

--- a/rbac/management/role/relation_api_dual_write_handler.py
+++ b/rbac/management/role/relation_api_dual_write_handler.py
@@ -57,7 +57,7 @@ class RelationApiDualWriteHandler:
         """Check whether replication enabled."""
         return ENVIRONMENT.get_value("REPLICATION_TO_RELATION_ENABLED", default=False, cast=bool)
 
-    def generate_relations_from_current_state_of_role(self):
+    def get_relations_from_current_state_of_role(self):
         """Generate relations from current state of role and UUIDs for v2 role and role binding from database."""
         if not self.replication_enabled():
             return

--- a/rbac/management/role/relation_api_dual_write_handler.py
+++ b/rbac/management/role/relation_api_dual_write_handler.py
@@ -125,10 +125,12 @@ class RelationApiDualWriteHandler:
             self.role_relations = relations
 
             if self.binding_mapping is None:
-                self.binding_mapping = BindingMapping.objects.create(role=self.role)
-
-            self.binding_mapping.mappings = mappings
-            self.binding_mapping.save()
+                self.binding_mapping = BindingMapping.objects.create(
+                    role=self.role,
+                    mappings=mappings)
+            else:
+                self.binding_mapping.mappings = mappings
+                self.binding_mapping.save(force_update=True)
 
             return relations
         except Exception as e:

--- a/rbac/management/role/relation_api_dual_write_handler.py
+++ b/rbac/management/role/relation_api_dual_write_handler.py
@@ -23,6 +23,7 @@ from migration_tool.migrate import migrate_role
 from migration_tool.utils import relationship_to_json
 
 from rbac.env import ENVIRONMENT
+from rbac.management.role.model import BindingMapping
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
@@ -44,6 +45,7 @@ class RelationApiDualWriteHandler:
             self.role_relations = []
             self.current_role_relations = []
             self.role = role
+            self.binding_mapping = None
             self.tenant_id = role.tenant_id
             self.org_id = role.tenant.org_id
             self.root_workspace = Workspace.objects.get(
@@ -57,7 +59,11 @@ class RelationApiDualWriteHandler:
         """Check whether replication enabled."""
         return ENVIRONMENT.get_value("REPLICATION_TO_RELATION_ENABLED", default=False, cast=bool)
 
-    def get_relations_from_current_state_of_role(self):
+    def get_current_role_relations(self):
+        """Get current roles relations."""
+        return self.current_role_relations
+
+    def load_relations_from_current_state_of_role(self):
         """Generate relations from current state of role and UUIDs for v2 role and role binding from database."""
         if not self.replication_enabled():
             return
@@ -65,36 +71,67 @@ class RelationApiDualWriteHandler:
             logger.info(
                 "[Dual Write] Generate relations from current state of role(%s): '%s'", self.role.uuid, self.role.name
             )
-            relations = migrate_role(
-                self.role, False, str(self.root_workspace.uuid), self.org_id, True, True, True, False
+
+            self.binding_mapping = self.role.binding_mapping
+
+            if self.binding_mapping is None:
+                raise Exception(f"BindingMapping for role {self.role.uuid} not found.")
+
+            relations, _ = migrate_role(
+                self.role,
+                write_relationships=False,
+                root_workspace=str(self.root_workspace.uuid),
+                default_workspace=self.org_id,
+                current_bindings=self.binding_mapping,
             )
+
             self.current_role_relations = relations
         except Exception as e:
             raise DualWriteException(e)
 
-    def regenerate_relations_and_mappings_for_role(self):
-        """Delete and generated relations with mapping for a role."""
+    def generate_replication_event_to_outbox(self, role):
+        """Generate replication event to outbox table."""
         if not self.replication_enabled():
-            return []
-        return self.generate_relations_and_mappings_for_role()
+            return
+        self.role = role
+        self._generate_relations_and_mappings_for_role()
+        return self.save_replication_event_to_outbox()
 
-    def generate_relations_and_mappings_for_role(self):
+    def save_replication_event_to_outbox(self):
+        """Generate and store replication event to outbox table."""
+        if not self.replication_enabled():
+            return {}
+        try:
+            replication_event = self._build_replication_event()
+            self._save_replication_event(replication_event)
+        except Exception as e:
+            raise DualWriteException(e)
+        return replication_event
+
+    def _generate_relations_and_mappings_for_role(self):
         """Generate relations and mappings for a role with new UUIDs for v2 role and role bindings."""
         if not self.replication_enabled():
             return []
         try:
             logger.info("[Dual Write] Generate new relations from role(%s): '%s'", self.role.uuid, self.role.name)
-            relations = migrate_role(self.role, False, str(self.root_workspace.uuid), self.org_id, True)
+
+            relations, mappings = migrate_role(
+                self.role,
+                write_relationships=False,
+                root_workspace=str(self.root_workspace.uuid),
+                default_workspace=self.org_id,
+                current_bindings=self.binding_mapping)
+
             self.role_relations = relations
+
+            self.binding_mapping.mappings = mappings
+            self.binding_mapping.save()
+
             return relations
         except Exception as e:
             raise DualWriteException(e)
 
-    def get_current_role_relations(self):
-        """Get current roles relations."""
-        return self.current_role_relations
-
-    def build_replication_event(self):
+    def _build_replication_event(self):
         """Build replication event."""
         if not self.replication_enabled():
             return {}
@@ -110,26 +147,7 @@ class RelationApiDualWriteHandler:
         replication_event = {"relations_to_add": relations_to_add, "relations_to_remove": relations_to_remove}
         return replication_event
 
-    def generate_replication_event_to_outbox(self, role):
-        """Generate replication event to outbox table."""
-        if not self.replication_enabled():
-            return
-        self.role = role
-        self.regenerate_relations_and_mappings_for_role()
-        return self.save_replication_event_to_outbox()
-
-    def save_replication_event_to_outbox(self):
-        """Generate and store replication event to outbox table."""
-        if not self.replication_enabled():
-            return {}
-        try:
-            replication_event = self.build_replication_event()
-            self.save_replication_event(replication_event)
-        except Exception as e:
-            raise DualWriteException(e)
-        return replication_event
-
-    def save_replication_event(self, replication_event):
+    def _save_replication_event(self, replication_event):
         """Save replication event."""
         if not self.replication_enabled():
             return

--- a/rbac/management/role/relation_api_dual_write_handler.py
+++ b/rbac/management/role/relation_api_dual_write_handler.py
@@ -72,10 +72,14 @@ class RelationApiDualWriteHandler:
                 "[Dual Write] Generate relations from current state of role(%s): '%s'", self.role.uuid, self.role.name
             )
 
-            self.binding_mapping = self.role.binding_mapping
-
-            if self.binding_mapping is None:
-                raise Exception(f"BindingMapping for role {self.role.uuid} not found.")
+            try:
+                self.binding_mapping = self.role.binding_mapping
+            except BindingMapping.DoesNotExist:
+                logger.warning(
+                    "[Dual Write] Binding mapping not found for role(%s): '%s'. Creating new binding mapping.",
+                    self.role.uuid,
+                    self.role.name,
+                )
 
             relations, _ = migrate_role(
                 self.role,

--- a/rbac/management/role/relation_api_dual_write_handler.py
+++ b/rbac/management/role/relation_api_dual_write_handler.py
@@ -72,14 +72,7 @@ class RelationApiDualWriteHandler:
                 "[Dual Write] Generate relations from current state of role(%s): '%s'", self.role.uuid, self.role.name
             )
 
-            try:
-                self.binding_mapping = self.role.binding_mapping
-            except BindingMapping.DoesNotExist:
-                logger.warning(
-                    "[Dual Write] Binding mapping not found for role(%s): '%s'. Creating new binding mapping.",
-                    self.role.uuid,
-                    self.role.name,
-                )
+            self.binding_mapping = self.role.binding_mapping
 
             relations, _ = migrate_role(
                 self.role,
@@ -90,6 +83,14 @@ class RelationApiDualWriteHandler:
             )
 
             self.current_role_relations = relations
+        except BindingMapping.DoesNotExist:
+            logger.warning(
+                "[Dual Write] Binding mapping not found for role(%s): '%s'. "
+                "Assuming no current relations exist. "
+                "If this is NOT the case, relations are inconsistent!",
+                self.role.uuid,
+                self.role.name,
+            )
         except Exception as e:
             raise DualWriteException(e)
 

--- a/rbac/management/role/relation_api_dual_write_handler.py
+++ b/rbac/management/role/relation_api_dual_write_handler.py
@@ -19,11 +19,11 @@
 import logging
 
 from management.models import Outbox, Workspace
+from management.role.model import BindingMapping
 from migration_tool.migrate import migrate_role
 from migration_tool.utils import relationship_to_json
 
 from rbac.env import ENVIRONMENT
-from rbac.management.role.model import BindingMapping
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
@@ -120,14 +120,13 @@ class RelationApiDualWriteHandler:
                 write_relationships=False,
                 root_workspace=str(self.root_workspace.uuid),
                 default_workspace=self.org_id,
-                current_bindings=self.binding_mapping)
+                current_bindings=self.binding_mapping,
+            )
 
             self.role_relations = relations
 
             if self.binding_mapping is None:
-                self.binding_mapping = BindingMapping.objects.create(
-                    role=self.role,
-                    mappings=mappings)
+                self.binding_mapping = BindingMapping.objects.create(role=self.role, mappings=mappings)
             else:
                 self.binding_mapping.mappings = mappings
                 self.binding_mapping.save(force_update=True)

--- a/rbac/management/role/serializer.py
+++ b/rbac/management/role/serializer.py
@@ -395,15 +395,22 @@ def validate_role_update(instance, validated_data):
 
 def update_role(role_name, update_data, tenant, clear_access=True):
     """Update role attribute."""
-    role, created = Role.objects.update_or_create(
-        name=role_name,
-        tenant=tenant,
-        defaults={
-            "name": update_data.get("updated_name"),
-            "display_name": update_data.get("updated_display_name"),
-            "description": update_data.get("updated_description"),
-        },
-    )
+    role = Role.objects.get(name=role_name, tenant=tenant)
+
+    update_fields = []
+
+    if "updated_name" in update_data:
+        role.name = update_data["updated_name"]
+        update_fields.append("name")
+    if "updated_display_name" in update_data:
+        role.display_name = update_data["updated_display_name"]
+        update_fields.append("display_name")
+    if "updated_description" in update_data:
+        role.description = update_data["updated_description"]
+        update_fields.append("description")
+
+    role.save(update_fields=update_fields)
+
     if clear_access:
         role.access.all().delete()
 

--- a/rbac/management/role/serializer.py
+++ b/rbac/management/role/serializer.py
@@ -18,7 +18,6 @@
 """Serializer for role management."""
 from django.utils.translation import gettext as _
 from management.group.model import Group
-from management.notifications.notification_handlers import role_obj_change_notification_handler
 from management.serializer_override_mixin import SerializerCreateOverrideMixin
 from management.utils import filter_queryset_by_tenant, get_principal, validate_and_get_key
 from rest_framework import serializers

--- a/rbac/management/role/serializer.py
+++ b/rbac/management/role/serializer.py
@@ -139,7 +139,6 @@ class RoleSerializer(serializers.ModelSerializer):
         role = Role.objects.create(name=name, description=description, display_name=display_name, tenant=tenant)
         create_access_for_role(role, access_list, tenant)
 
-        role_obj_change_notification_handler(role, "created", self.context["request"].user)
         return role
 
     def update(self, instance, validated_data):
@@ -153,7 +152,6 @@ class RoleSerializer(serializers.ModelSerializer):
 
         create_access_for_role(instance, access_list, tenant)
 
-        role_obj_change_notification_handler(instance, "updated", self.context["request"].user)
         return instance
 
     def get_external_role_id(self, obj):

--- a/rbac/management/role/view.py
+++ b/rbac/management/role/view.py
@@ -171,7 +171,7 @@ class RoleViewSet(
             # You would be able to remove `select_for_update` here,
             # and instead rely on REPEATABLE READ's lost update detection to abort the tx.
             # Nothing else should need to change.
-            
+
             # TODO: May be redundant with RolePermissions check
             access = user_has_perm(self.request, "role")
             if access == "None":

--- a/rbac/management/role/view.py
+++ b/rbac/management/role/view.py
@@ -34,7 +34,7 @@ from management.filters import CommonFilters
 from management.models import AuditLog, Permission
 from management.notifications.notification_handlers import role_obj_change_notification_handler
 from management.permissions import RoleAccessPermission
-from management.querysets import get_role_queryset
+from management.querysets import get_role_queryset, user_has_perm
 from management.role.relation_api_dual_write_handler import DualWriteException, RelationApiDualWriteHandler
 from management.role.serializer import AccessSerializer, RoleDynamicSerializer, RolePatchSerializer
 from management.utils import validate_uuid
@@ -171,6 +171,11 @@ class RoleViewSet(
             # You would be able to remove `select_for_update` here,
             # and instead rely on REPEATABLE READ's lost update detection to abort the tx.
             # Nothing else should need to change.
+            
+            # TODO: May be redundant with RolePermissions check
+            access = user_has_perm(self.request, "role")
+            if access == "None":
+                return Role.objects.none()
 
             return (
                 Role.objects.filter(tenant=self.request.tenant).select_related("binding_mapping").select_for_update()

--- a/rbac/management/role/view.py
+++ b/rbac/management/role/view.py
@@ -168,6 +168,12 @@ class RoleViewSet(
             # Getting the mapping here (which is necessary to lock it) also saves us
             # redundant queries later.
 
+            # NOTE: If we want to try REPEATABLE READ isolation instead of READ COMMITTED,
+            # this should work with that as well.
+            # You would be able to remove `select_for_update` here,
+            # and instead rely on REPEATABLE READ's lost update detection to abort the tx.
+            # Nothing else should need to change.
+
             return (Role.objects.filter(tenant=self.request.tenant)
                     .select_related("mappings")
                     .select_for_update())

--- a/rbac/management/role/view.py
+++ b/rbac/management/role/view.py
@@ -483,7 +483,7 @@ class RoleViewSet(
 
         instance.delete()
 
-        # These needs to come after destroy so that dual write handler sees the current policies.
+        # This needs to come after destroy so that dual write handler sees the current policies.
         self.delete_policies_if_no_role_attached(instance)
 
         dual_write_handler.save_replication_event_to_outbox()

--- a/rbac/management/role/view.py
+++ b/rbac/management/role/view.py
@@ -140,7 +140,8 @@ class RoleViewSet(
     def get_queryset(self):
         """Obtain queryset for requesting user based on access and action."""
 
-        if self.action not in ["update", "partial_update", "destroy"]:
+        # NOTE: partial_update intentionally omitted because it does not update access or policy.
+        if self.action not in ["update", "destroy"]:
             return get_role_queryset(self.request)
         else:
             # Update queryset differs from normal role queryset in a few ways:

--- a/rbac/migration_tool/migrate.py
+++ b/rbac/migration_tool/migrate.py
@@ -17,9 +17,10 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import dataclasses
 import logging
-from typing import FrozenSet
+from typing import FrozenSet, Any
 
 from django.conf import settings
+from kessel.relations.v1beta1 import common_pb2
 from management.role.model import BindingMapping, Role
 from management.workspace.model import Workspace
 from migration_tool.models import V1group, V2rolebinding
@@ -32,33 +33,35 @@ from .ingest import extract_info_into_v1_role
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
+BindingMappings = dict[str, dict[str, Any]]
 
-def spicedb_relationships(
+
+def get_kessel_relation_tuples(
     v2_role_bindings: FrozenSet[V2rolebinding],
     root_workspace: str,
-    v1_role,
-    in_transaction=False,
-    create_binding_to_db=True,
-):
-    """Generate a set of relationships for the given set of v2 role bindings."""
-    relationships = list()
-    binding_mappings = {}
+) -> tuple[list[common_pb2.Relationship], BindingMappings]:
+    """Generate a set of relationships and BindingMappings for the given set of v2 role bindings."""
+
+    relationships: list[common_pb2.Relationship] = list()
+
+    # Dictionary of v2 role binding ID to v2 role UUID and its permissions
+    # for the given v1 role.
+    binding_mappings: BindingMappings = {}
 
     for v2_role_binding in v2_role_bindings:
         relationships.append(
             create_relationship("role_binding", v2_role_binding.id, "role", v2_role_binding.role.id, "granted")
         )
 
-        if create_binding_to_db:
-            v2_role_data = v2_role_binding.role
+        v2_role_data = v2_role_binding.role
 
-            if binding_mappings.get(v2_role_binding.id) is None:
-                binding_mappings[v2_role_binding.id] = {}
+        if binding_mappings.get(v2_role_binding.id) is None:
+            binding_mappings[v2_role_binding.id] = {}
 
-            binding_mappings[v2_role_binding.id] = {
-                "v2_role_uuid": str(v2_role_data.id),
-                "permissions": list(v2_role_binding.role.permissions),
-            }
+        binding_mappings[v2_role_binding.id] = {
+            "v2_role_uuid": str(v2_role_data.id),
+            "permissions": list(v2_role_binding.role.permissions),
+        }
 
         for perm in v2_role_binding.role.permissions:
             relationships.append(create_relationship("role", v2_role_binding.role.id, "user", "*", perm))
@@ -89,28 +92,22 @@ def spicedb_relationships(
                 )
             )
 
-    if create_binding_to_db:
-        if in_transaction:
-            binding_mapping, _ = BindingMapping.objects.select_for_update().get_or_create(role=v1_role)
-        else:
-            binding_mapping, _ = BindingMapping.objects.get_or_create(role=v1_role)
-        binding_mapping.mappings = binding_mappings
-        binding_mapping.save()
-
-    return relationships
+    return relationships, binding_mappings
 
 
 def migrate_role(
     role: Role,
-    write_db: bool,
+    write_relationships: bool,
     root_workspace: str,
     default_workspace: str,
-    in_transaction=False,
-    use_binding_from_db=False,
-    use_mapping_from_db=False,
-    create_binding_to_db=True,
-):
+    # in_transaction=False,
+    # use_binding_from_db=False,
+    # use_mapping_from_db=False,
+    # create_binding_to_db=True,
+    current_bindings: BindingMapping | None = None,
+) -> tuple[list[common_pb2.Relationship], BindingMappings]:
     """Migrate a role from v1 to v2."""
+
     v1_role = extract_info_into_v1_role(role)
     # With the replicated role bindings algorithm, role bindings are scoped by group, so we need to add groups
     policies = role.policies.all()
@@ -124,17 +121,15 @@ def migrate_role(
     v2_roles = [
         v2_role
         for v2_role in v1_role_to_v2_mapping(
-            v1_role, role.id, root_workspace, default_workspace, use_binding_from_db, use_mapping_from_db
+            v1_role, root_workspace, default_workspace, current_bindings
         )
     ]
-    relationships = spicedb_relationships(
-        frozenset(v2_roles), root_workspace, role, in_transaction, create_binding_to_db
-    )
-    output_relationships(relationships, write_db)
-    return relationships
+    relationships, mappings = get_kessel_relation_tuples(frozenset(v2_roles), root_workspace)
+    output_relationships(relationships, write_relationships)
+    return relationships, mappings
 
 
-def migrate_workspace(tenant: Tenant, write_db: bool):
+def migrate_workspace(tenant: Tenant, write_relationships: bool):
     """Migrate a workspace from v1 to v2."""
     root_workspace = Workspace.objects.create(name="root", description="Root workspace", tenant=tenant)
     # Org id represents the default workspace for now
@@ -144,20 +139,20 @@ def migrate_workspace(tenant: Tenant, write_db: bool):
     ]
     # Include realm for tenant
     relationships.append(create_relationship("tenant", str(tenant.org_id), "realm", settings.ENV_NAME, "realm"))
-    output_relationships(relationships, write_db)
+    output_relationships(relationships, write_relationships)
     return str(root_workspace.uuid), tenant.org_id
 
 
-def migrate_users(tenant: Tenant, write_db: bool):
+def migrate_users(tenant: Tenant, write_relationships: bool):
     """Write users relationship to tenant."""
     relationships = [
         create_relationship("tenant", str(tenant.org_id), "user", str(principal.uuid), "member")
         for principal in tenant.principal_set.all()
     ]
-    output_relationships(relationships, write_db)
+    output_relationships(relationships, write_relationships)
 
 
-def migrate_users_for_groups(tenant: Tenant, write_db: bool):
+def migrate_users_for_groups(tenant: Tenant, write_relationships: bool):
     """Write users relationship to groups."""
     relationships = []
     for group in tenant.group_set.all():
@@ -167,21 +162,21 @@ def migrate_users_for_groups(tenant: Tenant, write_db: bool):
         )
         for user in user_set:
             relationships.append(create_relationship("group", str(group.uuid), "user", str(user.uuid), "member"))
-    output_relationships(relationships, write_db)
+    output_relationships(relationships, write_relationships)
 
 
-def migrate_data_for_tenant(tenant: Tenant, app_list: list, write_db: bool):
+def migrate_data_for_tenant(tenant: Tenant, app_list: list, write_relationships: bool):
     """Migrate all data for a given tenant."""
     logger.info("Creating workspace.")
-    root_workspace, default_workspace = migrate_workspace(tenant, write_db)
+    root_workspace, default_workspace = migrate_workspace(tenant, write_relationships)
     logger.info("Workspace migrated.")
 
     logger.info("Relating users to tenant.")
-    migrate_users(tenant, write_db)
+    migrate_users(tenant, write_relationships)
     logger.info("Finished relationship between users and tenant.")
 
     logger.info("Migrating relations of group and user.")
-    migrate_users_for_groups(tenant, write_db)
+    migrate_users_for_groups(tenant, write_relationships)
     logger.info("Finished migrating relations of group and user.")
 
     roles = tenant.role_set.all()
@@ -190,12 +185,22 @@ def migrate_data_for_tenant(tenant: Tenant, app_list: list, write_db: bool):
 
     for role in roles:
         logger.info(f"Migrating role: {role.name} with UUID {role.uuid}.")
-        migrate_role(role, write_db, root_workspace, default_workspace)
+
+        _, mappings = migrate_role(role, write_relationships, root_workspace, default_workspace)
+
+        # Insert is forced with `create` in order to prevent this from
+        # accidentally running concurrently with dual-writes.
+        # If migration should be rerun, then the bindings table should be dropped.
+        # If changing this to update_or_create,
+        # always ensure writes are paused before running.
+        # Thus must always be the case, but `create` will at least start failing you if you forget.
+        BindingMapping.objects.create(role=role, mappings=mappings)
+
         logger.info(f"Migration completed for role: {role.name} with UUID {role.uuid}.")
     logger.info(f"Migrated {roles.count()} roles for tenant: {tenant.org_id}")
 
 
-def migrate_data(exclude_apps: list = [], orgs: list = [], write_db: bool = False):
+def migrate_data(exclude_apps: list = [], orgs: list = [], write_relationships: bool = False):
     """Migrate all data for all tenants."""
     count = 0
     tenants = Tenant.objects.exclude(tenant_name="public")
@@ -205,7 +210,7 @@ def migrate_data(exclude_apps: list = [], orgs: list = [], write_db: bool = Fals
     for tenant in tenants.iterator():
         logger.info(f"Migrating data for tenant: {tenant.org_id}")
         try:
-            migrate_data_for_tenant(tenant, exclude_apps, write_db)
+            migrate_data_for_tenant(tenant, exclude_apps, write_relationships)
         except Exception as e:
             logger.error(f"Failed to migrate data for tenant: {tenant.org_id}. Error: {e}")
             raise e

--- a/rbac/migration_tool/migrate.py
+++ b/rbac/migration_tool/migrate.py
@@ -17,7 +17,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import dataclasses
 import logging
-from typing import FrozenSet, Any
+from typing import Any, FrozenSet, Optional
 
 from django.conf import settings
 from kessel.relations.v1beta1 import common_pb2
@@ -41,7 +41,6 @@ def get_kessel_relation_tuples(
     root_workspace: str,
 ) -> tuple[list[common_pb2.Relationship], BindingMappings]:
     """Generate a set of relationships and BindingMappings for the given set of v2 role bindings."""
-
     relationships: list[common_pb2.Relationship] = list()
 
     # Dictionary of v2 role binding ID to v2 role UUID and its permissions
@@ -100,10 +99,9 @@ def migrate_role(
     write_relationships: bool,
     root_workspace: str,
     default_workspace: str,
-    current_bindings: BindingMapping | None = None,
+    current_bindings: Optional[BindingMapping] = None,
 ) -> tuple[list[common_pb2.Relationship], BindingMappings]:
     """Migrate a role from v1 to v2."""
-
     v1_role = extract_info_into_v1_role(role)
     # With the replicated role bindings algorithm, role bindings are scoped by group, so we need to add groups
     policies = role.policies.all()
@@ -115,10 +113,7 @@ def migrate_role(
 
     # This is where we wire in the implementation we're using into the Migrator
     v2_roles = [
-        v2_role
-        for v2_role in v1_role_to_v2_mapping(
-            v1_role, root_workspace, default_workspace, current_bindings
-        )
+        v2_role for v2_role in v1_role_to_v2_mapping(v1_role, root_workspace, default_workspace, current_bindings)
     ]
     relationships, mappings = get_kessel_relation_tuples(frozenset(v2_roles), root_workspace)
     output_relationships(relationships, write_relationships)

--- a/rbac/migration_tool/migrate.py
+++ b/rbac/migration_tool/migrate.py
@@ -100,10 +100,6 @@ def migrate_role(
     write_relationships: bool,
     root_workspace: str,
     default_workspace: str,
-    # in_transaction=False,
-    # use_binding_from_db=False,
-    # use_mapping_from_db=False,
-    # create_binding_to_db=True,
     current_bindings: BindingMapping | None = None,
 ) -> tuple[list[common_pb2.Relationship], BindingMappings]:
     """Migrate a role from v1 to v2."""

--- a/rbac/migration_tool/sharedSystemRolesReplicatedRoleBindings.py
+++ b/rbac/migration_tool/sharedSystemRolesReplicatedRoleBindings.py
@@ -18,11 +18,10 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 import json
 import logging
 import uuid
-from typing import Callable, FrozenSet, Type
+from typing import Callable, FrozenSet, Optional, Type
 
 from management.models import BindingMapping
 from management.role.model import Role
-from management.workspace.model import Workspace
 from migration_tool.ingest import add_element
 from migration_tool.models import (
     V1group,
@@ -99,10 +98,9 @@ def v1_role_to_v2_mapping(
     v1_role: V1role,
     root_workspace: str,
     default_workspace: str,
-    binding_mapping: BindingMapping | None,
+    binding_mapping: Optional[BindingMapping],
 ) -> FrozenSet[V2rolebinding]:
     """Convert a V1 role to a set of V2 role bindings."""
-
     perm_groupings: Permissiongroupings = {}
     # Group V2 permissions by target
     for v1_perm in v1_role.permissions:
@@ -161,9 +159,10 @@ def v1_role_to_v2_mapping(
 custom_roles_created = 0
 
 
-def extract_system_roles(perm_groupings: dict[V1resourcedef, list[str]], v1_role: V1role, binding_mapping: BindingMapping | None):
+def extract_system_roles(
+    perm_groupings: dict[V1resourcedef, list[str]], v1_role: V1role, binding_mapping: Optional[BindingMapping]
+):
     """Extract system roles from a set of permissions."""
-
     candidate_system_roles = {}
     resource_roles: dict[V2role, list[V1resourcedef]] = {}
     system_roles = SystemRole.get_system_roles()
@@ -245,20 +244,6 @@ def split_resourcedef_literal(resourceDef: V1resourcedef):
             )  # If not JSON, assume comma-separated? Cost Management openshift assets are like this.
     else:
         return [json.loads(resourceDef.resource_id)]
-
-
-def shared_system_role_replicated_role_bindings_v1_to_v2_mapping(
-    v1_role: V1role,
-    v1_role_db_id,
-    root_workspace: Workspace,
-    default_workspace: Workspace,
-    use_binding_from_db=False,
-    use_mapping_from_db=False,
-) -> FrozenSet[V2rolebinding]:
-    """Convert a V1 role to a set of V2 role bindings."""
-    return v1_role_to_v2_mapping(
-        v1_role, v1_role_db_id, root_workspace, default_workspace, use_binding_from_db, use_mapping_from_db
-    )
 
 
 def v1groups_to_v2groups(v1groups: FrozenSet[V1group]):

--- a/rbac/migration_tool/sharedSystemRolesReplicatedRoleBindings.py
+++ b/rbac/migration_tool/sharedSystemRolesReplicatedRoleBindings.py
@@ -100,8 +100,6 @@ def v1_role_to_v2_mapping(
     root_workspace: str,
     default_workspace: str,
     binding_mapping: BindingMapping | None,
-    # use_binding_from_db=False,
-    # use_mapping_from_db=False,
 ) -> FrozenSet[V2rolebinding]:
     """Convert a V1 role to a set of V2 role bindings."""
 

--- a/tests/internal/test_views.py
+++ b/tests/internal/test_views.py
@@ -464,7 +464,11 @@ class InternalViewsetTests(IdentityRequest):
             **self.request.META,
         )
         migration_mock.assert_called_once_with(
-            {"exclude_apps": ["rbac", "costmanagement"], "orgs": ["acct00001", "acct00002"], "write_relationships": False}
+            {
+                "exclude_apps": ["rbac", "costmanagement"],
+                "orgs": ["acct00001", "acct00002"],
+                "write_relationships": False,
+            }
         )
         self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
         self.assertEqual(
@@ -478,7 +482,7 @@ class InternalViewsetTests(IdentityRequest):
             f"/_private/api/utils/data_migration/",
             **self.request.META,
         )
-        migration_mock.assert_called_once_with({"exclude_apps": [], "orgs": [], "write_relationships": False})
+        migration_mock.assert_calledonce_with({"exclude_apps": [], "orgs": [], "write_relationships": False})
         self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
         self.assertEqual(
             response.content.decode(),

--- a/tests/internal/test_views.py
+++ b/tests/internal/test_views.py
@@ -464,7 +464,7 @@ class InternalViewsetTests(IdentityRequest):
             **self.request.META,
         )
         migration_mock.assert_called_once_with(
-            {"exclude_apps": ["rbac", "costmanagement"], "orgs": ["acct00001", "acct00002"], "write_db": False}
+            {"exclude_apps": ["rbac", "costmanagement"], "orgs": ["acct00001", "acct00002"], "write_relationships": False}
         )
         self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
         self.assertEqual(
@@ -478,7 +478,7 @@ class InternalViewsetTests(IdentityRequest):
             f"/_private/api/utils/data_migration/",
             **self.request.META,
         )
-        migration_mock.assert_called_once_with({"exclude_apps": [], "orgs": [], "write_db": False})
+        migration_mock.assert_called_once_with({"exclude_apps": [], "orgs": [], "write_relationships": False})
         self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
         self.assertEqual(
             response.content.decode(),

--- a/tests/internal/test_views.py
+++ b/tests/internal/test_views.py
@@ -482,7 +482,7 @@ class InternalViewsetTests(IdentityRequest):
             f"/_private/api/utils/data_migration/",
             **self.request.META,
         )
-        migration_mock.assert_calledonce_with({"exclude_apps": [], "orgs": [], "write_relationships": False})
+        migration_mock.assert_called_once_with({"exclude_apps": [], "orgs": [], "write_relationships": False})
         self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
         self.assertEqual(
             response.content.decode(),

--- a/tests/management/role/test_view.py
+++ b/tests/management/role/test_view.py
@@ -337,7 +337,7 @@ class RoleViewsetTests(IdentityRequest):
                 ANY,
             )
 
-    @patch("management.role.relation_api_dual_write_handler.RelationApiDualWriteHandler.save_replication_event")
+    @patch("management.role.relation_api_dual_write_handler.RelationApiDualWriteHandler._save_replication_event")
     def test_create_role_with_display_success(self, mock_method):
         """Test that we can create a role."""
         role_name = "roleD"
@@ -1365,7 +1365,7 @@ class RoleViewsetTests(IdentityRequest):
         response = client.put(url, test_data, format="json", **self.headers)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
-    @patch("management.role.relation_api_dual_write_handler.RelationApiDualWriteHandler.save_replication_event")
+    @patch("management.role.relation_api_dual_write_handler.RelationApiDualWriteHandler._save_replication_event")
     def test_update_role(self, mock_method):
         """Test that updating a role with an invalid permission returns an error."""
         # Set up
@@ -1488,7 +1488,7 @@ class RoleViewsetTests(IdentityRequest):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(response.data.get("errors")[0].get("detail"), f"Permission does not exist: {permission}")
 
-    @patch("management.role.relation_api_dual_write_handler.RelationApiDualWriteHandler.save_replication_event")
+    @patch("management.role.relation_api_dual_write_handler.RelationApiDualWriteHandler._save_replication_event")
     def test_delete_role(self, mock_method):
         """Test that we can delete an existing role."""
         role_name = "roleA"


### PR DESCRIPTION
**NOTE: This is not a PR to merge into main. It is a PR into the branch in #1172 (dual-writes). Merging will update that PR only.**

---

This got larger than I initially intended as I dug deeper and realized a few things:

Initially we had just wanted to fix that the mappings, access, and policy for a Role were queried prior to the lock, and the first commit should theoretically fix that under certain assumptions (namely, that the Role is always locked before any of its policy, access, or mappings are updated, which currently isn't the case but is fixable).

However, I later realized that the access and policy tables are queried off of the initial Role object. It wasn't clear that those weren't already fetched, and if they were (or the queryset was updated to eagerly fetch), it would cause those to be read outside of the lock (and lead to possible inconsistency again).

This is pretty fragile, and the whole thing is complicated, so I decided to try a little bit more refactoring to simplify things. With the latest, things work like this:

1. During update & destroy, the role and mapping are retrieved and locked by modifying get_queryset logic (and so no additional get_objects are necessary, and django rest's innate logic will do the right thing)
2. During create, update, and destroy, we use an atomic block at the view level so that the lock lasts the duration of all of our updates
3. The dual write logic is handled in `perform_` hooks provided by django rest because these have access to the serializer and/or instance and can run before and after inserts/updates/deletes happen in SQL (which is what we need). This keeps us from having to do more queries and kinda organizes all the SQL logic in (mostly) one place.
4. The same current mapping object is used inside the dual write handler throughout (since this is 1-1 with the Role)

Unfortunately we're not done – what's left now is to handle similar locking and mapping updates for add/remove role to group APIs. But I think that may warrant a follow-up PR.