### PR TITLE
RHCLOUD-35053: Relate resources and workspaces to default (not root)

### DIFF
--- a/rbac/management/role/relation_api_dual_write_handler.py
+++ b/rbac/management/role/relation_api_dual_write_handler.py
@@ -18,7 +18,7 @@
 """Class to handle Dual Write API related operations."""
 import logging
 
-from management.models import Outbox, Workspace
+from management.models import Outbox
 from management.role.model import BindingMapping
 from migration_tool.migrate import migrate_role
 from migration_tool.utils import relationship_to_json
@@ -48,9 +48,6 @@ class RelationApiDualWriteHandler:
             self.binding_mapping = None
             self.tenant_id = role.tenant_id
             self.org_id = role.tenant.org_id
-            self.root_workspace = Workspace.objects.get(
-                name="root", description="Root workspace", tenant_id=self.tenant_id
-            )
             self.event_type = event_type
         except Exception as e:
             raise DualWriteException(e)
@@ -77,7 +74,6 @@ class RelationApiDualWriteHandler:
             relations, _ = migrate_role(
                 self.role,
                 write_relationships=False,
-                root_workspace=str(self.root_workspace.uuid),
                 default_workspace=self.org_id,
                 current_mapping=self.binding_mapping,
             )
@@ -123,7 +119,6 @@ class RelationApiDualWriteHandler:
             relations, mappings = migrate_role(
                 self.role,
                 write_relationships=False,
-                root_workspace=str(self.root_workspace.uuid),
                 default_workspace=self.org_id,
                 current_mapping=self.binding_mapping,
             )

--- a/rbac/migration_tool/sharedSystemRolesReplicatedRoleBindings.py
+++ b/rbac/migration_tool/sharedSystemRolesReplicatedRoleBindings.py
@@ -94,7 +94,6 @@ class SystemRole:
 
 def v1_role_to_v2_bindings(
     v1_role: V1role,
-    root_workspace: str,
     default_workspace: str,
     binding_mapping: Optional[BindingMapping],
 ) -> FrozenSet[V2rolebinding]:
@@ -126,13 +125,13 @@ def v1_role_to_v2_bindings(
         else:
             add_element(
                 perm_groupings,
-                V2boundresource("workspace", root_workspace),
+                V2boundresource("workspace", default_workspace),
                 v2_perm,
             )
     # Project permission sets to roles per set of resources
     resource_roles = permission_groupings_to_v2_role_and_resource(perm_groupings, v1_role, binding_mapping)
     # Construct rolebindings for each resource
-    v2_role_bindings = []
+    v2_role_bindings: list[V2rolebinding] = []
     v2_groups = v1groups_to_v2groups(v1_role.groups)
     for role, resources in resource_roles.items():
         for resource in resources:

--- a/tests/migration_tool/tests_migrate.py
+++ b/tests/migration_tool/tests_migrate.py
@@ -147,16 +147,16 @@ class MigrateTests(TestCase):
             call(f"role_binding:{rolebinding_a2}#granted@role:{v2_role_a2}"),
             call(f"role:{v2_role_a2}#inventory_hosts_write@user:*"),
             call(f"role_binding:{rolebinding_a2}#subject@group:{self.group_a2.uuid}"),
-            call(f"workspace:{self.aws_account_id_1}#parent@workspace:{root_workspace.uuid}"),
+            call(f"workspace:{self.aws_account_id_1}#parent@workspace:{org_id}"),
             call(f"workspace:{self.aws_account_id_1}#user_grant@role_binding:{rolebinding_a2}"),
             ## Role binding to role_a3
             call(f"role_binding:{rolebinding_a31}#granted@role:{v2_role_a31}"),
             call(f"role:{v2_role_a31}#inventory_hosts_write@user:*"),
-            call(f"workspace:{workspace_1}#parent@workspace:{root_workspace.uuid}"),
+            call(f"workspace:{workspace_1}#parent@workspace:{org_id}"),
             call(f"workspace:{workspace_1}#user_grant@role_binding:{rolebinding_a31}"),
             call(f"role_binding:{rolebinding_a32}#granted@role:{v2_role_a32}"),
             call(f"role:{v2_role_a32}#inventory_hosts_write@user:*"),
-            call(f"workspace:{workspace_2}#parent@workspace:{root_workspace.uuid}"),
+            call(f"workspace:{workspace_2}#parent@workspace:{org_id}"),
             call(f"workspace:{workspace_2}#user_grant@role_binding:{rolebinding_a32}"),
         ]
         logger_mock.info.assert_has_calls(tuples, any_order=True)


### PR DESCRIPTION
## Link(s) to Jira
- https://issues.redhat.com/browse/RHCLOUD-35053

## Description of Intent of Change(s)

Everything should go to/under the "default" workspace in order to maintain equivalent inheritance behavior, while at the same time allow for escaping inheritance with new workspaces under the root without having to move resources around. This PR changes migration logic to follow this.

As a result, dual write is also decoupled from the root workspace ID.

## Local Testing

Unit test updates. More tests to come in follow up PR.

## Checklist
- [x] if API spec changes are required, is the spec updated?
- [x] are there any pre/post merge actions required? if so, document here.
- [x] are theses changes covered by unit tests?
- [x] if warranted, are documentation changes accounted for?
- [x] does this require migration changes?
  - [x] if yes, are they backwards compatible?
- [x] is there known, direct impact to dependent teams/components?
  - [x] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
