### PR TITLE
RHCLOUD-35628 - Remove invalid service accounts

### DIFF
--- a/rbac/management/group/service_account_not_found_error.py
+++ b/rbac/management/group/service_account_not_found_error.py
@@ -4,4 +4,8 @@
 class ServiceAccountNotFoundError(Exception):
     """Raised when the specified service accounts were not found on IT."""
 
-    pass
+    def __init__(self, message, invalid: set[str]):
+        """Create a new instance of the ServiceAccountNotFoundError class."""
+        super().__init__(message)
+        self.message = message
+        self.invalid = invalid

--- a/rbac/management/group/view.py
+++ b/rbac/management/group/view.py
@@ -1182,7 +1182,10 @@ class GroupViewSet(
         """Invalidate the service accounts that were not found."""
         # Query groups where these service account principals are members
         groups = Group.objects.filter(principals__service_account_id__in=service_accounts).prefetch_related(
-            Prefetch("principals", queryset=Principal.objects.only("service_account_id", "user_id"))
+            Prefetch(
+                "principals",
+                queryset=Principal.objects.filter(uuid__in=service_accounts).only("service_account_id", "user_id"),
+            )
         )
 
         # For each service account,


### PR DESCRIPTION
## Link(s) to Jira
- https://issues.redhat.com/browse/RHCLOUD-35628

## Description of Intent of Change(s)
- changed from checking using uuid__in to service_account_id__in 

## Local Testing
How can the feature be exercised?
How can the bug be exploited and fix confirmed?
Is any special local setup required?

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
