### PR TITLE
[WIP][RHCLOUD-36065] Fix limit validation for GET /access/ endpoint

### DIFF
--- a/rbac/management/access/view.py
+++ b/rbac/management/access/view.py
@@ -137,7 +137,6 @@ class AccessView(APIView):
         """Return the paginator instance associated with the view, or `None`."""
         if not hasattr(self, "_paginator"):
             self._paginator = self.pagination_class()
-            self._paginator.max_limit = None
         return self._paginator
 
     def paginate_queryset(self, queryset):

--- a/rbac/management/access/view.py
+++ b/rbac/management/access/view.py
@@ -143,8 +143,6 @@ class AccessView(APIView):
         """Return a single page of results, or `None` if pagination is disabled."""
         if self.paginator is None:
             return None
-        if "limit" not in self.request.query_params:
-            self.paginator.default_limit = len(queryset)
         return self.paginator.paginate_queryset(queryset, self.request, view=self)
 
     def get_paginated_response(self, data):

--- a/rbac/management/access/view.py
+++ b/rbac/management/access/view.py
@@ -25,7 +25,6 @@ from management.utils import (
     get_principal_from_request,
     validate_and_get_key,
     validate_key,
-    validate_limit_and_offset,
 )
 from rest_framework import status
 from rest_framework.permissions import AllowAny
@@ -156,7 +155,6 @@ class AccessView(APIView):
 
     def validate_and_get_param(self, params):
         """Validate input parameters and get ordering and sub_key."""
-        validate_limit_and_offset(params)
         app = params.get(APPLICATION_KEY)
         sub_key = app
         ordering = validate_and_get_key(params, ORDER_FIELD, VALID_ORDER_VALUES, required=False)

--- a/tests/management/access/test_view.py
+++ b/tests/management/access/test_view.py
@@ -178,7 +178,7 @@ class AccessViewTests(IdentityRequest):
         self.assertIsNotNone(response.data.get("data"))
         self.assertIsInstance(response.data.get("data"), list)
         self.assertEqual(len(response.data.get("data")), 2)
-        self.assertEqual(response.data.get("meta").get("limit"), 2)
+        self.assertEqual(response.data.get("meta").get("limit"), 10)
         self.assertEqual(self.access_data, response.data.get("data")[0])
 
         # the platform default permission could also be retrieved
@@ -215,7 +215,7 @@ class AccessViewTests(IdentityRequest):
         self.assertIsNotNone(response.data.get("data"))
         self.assertIsInstance(response.data.get("data"), list)
         self.assertEqual(len(response.data.get("data")), 2)
-        self.assertEqual(response.data.get("meta").get("limit"), 2)
+        self.assertEqual(response.data.get("meta").get("limit"), 10)
         for access_data in response.data.get("data"):
             if access_data.get("resourceDefinitions"):
                 self.assertEqual(self.access_data, access_data)
@@ -314,7 +314,7 @@ class AccessViewTests(IdentityRequest):
         self.assertIsNotNone(response.data.get("data"))
         self.assertIsInstance(response.data.get("data"), list)
         self.assertEqual(len(response.data.get("data")), 2)
-        self.assertEqual(response.data.get("meta").get("limit"), 2)
+        self.assertEqual(response.data.get("meta").get("limit"), 10)
 
     @patch(
         "management.principal.proxy.PrincipalProxy.request_filtered_principals",
@@ -396,7 +396,7 @@ class AccessViewTests(IdentityRequest):
         self.assertIsNotNone(response.data.get("data"))
         self.assertIsInstance(response.data.get("data"), list)
         self.assertEqual(len(response.data.get("data")), 0)
-        self.assertEqual(response.data.get("meta").get("limit"), 0)
+        self.assertEqual(response.data.get("meta").get("limit"), 10)
 
     @patch(
         "management.principal.proxy.PrincipalProxy.request_filtered_principals",
@@ -439,7 +439,7 @@ class AccessViewTests(IdentityRequest):
         self.assertIsNotNone(response.data.get("data"))
         self.assertIsInstance(response.data.get("data"), list)
         self.assertEqual(len(response.data.get("data")), 0)
-        self.assertEqual(response.data.get("meta").get("limit"), 0)
+        self.assertEqual(response.data.get("meta").get("limit"), 10)
 
     @patch("management.cache.AccessCache.save_policy", return_value=None)
     @patch("management.cache.AccessCache.get_policy", return_value=None)
@@ -616,7 +616,7 @@ class AccessViewTests(IdentityRequest):
         self.assertIsNotNone(response.data.get("data"))
         self.assertIsInstance(response.data.get("data"), list)
         self.assertEqual(len(response.data.get("data")), 0)
-        self.assertEqual(response.data.get("meta").get("limit"), 0)
+        self.assertEqual(response.data.get("meta").get("limit"), 10)
 
     @patch(
         "management.principal.proxy.PrincipalProxy.request_filtered_principals",


### PR DESCRIPTION
## Link(s) to Jira
- [RHCLOUD-36065](https://issues.redhat.com/browse/RHCLOUD-36065)

## Description of Intent of Change(s)
`GET /access/` with invalid limit value returns 500
example:
`GET /api/rbac/v1/access/?application=&limit=aaa`

In this PR I removed the validate_limit_and_offset(params) because
1. we can use default limit and offset validation we already use for other endpoints from class `StandardResultsSetPagination`
2. the usage of  the `validate_limit_and_offset(params)` was not working because the function returns the dict object that was not captured in the function `validate_and_get_param()`

I updated the function so that `limit` and `offset` are validated consistently with our other endpoints using `StandardResultsSetPagination`: if `limit` is not a number, it defaults to 10, and if it exceeds 1000, it is capped at 1000


## Local Testing
call the /access/ endpoint with different values of `limit` query param
`GET /api/rbac/v1/access/?application=&limit=<value>`

- for non-digit value the default `limit=10` is returned -> example `limit=aaa`
- for empty value the default `limit=10` is returned -> example `limit=`
- for value 0 the default `limit=10` is returned -> example `limit=0`
- for negative number the default `limit=10` is returned -> example `limit=-10`
- for number > 1000 the max `limit=1000` is returned -> example `limit=1001`
- for integer between 0 and 1001 the given limit is returned -> example `limit=25`
