### PR TITLE
[RHCLOUD-35965] update error message for create a custom role with duplicate name

### DIFF
--- a/docs/source/specs/openapi.json
+++ b/docs/source/specs/openapi.json
@@ -1735,6 +1735,9 @@
               }
             }
           },
+          "400": {
+            "description": "Bad Input"
+          },
           "401": {
             "description": "Unauthorized"
           },

--- a/tests/management/role/test_view.py
+++ b/tests/management/role/test_view.py
@@ -1738,6 +1738,23 @@ class RoleViewsetTests(IdentityRequest):
         role = response.data.get("data")[0]
         self.assertEqual(role.get("groups_in_count"), 2)
 
+    def test_create_duplicate_role_fail(self):
+        """
+        Test that it is not possible to create a custom role with the same name for a tenant.
+        """
+        client = APIClient()
+        name = "Duplicate role name"
+        test_data = {"name": name, "access": []}
+
+        # Create new role
+        response = client.post(URL, test_data, format="json", **self.headers)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        # Try to create the same role again
+        response = client.post(URL, test_data, format="json", **self.headers)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data.get("errors")[0].get("detail"), f"Role '{name}' already exists for a tenant.")
+
 
 class RoleViewNonAdminTests(IdentityRequest):
     """Test the role view for nonadmin user."""


### PR DESCRIPTION
## Link(s) to Jira
- [RHCLOUD-35965](https://issues.redhat.com/browse/RHCLOUD-35965)

## Description of Intent of Change(s)
when you try to create duplicate custom role the error message looks like this

```
{
  "errors": [
    {
      "detail": "duplicate key value violates unique constraint \"unique role name per tenant\"\nDETAIL:  Key (name, tenant_id)=(Role name, 1) already exists.\n",
      "source": "role",
      "status": "400"
    }
  ]
}
```

this PR adds user friendly error message for that case
```
{
  "errors": [
    {
      "detail": "Role 'Role name' already exists for a tenant.",
      "source": "role",
      "status": "400"
    }
  ]
}
```

## Local Testing
Create new role with a name that not exists yet in database for your tenant
```
POST /roles/
{    
    "name": "Role name",
    "access": []
} 
```
Try to add the same role again, you should get the response code 400 and error message
```
{
  "errors": [
    {
      "detail": "Role 'Role name' already sexists for a tenant.",
      "source": "role",
      "status": "400"
    }
  ]
}
```

