### PR TITLE
Fix type error on exception

### DIFF
--- a/rbac/management/cache.py
+++ b/rbac/management/cache.py
@@ -69,7 +69,7 @@ class BasicCache:
                 self.disable_caching()
                 return False
         except Exception as e:
-            logger.exception("Error:", e)
+            logger.exception(f"Error: {e}")
 
     @contextlib.contextmanager
     def delete_handler(self, err_msg):


### PR DESCRIPTION
## Link(s) to Jira
- [RHCLOUD-36673](https://issues.redhat.com/browse/RHCLOUD-36673)

## Description of Intent of Change(s)
The what, why and how.
I am formatting the error message as an f string to make sure it gets passed as a string.
## Local Testing
How can the feature be exercised?
How can the bug be exploited and fix confirmed?
Is any special local setup required?
I replicated the error locally and fixed it.
To replicate the error I just ran a test script in the python cli
```
import logging
logger = logging.getLogger(__name__)
try:
    raise Exception('test')
except Exception as e:
    logger.exception("Error:", e)
```

Running that will return the same TypeError we see in glitch tip. Replacing the last line to use an f-string will log the exception as we expect.
```
logger.exception(f"Error: {e}")
```
## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
