### PR TITLE
RHCLOUD-36414: Parse userId from SSO response for service accounts

### DIFF
--- a/rbac/management/principal/it_service.py
+++ b/rbac/management/principal/it_service.py
@@ -455,6 +455,7 @@ class ITService:
         description = service_account_from_it_service.get("description")
         created_by = service_account_from_it_service.get("createdBy")
         created_at = service_account_from_it_service.get("createdAt")
+        user_id = service_account_from_it_service.get("userId")
 
         if client_id:
             service_account["clientId"] = client_id
@@ -470,6 +471,9 @@ class ITService:
 
         if created_at:
             service_account["time_created"] = created_at
+
+        if user_id:
+            service_account["userId"] = user_id
 
         # Hard code the type for every service account.
         service_account["type"] = "service-account"

--- a/tests/management/group/test_view.py
+++ b/tests/management/group/test_view.py
@@ -4480,7 +4480,7 @@ class GroupViewNonAdminTests(IdentityRequest):
 
     @override_settings(IT_BYPASS_TOKEN_VALIDATION=True)
     @patch("management.relation_replicator.outbox_replicator.OutboxReplicator._save_replication_event")
-    @patch("management.principal.it_service.ITService.request_service_accounts")
+    @patch("management.principal.it_service.requests.get")
     def test_add_service_account_principal_in_group_with_User_Access_Admin_success(self, mock_request, mock_method):
         """
         Test that non org admin with 'User Access administrator' role can add
@@ -4517,7 +4517,15 @@ class GroupViewNonAdminTests(IdentityRequest):
                 "type": "service-account",
             }
         ]
-        mock_request.return_value = mocked_values
+
+        class MockResponse:
+            def __init__(self, status_code, content, json):
+                self.status_code = status_code
+                self.content = content
+                self.json = json
+
+        mock_request.return_value = MockResponse(200, json.dumps(mocked_values), lambda: mocked_values)
+        mock_request.__name__ = "request_service_accounts"
 
         url = reverse("v1_management:group-principals", kwargs={"uuid": test_group.uuid})
         client = APIClient()

--- a/tests/management/group/test_view.py
+++ b/tests/management/group/test_view.py
@@ -4528,8 +4528,8 @@ class GroupViewNonAdminTests(IdentityRequest):
                 return self._json
 
         def mock_get(url: str, params: dict, *args, **kwargs):
-            if url.endswith("/service_accounts/v1") and not (
-                (client_ids := params.get("clientId")) or sa_uuid in client_ids
+            if url.endswith("/service_accounts/v1") and (
+                not (client_ids := params.get("clientId")) or sa_uuid in client_ids
             ):
                 return MockResponse(mocked_values)
             return MockResponse([])


### PR DESCRIPTION
## Link(s) to Jira
- https://issues.redhat.com/browse/RHCLOUD-36414

## Description of Intent of Change(s)

We're not correctly parsing the service account request when converting it to a dictionary. We were missing the newly added userId field.

## Local Testing
How can the feature be exercised?
How can the bug be exploited and fix confirmed?
Is any special local setup required?

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
