### PR TITLE
Fix replication counter trigger

### DIFF
--- a/rbac/management/relation_replicator/outbox_replicator.py
+++ b/rbac/management/relation_replicator/outbox_replicator.py
@@ -72,6 +72,7 @@ class OutboxReplicator(RelationReplicator):
 
         return {"relations_to_add": add_json, "relations_to_remove": remove_json}
 
+    @transaction.atomic
     def _save_replication_event(
         self,
         payload: ReplicationEventPayload,


### PR DESCRIPTION
## Link(s) to Jira
-

## Description of Intent of Change(s)
The what, why and how.
This makes the _save_replication_event function atomic. This is required for on_commit to be called. Right now the replication function is not a transaction so it won't trigger on_commit. With the transaction.atomic decorator it makes it atomic.
There is a performance risk with this change according to the [Django docs](https://docs.djangoproject.com/en/5.1/topics/db/transactions/#tying-transactions-to-http-requests)

The reason the test for this function is passing is because each TestCase is wrapped in a transaction behind the scenes.

## Local Testing
How can the feature be exercised?
How can the bug be exploited and fix confirmed?
Is any special local setup required?

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
