### PR TITLE
RHCLOUD-36577: Restrap the boot

### DIFF
--- a/rbac/internal/specs/openapi.json
+++ b/rbac/internal/specs/openapi.json
@@ -1128,6 +1128,16 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "force",
+            "in": "query",
+            "required": false,
+            "description": "Whether or not to force replication to happen, even if the Tenant is already bootstrapped. Cannot be 'true' if replication is on, due to inconsistency risk.",
+            "schema": {
+              "default": false,
+              "type": "boolean"
+            }
           }
         ],
         "responses": {
@@ -1752,7 +1762,7 @@
           }
         }
       },
-            "ServiceAccount": {
+      "ServiceAccount": {
         "required": [
           "clientId",
           "username",

--- a/rbac/internal/views.py
+++ b/rbac/internal/views.py
@@ -521,12 +521,13 @@ def bootstrap_tenant(request):
     logger.info("Running bootstrap tenant.")
 
     org_id = request.GET.get("org_id")
+    force = bool(request.GET.get("force", "false"))
     if not org_id:
         return HttpResponse('Invalid request, must supply the "org_id" query parameter.', status=400)
     with transaction.atomic():
         tenant = get_object_or_404(Tenant, org_id=org_id)
         bootstrap_service = V2TenantBootstrapService(OutboxReplicator())
-        bootstrap_service.bootstrap_tenant(tenant)
+        bootstrap_service.bootstrap_tenant(tenant, force=force)
     return HttpResponse(f"Bootstrap tenant with org_id {org_id} finished.", status=200)
 
 

--- a/rbac/internal/views.py
+++ b/rbac/internal/views.py
@@ -513,17 +513,29 @@ def data_migration(request):
 def bootstrap_tenant(request):
     """View method for bootstrapping a tenant.
 
-    POST /_private/api/utils/bootstrap_tenant/?org_id=12345
-    org_id is required,
+    POST /_private/api/utils/bootstrap_tenant/?org_id=12345&force=false
+
+    org_id:
+        (required) The org_id of the Tenant to bootstrap.
+
+    force:
+        Whether or not to force replication to happen, even if the Tenant is already bootstrapped.
+        Cannot be 'true' if replication is on, due to inconsistency risk.
     """
     if request.method != "POST":
         return HttpResponse('Invalid method, only "POST" is allowed.', status=405)
     logger.info("Running bootstrap tenant.")
 
     org_id = request.GET.get("org_id")
-    force = bool(request.GET.get("force", "false"))
+    force = request.GET.get("force", "false").lower() == "true"
     if not org_id:
         return HttpResponse('Invalid request, must supply the "org_id" query parameter.', status=400)
+    if force and settings.REPLICATION_TO_RELATION_ENABLED:
+        return HttpResponse(
+            "Forcing replication is not allowed when replication is on, "
+            "due to race condition with default group customization.",
+            status=400,
+        )
     with transaction.atomic():
         tenant = get_object_or_404(Tenant, org_id=org_id)
         bootstrap_service = V2TenantBootstrapService(OutboxReplicator())

--- a/rbac/management/group/relation_api_dual_write_group_handler.py
+++ b/rbac/management/group/relation_api_dual_write_group_handler.py
@@ -113,7 +113,7 @@ class RelationApiDualWriteGroupHandler(RelationApiDualWriteSubjectHandler):
             self._replicator.replicate(
                 ReplicationEvent(
                     event_type=self.event_type,
-                    info={"group_uuid": str(self.group.uuid)},
+                    info={"group_uuid": str(self.group.uuid), "org_id": str(self.group.tenant.org_id)},
                     partition_key=PartitionKey.byEnvironment(),
                     remove=self.relations_to_remove,
                     add=self.relations_to_add,

--- a/rbac/management/tenant_service/v2.py
+++ b/rbac/management/tenant_service/v2.py
@@ -43,10 +43,17 @@ class V2TenantBootstrapService:
         tenant = Tenant.objects.create(org_id=org_id, account_id=account_number)
         return self._bootstrap_tenant(tenant)
 
-    def bootstrap_tenant(self, tenant: Tenant) -> BootstrappedTenant:
-        """Bootstrap an existing tenant."""
+    def bootstrap_tenant(self, tenant: Tenant, force: bool = False) -> BootstrappedTenant:
+        """
+        Bootstrap an existing tenant.
+
+        If [force] is True, will re-bootstrap the tenant if already bootstrapped.
+        This does not change the RBAC data that already exists, but will replicate to Relations.
+        """
         try:
             mapping = TenantMapping.objects.get(tenant=tenant)
+            if force:
+                self._replicate_bootstrap(tenant, mapping)
             return BootstrappedTenant(tenant=tenant, mapping=mapping)
         except TenantMapping.DoesNotExist:
             return self._bootstrap_tenant(tenant)
@@ -262,6 +269,27 @@ class V2TenantBootstrapService:
 
         return BootstrappedTenant(tenant, mapping, default_workspace=default_workspace, root_workspace=root_workspace)
 
+    def _replicate_bootstrap(self, tenant: Tenant, mapping: TenantMapping):
+        """Replicate the bootstrapping of a tenant."""
+        built_in_workspaces = Workspace.objects.filter(
+            tenant=tenant, type__in=[Workspace.Types.ROOT, Workspace.Types.DEFAULT]
+        )
+        root = next(ws for ws in built_in_workspaces if ws.type == Workspace.Types.ROOT)
+        default = next(ws for ws in built_in_workspaces if ws.type == Workspace.Types.DEFAULT)
+
+        relationships = []
+        relationships.extend(self._built_in_hierarchy_tuples(default.id, root.id, tenant.org_id))
+        relationships.extend(self._bootstrap_default_access(tenant, mapping, str(default.id)))
+
+        self._replicator.replicate(
+            ReplicationEvent(
+                event_type=ReplicationEventType.BOOTSTRAP_TENANT,
+                info={"org_id": tenant.org_id, "internal": True},
+                partition_key=PartitionKey.byEnvironment(),
+                add=relationships,
+            )
+        )
+
     def _get_or_bootstrap_tenants(self, org_ids: set, ready: bool) -> list[BootstrappedTenant]:
         """Bootstrap list of tenants, used by import_bulk_users."""
         # Fetch existing tenants
@@ -365,9 +393,34 @@ class V2TenantBootstrapService:
 
         return tuples_to_add, tuples_to_remove
 
-    def _create_default_relation_tuples(
+    def _built_in_hierarchy_tuples(self, default_workspace_id, root_workspace_id, org_id) -> List[Relationship]:
+        """Create the tuples used to bootstrap the hierarchy of default->root->tenant->platform."""
+        tenant_id = f"{self._user_domain}/{org_id}"
+
+        return [
+            create_relationship(
+                ("rbac", "workspace"),
+                str(default_workspace_id),
+                ("rbac", "workspace"),
+                str(root_workspace_id),
+                "parent",
+            ),
+            create_relationship(
+                ("rbac", "workspace"), str(root_workspace_id), ("rbac", "tenant"), tenant_id, "parent"
+            ),
+            # Include platform for tenant
+            create_relationship(("rbac", "tenant"), tenant_id, ("rbac", "platform"), settings.ENV_NAME, "platform"),
+        ]
+
+    def _default_binding_tuples(
         self, default_workspace_id, role_binding_uuid, default_role_uuid, default_group_uuid
-    ):
+    ) -> List[Relationship]:
+        """
+        Create the tuples used to bootstrap default access for a Workspace.
+
+        Can be used for both default access and admin access as long as the correct arguments are provided.
+        Each of role binding, role, and group must refer to admin or default versions.
+        """
         return [
             create_relationship(
                 ("rbac", "workspace"),
@@ -429,7 +482,7 @@ class V2TenantBootstrapService:
             hasattr(tenant, "platform_default_groups") and tenant.platform_default_groups
         ):
             tuples_to_add.extend(
-                self._create_default_relation_tuples(
+                self._default_binding_tuples(
                     default_workspace_id,
                     default_user_role_binding_uuid,
                     platform_default_role_uuid,
@@ -444,7 +497,7 @@ class V2TenantBootstrapService:
         # Admin role binding is not customizable
         if admin_default_role_uuid:
             tuples_to_add.extend(
-                self._create_default_relation_tuples(
+                self._default_binding_tuples(
                     default_workspace_id,
                     default_admin_role_binding_uuid,
                     admin_default_role_uuid,
@@ -467,26 +520,8 @@ class V2TenantBootstrapService:
         root_workspace_id = root.id
         default_workspace_id = default.id
 
-        tenant_id = f"{self._user_domain}/{tenant.org_id}"
+        relationships.extend(self._built_in_hierarchy_tuples(default_workspace_id, root_workspace_id, tenant.org_id))
 
-        relationships.extend(
-            [
-                create_relationship(
-                    ("rbac", "workspace"),
-                    str(default_workspace_id),
-                    ("rbac", "workspace"),
-                    str(root.id),
-                    "parent",
-                ),
-                create_relationship(
-                    ("rbac", "workspace"), str(root_workspace_id), ("rbac", "tenant"), tenant_id, "parent"
-                ),
-                # Include platform for tenant
-                create_relationship(
-                    ("rbac", "tenant"), tenant_id, ("rbac", "platform"), settings.ENV_NAME, "platform"
-                ),
-            ]
-        )
         return root, default, relationships
 
     def _get_platform_default_policy_uuid(self) -> Optional[str]:

--- a/rbac/management/tenant_service/v2.py
+++ b/rbac/management/tenant_service/v2.py
@@ -106,7 +106,7 @@ class V2TenantBootstrapService:
         self._replicator.replicate(
             ReplicationEvent(
                 event_type=ReplicationEventType.EXTERNAL_USER_UPDATE,
-                info={"user_id": user_id},
+                info={"user_id": user_id, "org_id": user.org_id},
                 partition_key=PartitionKey.byEnvironment(),
                 add=tuples_to_add,
                 remove=tuples_to_remove,
@@ -218,7 +218,7 @@ class V2TenantBootstrapService:
         self._replicator.replicate(
             ReplicationEvent(
                 event_type=ReplicationEventType.EXTERNAL_USER_UPDATE,
-                info={"user_id": user_id},
+                info={"user_id": user_id, "org_id": user.org_id},
                 partition_key=PartitionKey.byEnvironment(),
                 remove=tuples_to_remove,
             )
@@ -284,7 +284,7 @@ class V2TenantBootstrapService:
         self._replicator.replicate(
             ReplicationEvent(
                 event_type=ReplicationEventType.BOOTSTRAP_TENANT,
-                info={"org_id": tenant.org_id, "internal": True},
+                info={"org_id": tenant.org_id, "forced": True},
                 partition_key=PartitionKey.byEnvironment(),
                 add=relationships,
             )

--- a/rbac/migration_tool/in_memory_tuples.py
+++ b/rbac/migration_tool/in_memory_tuples.py
@@ -207,6 +207,10 @@ class InMemoryTuples:
         """Return a representation of the store."""
         return f"InMemoryTuples({repr(self._tuples)})"
 
+    def __len__(self):
+        """Return the number of tuples in the store."""
+        return len(self._tuples)
+
 
 class TuplePredicate:
     """A predicate that can be used to filter relation tuples."""

--- a/tests/internal/test_views.py
+++ b/tests/internal/test_views.py
@@ -653,6 +653,7 @@ class InternalViewsetTests(IdentityRequest):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(tuples), 9)
 
+    @override_settings(REPLICATION_TO_RELATION_ENABLED=True)
     def test_cannot_force_bootstrapping_while_replication_enabled(self):
         org_id = "12345"
         response = self.client.post(

--- a/tests/management/tenant/test_model.py
+++ b/tests/management/tenant/test_model.py
@@ -352,6 +352,42 @@ class V2TenantBootstrapServiceTest(TestCase):
         # Assert no extra principals created
         self.assertEqual(4, Principal.objects.count())
 
+    def test_force_bootstrap_replicates_already_bootstrapped_unready_tenants(self):
+        bootstrapped = self.fixture.new_tenant(org_id="o1")
+        self.tuples.clear()
+
+        original_mapping = TenantMapping.objects.get(tenant=bootstrapped.tenant)
+        original_workspaces = list(Workspace.objects.filter(tenant=bootstrapped.tenant))
+
+        self.service.bootstrap_tenant(bootstrapped.tenant, force=True)
+
+        self.assertTenantBootstrapped("o1", existing=False)
+
+        new_mapping = TenantMapping.objects.get(tenant=bootstrapped.tenant)
+        new_workspaces = list(Workspace.objects.filter(tenant=bootstrapped.tenant))
+
+        self.assertEqual(original_mapping, new_mapping)
+        self.assertCountEqual(original_workspaces, new_workspaces)
+
+    def test_force_bootstrap_replicates_already_bootstrapped_ready_tenants(self):
+        bootstrapped = self.fixture.new_tenant(org_id="o1")
+        bootstrapped.tenant.ready = True
+        bootstrapped.tenant.save()
+        self.tuples.clear()
+
+        original_mapping = TenantMapping.objects.get(tenant=bootstrapped.tenant)
+        original_workspaces = list(Workspace.objects.filter(tenant=bootstrapped.tenant))
+
+        self.service.bootstrap_tenant(bootstrapped.tenant, force=True)
+
+        self.assertTenantBootstrapped("o1", existing=True)
+
+        new_mapping = TenantMapping.objects.get(tenant=bootstrapped.tenant)
+        new_workspaces = list(Workspace.objects.filter(tenant=bootstrapped.tenant))
+
+        self.assertEqual(original_mapping, new_mapping)
+        self.assertCountEqual(original_workspaces, new_workspaces)
+
     def assertAddedToDefaultGroup(self, user_id: str, tenant_mapping: TenantMapping, and_admin_group: bool = False):
         self.assertEqual(
             1,


### PR DESCRIPTION
## Link(s) to Jira
- [RHCLOUD-36577](https://issues.redhat.com/browse/RHCLOUD-36577)

## Description of Intent of Change(s)

In order to resync data after replication loss, allow re-bootstrapping a tenant which republishes its bootstrap outbox event.

This factors out some of the tuple construction logic so it can be reused without necessarily creating net-new Workspaces, which we don't want to do in this case.

I also added some additionally logging which could help recover from instances of replication loss.

**What is replication loss?**

Replication loss is when tuples which are meant to be sent to Relations for some reason will never be sent. For example, if the outbox is used with Debezium (what we use now), this happens if the replication slot is lost.

## Local Testing
How can the feature be exercised?
How can the bug be exploited and fix confirmed?
Is any special local setup required?

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
