### PR TITLE
[RHCLOUD-36625] Fix service account import

### DIFF
--- a/rbac/management/management/commands/utils.py
+++ b/rbac/management/management/commands/utils.py
@@ -129,5 +129,6 @@ def populate_service_account_data(file_name):
             user_id, client_id = row
             id_mapping[client_id] = user_id
     for principal in Principal.objects.filter(type=Principal.Types.SERVICE_ACCOUNT):
-        principal.user_id = id_mapping.get(principal.service_account_id)
-        principal.save()
+        if user_id := id_mapping.get(principal.service_account_id):
+            principal.user_id = user_id
+            principal.save()

--- a/tests/management/management/commands/test_utils.py
+++ b/tests/management/management/commands/test_utils.py
@@ -119,9 +119,10 @@ class TestProcessBatch(TestCase):
     def test_import_service_account_data(self):
         client_id_1 = "8c22358-c2ab-40cc-bbc1-e4eff3exxb37xx"
         client_id_2 = "1421687f3-2bc0-4128-9d52-b92b9a22a631"
+        client_id_not_in_file = "1421cc7f3-2bc0-4128-9d52-b92bddd2a631"
         user_id_1 = "b6333341-f028-4f29-852e-375132644bcc"
         user_id_2 = "181sdf16-414d-48dd-80a1-264df5d4ffd1"
-        id_mapping = {client_id_1: user_id_1, client_id_2: user_id_2}
+        user_id_3 = "18xx2f16-414d-48dd-80a1-24df5cccffd1"
         tenant_1 = Tenant.objects.create(tenant_name="test_tenant_1")
         tenant_2 = Tenant.objects.create(tenant_name="test_tenant_2")
         mock_file_content = f"""user_id,client_id
@@ -131,7 +132,7 @@ a210f23c-f2d2-40c6-b47c-43fa1bgg814a,0dffe7e11-c56e-4fcb-b7a6-66db2e013983
 212cdcfe-e332-445c-bc35-4cc0xx8391d2,164x0f206-1161-446c-8bfd-b05039feec71
 {user_id_2},{client_id_2}
 """
-        principals = Principal.objects.bulk_create(
+        Principal.objects.bulk_create(
             [
                 Principal(
                     username=SERVICE_ACCOUNT_USERNAME_FORMAT.format(clientId=client_id_1),
@@ -146,11 +147,18 @@ a210f23c-f2d2-40c6-b47c-43fa1bgg814a,0dffe7e11-c56e-4fcb-b7a6-66db2e013983
                     type=Principal.Types.SERVICE_ACCOUNT,
                     tenant=tenant_2,
                 ),
+                Principal(
+                    username=SERVICE_ACCOUNT_USERNAME_FORMAT.format(clientId=client_id_not_in_file),
+                    service_account_id=client_id_not_in_file,
+                    user_id=user_id_3,
+                    type=Principal.Types.SERVICE_ACCOUNT,
+                    tenant=tenant_2,
+                ),
             ]
         )
         with patch("builtins.open", mock_open(read_data=mock_file_content)):
             populate_service_account_data("file_name")
 
-        for principal in principals:
-            principal.refresh_from_db()
-            self.assertEqual(id_mapping[principal.service_account_id], principal.user_id)
+        self.assertEqual(Principal.objects.get(service_account_id=client_id_1).user_id, user_id_1)
+        self.assertEqual(Principal.objects.get(service_account_id=client_id_2).user_id, user_id_2)
+        self.assertEqual(Principal.objects.get(service_account_id=client_id_not_in_file).user_id, user_id_3)


### PR DESCRIPTION
Should not replace current user id if we don't find service account client id in the mapping

## Link(s) to Jira
- RHCLOUD-36625

## Description of Intent of Change(s)
The what, why and how.

## Local Testing
How can the feature be exercised?
How can the bug be exploited and fix confirmed?
Is any special local setup required?

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
