### PR TITLE
RHCLOUD-36015: Log/Raise warnings when empty messages are produced

### DIFF
--- a/rbac/management/relation_replicator/outbox_replicator.py
+++ b/rbac/management/relation_replicator/outbox_replicator.py
@@ -18,15 +18,26 @@
 """RelationReplicator which writes to the outbox table."""
 
 import logging
-from typing import Optional
-from typing import Protocol
+from typing import Any, Dict, List, Optional, Protocol, TypedDict
 
 from google.protobuf import json_format
+from kessel.relations.v1beta1.common_pb2 import Relationship
 from management.models import Outbox
-from management.relation_replicator.relation_replicator import RelationReplicator, ReplicationEvent
+from management.relation_replicator.relation_replicator import (
+    RelationReplicator,
+    ReplicationEvent,
+    ReplicationEventType,
+)
 
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
+
+
+class ReplicationEventPayload(TypedDict):
+    """Typed dictionary for ReplicationEvent payload."""
+
+    relations_to_add: List[Dict[str, Any]]
+    relations_to_remove: List[Dict[str, Any]]
 
 
 class OutboxReplicator(RelationReplicator):
@@ -39,33 +50,52 @@ class OutboxReplicator(RelationReplicator):
     def replicate(self, event: ReplicationEvent):
         """Replicate the given event to Kessel Relations via the Outbox."""
         payload = self._build_replication_event(event.add, event.remove)
-        self._save_replication_event(payload, event.event_type, event.event_info, event.partition_key)
+        self._save_replication_event(payload, event.event_type, event.event_info, str(event.partition_key))
 
-    def _build_replication_event(self, relations_to_add, relations_to_remove):
+    def _build_replication_event(
+        self, relations_to_add: list[Relationship], relations_to_remove: list[Relationship]
+    ) -> ReplicationEventPayload:
         """Build replication event."""
-        add_json = []
+        add_json: list[dict[str, Any]] = []
         for relation in relations_to_add:
             add_json.append(json_format.MessageToDict(relation))
 
-        remove_json = []
+        remove_json: list[dict[str, Any]] = []
         for relation in relations_to_remove:
             remove_json.append(json_format.MessageToDict(relation))
 
-        replication_event = {"relations_to_add": add_json, "relations_to_remove": remove_json}
-        return replication_event
+        return {"relations_to_add": add_json, "relations_to_remove": remove_json}
 
-    def _save_replication_event(self, payload, event_type, event_info: dict[str, object], aggregateid):
+    def _save_replication_event(
+        self,
+        payload: ReplicationEventPayload,
+        event_type: ReplicationEventType,
+        event_info: dict[str, object],
+        aggregateid: str,
+    ):
         """Save replication event."""
         # TODO: Can we add these as proper fields for kibana but also get logged in simple formatter?
+        logged_info = " ".join([f"info.{key}='{str(value)}'" for key, value in event_info.items()])
+
+        if not payload["relations_to_add"] and not payload["relations_to_remove"]:
+            logger.warning(
+                "[Dual Write] Skipping empty replication event. aggregateid='%s' event_type='%s' %s",
+                aggregateid,
+                event_type,
+                logged_info,
+            )
+            return
+
         logger.info(
-            "[Dual Write] Publishing replication event. event_type='%s' %s",
+            "[Dual Write] Publishing replication event. aggregateid='%s' event_type='%s' %s",
+            aggregateid,
             event_type,
-            " ".join([f"info.{key}='{str(value)}'" for key, value in event_info.items()]),
+            logged_info,
         )
         # https://debezium.io/documentation/reference/stable/transformations/outbox-event-router.html#basic-outbox-table
         outbox = Outbox(
             aggregatetype="relations-replication-event",
-            aggregateid=str(aggregateid),
+            aggregateid=aggregateid,
             event_type=event_type,
             payload=payload,
         )

--- a/tests/management/relation_replicator/test_outbox_replicator.py
+++ b/tests/management/relation_replicator/test_outbox_replicator.py
@@ -57,3 +57,22 @@ class OutboxReplicatorTest(TestCase):
             {"relations_to_add": [json_format.MessageToDict(principal_to_group)], "relations_to_remove": []},
         )
         self.assertEqual(logged_event.aggregatetype, "relations-replication-event")
+
+    def test_replicate_empty_event_warns_instead_of_saving(self):
+        """Test replicate with empty event warns."""
+        event = ReplicationEvent(
+            add=[],
+            remove=[],
+            event_type=ReplicationEventType.ADD_PRINCIPALS_TO_GROUP,
+            info={"key": "value"},
+            partition_key=PartitionKey.byEnvironment(),
+        )
+
+        with self.assertLogs("management.relation_replicator.outbox_replicator", level="WARNING") as logs:
+            self.replicator.replicate(event)
+
+        self.assertEqual(len(self.log), 0)
+        self.assertEqual(len(logs.output), 1)
+        self.assertIn("Skipping empty replication event.", logs.output[0])
+        self.assertIn("info.key='value'", logs.output[0])
+        self.assertIn(str(ReplicationEventType.ADD_PRINCIPALS_TO_GROUP), logs.output[0])

--- a/tests/management/relation_replicator/test_outbox_replicator.py
+++ b/tests/management/relation_replicator/test_outbox_replicator.py
@@ -16,6 +16,8 @@
 #
 """Test OutboxReplicator."""
 
+import logging
+
 from django.test import TestCase, override_settings
 from google.protobuf import json_format
 from management.relation_replicator.outbox_replicator import InMemoryLog, OutboxReplicator
@@ -28,8 +30,15 @@ class OutboxReplicatorTest(TestCase):
 
     def setUp(self):
         """Set up."""
+        super().setUp()
         self.log = InMemoryLog()
         self.replicator = OutboxReplicator(self.log)
+        self._prior_logging_disabled = logging.root.disabled
+        logging.disable(logging.NOTSET)
+
+    def tearDown(self) -> None:
+        super().tearDown()
+        logging.disable(self._prior_logging_disabled)
 
     @override_settings(ENV_NAME="test-env")
     def test_replicate_sends_event_to_log_as_json(self):

--- a/tests/management/relation_replicator/test_outbox_replicator.py
+++ b/tests/management/relation_replicator/test_outbox_replicator.py
@@ -25,6 +25,17 @@ from management.relation_replicator.relation_replicator import PartitionKey, Rep
 from migration_tool.utils import create_relationship
 
 
+@override_settings(
+    LOGGING={
+        "version": 1,
+        "disable_existing_loggers": False,
+        "loggers": {
+            "management.relation_replicator.outbox_replicator": {
+                "level": "INFO",
+            },
+        },
+    },
+)
 class OutboxReplicatorTest(TestCase):
     """Test OutboxReplicator."""
 

--- a/tests/management/relation_replicator/test_outbox_replicator.py
+++ b/tests/management/relation_replicator/test_outbox_replicator.py
@@ -66,11 +66,11 @@ class OutboxReplicatorTest(TestCase):
             {
                 "relations_to_add": [
                     json_format.MessageToDict(principal_to_group_add1),
-                    json_format.MessageToDict(principal_to_group_add2)
+                    json_format.MessageToDict(principal_to_group_add2),
                 ],
                 "relations_to_remove": [
                     json_format.MessageToDict(principal_to_group_remove1),
-                    json_format.MessageToDict(principal_to_group_remove2)
+                    json_format.MessageToDict(principal_to_group_remove2),
                 ],
             },
         )


### PR DESCRIPTION
## Link(s) to Jira
- https://issues.redhat.com/browse/RHCLOUD-36015

## Description of Intent of Change(s)
Saving an empty event to the outbox is inefficient, so this avoids doing that.

However, it is also surprising. In order to identify when these probably unintentional cases are happening, this also logs when it does.

## Local Testing
How can the feature be exercised?
How can the bug be exploited and fix confirmed?
Is any special local setup required?

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
