### PR TITLE
[RHCLOUD-35227] Replicate group removal 

### DIFF
--- a/rbac/management/group/relation_api_dual_write_group_handler.py
+++ b/rbac/management/group/relation_api_dual_write_group_handler.py
@@ -196,7 +196,7 @@ class RelationApiDualWriteGroupHandler:
                     )
                     .get()
                 )
-                
+
                 update_mapping(mapping)
 
                 if mapping.is_unassigned():

--- a/rbac/management/group/relation_api_dual_write_group_handler.py
+++ b/rbac/management/group/relation_api_dual_write_group_handler.py
@@ -33,6 +33,8 @@ from management.role.relation_api_dual_write_handler import (
 from migration_tool.models import V2boundresource, V2role, V2rolebinding
 from migration_tool.utils import create_relationship
 
+from api.models import Tenant
+
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
 
@@ -148,13 +150,16 @@ class RelationApiDualWriteGroupHandler:
         if self.group.tenant.tenant_name == "public":
             return
 
+        self._update_mapping_for_role_removal(role)
+        self._replicate()
+
+    def _update_mapping_for_role_removal(self, role: Role):
         def remove_group_from_binding(mapping: BindingMapping):
             self.group_relations_to_remove.append(mapping.remove_group_from_bindings(str(self.group.uuid)))
 
         self._update_mapping_for_role(
             role, update_mapping=remove_group_from_binding, create_default_mapping_for_system_role=lambda: None
         )
-        self._replicate()
 
     def _update_mapping_for_role(
         self,
@@ -210,7 +215,6 @@ class RelationApiDualWriteGroupHandler:
             # Because custom roles must be locked already by this point,
             # we don't need to lock the binding here.
             bindings: Iterable[BindingMapping] = role.binding_mappings.all()
-
             if not bindings:
                 logger.warning(
                     "[Dual Write] Binding mappings not found for role(%s): '%s'. "
@@ -223,3 +227,34 @@ class RelationApiDualWriteGroupHandler:
             for mapping in bindings:
                 update_mapping(mapping)
                 mapping.save(force_update=True)
+
+    def prepare_to_delete_group(self):
+        """Generate relations to delete."""
+        roles = Role.objects.filter(policies__group=self.group)
+
+        system_roles = roles.filter(tenant=Tenant.objects.get(tenant_name="public"))
+
+        # Custom roles are locked to prevent resources from being added/removed concurrently,
+        # in the case that the Roles had _no_ resources specified to begin with.
+        # This should not be necessary for system roles.
+        custom_roles = roles.filter(tenant=self.group.tenant).select_for_update()
+
+        custom_ids = []
+        for role in [*system_roles, *custom_roles]:
+            if role.id in custom_ids:
+                # it was needed to skip distinct clause because distinct doesn't work with select_for_update
+                continue
+            self._update_mapping_for_role_removal(role)
+            custom_ids.append(role.id)
+
+        if self.group.platform_default:
+            pass  # TODO: create default bindings,
+        else:
+            self.principals = self.group.principals.all()
+            self.group_relations_to_remove.extend(self._generate_relations())
+
+    def replicate_deleted_group(self):
+        """Prepare for delete."""
+        if not self.replication_enabled():
+            return
+        self._replicate()

--- a/rbac/management/group/relation_api_dual_write_group_handler.py
+++ b/rbac/management/group/relation_api_dual_write_group_handler.py
@@ -196,12 +196,14 @@ class RelationApiDualWriteGroupHandler:
                     )
                     .get()
                 )
+                
                 update_mapping(mapping)
-                mapping.save(force_update=True)
 
                 if mapping.is_unassigned():
                     self.group_relations_to_remove.extend(mapping.as_tuples())
                     mapping.delete()
+                else:
+                    mapping.save(force_update=True)
             except BindingMapping.DoesNotExist:
                 mapping = create_default_mapping_for_system_role()
                 if mapping is not None:


### PR DESCRIPTION
## Link(s) to Jira
- https://issues.redhat.com/browse/RHCLOUD-35227

## Description of Intent of Change(s)
Replicate group removals into relation API

WIP:
- [ ] Removal Custom Default groups 

## Local Testing
How can the feature be exercised?
How can the bug be exploited and fix confirmed?
Is any special local setup required?

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
