### PR TITLE
RHCLOUD-35357 & RHCLOUD-35303: Seed default group role relations alongside role seeding

### DIFF
--- a/rbac/management/role/relation_api_dual_write_handler.py
+++ b/rbac/management/role/relation_api_dual_write_handler.py
@@ -40,6 +40,7 @@ from api.models import Tenant
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
+
 class SeedingRelationApiDualWriteHandler:
     """Class to handle Dual Write API related operations specific to the seeding process."""
 

--- a/rbac/management/role/relation_api_dual_write_handler.py
+++ b/rbac/management/role/relation_api_dual_write_handler.py
@@ -107,7 +107,8 @@ class SeedingRelationApiDualWriteHandler:
         admin_default = self._get_admin_default_policy_uuid()
         platform_default = self._get_platform_default_policy_uuid()
 
-        if role.admin_default and admin_default: #Is it valid to skip this? If there are no default groups, the migration isn't going to succeed.
+        # Is it valid to skip this? If there are no default groups, the migration isn't going to succeed.
+        if role.admin_default and admin_default:
             relations.append(
                 create_relationship(("rbac", "role"), str(role.uuid), ("rbac", "role"), admin_default, "child")
             )
@@ -131,7 +132,7 @@ class SeedingRelationApiDualWriteHandler:
 
     def _create_metadata_from_role(self, role: Role) -> dict[str, object]:
         return {"role_uuid": role.uuid}
-    
+
     def _replicate(
         self,
         event_type: ReplicationEventType,
@@ -155,7 +156,7 @@ class SeedingRelationApiDualWriteHandler:
             )
         except Exception as e:
             raise DualWriteException(e)
-    
+
     def _get_platform_default_policy_uuid(self) -> Optional[str]:
         try:
             if self._platform_default_policy_uuid is None:

--- a/rbac/management/role/relation_api_dual_write_handler.py
+++ b/rbac/management/role/relation_api_dual_write_handler.py
@@ -43,7 +43,7 @@ logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 class SeedingRelationApiDualWriteHandler:
     """Class to handle Dual Write API related operations specific to the seeding process."""
 
-    _replicator: OutboxReplicator
+    _replicator: RelationReplicator
     _current_role_relations: list[common_pb2.Relationship]
 
     _public_tenant: Optional[Tenant] = None

--- a/rbac/management/role/relation_api_dual_write_handler.py
+++ b/rbac/management/role/relation_api_dual_write_handler.py
@@ -40,6 +40,178 @@ from api.models import Tenant
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
 
+<<<<<<< HEAD
+=======
+class DualWriteException(Exception):
+    """DualWrite exception."""
+
+    pass
+
+
+class ReplicationEventType(str, Enum):
+    """Replication event type."""
+
+    CREATE_SYSTEM_ROLE = "create_system_role"
+    UPDATE_SYSTEM_ROLE = "update_system_role"
+    DELETE_SYSTEM_ROLE = "delete_system_role"
+    CREATE_CUSTOM_ROLE = "create_custom_role"
+    UPDATE_CUSTOM_ROLE = "update_custom_role"
+    DELETE_CUSTOM_ROLE = "delete_custom_role"
+    ASSIGN_ROLE = "assign_role"
+    UNASSIGN_ROLE = "unassign_role"
+    CREATE_GROUP = "create_group"
+    UPDATE_GROUP = "update_group"
+    DELETE_GROUP = "delete_group"
+    ADD_PRINCIPALS_TO_GROUP = "add_principals_to_group"
+    REMOVE_PRINCIPALS_FROM_GROUP = "remove_principals_from_group"
+    BOOTSTRAP_TENANT = "bootstrap_tenant"
+    EXTERNAL_USER_UPDATE = "external_user_update"
+
+
+class ReplicationEvent:
+    """What tuples changes to replicate."""
+
+    event_type: ReplicationEventType
+    event_info: dict[str, object]
+    partition_key: str
+    add: list[common_pb2.Relationship]
+    remove: list[common_pb2.Relationship]
+
+    def __init__(
+        self,
+        event_type: ReplicationEventType,
+        partition_key: str,
+        add: list[common_pb2.Relationship] = [],
+        remove: list[common_pb2.Relationship] = [],
+        info: dict[str, object] = {},
+    ):
+        """Initialize ReplicationEvent."""
+        self.partition_key = partition_key
+        self.event_type = event_type
+        self.add = add
+        self.remove = remove
+        self.event_info = info
+
+
+class RelationReplicator(ABC):
+    """Type responsible for replicating relations to Kessel Relations."""
+
+    @abstractmethod
+    def replicate(self, event: ReplicationEvent):
+        """Replicate the given event to Kessel Relations."""
+        pass
+
+
+class OutboxReplicator(RelationReplicator):
+    """Replicates relations via the outbox table."""
+
+    def replicate(self, event: ReplicationEvent):
+        """Replicate the given event to Kessel Relations via the Outbox."""
+        payload = self._build_replication_event(event.add, event.remove)
+        self._save_replication_event(payload, event.event_type, event.event_info, event.partition_key)
+
+    def _build_replication_event(self, relations_to_add, relations_to_remove):
+        """Build replication event."""
+        add_json = []
+        for relation in relations_to_add:
+            add_json.append(json_format.MessageToDict(relation))
+
+        remove_json = []
+        for relation in relations_to_remove:
+            remove_json.append(json_format.MessageToDict(relation))
+
+        replication_event = {"relations_to_add": add_json, "relations_to_remove": remove_json}
+        return replication_event
+
+    def _save_replication_event(self, payload, event_type, event_info: dict[str, object], aggregateid):
+        """Save replication event."""
+        # TODO: Can we add these as proper fields for kibana but also get logged in simple formatter?
+        logger.info(
+            "[Dual Write] Publishing replication event. event_type='%s' %s",
+            event_type,
+            " ".join([f"info.{key}='{str(value)}'" for key, value in event_info.items()]),
+        )
+        # https://debezium.io/documentation/reference/stable/transformations/outbox-event-router.html#basic-outbox-table
+        outbox_record = Outbox.objects.create(
+            aggregatetype="relations-replication-event",
+            aggregateid=aggregateid,
+            event_type=event_type,
+            payload=payload,
+        )
+        outbox_record.delete()
+
+
+class NoopReplicator(RelationReplicator):
+    """Noop replicator."""
+
+    def replicate(self, event: ReplicationEvent):
+        """Noop."""
+        pass
+
+
+class SeedingRelationApiDualWriteHandler:
+    """Class to handle Dual Write API related operations specific to the seeding process."""
+
+    _replicator: RelationReplicator
+    _role: Role
+    _current_role_relations: list[common_pb2.Relationship]
+
+    def __init__(self, replicator: Optional[RelationReplicator] = None):
+        _replicator = replicator if replicator else OutboxReplicator(None)
+
+    def replication_enabled(self):
+        """Check whether replication enabled."""
+        return settings.REPLICATION_TO_RELATION_ENABLED is True
+
+    def prepare_for_update(self, role: Role):
+        if not self.replication_enabled():
+            return
+        
+        self._role = role
+        self._replicator.record = role
+        self._current_role_relations = self._generate_relations_for_role(role)
+
+    def replicate_update_system_role(self, role: Role):
+        if not self.replication_enabled():
+            return
+        
+        self._replicate(ReplicationEventType.UPDATE_SYSTEM_ROLE, self._current_role_relations, self._generate_relations_for_role(role))
+        
+    def replicate_new_system_role(self, role: Role):
+        if not self.replication_enabled():
+            return
+        self._replicate(ReplicationEventType.CREATE_SYSTEM_ROLE, list[common_pb2.Relationship], self._generate_relations_for_role(role))
+
+    def replicate_deleted_system_role(self, role: Role):
+        if not self.replication_enabled():
+            return
+        self._replicate(ReplicationEventType.DELETE_SYSTEM_ROLE, self._generate_relations_for_role(role), list[common_pb2.Relationship])
+    
+    def _generate_relations_for_role(self, role: Role) -> list[common_pb2.Relationship]:
+        if role.admin_default:
+            pass
+        if role.platform_default:
+            pass
+
+    def _replicate(self, event_type: str, remove: list[common_pb2.Relationship], add: list[common_pb2.Relationship]):
+        if not self.replication_enabled():
+            return
+        try:
+            self._replicator.replicate(
+                ReplicationEvent(
+                    type=self.event_type,
+                    # TODO: need to think about partitioning
+                    # Maybe resource id
+                    partition_key="rbactodo",
+                    remove=remove,
+                    add=add,
+                ),
+            )
+        except Exception as e:
+            raise DualWriteException(e)
+        
+
+>>>>>>> c5697871 (More seeding replicator)
 class RelationApiDualWriteHandler:
     """Class to handle Dual Write API related operations."""
 

--- a/rbac/management/role/relation_api_dual_write_handler.py
+++ b/rbac/management/role/relation_api_dual_write_handler.py
@@ -21,6 +21,7 @@ from typing import Optional
 
 from django.conf import settings
 from kessel.relations.v1beta1 import common_pb2
+from management.group.model import Group
 from management.models import Workspace
 from management.relation_replicator.noop_replicator import NoopReplicator
 from management.relation_replicator.outbox_replicator import OutboxReplicator
@@ -39,121 +40,15 @@ from api.models import Tenant
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
-
-<<<<<<< HEAD
-=======
-class DualWriteException(Exception):
-    """DualWrite exception."""
-
-    pass
-
-
-class ReplicationEventType(str, Enum):
-    """Replication event type."""
-
-    CREATE_SYSTEM_ROLE = "create_system_role"
-    UPDATE_SYSTEM_ROLE = "update_system_role"
-    DELETE_SYSTEM_ROLE = "delete_system_role"
-    CREATE_CUSTOM_ROLE = "create_custom_role"
-    UPDATE_CUSTOM_ROLE = "update_custom_role"
-    DELETE_CUSTOM_ROLE = "delete_custom_role"
-    ASSIGN_ROLE = "assign_role"
-    UNASSIGN_ROLE = "unassign_role"
-    CREATE_GROUP = "create_group"
-    UPDATE_GROUP = "update_group"
-    DELETE_GROUP = "delete_group"
-    ADD_PRINCIPALS_TO_GROUP = "add_principals_to_group"
-    REMOVE_PRINCIPALS_FROM_GROUP = "remove_principals_from_group"
-    BOOTSTRAP_TENANT = "bootstrap_tenant"
-    EXTERNAL_USER_UPDATE = "external_user_update"
-
-
-class ReplicationEvent:
-    """What tuples changes to replicate."""
-
-    event_type: ReplicationEventType
-    event_info: dict[str, object]
-    partition_key: str
-    add: list[common_pb2.Relationship]
-    remove: list[common_pb2.Relationship]
-
-    def __init__(
-        self,
-        event_type: ReplicationEventType,
-        partition_key: str,
-        add: list[common_pb2.Relationship] = [],
-        remove: list[common_pb2.Relationship] = [],
-        info: dict[str, object] = {},
-    ):
-        """Initialize ReplicationEvent."""
-        self.partition_key = partition_key
-        self.event_type = event_type
-        self.add = add
-        self.remove = remove
-        self.event_info = info
-
-
-class RelationReplicator(ABC):
-    """Type responsible for replicating relations to Kessel Relations."""
-
-    @abstractmethod
-    def replicate(self, event: ReplicationEvent):
-        """Replicate the given event to Kessel Relations."""
-        pass
-
-
-class OutboxReplicator(RelationReplicator):
-    """Replicates relations via the outbox table."""
-
-    def replicate(self, event: ReplicationEvent):
-        """Replicate the given event to Kessel Relations via the Outbox."""
-        payload = self._build_replication_event(event.add, event.remove)
-        self._save_replication_event(payload, event.event_type, event.event_info, event.partition_key)
-
-    def _build_replication_event(self, relations_to_add, relations_to_remove):
-        """Build replication event."""
-        add_json = []
-        for relation in relations_to_add:
-            add_json.append(json_format.MessageToDict(relation))
-
-        remove_json = []
-        for relation in relations_to_remove:
-            remove_json.append(json_format.MessageToDict(relation))
-
-        replication_event = {"relations_to_add": add_json, "relations_to_remove": remove_json}
-        return replication_event
-
-    def _save_replication_event(self, payload, event_type, event_info: dict[str, object], aggregateid):
-        """Save replication event."""
-        # TODO: Can we add these as proper fields for kibana but also get logged in simple formatter?
-        logger.info(
-            "[Dual Write] Publishing replication event. event_type='%s' %s",
-            event_type,
-            " ".join([f"info.{key}='{str(value)}'" for key, value in event_info.items()]),
-        )
-        # https://debezium.io/documentation/reference/stable/transformations/outbox-event-router.html#basic-outbox-table
-        outbox_record = Outbox.objects.create(
-            aggregatetype="relations-replication-event",
-            aggregateid=aggregateid,
-            event_type=event_type,
-            payload=payload,
-        )
-        outbox_record.delete()
-
-
-class NoopReplicator(RelationReplicator):
-    """Noop replicator."""
-
-    def replicate(self, event: ReplicationEvent):
-        """Noop."""
-        pass
-
-
 class SeedingRelationApiDualWriteHandler:
     """Class to handle Dual Write API related operations specific to the seeding process."""
 
     _replicator: OutboxReplicator
     _current_role_relations: list[common_pb2.Relationship]
+
+    _public_tenant: Optional[Tenant] = None
+    _platform_default_policy_uuid: Optional[str] = None
+    _admin_default_policy_uuid: Optional[str] = None
 
     def __init__(self, replicator: Optional[OutboxReplicator] = None):
         """Initialize SeedingRelationApiDualWriteHandler."""
@@ -206,14 +101,16 @@ class SeedingRelationApiDualWriteHandler:
         """Generate system role permissions."""
         relations = []
 
-        if role.admin_default:
-            # Get actual id from somewhere? Prolly needs to be a uuid
+        admin_default = self._get_admin_default_policy_uuid()
+        platform_default = self._get_platform_default_policy_uuid()
+
+        if role.admin_default and admin_default: #Is it valid to skip this? If there are no default groups, the migration isn't going to succeed.
             relations.append(
-                create_relationship(("rbac", "role"), str(role.uuid), ("rbac", "role"), "admin_default", "child")
+                create_relationship(("rbac", "role"), str(role.uuid), ("rbac", "role"), admin_default, "child")
             )
-        if role.platform_default:
+        if role.platform_default and platform_default:
             relations.append(
-                create_relationship(("rbac", "role"), str(role.uuid), ("rbac", "role"), "platform_default", "child")
+                create_relationship(("rbac", "role"), str(role.uuid), ("rbac", "role"), platform_default, "child")
             )
 
         permissions = list()
@@ -250,9 +147,35 @@ class SeedingRelationApiDualWriteHandler:
             )
         except Exception as e:
             raise DualWriteException(e)
+    
+    def _get_platform_default_policy_uuid(self) -> Optional[str]:
+        try:
+            if self._platform_default_policy_uuid is None:
+                policy = Group.objects.get(
+                    platform_default=True, system=True, tenant=self._get_public_tenant()
+                ).policies.get()
+                self._platform_default_policy_uuid = str(policy.uuid)
+            return self._platform_default_policy_uuid
+        except Group.DoesNotExist:
+            return None
+
+    def _get_admin_default_policy_uuid(self) -> Optional[str]:
+        try:
+            if self._admin_default_policy_uuid is None:
+                policy = Group.objects.get(
+                    admin_default=True, system=True, tenant=self._get_public_tenant()
+                ).policies.get()
+                self._admin_default_policy_uuid = str(policy.uuid)
+            return self._admin_default_policy_uuid
+        except Group.DoesNotExist:
+            return None
+
+    def _get_public_tenant(self) -> Tenant:
+        if self._public_tenant is None:
+            self._public_tenant = Tenant.objects.get(tenant_name="public")
+        return self._public_tenant
 
 
->>>>>>> c5697871 (More seeding replicator)
 class RelationApiDualWriteHandler:
     """Class to handle Dual Write API related operations."""
 

--- a/rbac/management/role/relation_api_dual_write_handler.py
+++ b/rbac/management/role/relation_api_dual_write_handler.py
@@ -16,8 +16,8 @@
 #
 
 """Class to handle Dual Write API related operations."""
-from abc import ABC
 import logging
+from abc import ABC
 from typing import Optional
 
 from django.conf import settings
@@ -43,10 +43,12 @@ logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
 
 class BaseRelationApiDualWriteHandler(ABC):
+    """Base class to handle Dual Write API related operations on roles."""
+
     _replicator: RelationReplicator
     # TODO: continue factoring common behavior into this base class, and potentially into a higher base class
     # for the general pattern
-    
+
     def __init__(self, replicator: Optional[RelationReplicator] = None):
         """Initialize SeedingRelationApiDualWriteHandler."""
         if not self.replication_enabled():
@@ -57,6 +59,7 @@ class BaseRelationApiDualWriteHandler(ABC):
     def replication_enabled(self):
         """Check whether replication enabled."""
         return settings.REPLICATION_TO_RELATION_ENABLED is True
+
 
 class SeedingRelationApiDualWriteHandler(BaseRelationApiDualWriteHandler):
     """Class to handle Dual Write API related operations specific to the seeding process."""

--- a/rbac/management/role/relation_api_dual_write_handler.py
+++ b/rbac/management/role/relation_api_dual_write_handler.py
@@ -240,7 +240,7 @@ class SeedingRelationApiDualWriteHandler:
         try:
             self._replicator.replicate(
                 ReplicationEvent(
-                    type=event_type,
+                    event_type=event_type,
                     # TODO: need to think about partitioning
                     # Maybe resource id
                     partition_key="rbactodo",

--- a/rbac/management/role/relation_api_dual_write_handler.py
+++ b/rbac/management/role/relation_api_dual_write_handler.py
@@ -50,7 +50,7 @@ class SeedingRelationApiDualWriteHandler:
     _platform_default_policy_uuid: Optional[str] = None
     _admin_default_policy_uuid: Optional[str] = None
 
-    def __init__(self, replicator: Optional[OutboxReplicator] = None):
+    def __init__(self, replicator: Optional[RelationReplicator] = None):
         """Initialize SeedingRelationApiDualWriteHandler."""
         self._replicator = replicator if replicator else OutboxReplicator()
 

--- a/tests/management/role/test_dual_write.py
+++ b/tests/management/role/test_dual_write.py
@@ -625,7 +625,6 @@ class DualWriteSystemRolesTestCase(DualWriteTestCase):
         tuples = self.tuples.find_tuples(predicate=resource_type("rbac", "role"))
         self.assertEquals(len(tuples), 0)
 
-
     def test_delete_system_role(self):
         role = self.given_v1_system_role("d_r1", ["app1:hosts:read", "inventory:hosts:write"])
 

--- a/tests/management/role/test_dual_write.py
+++ b/tests/management/role/test_dual_write.py
@@ -32,7 +32,6 @@ from management.relation_replicator.relation_replicator import ReplicationEventT
 from management.role.model import Access, ResourceDefinition, Role, BindingMapping
 from management.role.relation_api_dual_write_handler import (
     RelationApiDualWriteHandler,
-    ReplicationEventType,
     SeedingRelationApiDualWriteHandler,
 )
 from management.tenant_service.tenant_service import BootstrappedTenant
@@ -624,7 +623,7 @@ class DualWriteSystemRolesTestCase(DualWriteTestCase):
         )
         dual_write_handler.replicate_update_system_role(role)
 
-        # check if only 1 relation exists in replicator.
+        # check if only 2 relations exists in replicator.
         tuples = self.tuples.find_tuples(predicate=resource_type("rbac", "role"))
         self.assertEquals(len(tuples), 2)
         parents = [rel.subject_id for rel in tuples if rel.relation == "child" and rel.resource_id == str(role.uuid)]

--- a/tests/management/role/test_dual_write.py
+++ b/tests/management/role/test_dual_write.py
@@ -99,7 +99,9 @@ class DualWriteTestCase(TestCase):
         self, name: str, permissions: list[str], platform_default=False, admin_default=False
     ) -> Role:
         """Create a new system role with the given ID and permissions."""
-        role = self.fixture.new_system_role(name=name, permissions=permissions, platform_default=platform_default, admin_default=admin_default)
+        role = self.fixture.new_system_role(
+            name=name, permissions=permissions, platform_default=platform_default, admin_default=admin_default
+        )
         dual_write_handler = SeedingRelationApiDualWriteHandler(replicator=InMemoryRelationReplicator(self.tuples))
         dual_write_handler.replicate_new_system_role(role)
         return role
@@ -689,7 +691,7 @@ class DualWriteSystemRolesTestCase(DualWriteTestCase):
         # Delete system role
         dual_write_handler = SeedingRelationApiDualWriteHandler(replicator=InMemoryRelationReplicator(self.tuples))
         dual_write_handler.replicate_deleted_system_role(role)
-        
+
         # Check if relations do not exist in replicator.
         tuples = self.tuples.find_tuples(predicate=resource_type("rbac", "role"))
         self.assertEquals(len(tuples), 0)
@@ -913,9 +915,15 @@ class RbacFixture:
         """Create a new tenant with the given name and organization ID."""
         return Tenant.objects.create(tenant_name=f"org{org_id}", org_id=org_id)
 
-    def new_system_role(self, name: str, permissions: list[str], platform_default = False, admin_default = False) -> Role:
+    def new_system_role(self, name: str, permissions: list[str], platform_default=False, admin_default=False) -> Role:
         """Create a new system role with the given name and permissions."""
-        role = Role.objects.create(name=name, system=True, platform_default=platform_default, admin_default=admin_default, tenant=self.public_tenant)
+        role = Role.objects.create(
+            name=name,
+            system=True,
+            platform_default=platform_default,
+            admin_default=admin_default,
+            tenant=self.public_tenant,
+        )
 
         access_list = [
             Access(


### PR DESCRIPTION
## Link(s) to Jira
- https://issues.redhat.com/browse/RHCLOUD-35357 
- https://issues.redhat.com/browse/RHCLOUD-35303

## Description of Intent of Change(s)
- Implements a new `SeedingRelationApiDualWriteHandler` for handling seeding specific operations.
- System role replication added to `seed_roles()` for creating, updating and deleting system roles.
- Grab platform default and admin default policy for use in "parent" roles
- 

## Local Testing
How can the feature be exercised?
How can the bug be exploited and fix confirmed?
Is any special local setup required?

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
