### PR TITLE
Require "parent_id" field on Workspace POST

### DIFF
--- a/docs/source/specs/typespec/main.tsp
+++ b/docs/source/specs/typespec/main.tsp
@@ -121,7 +121,10 @@ namespace Workspaces {
         name: string;
     }
 
-    alias CreateWorkspaceRequest = BasicWorkspace;
+    model CreateWorkspaceRequest extends BasicWorkspace{
+        @doc("Parent UUID of Workspace A")
+        parent_id: UUID = "Parent UUID of Workspace A";
+    }
 
     model CreateWorkspaceResponse extends Workspace{
         @statusCode _: 201;

--- a/docs/source/specs/v2/openapi.v2.yaml
+++ b/docs/source/specs/v2/openapi.v2.yaml
@@ -158,7 +158,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Workspaces.BasicWorkspace'
+              $ref: '#/components/schemas/Workspaces.CreateWorkspaceRequest'
   /workspaces/{uuid}/:
     get:
       tags:
@@ -643,6 +643,18 @@ components:
           type: string
           description: Description of Workspace A
           default: Description of Workspace A
+    Workspaces.CreateWorkspaceRequest:
+      type: object
+      required:
+        - parent_id
+      properties:
+        parent_id:
+          allOf:
+            - $ref: '#/components/schemas/UUID'
+          description: Parent UUID of Workspace A
+          default: Parent UUID of Workspace A
+      allOf:
+        - $ref: '#/components/schemas/Workspaces.BasicWorkspace'
     Workspaces.CreateWorkspaceResponse:
       type: object
       allOf:

--- a/rbac/management/workspace/view.py
+++ b/rbac/management/workspace/view.py
@@ -30,7 +30,7 @@ from .serializer import WorkspaceSerializer, WorkspaceWithAncestrySerializer
 
 VALID_PATCH_FIELDS = ["name", "description", "parent_id"]
 REQUIRED_PUT_FIELDS = ["name", "description", "parent_id"]
-REQUIRED_CREATE_FIELDS = ["name"]
+REQUIRED_CREATE_FIELDS = ["name", "parent_id"]
 INCLUDE_ANCESTRY_KEY = "include_ancestry"
 VALID_BOOLEAN_VALUES = ["true", "false"]
 

--- a/tests/management/workspace/test_view.py
+++ b/tests/management/workspace/test_view.py
@@ -89,16 +89,14 @@ class WorkspaceViewTestsV2Enabled(WorkspaceViewTests):
         url = reverse("workspace-list")
         client = APIClient()
         response = client.post(url, workspace, format="json", **self.headers)
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        data = response.data
-        self.assertEqual(data.get("name"), "New Workspace")
-        self.assertNotEquals(data.get("uuid"), "")
-        self.assertIsNotNone(data.get("uuid"))
-        self.assertNotEquals(data.get("created"), "")
-        self.assertNotEquals(data.get("modified"), "")
-        self.assertEquals(data.get("description"), "Workspace")
-        self.assertEquals(data.get("type"), "standard")
-        self.assertEqual(response.get("content-type"), "application/json")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        status_code = response.data.get("status")
+        detail = response.data.get("detail")
+        self.assertIsNotNone(detail)
+        self.assertEqual(detail, "Field 'parent_id' is required.")
+
+        self.assertEqual(status_code, 400)
+        self.assertEqual(response.get("content-type"), "application/problem+json")
 
     def test_create_workspace_empty_body(self):
         """Test for creating a workspace."""


### PR DESCRIPTION
## Link(s) to Jira
- https://issues.redhat.com/browse/RHCLOUD-35802

## Description of Intent of Change(s)
We should be requiring `parent_id` on `POST` requests for `Workspace` objects

## Local Testing
Verify unit tests or send a `POST` request with/without `parent_id`.

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [x] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
