### PR TITLE
RHCLOUD-36624: Ensure usernames are lowercased for Principal lookups

### DIFF
--- a/rbac/api/models.py
+++ b/rbac/api/models.py
@@ -67,7 +67,22 @@ class TenantAwareModel(models.Model):
 class User:
     """A request User. Might also represent a service account."""
 
-    username: Optional[str] = None
+    _username: Optional[str] = None
+
+    @property
+    def username(self) -> Optional[str]:
+        """Return the username."""
+        return self._username
+
+    @username.setter
+    def username(self, value: Optional[str]) -> None:
+        """
+        Set the username.
+
+        Lower-cases the username due to case insensitivity.
+        """
+        self._username = value.lower() if value else None
+
     account: Optional[str] = None
     admin: bool = False
     access = {}

--- a/rbac/management/tenant_service/tenant_service.py
+++ b/rbac/management/tenant_service/tenant_service.py
@@ -1,5 +1,6 @@
 """Common objects for tenant services."""
 
+import logging
 from typing import NamedTuple, Optional, Protocol
 
 from management.principal.model import Principal
@@ -7,6 +8,8 @@ from management.tenant_mapping.model import TenantMapping
 from management.workspace.model import Workspace
 
 from api.models import Tenant, User
+
+logger = logging.getLogger(__name__)
 
 
 def _ensure_principal_with_user_id_in_tenant(user: User, tenant: Tenant, upsert: bool = False):
@@ -24,6 +27,10 @@ def _ensure_principal_with_user_id_in_tenant(user: User, tenant: Tenant, upsert:
             principal = Principal.objects.get(username=user.username, tenant=tenant)
         except Principal.DoesNotExist:
             pass
+        except Principal.MultipleObjectsReturned:
+            logger.warning(
+                f"Multiple principals returned for the same username. username={user.username} org_id={tenant.org_id}"
+            )
 
     if not created and principal and principal.user_id != user.user_id:
         principal.user_id = user.user_id

--- a/rbac/management/tenant_service/v2.py
+++ b/rbac/management/tenant_service/v2.py
@@ -155,7 +155,6 @@ class V2TenantBootstrapService:
             if not user.is_active:
                 continue
             if user.org_id is None:
-                logger.warning(f"Cannot update user without org_id. Skipping. username={user.username}")
                 continue
             bootstrapped = bootstrapped_mapping[user.org_id]
             key = (user.org_id, user.username)


### PR DESCRIPTION
## Link(s) to Jira

- https://issues.redhat.com/browse/RHCLOUD-36624

## Description of Intent of Change(s)

We found that many Principals did not have user IDs. We traced this ultimately to the import not matching users correctly by username due to case mismatch.

## Local Testing
How can the feature be exercised?

Unit tests

How can the bug be exploited and fix confirmed?

Rerunning the import

Is any special local setup required?

No

## Checklist
- [x] if API spec changes are required, is the spec updated?
- [x] are there any pre/post merge actions required? if so, document here.
- [x] are theses changes covered by unit tests?
- [x] if warranted, are documentation changes accounted for?
- [x] does this require migration changes?
  - [x] if yes, are they backwards compatible?
- [x] is there known, direct impact to dependent teams/components?
  - [x] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [x] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [x] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
