### PR TITLE
[RHCLOUD-35976] Role removal - fix condition for the system role identification

### DIFF
--- a/rbac/management/role/view.py
+++ b/rbac/management/role/view.py
@@ -513,7 +513,7 @@ class RoleViewSet(
 
         Assumes concurrent updates are prevented (e.g. with atomic block and locks).
         """
-        if instance.system or instance.platform_default:
+        if instance.tenant_id == Tenant.objects.get(tenant_name="public").id:
             key = "role"
             message = "System roles cannot be deleted."
             error = {key: [_(message)]}

--- a/tests/management/role/test_view.py
+++ b/tests/management/role/test_view.py
@@ -186,10 +186,10 @@ class RoleViewsetTests(IdentityRequest):
         self.sysPubRole = Role(**sys_pub_role_config, tenant=self.public_tenant)
         self.sysPubRole.save()
 
-        self.sysRole = Role(**sys_role_config, tenant=self.tenant)
+        self.sysRole = Role(**sys_role_config, tenant=self.public_tenant)
         self.sysRole.save()
 
-        self.defRole = Role(**def_role_config, tenant=self.tenant)
+        self.defRole = Role(**def_role_config, tenant=self.public_tenant)
         self.defRole.save()
 
         self.ext_tenant = ExtTenant.objects.create(name="foo")


### PR DESCRIPTION
[RHCLOUD-35976](https://issues.redhat.com/browse/RHCLOUD-35976)

when we remove the role, we need to check that the role is not a system role (because it is not allowed to remove system roles)

in that check we should identify the system role as a role that belongs to the public tenant