### PR TITLE
RHCLOUD-35350 - Ensure access continuity

### DIFF
--- a/rbac/management/relation_replicator/relation_replicator.py
+++ b/rbac/management/relation_replicator/relation_replicator.py
@@ -77,10 +77,14 @@ class ReplicationEvent:
         info: dict[str, object] = {},
     ):
         """Initialize ReplicationEvent."""
+        add_set = set(add)
+        remove_set = set(remove)
+        intersection = add_set.intersection(remove_set)
+        self.add = list(add_set.difference(intersection))
+        self.remove = list(remove_set.difference(intersection))
+
         self.partition_key = partition_key
         self.event_type = event_type
-        self.add = add
-        self.remove = remove
         self.event_info = info
 
 

--- a/rbac/management/relation_replicator/relation_replicator.py
+++ b/rbac/management/relation_replicator/relation_replicator.py
@@ -77,11 +77,17 @@ class ReplicationEvent:
         info: dict[str, object] = {},
     ):
         """Initialize ReplicationEvent."""
-        add_set = set(add)
-        remove_set = set(remove)
-        intersection = add_set.intersection(remove_set)
-        self.add = list(add_set.difference(intersection))
-        self.remove = list(remove_set.difference(intersection))
+        add_set = {rel.relation: rel for rel in add}
+        remove_set = {rel.relation: rel for rel in remove}
+
+        # remove duplicates
+        intersection = set(add_set.keys()).intersection(set(remove_set.keys()))
+        for key in intersection:
+            del add_set[key]
+            del remove_set[key]
+
+        self.add = list(add_set.values())
+        self.remove = list(remove_set.values())
 
         self.partition_key = partition_key
         self.event_type = event_type


### PR DESCRIPTION
## Link(s) to Jira
- https://issues.redhat.com/browse/RHCLOUD-35350

## Description of Intent of Change(s)
The what, why and how.

In order for access continuity, ensure relation replication has no period where access is removed and not yet granted back for a single replication event

 - Updates replication event to remove intersection of add and remove tuples. 
 - Creates a wrapper class to hash the relationship tuples for set operations

## Local Testing
How can the feature be exercised?
How can the bug be exploited and fix confirmed?
Is any special local setup required?

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
