### PR TITLE
RHCLOUD-36017 Custom roles cannot be created or updated using existin…

### DIFF
--- a/rbac/management/role/view.py
+++ b/rbac/management/role/view.py
@@ -269,6 +269,11 @@ class RoleViewSet(
         """
         self.validate_role(request)
         try:
+            if Role.objects.filter(display_name=request.data.get("name"), system=True).exists():
+                return Response(
+                    {"Error": f"The role name '{request.data.get('name')}' is reserved, please use another name"},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
             with transaction.atomic():
                 return super().create(request=request, args=args, kwargs=kwargs)
         except IntegrityError as e:
@@ -465,6 +470,11 @@ class RoleViewSet(
         self.validate_role(request)
 
         try:
+            if Role.objects.filter(display_name=request.data.get("name"), system=True).exists():
+                return Response(
+                    {"Error": f"The role name '{request.data.get('name')}' is reserved, please use another name"},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
             with transaction.atomic():
                 return super().update(request=request, args=args, kwargs=kwargs)
         except DualWriteException as e:

--- a/tests/management/role/test_view.py
+++ b/tests/management/role/test_view.py
@@ -1773,6 +1773,33 @@ class RoleViewsetTests(IdentityRequest):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(response.data.get("errors")[0].get("detail"), f"Role '{name}' already exists for a tenant.")
 
+    def test_create_custom_role_with_same_name_as_system_role(self):
+        """Test that trying to create a custom role with the same name as a system role is not possible"""
+        client = APIClient()
+        name = "system_display"
+        test_data = {"name": name, "access": []}
+
+        # Attempt to create custom role with the same name as system role
+        response = client.post(URL, test_data, format="json", **self.headers)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        # Assert output message is correct
+        self.assertEqual(response.data.get("Error"), f"The role name '{name}' is reserved, please use another name")
+
+    def test_update_custom_role_with_same_name_as_system_role(self):
+        """Test that trying to update a custom role with the same name as a system role is not possible"""
+        url = reverse("v1_management:role-detail", kwargs={"uuid": self.defRole.uuid})
+        client = APIClient()
+        name = "system_display"
+        test_data = {"name": name, "access": []}
+
+        # Attempt to create custom role with the same name as system role
+        response = client.put(url, test_data, format="json", **self.headers)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        # Assert output message is correct
+        self.assertEqual(response.data.get("Error"), f"The role name '{name}' is reserved, please use another name")
+
 
 class RoleViewNonAdminTests(IdentityRequest):
     """Test the role view for nonadmin user."""


### PR DESCRIPTION
…g display_name for any system roles

## Link(s) to Jira
https://issues.redhat.com/browse/RHCLOUD-36017

## Description of Intent of Change(s)
When trying to create or update a custom role through the API you cannot use the same 'display_name' as any system role that exists. 

## Local Testing
How can the feature be exercised?
How can the bug be exploited and fix confirmed?
Is any special local setup required?

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
