### PR TITLE
[RHCLOUD-34787] Dual Write: Generate replication event for adding and removing roles from group

### DIFF
--- a/rbac/management/group/definer.py
+++ b/rbac/management/group/definer.py
@@ -189,12 +189,11 @@ def remove_roles(group, roles_or_role_ids, tenant, user=None):
     roles = group.roles().filter(name__in=role_names)
     # TODO: lock custom roles like above
     for policy in group.policies.all():
-        # Only remove the role if it was attached
         for role in roles:
+            # Only remove the role if it was attached
             if policy.roles.filter(pk=role.pk).exists():
                 policy.roles.remove(role)
                 logger.info(f"Removing role {role} from group {group.name} for tenant {tenant.org_id}.")
-                tuples_to_remove: list[Relationship] = []
 
                 dual_write_handler = RelationApiDualWriteGroupHandler(
                     group, ReplicationEventType.ASSIGN_ROLE, []

--- a/rbac/management/group/definer.py
+++ b/rbac/management/group/definer.py
@@ -202,7 +202,7 @@ def remove_roles(group, roles_or_role_ids, tenant, user=None):
                 logger.info(f"Removing role {role} from group {group.name} for tenant {tenant.org_id}.")
 
                 dual_write_handler = RelationApiDualWriteGroupHandler(
-                    group, ReplicationEventType.ASSIGN_ROLE, []
+                    group, ReplicationEventType.UNASSIGN_ROLE, []
                 )
                 dual_write_handler.replicate_removed_role(role)
 

--- a/rbac/management/group/definer.py
+++ b/rbac/management/group/definer.py
@@ -194,7 +194,6 @@ def remove_roles(group, roles_or_role_ids, tenant, user=None):
     # This should not be necessary for system roles
     custom_roles = Role.objects.filter(tenant=tenant, name__in=role_names).select_for_update()
 
-    # TODO: lock custom roles like above
     for policy in group.policies.all():
         for role in [*system_roles, *custom_roles]:
             # Only remove the role if it was attached

--- a/rbac/management/group/relation_api_dual_write_group_handler.py
+++ b/rbac/management/group/relation_api_dual_write_group_handler.py
@@ -115,6 +115,9 @@ class RelationApiDualWriteGroupHandler:
         """Replicate added role. role needs to be locked"""
         if not self.replication_enabled():
             return
+        # TODO - This needs to be removed to seed the default groups.
+        if self.group.tenant.tenant_name == "public":
+            return
 
         if role.system:
             try:
@@ -148,6 +151,10 @@ class RelationApiDualWriteGroupHandler:
     def replicate_removed_role(self, role: Role):
         if not self.replication_enabled():
             return
+        # TODO - This needs to be removed to seed the default groups.
+        if self.group.tenant.tenant_name == "public":
+            return
+
         # This logic can be the same for system vs custom b/c we'd never create a binding in this path
         bindings: Iterable[BindingMapping] = role.binding_mappings.select_for_update().all()
         for binding in bindings:

--- a/rbac/management/group/relation_api_dual_write_group_handler.py
+++ b/rbac/management/group/relation_api_dual_write_group_handler.py
@@ -18,7 +18,6 @@
 """Class to handle Dual Write API related operations."""
 import logging
 from typing import Iterable, Optional
-from uuid import uuid4
 
 from django.conf import settings
 from management.principal.model import Principal
@@ -111,7 +110,7 @@ class RelationApiDualWriteGroupHandler:
             raise DualWriteException(e)
 
     def replicate_added_role(self, role: Role):
-        """Replicate added role. role needs to be locked"""
+        """Replicate added role."""
         if not self.replication_enabled():
             return
         # TODO - This needs to be removed to seed the default groups.
@@ -148,6 +147,7 @@ class RelationApiDualWriteGroupHandler:
         self._replicate()
 
     def replicate_removed_role(self, role: Role):
+        """Replicate removed role."""
         if not self.replication_enabled():
             return
         # TODO - This needs to be removed to seed the default groups.
@@ -165,5 +165,3 @@ class RelationApiDualWriteGroupHandler:
             else:
                 binding.save()
         self._replicate()
-
-

--- a/rbac/management/group/relation_api_dual_write_group_handler.py
+++ b/rbac/management/group/relation_api_dual_write_group_handler.py
@@ -31,7 +31,6 @@ from management.role.relation_api_dual_write_handler import (
     ReplicationEventType,
 )
 from migration_tool.utils import create_relationship
-from migration_tool.models import V2boundresource, V2role, V2rolebinding
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
@@ -166,3 +165,5 @@ class RelationApiDualWriteGroupHandler:
             else:
                 binding.save()
         self._replicate()
+
+

--- a/rbac/management/group/relation_api_dual_write_group_handler.py
+++ b/rbac/management/group/relation_api_dual_write_group_handler.py
@@ -43,7 +43,6 @@ class RelationApiDualWriteGroupHandler:
         self,
         group,
         event_type: ReplicationEventType,
-        principals: list[Principal],
         replicator: Optional[RelationReplicator] = None,
     ):
         """Initialize RelationApiDualWriteGroupHandler."""
@@ -52,7 +51,7 @@ class RelationApiDualWriteGroupHandler:
         try:
             self.group_relations_to_add = []
             self.group_relations_to_remove = []
-            self.principals = principals
+            self.principals = []
             self.group = group
             self.event_type = event_type
             self._replicator = replicator if replicator else OutboxReplicator(group)
@@ -75,21 +74,21 @@ class RelationApiDualWriteGroupHandler:
 
         return relations
 
-    def replicate_new_principals(self):
+    def replicate_new_principals(self, principals: list[Principal]):
         """Replicate new principals into group."""
         if not self.replication_enabled():
             return
         logger.info("[Dual Write] Generate new relations from Group(%s): '%s'", self.group.uuid, self.group.name)
-
+        self.principals = principals
         self.group_relations_to_add = self._generate_relations()
         self._replicate()
 
-    def replicate_removed_principals(self):
+    def replicate_removed_principals(self, principals: list[Principal]):
         """Replicate removed principals from group."""
         if not self.replication_enabled():
             return
         logger.info("[Dual Write] Generate new relations from Group(%s): '%s'", self.group.uuid, self.group.name)
-
+        self.principals = principals
         self.group_relations_to_remove = self._generate_relations()
 
         self._replicate()

--- a/rbac/management/group/view.py
+++ b/rbac/management/group/view.py
@@ -704,9 +704,9 @@ class GroupViewSet(
                     group, new_principals = self.add_principals(group, principals_from_response, org_id=org_id)
 
                 dual_write_handler = RelationApiDualWriteGroupHandler(
-                    group, ReplicationEventType.ADD_PRINCIPALS_TO_GROUP, new_principals + new_service_accounts
+                    group, ReplicationEventType.ADD_PRINCIPALS_TO_GROUP
                 )
-                dual_write_handler.replicate_new_principals()
+                dual_write_handler.replicate_new_principals(new_principals + new_service_accounts)
 
             # Serialize the group...
             output = GroupSerializer(group)
@@ -920,9 +920,8 @@ class GroupViewSet(
                 dual_write_handler = RelationApiDualWriteGroupHandler(
                     group,
                     ReplicationEventType.REMOVE_PRINCIPALS_FROM_GROUP,
-                    principals_to_remove + service_accounts_to_remove,
                 )
-                dual_write_handler.replicate_removed_principals()
+                dual_write_handler.replicate_removed_principals(principals_to_remove + service_accounts_to_remove)
 
         return response
 

--- a/rbac/management/role/model.py
+++ b/rbac/management/role/model.py
@@ -194,9 +194,6 @@ class BindingMapping(models.Model):
 
         return tuples
 
-    def is_empty(self):
-        return len(self.mappings["groups"]) == 0
-
     def remove_group_from_bindings(self, group_id: str) -> Relationship:
         """Remove group from mappings."""
         self.mappings["groups"] = [group for group in self.mappings["groups"] if group != group_id]

--- a/rbac/management/role/model.py
+++ b/rbac/management/role/model.py
@@ -198,14 +198,14 @@ class BindingMapping(models.Model):
         """Remove group from mappings."""
         self.mappings["groups"] = [group for group in self.mappings["groups"] if group != group_id]
         return create_relationship(
-            ("rbac", "role_binding"), self.mappings["id"], ("rbac", "group"), group_id, "member"
+            ("rbac", "role_binding"), self.mappings["id"], ("rbac", "group"), group_id, "subject"
         )
 
     def add_group_to_bindings(self, group_id: str) -> Relationship:
         """Add group to mappings."""
         self.mappings["groups"].append(group_id)
         return create_relationship(
-            ("rbac", "role_binding"), self.mappings["id"], ("rbac", "group"), group_id, "member"
+            ("rbac", "role_binding"), self.mappings["id"], ("rbac", "group"), group_id, "subject"
         )
 
     def update_mappings_from_role_binding(self, role_binding: V2rolebinding):

--- a/rbac/management/role/model.py
+++ b/rbac/management/role/model.py
@@ -179,7 +179,7 @@ class BindingMapping(models.Model):
         for group in v2_role_binding.groups:
             # These might be duplicate but it is OK, spiceDB will handle duplication through touch
             tuples.append(
-                create_relationship(("rbac", "role_binding"), v2_role_binding.id, ("rbac", "group"), group, "member")
+                create_relationship(("rbac", "role_binding"), v2_role_binding.id, ("rbac", "group"), group, "subject")
             )
 
         tuples.append(

--- a/rbac/management/role/model.py
+++ b/rbac/management/role/model.py
@@ -133,7 +133,7 @@ class BindingMapping(models.Model):
     resource_id = models.CharField(max_length=256, null=False)
 
     @classmethod
-    def for_group_and_role(cls, role: Role, group_uuid, org_id):
+    def for_group_and_role(cls, role: Role, group_uuid: str, org_id: str):
         """Create instance of BindingMapping from given parameters."""
         id = str(uuid4())
         binding = V2rolebinding(
@@ -195,6 +195,10 @@ class BindingMapping(models.Model):
         )
 
         return tuples
+
+    def is_unassigned(self):
+        """Return true if mapping is not assigned to any groups."""
+        return len(self.mappings["groups"]) == 0
 
     def remove_group_from_bindings(self, group_id: str) -> Relationship:
         """Remove group from mappings."""

--- a/rbac/management/role/model.py
+++ b/rbac/management/role/model.py
@@ -133,6 +133,18 @@ class BindingMapping(models.Model):
     resource_id = models.CharField(max_length=256, null=False)
 
     @classmethod
+    def for_group_and_role(cls, role: Role, group_uuid, org_id):
+        id = str(uuid4())
+        binding = V2rolebinding(
+            id,
+            V2role(str(role.uuid), True, frozenset()),
+            # TODO: don't use org id once we have workspace built ins
+            V2boundresource(("rbac", "workspace"), org_id),
+            groups=[str(group_uuid)],
+        )
+        return BindingMapping.for_role_binding(binding, role)
+
+    @classmethod
     def for_role_binding(cls, role_binding: V2rolebinding, v1_role: Union[Role, str]):
         """Create a new BindingMapping for a V2rolebinding."""
         mappings = role_binding.as_minimal_dict()

--- a/rbac/management/role/model.py
+++ b/rbac/management/role/model.py
@@ -30,9 +30,9 @@ from management.cache import AccessCache
 from management.models import Permission, Principal
 from management.rbac_fields import AutoDateTimeField
 from migration_tool.models import V2boundresource, V2role, V2rolebinding
+from migration_tool.utils import create_relationship
 
 from api.models import TenantAwareModel
-from migration_tool.utils import create_relationship
 
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
@@ -134,6 +134,7 @@ class BindingMapping(models.Model):
 
     @classmethod
     def for_group_and_role(cls, role: Role, group_uuid, org_id):
+        """Create instance of BindingMapping from given parameters."""
         id = str(uuid4())
         binding = V2rolebinding(
             id,
@@ -164,6 +165,7 @@ class BindingMapping(models.Model):
         )
 
     def as_tuples(self) -> list[Relationship]:
+        """Create a tuples from BindingMapping model."""
         v2_role_binding = self.get_role_binding()
         tuples: list[Relationship] = list()
 

--- a/rbac/management/role/relation_api_dual_write_handler.py
+++ b/rbac/management/role/relation_api_dual_write_handler.py
@@ -27,7 +27,7 @@ from kessel.relations.v1beta1 import common_pb2
 from management.models import Outbox
 from management.role.model import BindingMapping, Role
 from migration_tool.migrate import migrate_role
-from migration_tool.sharedSystemRolesReplicatedRoleBindings import SystemRole, v1_perm_to_v2_perm
+from migration_tool.sharedSystemRolesReplicatedRoleBindings import v1_perm_to_v2_perm
 from migration_tool.utils import create_relationship
 
 

--- a/rbac/management/role/relation_api_dual_write_handler.py
+++ b/rbac/management/role/relation_api_dual_write_handler.py
@@ -325,8 +325,6 @@ class RelationApiDualWriteHandler:
         for permissions, role in SystemRole.get_system_roles().items():
             for permission in permissions:
                 self.role_relations.append(
-                    create_relationship(
-                        ("rbac", "role"), str(role.id), ("rbac", "user"), str("*"), permission
-                    )
+                    create_relationship(("rbac", "role"), str(role.id), ("rbac", "user"), str("*"), permission)
                 )
         self._replicate()

--- a/rbac/management/role/relation_api_dual_write_handler.py
+++ b/rbac/management/role/relation_api_dual_write_handler.py
@@ -319,7 +319,7 @@ class RelationApiDualWriteHandler:
         except Exception as e:
             raise DualWriteException(e)
 
-    def replicate_system_role_permissions(self):
+    def replicate_new_system_role_permissions(self):
         """Replicate system role permissions."""
         SystemRole.set_system_role(self.role)
         for permissions, role in SystemRole.get_system_roles().items():

--- a/rbac/management/role/relation_api_dual_write_handler.py
+++ b/rbac/management/role/relation_api_dual_write_handler.py
@@ -27,7 +27,7 @@ from kessel.relations.v1beta1 import common_pb2
 from management.models import Outbox
 from management.role.model import BindingMapping, Role
 from migration_tool.migrate import migrate_role
-from migration_tool.sharedSystemRolesReplicatedRoleBindings import SystemRole
+from migration_tool.sharedSystemRolesReplicatedRoleBindings import SystemRole, v1_perm_to_v2_perm
 from migration_tool.utils import create_relationship
 
 
@@ -319,12 +319,17 @@ class RelationApiDualWriteHandler:
         except Exception as e:
             raise DualWriteException(e)
 
-    def replicate_new_system_role_permissions(self):
+    # TODO: Remove/replace - placeholder for testing
+    def replicate_new_system_role_permissions(self, role: Role):
         """Replicate system role permissions."""
-        SystemRole.set_system_role(self.role)
-        for permissions, role in SystemRole.get_system_roles().items():
-            for permission in permissions:
-                self.role_relations.append(
-                    create_relationship(("rbac", "role"), str(role.id), ("rbac", "user"), str("*"), permission)
-                )
+        permissions = list()
+        for access in role.access.all():
+            v1_perm = access.permission
+            v2_perm = v1_perm_to_v2_perm(v1_perm)
+            permissions.append(v2_perm)
+
+        for permission in permissions:
+            self.role_relations.append(
+                create_relationship(("rbac", "role"), str(role.uuid), ("rbac", "user"), str("*"), permission)
+            )
         self._replicate()

--- a/rbac/migration_tool/in_memory_tuples.py
+++ b/rbac/migration_tool/in_memory_tuples.py
@@ -19,6 +19,13 @@ class RelationTuple(NamedTuple):
     subject_id: str
     subject_relation: str
 
+    def stringify(self):
+        """Display all attributes in one line."""
+        return (
+            f"{self.resource_type_namespace}/{self.resource_type_name}:{self.resource_id}#{self.relation}"
+            f"@{self.subject_type_namespace}/{self.subject_type_name}:{self.subject_id}"
+        )
+
 
 T = TypeVar("T", bound=Hashable)
 

--- a/rbac/migration_tool/migrate.py
+++ b/rbac/migration_tool/migrate.py
@@ -39,21 +39,7 @@ def get_kessel_relation_tuples(
     relationships: list[common_pb2.Relationship] = list()
 
     for v2_role_binding in v2_role_bindings:
-        relationships.append(
-            create_relationship(
-                ("rbac", "role_binding"), v2_role_binding.id, ("rbac", "role"), v2_role_binding.role.id, "granted"
-            )
-        )
-
-        for perm in v2_role_binding.role.permissions:
-            relationships.append(
-                create_relationship(("rbac", "role"), v2_role_binding.role.id, ("rbac", "user"), "*", perm)
-            )
-        for group in v2_role_binding.groups:
-            # These might be duplicate but it is OK, spiceDB will handle duplication through touch
-            relationships.append(
-                create_relationship(("rbac", "role_binding"), v2_role_binding.id, ("rbac", "group"), group, "subject")
-            )
+        relationships.extend(v2_role_binding.as_tuples())
 
         bound_resource = v2_role_binding.resource
 
@@ -79,16 +65,6 @@ def get_kessel_relation_tuples(
                     "parent",
                 )
             )
-
-        relationships.append(
-            create_relationship(
-                bound_resource.resource_type,
-                bound_resource.resource_id,
-                ("rbac", "role_binding"),
-                v2_role_binding.id,
-                "user_grant",
-            )
-        )
 
     return relationships
 

--- a/rbac/migration_tool/models.py
+++ b/rbac/migration_tool/models.py
@@ -71,7 +71,7 @@ class V2role:
         return {
             "id": self.id,
             "is_system": self.is_system,
-            "permissions": list(self.permissions),
+            **({"permissions": list(self.permissions)} if not self.is_system else {}),
         }
 
 

--- a/rbac/migration_tool/models.py
+++ b/rbac/migration_tool/models.py
@@ -62,6 +62,11 @@ class V2boundresource:
 class V2role:
     """V2 role definition."""
 
+    @classmethod
+    def for_system_role(cls, id: str) -> "V2role":
+        """Create a V2 role for a system role."""
+        return cls(id=id, is_system=True, permissions=frozenset())
+
     id: str
     is_system: bool
     permissions: frozenset[str]

--- a/rbac/migration_tool/models.py
+++ b/rbac/migration_tool/models.py
@@ -71,7 +71,7 @@ class V2role:
         return {
             "id": self.id,
             "is_system": self.is_system,
-            "permissions": list(self.permissions) if not self.is_system else []
+            "permissions": list(self.permissions) if not self.is_system else [],
         }
 
 

--- a/rbac/migration_tool/models.py
+++ b/rbac/migration_tool/models.py
@@ -71,7 +71,7 @@ class V2role:
         return {
             "id": self.id,
             "is_system": self.is_system,
-            **({"permissions": list(self.permissions)} if not self.is_system else {}),
+            "permissions": list(self.permissions) if not self.is_system else []
         }
 
 

--- a/rbac/migration_tool/sharedSystemRolesReplicatedRoleBindings.py
+++ b/rbac/migration_tool/sharedSystemRolesReplicatedRoleBindings.py
@@ -71,13 +71,16 @@ class SystemRole:
             # Skip roles such as OCM since they don't have permission
             if role.external_role_id():
                 continue
-            permission_list = list()
-            for access in role.access.all():
-                v2_perm = cleanNameForV2SchemaCompatibility(access.permission.permission)
-                v2_perm = inventory_to_workspace(v2_perm)
-                permission_list.append(v2_perm)
-            add_system_role(cls.SYSTEM_ROLES, V2role(str(role.uuid), True, frozenset(permission_list)))
+            cls.set_system_role(role)
 
+    @classmethod
+    def set_system_role(cls, role):
+        permission_list = list()
+        for access in role.access.all():
+            v2_perm = cleanNameForV2SchemaCompatibility(access.permission.permission)
+            v2_perm = inventory_to_workspace(v2_perm)
+            permission_list.append(v2_perm)
+        add_system_role(cls.SYSTEM_ROLES, V2role(str(role.uuid), True, frozenset(permission_list)))
 
 def v1_role_to_v2_bindings(
     v1_role: Role,

--- a/rbac/migration_tool/sharedSystemRolesReplicatedRoleBindings.py
+++ b/rbac/migration_tool/sharedSystemRolesReplicatedRoleBindings.py
@@ -75,12 +75,14 @@ class SystemRole:
 
     @classmethod
     def set_system_role(cls, role):
+        """Set the system role."""
         permission_list = list()
         for access in role.access.all():
             v2_perm = cleanNameForV2SchemaCompatibility(access.permission.permission)
             v2_perm = inventory_to_workspace(v2_perm)
             permission_list.append(v2_perm)
         add_system_role(cls.SYSTEM_ROLES, V2role(str(role.uuid), True, frozenset(permission_list)))
+
 
 def v1_role_to_v2_bindings(
     v1_role: Role,

--- a/rbac/migration_tool/utils.py
+++ b/rbac/migration_tool/utils.py
@@ -2,7 +2,7 @@
 
 import json
 import logging
-from typing import Tuple
+from typing import Optional, Tuple
 
 import grpc
 from django.conf import settings
@@ -55,13 +55,20 @@ def validate_and_create_obj_ref(obj_name: Tuple[str, str], obj_id):
 
 
 def create_relationship(
-    resource_name: Tuple[str, str], resource_id, subject_name: Tuple[str, str], subject_id, relation
+    resource_name: Tuple[str, str],
+    resource_id,
+    subject_name: Tuple[str, str],
+    subject_id,
+    relation,
+    subject_relation: Optional[str] = None,
 ):
     """Create a relationship between a resource and a subject."""
     return common_pb2.Relationship(
         resource=validate_and_create_obj_ref(resource_name, resource_id),
         relation=relation,
-        subject=common_pb2.SubjectReference(subject=validate_and_create_obj_ref(subject_name, subject_id)),
+        subject=common_pb2.SubjectReference(
+            subject=validate_and_create_obj_ref(subject_name, subject_id), relation=subject_relation
+        ),
     )
 
 

--- a/tests/management/role/test_dual_write.py
+++ b/tests/management/role/test_dual_write.py
@@ -81,9 +81,9 @@ class DualWriteTestCase(TestCase):
     def given_v1_system_role(self, name: str, permissions: list[str]) -> Role:
         """Create a new system role with the given ID and permissions."""
         role = self.fixture.new_system_role(name=name, permissions=permissions)
-        # TODO: Need to replicate system role permission relations
-        # This is different from group assignment
-        dual_write = self.dual_write_handler_for_system_role(role, self.tenant, ReplicationEventType.CREATE_SYSTEM_ROLE)
+        dual_write = self.dual_write_handler_for_system_role(
+            role, self.tenant, ReplicationEventType.CREATE_SYSTEM_ROLE
+        )
         dual_write.replicate_new_system_role_permissions()
         return role
 
@@ -166,7 +166,8 @@ class DualWriteTestCase(TestCase):
         """Assign the [roles] to the [group]."""
 
         dual_write_handler = RelationApiDualWriteGroupHandler(
-            group, ReplicationEventType.ASSIGN_ROLE,
+            group,
+            ReplicationEventType.ASSIGN_ROLE,
             [],
             replicator=InMemoryRelationReplicator(self.tuples),
         )
@@ -178,7 +179,8 @@ class DualWriteTestCase(TestCase):
 
         policy = self.fixture.remove_role_to_group(roles[0], group, self.tenant)
         dual_write_handler = RelationApiDualWriteGroupHandler(
-            group, ReplicationEventType.UNASSIGN_ROLE,
+            group,
+            ReplicationEventType.UNASSIGN_ROLE,
             [],
             replicator=InMemoryRelationReplicator(self.tuples),
         )

--- a/tests/management/role/test_dual_write.py
+++ b/tests/management/role/test_dual_write.py
@@ -79,8 +79,8 @@ class DualWriteTestCase(TestCase):
     def default_workspace(self, tenant: Optional[Tenant] = None) -> str:
         """Return the default workspace ID."""
         tenant = tenant if tenant is not None else self.tenant
-        assert self.tenant.org_id is not None, "Tenant org_id should not be None"
-        return self.tenant.org_id
+        assert tenant.org_id is not None, "Tenant org_id should not be None"
+        return tenant.org_id
 
     def dual_write_handler(self, role: Role, event_type: ReplicationEventType) -> RelationApiDualWriteHandler:
         """Create a RelationApiDualWriteHandler for the given role and event type."""
@@ -279,7 +279,7 @@ class DualWriteTestCase(TestCase):
                 all_of(
                     resource_type("rbac", "role_binding"),
                     relation("subject"),
-                    subject("rbac", "group", group_id),
+                    subject("rbac", "group", group_id, "member"),
                 )
                 for group_id in for_groups
             ],
@@ -353,7 +353,7 @@ class DualWriteGroupRolesTestCase(DualWriteTestCase):
             all_of(
                 resource_type("rbac", "role_binding"),
                 relation("subject"),
-                subject_type("rbac", "group"),
+                subject_type("rbac", "group", "member"),
             )
         )
 
@@ -364,7 +364,7 @@ class DualWriteGroupRolesTestCase(DualWriteTestCase):
                     all_of(
                         resource("rbac", "role_binding", mapping["id"]),
                         relation("subject"),
-                        subject("rbac", "group", group_from_mapping),
+                        subject("rbac", "group", group_from_mapping, "member"),
                     )
                 )
                 self.assertEquals(len(tuples), 1)

--- a/tests/management/role/test_view.py
+++ b/tests/management/role/test_view.py
@@ -88,13 +88,20 @@ def relation_api_tuples_for_v1_role(v1_role_uuid, default_workspace_uuid):
     return relations
 
 
-def relation_api_tuple(resource_type, resource_id, relation, subject_type, subject_id):
+def relation_api_tuple(resource_type, resource_id, relation, subject_type, subject_id, subject_relation=None):
     """Helper function for creating a relation tuple in json."""
     return {
         "resource": relation_api_resource(resource_type, resource_id),
         "relation": relation,
-        "subject": {"subject": relation_api_resource(subject_type, subject_id)},
+        "subject": relation_api_subject(subject_type, subject_id, subject_relation),
     }
+
+
+def relation_api_subject(subject_type, subject_id, subject_relation=None):
+    subject = {"subject": relation_api_resource(subject_type, subject_id)}
+    if subject_relation is not None:
+        subject["relation"] = subject_relation
+    return subject
 
 
 def relation_api_resource(type_resource, id_resource):


### PR DESCRIPTION
## Link(s) to Jira
- https://issues.redhat.com/browse/RHCLOUD-34787

## Description of Intent of Change(s)
- this generates replication event during add/remove roles from group 
- PR also adds method to generate replication event for permissions relations of system role (used only for tests)

## Local Testing
```
POST http://localhost:8000/api/rbac/v1/groups/6277ca72-6b65-463e-bc3d-e0d47481adee/roles/
x-rh-identity: 
Content-Type: application/json

{"roles":["b7d2f47a-6042-433c-9d43-8873b3517a65"]}
```

```
### DELETE  ROLE to group
DELETE http://localhost:8000/api/rbac/v1/groups/6277ca72-6b65-463e-bc3d-e0d47481adee/roles/?roles=b7d2f47a-6042-433c-9d43-8873b3517a65
x-rh-identity: 

```

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
