### PR TITLE
Lazily mark tenants ready + optimization

### DIFF
--- a/rbac/management/notifications/notification_handlers.py
+++ b/rbac/management/notifications/notification_handlers.py
@@ -57,7 +57,7 @@ def notify_all(event_type, payload):
     """Notify all tenants."""
     # To avoid memory overloaded, use iterator:
     # https://docs.djangoproject.com/en/4.0/ref/models/querysets/#django.db.models.query.QuerySet.iterator
-    for tenant in Tenant.objects.exclude(tenant_name="public").iterator():
+    for tenant in Tenant.objects.exclude(tenant_name="public").filter(ready=True).iterator():
         # Tenant name pattern is acct12345
         notify(event_type, payload, tenant.org_id)
 

--- a/rbac/management/seeds.py
+++ b/rbac/management/seeds.py
@@ -73,7 +73,7 @@ def purge_cache():
     from rbac.settings import MAX_SEED_THREADS
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=MAX_SEED_THREADS) as executor:
-        tenants = Tenant.objects.all()
+        tenants = Tenant.objects.filter(ready=True)
         tenant_count = tenants.count()
         for idx, tenant in enumerate(list(tenants)):
             progress = f"[{idx + 1} of {tenant_count}]."

--- a/rbac/rbac/middleware.py
+++ b/rbac/rbac/middleware.py
@@ -115,6 +115,9 @@ class IdentityHeaderMiddleware(MiddlewareMixin):
             try:
                 # If the tenant already exists, we assume it must be bootstrapped if dual writes are enabled.
                 tenant = Tenant.objects.get(org_id=request.user.org_id)
+                if not tenant.ready:
+                    tenant.ready = True
+                    tenant.save(update_fields=["ready"])
             except Tenant.DoesNotExist:
                 if request.user.system:
                     raise Http404()


### PR DESCRIPTION
## Link(s) to Jira
- https://issues.redhat.com/browse/RHCLOUD-36441

## Description of Intent of Change(s)
As part of the Kessel migration, we've increased our tenant count 100x and need to ensure that we:

- [ ] DO NOT set ready=True during bulk user import, to ensure tenants which haven't used console before are not initialized as ready, to exclude them from other queries.
- [x] set ready=True in middleware if we do find an existing tenant
- [ ] set ready=True in middleware if we are creating the tenant from a user-initiated request
- [x] update notifications tenant query to exclude tenants which are not ready
- [x] update seed tenant query to exclude tenants which are not ready
- [ ] set all current tenants where there are no principals to ready=False in stage DB
- [ ] test coverage

## Local Testing
How can the feature be exercised?
How can the bug be exploited and fix confirmed?
Is any special local setup required?

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
