### PR TITLE
Ensure we allow `application/problem+json` as a valid `Accept` header value in v2

### DIFF
--- a/rbac/api/common/renderers.py
+++ b/rbac/api/common/renderers.py
@@ -1,0 +1,26 @@
+#
+# Copyright 2024 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+"""Shared DRF renderers."""
+from rest_framework.renderers import JSONRenderer
+
+
+class ProblemJSONRenderer(JSONRenderer):
+    """Renderer for accepting application/problem+json in Accept header."""
+
+    media_type = "application/problem+json"
+    format = "json"

--- a/rbac/management/base_viewsets.py
+++ b/rbac/management/base_viewsets.py
@@ -1,0 +1,33 @@
+# Copyright 2024 Red Hat, Inc.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""Base viewset for v2 APIs."""
+from rest_framework import mixins, viewsets
+from rest_framework.settings import api_settings
+
+from api.common.renderers import ProblemJSONRenderer
+
+
+class BaseV2ViewSet(
+    mixins.CreateModelMixin,
+    mixins.DestroyModelMixin,
+    mixins.RetrieveModelMixin,
+    mixins.UpdateModelMixin,
+    mixins.ListModelMixin,
+    viewsets.GenericViewSet,
+):
+    """Base views to be inhertied for v2 API views."""
+
+    renderer_classes = api_settings.DEFAULT_RENDERER_CLASSES + [ProblemJSONRenderer]

--- a/rbac/management/workspace/view.py
+++ b/rbac/management/workspace/view.py
@@ -19,13 +19,12 @@ import json
 
 from django.utils.translation import gettext as _
 from django_filters import rest_framework as filters
+from management.base_viewsets import BaseV2ViewSet
 from management.permissions import WorkspaceAccessPermission
 from management.utils import validate_uuid
-from rest_framework import mixins, serializers, viewsets
+from rest_framework import serializers
 from rest_framework.filters import OrderingFilter
-from rest_framework.settings import api_settings
 
-from api.common.renderers import ProblemJSONRenderer
 from .model import Workspace
 from .serializer import WorkspaceSerializer
 
@@ -34,14 +33,7 @@ REQUIRED_PUT_FIELDS = ["name", "description", "parent_id"]
 REQUIRED_CREATE_FIELDS = ["name"]
 
 
-class WorkspaceViewSet(
-    mixins.CreateModelMixin,
-    mixins.DestroyModelMixin,
-    mixins.RetrieveModelMixin,
-    mixins.UpdateModelMixin,
-    mixins.ListModelMixin,
-    viewsets.GenericViewSet,
-):
+class WorkspaceViewSet(BaseV2ViewSet):
     """Workspace View.
 
     A viewset that provides default `create()`, `destroy` and `retrieve()`.
@@ -52,7 +44,6 @@ class WorkspaceViewSet(
     queryset = Workspace.objects.annotate()
     lookup_field = "uuid"
     serializer_class = WorkspaceSerializer
-    renderer_classes = api_settings.DEFAULT_RENDERER_CLASSES + [ProblemJSONRenderer]
     ordering_fields = ("name",)
     ordering = ("name",)
     filter_backends = (filters.DjangoFilterBackend, OrderingFilter)

--- a/rbac/management/workspace/view.py
+++ b/rbac/management/workspace/view.py
@@ -23,7 +23,9 @@ from management.permissions import WorkspaceAccessPermission
 from management.utils import validate_uuid
 from rest_framework import mixins, serializers, viewsets
 from rest_framework.filters import OrderingFilter
+from rest_framework.settings import api_settings
 
+from api.common.renderers import ProblemJSONRenderer
 from .model import Workspace
 from .serializer import WorkspaceSerializer
 
@@ -50,6 +52,7 @@ class WorkspaceViewSet(
     queryset = Workspace.objects.annotate()
     lookup_field = "uuid"
     serializer_class = WorkspaceSerializer
+    renderer_classes = api_settings.DEFAULT_RENDERER_CLASSES + [ProblemJSONRenderer]
     ordering_fields = ("name",)
     ordering = ("name",)
     filter_backends = (filters.DjangoFilterBackend, OrderingFilter)

--- a/tests/management/workspace/test_view.py
+++ b/tests/management/workspace/test_view.py
@@ -410,6 +410,7 @@ class WorkspaceViewTests(IdentityRequest):
 
         url = reverse("workspace-detail", kwargs={"uuid": workspace.uuid})
         client = APIClient()
+        self.headers["HTTP_ACCEPT"] = "application/problem+json"
         response = client.delete(url, None, format="json", **self.headers)
 
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)

--- a/tests/management/workspace/test_view.py
+++ b/tests/management/workspace/test_view.py
@@ -68,6 +68,7 @@ class WorkspaceViewTests(IdentityRequest):
         self.assertNotEquals(data.get("created"), "")
         self.assertNotEquals(data.get("modified"), "")
         self.assertEquals(data.get("description"), "Workspace")
+        self.assertEqual(response.get("content-type"), "application/json")
 
     def test_create_workspace_without_parent(self):
         """Test for creating a workspace."""
@@ -84,6 +85,7 @@ class WorkspaceViewTests(IdentityRequest):
         self.assertNotEquals(data.get("created"), "")
         self.assertNotEquals(data.get("modified"), "")
         self.assertEquals(data.get("description"), "Workspace")
+        self.assertEqual(response.get("content-type"), "application/json")
 
     def test_create_workspace_empty_body(self):
         """Test for creating a workspace."""
@@ -100,6 +102,7 @@ class WorkspaceViewTests(IdentityRequest):
         self.assertEqual(detail, "Field 'name' is required.")
 
         self.assertEqual(status_code, 400)
+        self.assertEqual(response.get("content-type"), "application/problem+json")
 
     def test_create_workspace_unauthorized(self):
         """Test for creating a workspace."""
@@ -119,6 +122,7 @@ class WorkspaceViewTests(IdentityRequest):
         detail = response.data.get("detail")
         self.assertEqual(detail, "You do not have permission to perform this action.")
         self.assertEqual(status_code, 403)
+        self.assertEqual(response.get("content-type"), "application/problem+json")
 
     def test_duplicate_create_workspace(self):
         """Test that creating a duplicate workspace is allowed."""
@@ -137,6 +141,7 @@ class WorkspaceViewTests(IdentityRequest):
         client = APIClient()
         response = client.post(url, test_data, format="json", **self.headers)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.get("content-type"), "application/json")
 
     def test_update_workspace(self):
         """Test for updating a workspace."""
@@ -168,6 +173,7 @@ class WorkspaceViewTests(IdentityRequest):
         update_workspace = Workspace.objects.filter(id=workspace.id).first()
         self.assertEquals(update_workspace.name, "Updated name")
         self.assertEquals(update_workspace.description, "Updated description")
+        self.assertEqual(response.get("content-type"), "application/json")
 
     def test_partial_update_workspace_with_put_method(self):
         """Test for updating a workspace."""
@@ -195,6 +201,7 @@ class WorkspaceViewTests(IdentityRequest):
         self.assertEqual(detail, "Field 'description' is required.")
         self.assertEqual(status_code, 400)
         self.assertEqual(instance, url)
+        self.assertEqual(response.get("content-type"), "application/problem+json")
 
     def test_update_workspace_same_parent(self):
         """Test for updating a workspace."""
@@ -229,6 +236,7 @@ class WorkspaceViewTests(IdentityRequest):
         self.assertIsNotNone(detail)
         self.assertEqual(detail, "Parent ID and UUID can't be same")
         self.assertEqual(status_code, 400)
+        self.assertEqual(response.get("content-type"), "application/problem+json")
 
     def test_update_workspace_parent_doesnt_exist(self):
         """Test for updating a workspace."""
@@ -261,6 +269,7 @@ class WorkspaceViewTests(IdentityRequest):
         self.assertEqual(detail, f"Parent workspace '{parent}' doesn't exist in tenant")
         self.assertEqual(status_code, 400)
         self.assertEqual(instance, url)
+        self.assertEqual(response.get("content-type"), "application/problem+json")
 
     def test_partial_update_workspace(self):
         """Test for updating a workspace."""
@@ -288,6 +297,7 @@ class WorkspaceViewTests(IdentityRequest):
 
         update_workspace = Workspace.objects.filter(id=workspace.id).first()
         self.assertEquals(update_workspace.name, "Updated name")
+        self.assertEqual(response.get("content-type"), "application/json")
 
     def test_update_workspace_empty_body(self):
         """Test for updating a workspace with empty body"""
@@ -305,6 +315,7 @@ class WorkspaceViewTests(IdentityRequest):
         self.assertEqual(detail, "Field 'name' is required.")
         self.assertEqual(status_code, 400)
         self.assertEqual(instance, url)
+        self.assertEqual(response.get("content-type"), "application/problem+json")
 
     def test_update_duplicate_workspace(self):
         workspace_data = {
@@ -336,6 +347,7 @@ class WorkspaceViewTests(IdentityRequest):
 
         response = client.put(url, workspace_data_for_put, format="json", **self.headers)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.get("content-type"), "application/json")
 
     def test_update_workspace_unauthorized(self):
         workspace = {}
@@ -355,6 +367,7 @@ class WorkspaceViewTests(IdentityRequest):
 
         self.assertEqual(detail, "You do not have permission to perform this action.")
         self.assertEqual(status_code, 403)
+        self.assertEqual(response.get("content-type"), "application/problem+json")
 
     def test_get_workspace(self):
         url = reverse("workspace-detail", kwargs={"uuid": self.init_workspace.uuid})
@@ -369,6 +382,7 @@ class WorkspaceViewTests(IdentityRequest):
         self.assertIsNotNone(data.get("uuid"))
         self.assertNotEquals(data.get("created"), "")
         self.assertNotEquals(data.get("modified"), "")
+        self.assertEqual(response.get("content-type"), "application/json")
 
     def test_get_workspace_not_found(self):
         url = reverse("workspace-detail", kwargs={"uuid": "XXXX"})
@@ -381,6 +395,7 @@ class WorkspaceViewTests(IdentityRequest):
 
         self.assertEqual(detail, "Not found.")
         self.assertEqual(status_code, 404)
+        self.assertEqual(response.get("content-type"), "application/problem+json")
 
     def test_get_workspace_unauthorized(self):
         request_context = self._create_request_context(self.customer_data, self.user_data, is_org_admin=False)
@@ -398,6 +413,7 @@ class WorkspaceViewTests(IdentityRequest):
 
         self.assertEqual(detail, "You do not have permission to perform this action.")
         self.assertEqual(status_code, 403)
+        self.assertEqual(response.get("content-type"), "application/problem+json")
 
     def test_delete_workspace(self):
         workspace_data = {
@@ -410,10 +426,12 @@ class WorkspaceViewTests(IdentityRequest):
 
         url = reverse("workspace-detail", kwargs={"uuid": workspace.uuid})
         client = APIClient()
-        self.headers["HTTP_ACCEPT"] = "application/problem+json"
-        response = client.delete(url, None, format="json", **self.headers)
+        test_headers = self.headers.copy()
+        test_headers["HTTP_ACCEPT"] = "application/problem+json"
+        response = client.delete(url, None, format="json", **test_headers)
 
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertEqual(response.headers.get("content-type"), None)
         deleted_workspace = Workspace.objects.filter(id=workspace.id).first()
         self.assertIsNone(deleted_workspace)
 
@@ -427,6 +445,7 @@ class WorkspaceViewTests(IdentityRequest):
         detail = response.data.get("detail")
         self.assertEqual(detail, "Not found.")
         self.assertEqual(status_code, 404)
+        self.assertEqual(response.get("content-type"), "application/problem+json")
 
     def test_delete_workspace_unauthorized(self):
         request_context = self._create_request_context(self.customer_data, self.user_data, is_org_admin=False)
@@ -443,6 +462,7 @@ class WorkspaceViewTests(IdentityRequest):
         detail = response.data.get("detail")
         self.assertEqual(detail, "You do not have permission to perform this action.")
         self.assertEqual(status_code, 403)
+        self.assertEqual(response.get("content-type"), "application/problem+json")
 
     def test_get_workspace_list(self):
         """Test for listing workspaces."""
@@ -453,6 +473,7 @@ class WorkspaceViewTests(IdentityRequest):
         payload = response.data
         self.assertIsInstance(payload.get("data"), list)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.get("content-type"), "application/json")
         self.assertEqual(payload.get("meta").get("count"), Workspace.objects.count())
         for keyname in ["meta", "links", "data"]:
             self.assertIn(keyname, payload)


### PR DESCRIPTION
## Link(s) to Jira
- RHCLOUD-35321

## Description of Intent of Change(s)
Since we are starting to use `application/problem+json` as a response content type in v2 APIs [1], we need RBAC/Django to accept this as a valid `Accept` header value, given clients built off the API spec will be sending this.

Currently, if you send a request to `/api/rbac/v2/workspaces/<uuid>/ -XDELETE -H 'Accept: application/problem+json'` which is what a client built off the spec will do (with the `Accept` header), you'll get an error from RBAC: "Not acceptable 406".

We _do_ set the correct `content-type` to align with the spec [2], however Django complains becasue it can't find the `application/problem+json` renderer.

This implements a custom renderer in Django Rest Framework [3] on the v2 views, specifically workspaces now, specifying it in the `renderer_classes` of the view, and setting the `media_type` (used to match the `Accept` value(s) to a renderer) and `format` (response) properties accordingly.

The `DELETE` test was modified prior to this change to add `Accept: application/problem+json` to confirm it failed (it did), and now succeeds with the changes in place.

[1] [https://github.com/RedHatInsights/insights-rbac/blob/master/docs/source/specs/v2/openapi.v2.yaml]
[2] https://github.com/RedHatInsights/insights-rbac/blob/master/rbac/api/common/exception_handler.py#L93
[3] [https://www.django-rest-framework.org/api-guide/renderers/#custom-renderers]

## Local Testing
To exploit the bug on `main`, which also presents through a generated API client, send the following request:

```bash
curl http://localhost:8000/api/rbac/v2/workspaces/<uuid>/ -XDELETE -H 'Accept: application/problem+json'
```

You'll see a 406 response. Now check this branch out and run the same curl. You should also see `application/json`, `application/problem+json` accordingly, depending on success/failure of the requests.

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [x] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
