### PR TITLE
[RHCLOUD-36189] Cross account request limit fix

### DIFF
--- a/rbac/api/cross_access/view.py
+++ b/rbac/api/cross_access/view.py
@@ -22,7 +22,7 @@ from django_filters import rest_framework as filters
 from management.filters import CommonFilters
 from management.models import Role
 from management.principal.proxy import PrincipalProxy
-from management.utils import validate_and_get_key, validate_limit_and_offset, validate_uuid
+from management.utils import validate_and_get_key, validate_uuid
 from rest_framework import mixins, viewsets
 from rest_framework import status as http_status
 from rest_framework.filters import OrderingFilter
@@ -130,8 +130,6 @@ class CrossAccountRequestViewSet(
 
     def list(self, request, *args, **kwargs):
         """List cross account requests for account/user_id."""
-        validate_limit_and_offset(self.request.query_params)
-
         result = super().list(request=request, args=args, kwargs=kwargs)
         # The approver's view requires requester's info such as first name, last name, email address.
         if validate_and_get_key(self.request.query_params, QUERY_BY_KEY, VALID_QUERY_BY_KEY, ORG_ID) == ORG_ID:

--- a/rbac/management/utils.py
+++ b/rbac/management/utils.py
@@ -26,7 +26,7 @@ from management.models import Access, Group, Policy, Principal, Role
 from management.permissions.principal_access import PrincipalAccessPermission
 from management.principal.it_service import ITService
 from management.principal.proxy import PrincipalProxy
-from rest_framework import serializers, status
+from rest_framework import serializers
 from rest_framework.request import Request
 
 from api.models import CrossAccountRequest, Tenant
@@ -277,17 +277,6 @@ def validate_group_name(name):
         key = "Group name Validation"
         message = f"{name} is reserved, please use another name."
         raise serializers.ValidationError({key: _(message)})
-
-
-def validate_limit_and_offset(query_params):
-    """Limit and offset should not be negative number."""
-    if (int(query_params.get("limit", 10)) < 0) | (int(query_params.get("offset", 0)) < 0):
-        error = {
-            "detail": "Values for limit and offset must be positive numbers.",
-            "source": "CrossAccountRequest",
-            "status": str(status.HTTP_400_BAD_REQUEST),
-        }
-        return {"errors": [error]}
 
 
 def roles_for_cross_account_principal(principal):


### PR DESCRIPTION
## Link(s) to Jira
- [RHCLOUD-36189](https://issues.redhat.com/browse/RHCLOUD-36189)

## Description of Intent of Change(s)
when an invalid value for `limit` or `offset` is used in the request to the `GET /cross-account-requests/` endpoint, the server returns a 500 error

after change the default values are returned (limit=10, offset=0)

In this PR I removed the `validate_limit_and_offset()` because
- we can use default limit and offset validation as we already use for other endpoints from class `StandardResultsSetPagination`
- the usage of the `validate_limit_and_offset()` was not working because the function returns the dict object that was not captured in the code

## Local Testing
send request to the endpoint 
`GET /api/rbac/v1/cross-account-requests/?limit=<value>&offset=<value>`
with different values for the limit and offset

