### PR TITLE
[NO JIRA] Log if the metrics server stared successfully

### DIFF
--- a/rbac/rbac/celery.py
+++ b/rbac/rbac/celery.py
@@ -17,14 +17,20 @@
 """Celery setup."""
 from __future__ import absolute_import, unicode_literals
 
+import logging
 import os
+import sys
 
+import sentry_sdk
 from app_common_python import LoadedConfig
 from celery import Celery
 from celery.schedules import crontab
 from celery.signals import worker_ready
 from django.conf import settings
 from prometheus_client import CollectorRegistry, multiprocess, start_http_server
+
+
+logger = logging.getLogger("__name__")
 
 # set the default Django settings module for the 'celery' program.
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "rbac.settings")
@@ -73,4 +79,13 @@ def start_metrics_server(sender=None, **kwargs):
     """Start the metrics server."""
     registry = CollectorRegistry()
     multiprocess.MultiProcessCollector(registry)
-    start_http_server(LoadedConfig.metricsPort, addr="0.0.0.0", registry=registry)
+    metrics_port = LoadedConfig.metricsPort or 9000
+
+    try:
+        start_http_server(metrics_port, addr="0.0.0.0", registry=registry)
+        logger.info(f"Server started and exposing to port {metrics_port}.")
+    except Exception as e:
+        sentry_sdk.capture_exception(e)
+        logger.error(f"Failed to start metrics server: {e}")
+        # Exit the entire process, we don't want to spin up the worker without metrics
+        sys.exit(1)


### PR DESCRIPTION
## Link(s) to Jira
-

## Description of Intent of Change(s)
We have to ensure the worker does not start if the metrics server is not up.
And we have to log if the metrics server started successfully.

## Local Testing
How can the feature be exercised?
How can the bug be exploited and fix confirmed?
Is any special local setup required?

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
