### PR TITLE
RHCLOUD-36364: Only commit to outbox from user listener while advisory lock acquired

### DIFF
--- a/rbac/internal/views.py
+++ b/rbac/internal/views.py
@@ -516,9 +516,10 @@ def bootstrap_tenant(request):
     org_id = request.GET.get("org_id")
     if not org_id:
         return HttpResponse('Invalid request, must supply the "org_id" query parameter.', status=400)
-    tenant = get_object_or_404(Tenant, org_id=org_id)
-    bootstrap_service = V2TenantBootstrapService(OutboxReplicator())
-    bootstrap_service.bootstrap_tenant(tenant)
+    with transaction.atomic():
+        tenant = get_object_or_404(Tenant, org_id=org_id)
+        bootstrap_service = V2TenantBootstrapService(OutboxReplicator())
+        bootstrap_service.bootstrap_tenant(tenant)
     return HttpResponse(f"Bootstrap tenant with org_id {org_id} finished.", status=200)
 
 

--- a/rbac/management/group/definer.py
+++ b/rbac/management/group/definer.py
@@ -97,7 +97,10 @@ def clone_default_group_in_public_schema(group, tenant) -> Optional[Group]:
     if settings.V2_BOOTSTRAP_TENANT:
         tenant_bootstrap_service = V2TenantBootstrapService(OutboxReplicator())
         bootstrapped_tenant = tenant_bootstrap_service.bootstrap_tenant(tenant)
-        group_uuid = bootstrapped_tenant.mapping.default_group_uuid
+        mapping = bootstrapped_tenant.mapping
+        # Mapping is always present with V2
+        assert mapping is not None
+        group_uuid = mapping.default_group_uuid
     else:
         group_uuid = uuid4()
 

--- a/rbac/management/principal/cleaner.py
+++ b/rbac/management/principal/cleaner.py
@@ -238,6 +238,7 @@ def process_principal_events_from_umb(bootstrap_service: Optional[TenantBootstra
     try:
         while UMB_CLIENT.canRead(15):  # Check if queue is empty, 15 sec timeout
             frame = UMB_CLIENT.receiveFrame()
+            logger.info("process_tenant_principal_events: Processing frame. info=%s", frame.info())
             if not process_umb_event(frame, UMB_CLIENT, bootstrap_service):
                 break
     finally:

--- a/rbac/management/principal/cleaner.py
+++ b/rbac/management/principal/cleaner.py
@@ -228,7 +228,7 @@ def process_principal_events_from_umb(bootstrap_service: Optional[TenantBootstra
     while UMB_CLIENT.canRead(15):  # Check if queue is empty, 15 sec timeout
         frame = UMB_CLIENT.receiveFrame()
         if not process_umb_event(frame, UMB_CLIENT, bootstrap_service):
-            return
+            break
     UMB_CLIENT.disconnect()
     logger.info("process_tenant_principal_events: Principal event processing finished.")
 

--- a/rbac/management/principal/cleaner.py
+++ b/rbac/management/principal/cleaner.py
@@ -43,7 +43,7 @@ logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 PROXY = PrincipalProxy()  # pylint: disable=invalid-name
 CERT_LOC = "/opt/rbac/rbac/management/principal/umb_certs/cert.pem"
 KEY_LOC = "/opt/rbac/rbac/management/principal/umb_certs/key.pem"
-LOCK_ID = hash(settings.ENV_NAME)
+LOCK_ID = 42  # For Keith, with Love
 
 
 def clean_tenant_principals(tenant):

--- a/rbac/management/principal/cleaner.py
+++ b/rbac/management/principal/cleaner.py
@@ -21,7 +21,6 @@ import os
 import ssl
 from typing import Optional
 
-from py import log
 import xmltodict
 from django.conf import settings
 from django.db import connection, transaction

--- a/rbac/management/tenant_service/v2.py
+++ b/rbac/management/tenant_service/v2.py
@@ -3,7 +3,6 @@
 from typing import List, Optional
 
 from django.conf import settings
-from django.db import transaction
 from django.db.models import Prefetch, Q
 from kessel.relations.v1beta1.common_pb2 import Relationship
 from management.group.model import Group
@@ -38,13 +37,11 @@ class V2TenantBootstrapService:
         self._replicator = replicator
         self._public_tenant = public_tenant
 
-    @transaction.atomic
     def new_bootstrapped_tenant(self, org_id: str, account_number: Optional[str] = None) -> BootstrappedTenant:
         """Create a new tenant."""
         tenant = Tenant.objects.create(org_id=org_id, account_id=account_number)
         return self._bootstrap_tenant(tenant)
 
-    @transaction.atomic
     def bootstrap_tenant(self, tenant: Tenant) -> BootstrappedTenant:
         """Bootstrap an existing tenant."""
         try:
@@ -53,7 +50,6 @@ class V2TenantBootstrapService:
         except TenantMapping.DoesNotExist:
             return self._bootstrap_tenant(tenant)
 
-    @transaction.atomic
     def update_user(
         self, user: User, upsert: bool = False, bootstrapped_tenant: Optional[BootstrappedTenant] = None
     ) -> Optional[BootstrappedTenant]:
@@ -105,7 +101,6 @@ class V2TenantBootstrapService:
 
         return bootstrapped_tenant
 
-    @transaction.atomic
     def import_bulk_users(self, users: list[User]):
         """
         Bootstrap multiple users in a tenant.

--- a/tests/management/principal/test_cleaner.py
+++ b/tests/management/principal/test_cleaner.py
@@ -497,6 +497,45 @@ class PrincipalUMBTests(IdentityRequest):
         self.assertTrue(Tenant.objects.filter(org_id="17685860").exists())
         self.assertTrue(Principal.objects.filter(user_id=self.principal_user_id).exists())
 
+    @patch(
+        "management.principal.proxy.PrincipalProxy.request_filtered_principals",
+        return_value={
+            "status_code": 200,
+            "data": [
+                {
+                    "user_id": 56780000,
+                    "org_id": "17685860",
+                    "username": "principal-test",
+                    "email": "test_user@email.com",
+                    "first_name": "user",
+                    "last_name": "test",
+                    "is_org_admin": False,
+                    "is_active": True,
+                }
+            ],
+        },
+    )
+    @patch("management.principal.cleaner.UMB_CLIENT")
+    @patch("management.principal.cleaner._lock_listener")
+    def test_does_not_update_user_if_lock_not_acquired(self, lock, client_mock, proxy_mock):
+        """Test that we can run principal creation event."""
+        lock.return_value = False
+        client_mock.canRead.return_value = True
+        client_mock.receiveFrame.return_value = MagicMock(body=FRAME_BODY_CREATION)
+
+        public_tenant = Tenant.objects.get(tenant_name="public")
+        Group.objects.create(name="default", platform_default=True, tenant=public_tenant)
+        tenant = Tenant.objects.get(org_id="17685860")
+        Principal.objects.create(tenant=tenant, username="principal-test")
+
+        process_principal_events_from_umb()
+
+        client_mock.receiveFrame.assert_called_once()
+        client_mock.disconnect.assert_called_once()
+        client_mock.ack.assert_not_called()
+
+        self.assertFalse(Principal.objects.filter(user_id=self.principal_user_id).exists())
+
 
 @override_settings(V2_BOOTSTRAP_TENANT=True, PRINCIPAL_CLEANUP_UPDATE_ENABLED_UMB=True)
 class PrincipalUMBTestsWithV2TenantBootstrap(PrincipalUMBTests):


### PR DESCRIPTION
## Link(s) to Jira
- https://issues.redhat.com/browse/RHCLOUD-36364

## Description of Intent of Change(s)

We need the listener process to commit outbox changes in order. Specifically we need to avoid the race that:

1. Process P1 receives a message for user U1 and looks up the user's current state (admin=true)
2. The user state changes (admin=false)
3. Process P2 receives a message for user U1 and looks up the user's current state (admin=false)
4. P2 commits this change
5. P1 commits the old change

In this case the state would be inconsistent until the next user update, potentially indefinitely.

This avoids this by requiring an advisory lock to commit the change:

1. P1 locks
2. P2 cannot acquire the lock
3. P1 commits

## Local Testing
How can the feature be exercised?
How can the bug be exploited and fix confirmed?
Is any special local setup required?

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
