### PR TITLE
Set log settings back outbox replication test 

### DIFF
--- a/tests/management/relation_replicator/test_outbox_replicator.py
+++ b/tests/management/relation_replicator/test_outbox_replicator.py
@@ -45,12 +45,12 @@ class OutboxReplicatorTest(TestCase):
         super().setUp()
         self.log = InMemoryLog()
         self.replicator = OutboxReplicator(self.log)
-        self._prior_logging_disabled = logging.root.disabled
+        self._prior_logging_disable_level = logging.root.manager.disable
         logging.disable(logging.NOTSET)
 
     def tearDown(self) -> None:
         super().tearDown()
-        logging.disable(self._prior_logging_disabled)
+        logging.disable(self._prior_logging_disable_level)
 
     @override_settings(ENV_NAME="test-env")
     def test_replicate_sends_event_to_log_as_json(self):


### PR DESCRIPTION
## Link(s) to Jira
- [CI Failure](https://ci.ext.devshift.net/job/RedHatInsights-insights-rbac-pr-check/3209/console)

## Description of Intent of Change(s)
There is bunch of redis connectivity errors, which is looking they did not cause CI failure, however, their volume seems to disrupt the log report generation and it cause CI failure.

Those errors were also here before but there were not displayed in tests and now it looks that they are displayed because of tests in `management/relation_replicator/test_outbox_replicator.py` . Log level is changed [here](https://github.com/RedHatInsights/insights-rbac/blob/master/tests/management/relation_replicator/test_outbox_replicator.py#L43-L53). 

log report generation error: 
```
3 tests in 75.242s
08:21:44 
08:21:44 OK
08:21:44 Destroying test database for alias 'default' ('test_rbac')...
08:21:44 py39: commands[1]> coverage report --show-missing
08:21:44 Traceback (most recent call last):
08:21:44   File "/opt/app-root/.tox/py39/bin/coverage", line 8, in <module>
08:21:44     sys.exit(main())
08:21:44   File "/opt/app-root/.tox/py39/lib64/python3.9/site-packages/coverage/cmdline.py", line 970, in main
08:21:44     status = CoverageScript().command_line(argv)
08:21:44   File "/opt/app-root/.tox/py39/lib64/python3.9/site-packages/coverage/cmdline.py", line 708, in command_line
08:21:44     total = self.coverage.report(
08:21:44   File "/opt/app-root/.tox/py39/lib64/python3.9/site-packages/coverage/control.py", line 1088, in report
08:21:44     return reporter.report(morfs, outfile=file)
08:21:44   File "/opt/app-root/.tox/py39/lib64/python3.9/site-packages/coverage/report.py", line 182, in report
08:21:44     for fr, analysis in get_analysis_to_report(self.coverage, morfs):
08:21:44   File "/opt/app-root/.tox/py39/lib64/python3.9/site-packages/coverage/report_core.py", line 101, in get_analysis_to_report
08:21:44     analysis = coverage._analyze(morf)
08:21:44   File "/opt/app-root/.tox/py39/lib64/python3.9/site-packages/coverage/control.py", line 946, in _analyze
08:21:44     return analysis_from_file_reporter(data, self.config.precision, file_reporter, filename)
08:21:44   File "/opt/app-root/.tox/py39/lib64/python3.9/site-packages/coverage/results.py", line 31, in analysis_from_file_reporter
08:21:44     statements = file_reporter.lines()
08:21:44   File "/opt/app-root/.tox/py39/lib64/python3.9/site-packages/coverage/python.py", line 195, in lines
08:21:44     return self.parser.statements
08:21:44   File "/opt/app-root/.tox/py39/lib64/python3.9/site-packages/coverage/python.py", line 190, in parser
08:21:44     self._parser.parse_source()
08:21:44   File "/opt/app-root/.tox/py39/lib64/python3.9/site-packages/coverage/parser.py", line 267, in parse_source
08:21:44     self._raw_parse()
08:21:44   File "/opt/app-root/.tox/py39/lib64/python3.9/site-packages/coverage/parser.py", line 199, in _raw_parse
08:21:44     self.raw_statements.update(byte_parser._find_statements())
08:21:44   File "/opt/app-root/.tox/py39/lib64/python3.9/site-packages/coverage/parser.py", line 459, in _find_statements
08:21:44     yield from bp._line_numbers()
08:21:44   File "/opt/app-root/.tox/py39/lib64/python3.9/site-packages/coverage/parser.py", line 440, in _line_numbers
08:21:44     assert line_num != last_line_num, f"Oops, {byte_incr = }, {line_incr = }"
08:21:44 AssertionError: Oops, byte_incr = 4, line_incr = 2
08:21:44 py39: exit 1 (1.06 seconds) /opt/app-root> coverage report --show-missing pid=25889
````

## Local Testing
How can the feature be exercised?
How can the bug be exploited and fix confirmed?
Is any special local setup required?

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

