### PR TITLE
Ensure timestamps are returned in workspace serializer

### DIFF
--- a/rbac/management/workspace/serializer.py
+++ b/rbac/management/workspace/serializer.py
@@ -28,12 +28,21 @@ class WorkspaceSerializer(serializers.ModelSerializer):
     uuid = serializers.UUIDField(read_only=True, required=False)
     description = serializers.CharField(allow_null=True, required=False, max_length=255)
     parent_id = serializers.UUIDField(allow_null=True, required=False)
+    created = serializers.DateTimeField(read_only=True)
+    modified = serializers.DateTimeField(read_only=True)
 
     class Meta:
         """Metadata for the serializer."""
 
         model = Workspace
-        fields = ("name", "uuid", "parent_id", "description")
+        fields = (
+            "name",
+            "uuid",
+            "parent_id",
+            "description",
+            "created",
+            "modified",
+        )
 
     def create(self, validated_data):
         """Create the workspace object in the database."""

--- a/tests/management/workspace/test_serializer.py
+++ b/tests/management/workspace/test_serializer.py
@@ -40,6 +40,9 @@ class WorkspaceSerializerTest(TestCase):
         Workspace.objects.update(parent=None)
         Workspace.objects.all().delete()
 
+    def _format_timestamps(self, timestamp):
+        return timestamp.isoformat(timespec="microseconds").replace("+00:00", "Z")
+
     def test_get_workspace_detail_child(self):
         """Return GET /workspace/<uuid>/ serializer response for child"""
         serializer = WorkspaceSerializer(self.child)
@@ -48,6 +51,8 @@ class WorkspaceSerializerTest(TestCase):
             "name": self.child.name,
             "description": self.child.description,
             "parent_id": str(self.parent.uuid),
+            "created": self._format_timestamps(self.child.created),
+            "modified": self._format_timestamps(self.child.modified),
         }
 
         self.assertDictEqual(serializer.data, expected_data)
@@ -60,6 +65,8 @@ class WorkspaceSerializerTest(TestCase):
             "name": self.parent.name,
             "description": self.parent.description,
             "parent_id": None,
+            "created": self._format_timestamps(self.parent.created),
+            "modified": self._format_timestamps(self.parent.modified),
         }
 
         self.assertDictEqual(serializer.data, expected_data)


### PR DESCRIPTION
## Link(s) to Jira
- https://issues.redhat.com/browse/RHCLOUD-35150

## Description of Intent of Change(s)
Currently we have our base workspace model defined in the API spec as having a "created" and "modified" field, however those fields are not returned on list/details endpoints. This fixes that by adding them to the serializer.

## Local Testing
Using the `GET /workspaces/` and `GET /workspaces/<uuid>/` API endpoint locally, confirm `created` and `modified` now exist on the payload, per the spec.

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
