### PR TITLE
[RHCLOUD-36043] add tenant in the Role queries

### DIFF
--- a/rbac/management/group/definer.py
+++ b/rbac/management/group/definer.py
@@ -61,7 +61,7 @@ def seed_group() -> Tuple[Group, Group]:
             tenant=public_tenant,
         )
 
-        platform_roles = Role.objects.filter(platform_default=True)
+        platform_roles = Role.objects.filter(platform_default=True, tenant=public_tenant)
         update_group_roles(group, platform_roles, public_tenant)
         logger.info("Finished seeding default group %s.", name)
 
@@ -76,7 +76,7 @@ def seed_group() -> Tuple[Group, Group]:
             defaults={"description": admin_group_description, "name": admin_name, "system": True},
             tenant=public_tenant,
         )
-        admin_roles = Role.objects.filter(admin_default=True)
+        admin_roles = Role.objects.filter(admin_default=True, tenant=public_tenant)
         update_group_roles(admin_group, admin_roles, public_tenant)
         logger.info("Finished seeding default org admin group %s.", name)
 

--- a/rbac/management/role/definer.py
+++ b/rbac/management/role/definer.py
@@ -88,7 +88,9 @@ def _make_role(data, dual_write_handler, force_create_relationships=False):
     else:
         if role.version != defaults["version"]:
             dual_write_handler.prepare_for_update(role)
-            Role.objects.filter(name=name).update(**defaults, display_name=display_name, modified=timezone.now())
+            Role.objects.filter(name=name, tenant=public_tenant).update(
+                **defaults, display_name=display_name, modified=timezone.now()
+            )
             logger.info("Updated system role %s.", name)
             role.access.all().delete()
             role_obj_change_notification_handler(role, "updated")
@@ -152,7 +154,8 @@ def seed_roles(force_create_relationships=False):
                 current_role_ids.update(file_role_ids)
 
     # Find roles in DB but not in config
-    roles_to_delete = Role.objects.filter(system=True).exclude(id__in=current_role_ids)
+    public_tenant = Tenant.objects.get(tenant_name="public")
+    roles_to_delete = Role.objects.filter(system=True, tenant=public_tenant).exclude(id__in=current_role_ids)
     logger.info(f"The following '{roles_to_delete.count()}' roles(s) eligible for removal: {roles_to_delete.values()}")
     if destructive_ok("seeding"):
         logger.info(f"Removing the following role(s): {roles_to_delete.values()}")


### PR DESCRIPTION
## Link(s) to Jira
- [RHCLOUD-36043](https://issues.redhat.com/browse/RHCLOUD-36043)

## Description of Intent of Change(s)
We have 5 roles in production and 1 role in staging with `system=true,` none of which belong to the public tenant. The roles were likely created as custom roles initially but were later overwritten by RBAC seeding job. 

First step is to fix queries by adding tenant in the filter.

## Local Testing
Without the change:
Create new custom role under non-public tenants and change it (manual change in DB) to `system=true`.
Run seeding job and check in logs that the role was marked as eligible for removal.

With the change:
Run seeding job and check in logs that the role is not marked as eligible for removal.

