### PR TITLE
remove drift app from ROLE_CREATE_ALLOW_LIST

### DIFF
--- a/deploy/rbac-clowdapp.yml
+++ b/deploy/rbac-clowdapp.yml
@@ -747,7 +747,7 @@ parameters:
   value: 'False'
 - description: Application allow list for role creation in RBAC
   name: ROLE_CREATE_ALLOW_LIST
-  value: cost-management,remediations,inventory,drift,policies,advisor,vulnerability,compliance,automation-analytics,notifications,patch,integrations,ros,staleness,config-manager,idmsvc
+  value: cost-management,remediations,inventory,policies,advisor,vulnerability,compliance,automation-analytics,notifications,patch,integrations,ros,staleness,config-manager,idmsvc
 - description: Application exclude list for v2 migration (all permissions)
   name: V2_MIGRATION_APP_EXCLUDE_LIST
   value: approval


### PR DESCRIPTION
[RHINENG-12496](https://issues.redhat.com/browse/RHINENG-12496)

**Drift** app has been removed from Console Dot 1st of October 2024 and we started to remove system roles and permissions (https://github.com/RedHatInsights/rbac-config/pull/564), so we need to remove Drift from `ROLE_CREATE_ALLOW_LIST`