### PR TITLE
[RHCLOUD-36065] Fix limit validation for GET /access/ endpoint

### DIFF
--- a/rbac/management/access/view.py
+++ b/rbac/management/access/view.py
@@ -25,7 +25,6 @@ from management.utils import (
     get_principal_from_request,
     validate_and_get_key,
     validate_key,
-    validate_limit_and_offset,
 )
 from rest_framework import status
 from rest_framework.permissions import AllowAny
@@ -156,7 +155,6 @@ class AccessView(APIView):
 
     def validate_and_get_param(self, params):
         """Validate input parameters and get ordering and sub_key."""
-        validate_limit_and_offset(params)
         app = params.get(APPLICATION_KEY)
         sub_key = app
         ordering = validate_and_get_key(params, ORDER_FIELD, VALID_ORDER_VALUES, required=False)

--- a/tests/management/access/test_view.py
+++ b/tests/management/access/test_view.py
@@ -754,3 +754,27 @@ class AccessViewTests(IdentityRequest):
         response = client.get(url, **self.test_headers)
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_get_access_with_invalid_limit(self):
+        """Test that we get expected value of limit when invalid limit value is provided in the request."""
+        # Create platform default group with default roles
+        self.create_platform_default_resource()
+
+        client = APIClient()
+        default_limit = 10
+        expected_count = 1
+
+        # Request query without 'limit' query param => default value 'limit=10' in the response
+        url = f"{reverse('v1_management:access')}?application="
+        response = client.get(url, **self.headers)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data.get("meta").get("limit"), expected_count)
+        self.assertEqual(response.data.get("meta").get("count"), expected_count)
+
+        # Request query with invalid value of 'limit' query param => default value 'limit=10 'in the response
+        for limit in ["", 0, -10, "xxxxx"]:
+            url = f"{reverse('v1_management:access')}?application=&limit={limit}"
+            response = client.get(url, **self.headers)
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            self.assertEqual(response.data.get("meta").get("limit"), default_limit)
+            self.assertEqual(response.data.get("meta").get("count"), expected_count)


### PR DESCRIPTION
## Link(s) to Jira
- [RHCLOUD-36065](https://issues.redhat.com/browse/RHCLOUD-36065)

## Description of Intent of Change(s)
`GET /access/` with invalid limit value returns 500
example:
`GET /api/rbac/v1/access/?application=&limit=aaa`

In this PR I removed the `validate_limit_and_offset(params)` because
1. we can use default limit and offset validation as we already use for other endpoints from class `StandardResultsSetPagination`
2. the usage of  the `validate_limit_and_offset(params)` was not working because the function returns the dict object that was not captured in the function `validate_and_get_param()`

## Local Testing
call the /access/ endpoint with different values of `limit` query param
`GET /api/rbac/v1/access/?application=&limit=<value>`

- for non-digit value the default `limit=10` is returned -> example `limit=aaa`
- for empty value the default `limit=10` is returned -> example `limit=`

rest of cases without change (=works same as before the change)
- for value 0 the default `limit=10` is returned -> example `limit=0`
- for negative number the default `limit=10` is returned -> example `limit=-10`
- for integer higher than 0 the given limit is returned -> example `limit=25`
