### PR TITLE
Make max task as integer for debezium config

### DIFF
--- a/deploy/debezium-connector.yml
+++ b/deploy/debezium-connector.yml
@@ -11,7 +11,7 @@ objects:
       strimzi.io/cluster: ${KAFKA_CONNECT_INSTANCE}
   spec:
     class: io.debezium.connector.postgresql.PostgresConnector
-    tasksMax: ${MAX_TASKS}
+    tasksMax: ${{MAX_TASKS}}
     config:
       database.server.name: ${DB_SERVERNAME}
       database.dbname: ${DB_NAME}


### PR DESCRIPTION
## Link(s) to Jira
-

## Description of Intent of Change(s)
Fixes error in deploy tekton pipeline:

```
[2024-09-11 21:33:06] [ERROR] [openshift_base.py:apply_action:885] - [crcs02ue1/rbac-stage] [https://api.crcs02ue1.urby.p1.openshiftapps.com:6443/]: The KafkaConnector "rbac-debezium" is invalid: 
* spec.tasksMax: Invalid value: "string": spec.tasksMax in body must be of type integer: "string"
* .spec.tasksMax: Invalid value: 0: .spec.tasksMax accessor error: 1 is of the type string, expected int64
 (error details: https://github.com/RedHatInsights/insights-rbac/blob/master/deploy/debezium-connector.yml)
[2024-09-11 21:33:06] [INFO] [openshift_base.py:validate_realized_data:1176] - ['validating', 'crcs02ue1', 'rbac-stage', 'ClowdApp', 'rbac']
```

## Local Testing


## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
