### PR TITLE
[RHCLOUD-36368] Make data migration callable during maintenance mode

### DIFF
--- a/rbac/rbac/middleware.py
+++ b/rbac/rbac/middleware.py
@@ -452,7 +452,9 @@ class ReadOnlyApiMiddleware(MiddlewareMixin):  # pylint: disable=too-few-public-
 
     def _should_deny_all_writes(self, request):
         """Determine whether or not to deny all API writes."""
-        return settings.READ_ONLY_API_MODE and self._is_write_request(request)
+        resolver = resolve(request.path)
+        api_namespace = resolver.app_name if resolver else ""
+        return settings.READ_ONLY_API_MODE and self._is_write_request(request) and api_namespace != "internal"
 
     def _should_deny_v2_writes(self, request):
         """Determine whether or not to deny v2 writes."""

--- a/rbac/rbac/urls.py
+++ b/rbac/rbac/urls.py
@@ -38,7 +38,7 @@ if API_PATH_PREFIX != "":
 urlpatterns = [
     re_path(r"^{}v1/".format(API_PATH_PREFIX), include(("api.urls", "v1_api"))),
     re_path(r"^{}v1/".format(API_PATH_PREFIX), include(("management.urls", "v1_management"))),
-    re_path(r"^_private/", include("internal.urls")),
+    re_path(r"^_private/", include(("internal.urls", "internal"))),
     path("", include("django_prometheus.urls")),
 ]
 

--- a/tests/internal/test_views.py
+++ b/tests/internal/test_views.py
@@ -459,6 +459,7 @@ class InternalViewsetTests(IdentityRequest):
         )
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
+    @override_settings(READ_ONLY_API_MODE=True)
     @patch("management.tasks.migrate_data_in_worker.delay")
     def test_run_migrations_of_data(self, migration_mock):
         """Test that we can trigger migrations of data to migrate from V1 to V2."""
@@ -466,6 +467,7 @@ class InternalViewsetTests(IdentityRequest):
             f"/_private/api/utils/data_migration/?exclude_apps=rbac,costmanagement&orgs=acct00001,acct00002",
             **self.request.META,
         )
+        self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
         migration_mock.assert_called_once_with(
             {
                 "exclude_apps": ["rbac", "costmanagement"],
@@ -473,7 +475,6 @@ class InternalViewsetTests(IdentityRequest):
                 "write_relationships": "False",
             }
         )
-        self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
         self.assertEqual(
             response.content.decode(),
             "Data migration from V1 to V2 are running in a background worker.",


### PR DESCRIPTION
During maintenance mode, only GET method is allowed in requests. But we would like to run the data migration through internal endpoint.

## Link(s) to Jira
- https://issues.redhat.com/browse/RHCLOUD-36368

## Description of Intent of Change(s)
The what, why and how.

## Local Testing
How can the feature be exercised?
How can the bug be exploited and fix confirmed?
Is any special local setup required?

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
