### PR TITLE
New debezium heartbeat prefix

### DIFF
--- a/deploy/debezium-connector.yml
+++ b/deploy/debezium-connector.yml
@@ -26,6 +26,7 @@ objects:
       transforms.outbox.table.field.payload: ${PAYLOAD_NAME}
       plugin.name: pgoutput
       heartbeat.interval.ms: 300000
+      topic.heartbeat.prefix: ${TOPIC_HEARTBEAT_PREFIX}
 parameters:
 - name: DB_SERVERNAME
   required: true
@@ -63,3 +64,6 @@ parameters:
 - name: TOPIC_PREFIX
   value: rbac
   description: Topic name prefix for the connector
+- name: TOPIC_HEARTBEAT_PREFIX
+  value: debezium-heartbeat
+  description: Prefix for the connector heartbeat topic


### PR DESCRIPTION
## Link(s) to Jira
-

## Description of Intent of Change(s)
The what, why and how.
We need to make our own topic for the debezium connector's heartbeat. The default prefix for the topic is `__debezium.heartbeat`. This won't work for us since we cannot make topic's with `_`'s .
## Local Testing
How can the feature be exercised?
How can the bug be exploited and fix confirmed?
Is any special local setup required?

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
