### PR TITLE
Set partition key to environment name

### DIFF
--- a/rbac/management/group/relation_api_dual_write_group_handler.py
+++ b/rbac/management/group/relation_api_dual_write_group_handler.py
@@ -113,9 +113,7 @@ class RelationApiDualWriteGroupHandler:
                 ReplicationEvent(
                     event_type=self.event_type,
                     info={"group_uuid": str(self.group.uuid)},
-                    # TODO: need to think about partitioning
-                    # Maybe resource id
-                    partition_key="rbactodo",
+                    partition_key="settings.ENV_NAME",
                     remove=self.group_relations_to_remove,
                     add=self.group_relations_to_add,
                 ),

--- a/rbac/management/role/relation_api_dual_write_handler.py
+++ b/rbac/management/role/relation_api_dual_write_handler.py
@@ -162,7 +162,7 @@ class SeedingRelationApiDualWriteHandler(BaseRelationApiDualWriteHandler):
                     info=metadata,
                     # TODO: need to think about partitioning
                     # Maybe resource id
-                    partition_key="rbactodo",
+                    partition_key="settings.ENV_NAME",
                     remove=remove,
                     add=add,
                 ),
@@ -301,9 +301,7 @@ class RelationApiDualWriteHandler(BaseRelationApiDualWriteHandler):
                 ReplicationEvent(
                     event_type=self.event_type,
                     info={"v1_role_uuid": str(self.role.uuid)},
-                    # TODO: need to think about partitioning
-                    # Maybe resource id
-                    partition_key="rbactodo",
+                    partition_key="settings.ENV_NAME",
                     remove=self.current_role_relations,
                     add=self.role_relations,
                 ),

--- a/rbac/management/tenant_service/v2.py
+++ b/rbac/management/tenant_service/v2.py
@@ -95,7 +95,7 @@ class V2TenantBootstrapService:
             ReplicationEvent(
                 event_type=ReplicationEventType.EXTERNAL_USER_UPDATE,
                 info={"user_id": user_id},
-                partition_key="rbactodo",
+                partition_key="settings.ENV_NAME",
                 add=tuples_to_add,
                 remove=tuples_to_remove,
             )
@@ -160,7 +160,7 @@ class V2TenantBootstrapService:
             ReplicationEvent(
                 event_type=ReplicationEventType.EXTERNAL_USER_UPDATE,
                 info={"bulk_import": ",".join([user.user_id for user in users if user.user_id is not None])},
-                partition_key="rbactodo",
+                partition_key="settings.ENV_NAME",
                 add=tuples_to_add,
                 remove=tuples_to_remove,
             )
@@ -223,7 +223,7 @@ class V2TenantBootstrapService:
             ReplicationEvent(
                 event_type=ReplicationEventType.EXTERNAL_USER_UPDATE,
                 info={"user_id": user_id},
-                partition_key="rbactodo",
+                partition_key="settings.ENV_NAME",
                 remove=tuples_to_remove,
             )
         )
@@ -286,7 +286,7 @@ class V2TenantBootstrapService:
             ReplicationEvent(
                 event_type=ReplicationEventType.BOOTSTRAP_TENANT,
                 info={"org_id": tenant.org_id, "default_workspace_uuid": str(default_workspace.uuid)},
-                partition_key="rbactodo",
+                partition_key="settings.ENV_NAME",
                 add=relationships,
             )
         )

--- a/rbac/migration_tool/migrate.py
+++ b/rbac/migration_tool/migrate.py
@@ -18,6 +18,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 import logging
 from typing import Iterable
 
+from django.conf import settings
 from kessel.relations.v1beta1 import common_pb2
 from management.models import Workspace
 from management.principal.model import Principal
@@ -113,7 +114,7 @@ def migrate_data_for_tenant(tenant: Tenant, exclude_apps: list, replicator: Rela
         ReplicationEvent(
             event_type=ReplicationEventType.MIGRATE_TENANT_GROUPS,
             info={"tenant": tenant.org_id},
-            partition_key="rbactodo",
+            partition_key="settings.ENV_NAME",
             add=tuples,
         )
     )
@@ -143,7 +144,7 @@ def migrate_data_for_tenant(tenant: Tenant, exclude_apps: list, replicator: Rela
             ReplicationEvent(
                 event_type=ReplicationEventType.MIGRATE_CUSTOM_ROLE,
                 info={"role_uuid": str(role.uuid)},
-                partition_key="rbactodo",
+                partition_key="settings.ENV_NAME",
                 add=tuples,
             )
         )


### PR DESCRIPTION
## Link(s) to Jira
- https://issues.redhat.com/browse/RHCLOUD-35627

## Description of Intent of Change(s)
Sets the partition key used by Debezium connectors to current
environment name. 

This will keep debezium outbox messages in a guaranteed order per
environment. It will limit our future options for parallelism, but is a
safer approach currently.

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
