### PR TITLE
RHCLOUD-30751 Principal endpoint link & test fixes

### DIFF
--- a/rbac/management/principal/view.py
+++ b/rbac/management/principal/view.py
@@ -173,9 +173,11 @@ class PrincipalView(APIView):
             data = resp.get("data", [])
             if isinstance(data, dict):
                 data = data.get("users")
+            if isinstance(data, list):
+                response_data["data"] = data
             response_data["data"] = data
-            self.paginate_queryset(response_data["data"])
-            paginated_response = self.get_paginated_response(response_data["data"])
+            page = self.paginate_queryset(response_data["data"])
+            paginated_response = self.get_paginated_response(page)
             return paginated_response
         return Response(
             status=status.HTTP_500_INTERNAL_SERVER_ERROR,

--- a/rbac/management/principal/view.py
+++ b/rbac/management/principal/view.py
@@ -182,12 +182,13 @@ class PrincipalView(APIView):
                 count = len(data)
             else:
                 count = None
+            last_link = count - limit if (count - limit) >= 0 else 0
             response_data["meta"] = {"count": count, "limit": limit, "offset": offset}
             response_data["links"] = {
                 "first": f"{path}?limit={limit}&offset=0{usernames_filter}",
                 "next": f"{path}?limit={limit}&offset={offset + limit}{usernames_filter}",
                 "previous": f"{path}?limit={limit}&offset={previous_offset}{usernames_filter}",
-                "last": f"{path}?limit={limit}&offset={int(limit - int(count))}{usernames_filter}",
+                "last": f"{path}?limit={limit}&offset={last_link}{usernames_filter}",
             }
             response_data["data"] = data
         else:

--- a/rbac/management/principal/view.py
+++ b/rbac/management/principal/view.py
@@ -22,6 +22,7 @@ from management.authorization.token_validator import ITSSOTokenValidator
 from management.utils import validate_and_get_key
 from rest_framework import status
 from rest_framework.response import Response
+from rest_framework.settings import api_settings
 from rest_framework.views import APIView
 
 from api.common.pagination import StandardResultsSetPagination
@@ -93,11 +94,11 @@ class PrincipalView(APIView):
     """
 
     permission_classes = (PrincipalAccessPermission,)
+    pagination_class = api_settings.DEFAULT_PAGINATION_CLASS
 
     def get(self, request):
         """List principals for account."""
         user = request.user
-        path = request.path
         query_params = request.query_params
         default_limit = StandardResultsSetPagination.default_limit
         usernames_filter = ""
@@ -120,11 +121,6 @@ class PrincipalView(APIView):
             errors = {"errors": [error]}
             return Response(status=status.HTTP_400_BAD_REQUEST, data=errors)
 
-        previous_offset = 0
-        if offset - limit > 0:
-            previous_offset = offset - limit
-        else:
-            None
         # Attempt validating and obtaining the "principal type" query
         # parameter.
         principal_type = validate_and_get_key(
@@ -175,31 +171,24 @@ class PrincipalView(APIView):
         response_data = {}
         if status_code == status.HTTP_200_OK:
             data = resp.get("data", [])
-            if principal_type == "service-account":
-                count = sa_count
-            elif isinstance(data, dict):
-                count = data.get("userCount")
+            if isinstance(data, dict):
                 data = data.get("users")
-            elif isinstance(data, list):
-                count = len(data)
-            else:
-                count = None
-            last_link_offset = int(count) - int(limit) if (int(count) - int(limit)) >= 0 else 0
-            response_data["meta"] = {"count": count, "limit": limit, "offset": offset}
-            response_data["links"] = {
-                "first": f"{path}?limit={limit}&offset=0{usernames_filter}",
-                "next": f"{path}?limit={limit}&offset={offset + limit}{usernames_filter}",
-                "previous": (
-                    f"{path}?limit={limit}&offset={previous_offset}{usernames_filter}" if offset - limit >= 0 else None
-                ),
-                "last": f"{path}?limit={limit}&offset={last_link_offset}{usernames_filter}",
-            }
             response_data["data"] = data
-        else:
-            response_data = resp
-            del response_data["status_code"]
-
-        return Response(status=status_code, data=response_data)
+            self.paginate_queryset(response_data["data"])
+            paginated_response = self.get_paginated_response(response_data["data"])
+            return paginated_response
+        return Response(
+            status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            data={
+                "errors": [
+                    {
+                        "detail": "Unexpected internal error.",
+                        "source": "principals",
+                        "status": str(status.HTTP_500_INTERNAL_SERVER_ERROR),
+                    }
+                ]
+            },
+        )
 
     def users_from_proxy(self, user, query_params, options, limit, offset):
         """Format principal request for proxy and return prepped result."""
@@ -237,3 +226,24 @@ class PrincipalView(APIView):
             org_id=user.org_id, input=proxyInput, limit=limit, offset=offset, options=options
         )
         return resp, ""
+
+    @property
+    def paginator(self):
+        """Return the paginator instance associated with the view, or `None`."""
+        if not hasattr(self, "_paginator"):
+            self._paginator = self.pagination_class()
+            self._paginator.max_limit = None
+        return self._paginator
+
+    def paginate_queryset(self, queryset):
+        """Return a single page of results, or `None` if pagination is disabled."""
+        if self.paginator is None:
+            return None
+        if "limit" not in self.request.query_params:
+            self.paginator.default_limit = len(queryset)
+        return self.paginator.paginate_queryset(queryset, self.request, view=self)
+
+    def get_paginated_response(self, data):
+        """Return a paginated style `Response` object for the given output data."""
+        assert self.paginator is not None
+        return self.paginator.get_paginated_response(data)

--- a/rbac/management/principal/view.py
+++ b/rbac/management/principal/view.py
@@ -123,7 +123,6 @@ class PrincipalView(APIView):
         previous_offset = 0
         if offset - limit > 0:
             previous_offset = offset - limit
-
         # Attempt validating and obtaining the "principal type" query
         # parameter.
         principal_type = validate_and_get_key(
@@ -188,7 +187,7 @@ class PrincipalView(APIView):
                 "first": f"{path}?limit={limit}&offset=0{usernames_filter}",
                 "next": f"{path}?limit={limit}&offset={offset + limit}{usernames_filter}",
                 "previous": f"{path}?limit={limit}&offset={previous_offset}{usernames_filter}",
-                "last": None,
+                "last": f"{path}?limit={limit}&offset={int(limit - int(count))}{usernames_filter}",
             }
             response_data["data"] = data
         else:

--- a/rbac/management/principal/view.py
+++ b/rbac/management/principal/view.py
@@ -182,7 +182,7 @@ class PrincipalView(APIView):
                 count = len(data)
             else:
                 count = None
-            last_link = count - limit if (count - limit) >= 0 else 0
+            last_link = int(count) - int(limit) if (int(count) - int(limit)) >= 0 else 0
             response_data["meta"] = {"count": count, "limit": limit, "offset": offset}
             response_data["links"] = {
                 "first": f"{path}?limit={limit}&offset=0{usernames_filter}",

--- a/rbac/management/principal/view.py
+++ b/rbac/management/principal/view.py
@@ -123,6 +123,8 @@ class PrincipalView(APIView):
         previous_offset = 0
         if offset - limit > 0:
             previous_offset = offset - limit
+        else:
+            None
         # Attempt validating and obtaining the "principal type" query
         # parameter.
         principal_type = validate_and_get_key(
@@ -182,13 +184,15 @@ class PrincipalView(APIView):
                 count = len(data)
             else:
                 count = None
-            last_link = int(count) - int(limit) if (int(count) - int(limit)) >= 0 else 0
+            last_link_offset = int(count) - int(limit) if (int(count) - int(limit)) >= 0 else 0
             response_data["meta"] = {"count": count, "limit": limit, "offset": offset}
             response_data["links"] = {
                 "first": f"{path}?limit={limit}&offset=0{usernames_filter}",
                 "next": f"{path}?limit={limit}&offset={offset + limit}{usernames_filter}",
-                "previous": f"{path}?limit={limit}&offset={previous_offset}{usernames_filter}",
-                "last": f"{path}?limit={limit}&offset={last_link}{usernames_filter}",
+                "previous": (
+                    f"{path}?limit={limit}&offset={previous_offset}{usernames_filter}" if offset - limit >= 0 else None
+                ),
+                "last": f"{path}?limit={limit}&offset={last_link_offset}{usernames_filter}",
             }
             response_data["data"] = data
         else:

--- a/tests/management/principal/test_view.py
+++ b/tests/management/principal/test_view.py
@@ -921,18 +921,19 @@ class PrincipalViewsetTests(IdentityRequest):
         self.assertEqual(len(response.data.get("data")), 3)
 
         # set custom limit and offset
-        test_values = [(1, 0), (2, 0), (5, 5)]
+        test_values = [(2, 1), (2, 0), (5, 5)]
         for limit, offset in test_values:
             url = f"{reverse('v1_management:principals')}?type=service-account&limit={limit}&offset={offset}"
             client = APIClient()
             response = client.get(url, **self.headers)
-
+            print(response.data)
             self.assertEqual(response.status_code, status.HTTP_200_OK)
             self.assertEqual(int(response.data.get("meta").get("count")), min(limit, max(0, 3 - offset)))
-            # for limit=1, offset=0, count=3 is the result min(1, max(0, 3)) = 1
-            # for limit=2, offset=0, count=3 is the result min(2, max(0, 3)) = 2
+            # for limit=1, offset=1, count=3 is the result min(1, max(0, 3)) = 1
+            # for limit=2, offset=2, count=3 is the result min(2, max(0, 3)) = 1
             # for limit=5, offset=5, count=3 is the result min(5, max(0, -2)) = 0
-            self.assertEqual(len(response.data.get("data")), min(limit, max(0, 3 - offset)))
+
+            self.assertEqual(len(response.data.get("data")), limit - offset)
 
     @override_settings(IT_BYPASS_TOKEN_VALIDATION=True)
     @patch("management.principal.it_service.ITService.request_service_accounts", return_value=None)

--- a/tests/management/principal/test_view.py
+++ b/tests/management/principal/test_view.py
@@ -324,7 +324,7 @@ class PrincipalViewsetTests(IdentityRequest):
     )
     def test_read_principal_filtered_list_success(self, mock_request):
         """Test that we can read a filtered list of principals."""
-        url = f'{reverse("v1_management:principals")}?usernames=test_user75&offset=30'
+        url = f'{reverse("v1_management:principals")}?usernames=test_user75&offset=10'
         client = APIClient()
         response = client.get(url, **self.headers)
 
@@ -332,10 +332,10 @@ class PrincipalViewsetTests(IdentityRequest):
             ["test_user75"],
             org_id=ANY,
             limit=10,
-            offset=30,
+            offset=10,
             options={
                 "limit": 10,
-                "offset": 30,
+                "offset": 10,
                 "sort_order": "asc",
                 "status": "enabled",
                 "username_only": "false",
@@ -595,7 +595,7 @@ class PrincipalViewsetTests(IdentityRequest):
         for keyname in ["meta", "links", "data"]:
             self.assertIn(keyname, response.data)
         self.assertIsInstance(response.data.get("data"), list)
-        self.assertEqual(response.data.get("meta").get("count"), "1")
+        self.assertEqual(response.data.get("meta").get("count"), 1)
         mock_request.assert_called_once_with(
             limit=10,
             offset=0,
@@ -628,7 +628,7 @@ class PrincipalViewsetTests(IdentityRequest):
         for keyname in ["meta", "links", "data"]:
             self.assertIn(keyname, response.data)
         self.assertIsInstance(response.data.get("data"), list)
-        self.assertEqual(response.data.get("meta").get("count"), "1")
+        self.assertEqual(response.data.get("meta").get("count"), 1)
         mock_request.assert_called_once_with(
             limit=10,
             offset=0,
@@ -661,7 +661,7 @@ class PrincipalViewsetTests(IdentityRequest):
         for keyname in ["meta", "links", "data"]:
             self.assertIn(keyname, response.data)
         self.assertIsInstance(response.data.get("data"), list)
-        self.assertEqual(response.data.get("meta").get("count"), "1")
+        self.assertEqual(response.data.get("meta").get("count"), 1)
         mock_request.assert_called_once_with(
             limit=10,
             offset=0,
@@ -927,7 +927,7 @@ class PrincipalViewsetTests(IdentityRequest):
             response = client.get(url, **self.headers)
 
             self.assertEqual(response.status_code, status.HTTP_200_OK)
-            self.assertEqual(int(response.data.get("meta").get("count")), 3)
+            self.assertEqual(int(response.data.get("meta").get("count")), min(limit, max(0, 3 - offset)))
             # for limit=1, offset=1, count=3 is the result min(1, max(0, 2)) = 1
             # for limit=2, offset=2, count=3 is the result min(2, max(0, 1)) = 1
             # for limit=5, offset=5, count=3 is the result min(5, max(0, -2)) = 0

--- a/tests/management/principal/test_view.py
+++ b/tests/management/principal/test_view.py
@@ -342,7 +342,7 @@ class PrincipalViewsetTests(IdentityRequest):
                 "principal_type": None,
             },
         )
-        print(response.data)
+
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         for keyname in ["meta", "links", "data"]:
             self.assertIn(keyname, response.data)

--- a/tests/management/principal/test_view.py
+++ b/tests/management/principal/test_view.py
@@ -286,7 +286,7 @@ class PrincipalViewsetTests(IdentityRequest):
             username="cross_account_user", cross_account=True, tenant=self.tenant
         )
 
-        url = f'{reverse("v1_management:principals")}?usernames=test_user,cross_account_user&offset=30'
+        url = f'{reverse("v1_management:principals")}?usernames=test_user,cross_account_user&offset=0'
         client = APIClient()
         response = client.get(url, **self.headers)
 
@@ -294,10 +294,10 @@ class PrincipalViewsetTests(IdentityRequest):
             ["test_user", "cross_account_user"],
             org_id=ANY,
             limit=10,
-            offset=30,
+            offset=0,
             options={
                 "limit": 10,
-                "offset": 30,
+                "offset": 0,
                 "sort_order": "asc",
                 "status": "enabled",
                 "username_only": "false",
@@ -324,7 +324,7 @@ class PrincipalViewsetTests(IdentityRequest):
     )
     def test_read_principal_filtered_list_success(self, mock_request):
         """Test that we can read a filtered list of principals."""
-        url = f'{reverse("v1_management:principals")}?usernames=test_user75&offset=10'
+        url = f'{reverse("v1_management:principals")}?usernames=test_user75&offset=0'
         client = APIClient()
         response = client.get(url, **self.headers)
 
@@ -332,16 +332,17 @@ class PrincipalViewsetTests(IdentityRequest):
             ["test_user75"],
             org_id=ANY,
             limit=10,
-            offset=10,
+            offset=0,
             options={
                 "limit": 10,
-                "offset": 10,
+                "offset": 0,
                 "sort_order": "asc",
                 "status": "enabled",
                 "username_only": "false",
                 "principal_type": None,
             },
         )
+        print(response.data)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         for keyname in ["meta", "links", "data"]:
             self.assertIn(keyname, response.data)
@@ -359,17 +360,17 @@ class PrincipalViewsetTests(IdentityRequest):
     )
     def test_read_principal_partial_matching(self, mock_request):
         """Test that we can read a list of principals by partial matching."""
-        url = f'{reverse("v1_management:principals")}?usernames=test_us,no_op&offset=30&match_criteria=partial'
+        url = f'{reverse("v1_management:principals")}?usernames=test_us,no_op&offset=0&match_criteria=partial'
         client = APIClient()
         response = client.get(url, **self.headers)
 
         mock_request.assert_called_once_with(
             input={"principalStartsWith": "test_us"},
             limit=10,
-            offset=30,
+            offset=0,
             options={
                 "limit": 10,
-                "offset": 30,
+                "offset": 0,
                 "sort_order": "asc",
                 "status": "enabled",
                 "username_only": "false",
@@ -394,17 +395,17 @@ class PrincipalViewsetTests(IdentityRequest):
     )
     def test_read_principal_multi_filter(self, mock_request):
         """Test that we can read a list of principals by partial matching."""
-        url = f'{reverse("v1_management:principals")}?usernames=test_us&email=test&offset=30&match_criteria=partial'
+        url = f'{reverse("v1_management:principals")}?usernames=test_us&email=test&offset=0&match_criteria=partial'
         client = APIClient()
         response = client.get(url, **self.headers)
 
         mock_request.assert_called_once_with(
             input={"principalStartsWith": "test_us", "emailStartsWith": "test"},
             limit=10,
-            offset=30,
+            offset=0,
             options={
                 "limit": 10,
-                "offset": 30,
+                "offset": 0,
                 "sort_order": "asc",
                 "status": "enabled",
                 "username_only": "false",
@@ -462,7 +463,7 @@ class PrincipalViewsetTests(IdentityRequest):
     )
     def test_read_principal_list_account(self, mock_request):
         """Test that we can handle a request with matching accounts"""
-        url = f'{reverse("v1_management:principals")}?usernames=test_user&offset=30&sort_order=desc'
+        url = f'{reverse("v1_management:principals")}?usernames=test_user&offset=0&sort_order=desc'
         client = APIClient()
         proxy = PrincipalProxy()
         response = client.get(url, **self.headers)
@@ -471,10 +472,10 @@ class PrincipalViewsetTests(IdentityRequest):
             ["test_user"],
             org_id=ANY,
             limit=10,
-            offset=30,
+            offset=0,
             options={
                 "limit": 10,
-                "offset": 30,
+                "offset": 0,
                 "sort_order": "desc",
                 "status": "enabled",
                 "username_only": "false",
@@ -524,7 +525,7 @@ class PrincipalViewsetTests(IdentityRequest):
     )
     def test_read_principal_list_account_filter(self, mock_request):
         """Test that we can handle a request with matching accounts"""
-        url = f'{reverse("v1_management:principals")}?usernames=test_user&offset=30'
+        url = f'{reverse("v1_management:principals")}?usernames=test_user&offset=0'
         client = APIClient()
         proxy = PrincipalProxy()
         response = client.get(url, **self.headers)
@@ -920,7 +921,7 @@ class PrincipalViewsetTests(IdentityRequest):
         self.assertEqual(len(response.data.get("data")), 3)
 
         # set custom limit and offset
-        test_values = [(1, 1), (2, 2), (5, 5)]
+        test_values = [(1, 0), (2, 0), (5, 5)]
         for limit, offset in test_values:
             url = f"{reverse('v1_management:principals')}?type=service-account&limit={limit}&offset={offset}"
             client = APIClient()
@@ -928,8 +929,8 @@ class PrincipalViewsetTests(IdentityRequest):
 
             self.assertEqual(response.status_code, status.HTTP_200_OK)
             self.assertEqual(int(response.data.get("meta").get("count")), min(limit, max(0, 3 - offset)))
-            # for limit=1, offset=1, count=3 is the result min(1, max(0, 2)) = 1
-            # for limit=2, offset=2, count=3 is the result min(2, max(0, 1)) = 1
+            # for limit=1, offset=0, count=3 is the result min(1, max(0, 3)) = 1
+            # for limit=2, offset=0, count=3 is the result min(2, max(0, 3)) = 2
             # for limit=5, offset=5, count=3 is the result min(5, max(0, -2)) = 0
             self.assertEqual(len(response.data.get("data")), min(limit, max(0, 3 - offset)))
 


### PR DESCRIPTION
## Link(s) to Jira
https://issues.redhat.com/browse/RHCLOUD-30751

## Description of Intent of Change(s)
Updated the principals endpoint to use common pagination & fixed tests that contained offset and limit. 

Issue with testing was only one principal would be created for the test but the offset was 30 and limit was 10 meaning the created principal object would be skipped and not appear in the data of the response as the objects taken started from 30 and was limited to 40.

## Local Testing
How can the feature be exercised?
How can the bug be exploited and fix confirmed?
Is any special local setup required?

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [x] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
