### PR TITLE
Refactor process_response metrics and logging

### DIFF
--- a/rbac/rbac/middleware.py
+++ b/rbac/rbac/middleware.py
@@ -386,18 +386,9 @@ class IdentityHeaderMiddleware(MiddlewareMixin):
             request (object): The request object
             response (object): The response object
         """
-        is_internal = False
-        if any([request.path.startswith(prefix) for prefix in settings.INTERNAL_API_PATH_PREFIXES]):
-            # This request is for a private API endpoint
-            is_internal = True
-            IdentityHeaderMiddleware.log_request(request, response, is_internal)
-            return response
-
-        behalf = "principal"
-        is_system = False
-
-        if is_system:
-            behalf = "system"
+        is_internal = any([request.path.startswith(prefix) for prefix in settings.INTERNAL_API_PATH_PREFIXES])
+        # This request is for a private API endpoint
+        behalf = "system" if request.user.system else "principal"
 
         req_sys_counter.labels(
             behalf=behalf,
@@ -408,6 +399,7 @@ class IdentityHeaderMiddleware(MiddlewareMixin):
 
         IdentityHeaderMiddleware.log_request(request, response, is_internal)
         return response
+
 
     def should_load_user_permissions(self, request: WSGIRequest, user: User) -> bool:
         """Decide whether RBAC should load the access permissions for the user based on the given request."""

--- a/rbac/rbac/middleware.py
+++ b/rbac/rbac/middleware.py
@@ -408,7 +408,6 @@ class IdentityHeaderMiddleware(MiddlewareMixin):
         IdentityHeaderMiddleware.log_request(request, response, is_internal)
         return response
 
-
     def should_load_user_permissions(self, request: WSGIRequest, user: User) -> bool:
         """Decide whether RBAC should load the access permissions for the user based on the given request."""
         # Organization administrators will have already all the permissions so there is no need to load permissions for

--- a/rbac/rbac/middleware.py
+++ b/rbac/rbac/middleware.py
@@ -393,8 +393,6 @@ class IdentityHeaderMiddleware(MiddlewareMixin):
             username = request.user.username
             if username:
                 is_system = request.user.system
-            else:
-                is_system = False
 
         behalf = "system" if is_system else "principal"
 

--- a/rbac/rbac/middleware.py
+++ b/rbac/rbac/middleware.py
@@ -389,7 +389,6 @@ class IdentityHeaderMiddleware(MiddlewareMixin):
         is_internal = any([request.path.startswith(prefix) for prefix in settings.INTERNAL_API_PATH_PREFIXES])
         is_system = False
 
-        # This request is for a private API endpoint
         if hasattr(request, "user") and request.user:
             username = request.user.username
             if username:

--- a/rbac/rbac/middleware.py
+++ b/rbac/rbac/middleware.py
@@ -387,8 +387,17 @@ class IdentityHeaderMiddleware(MiddlewareMixin):
             response (object): The response object
         """
         is_internal = any([request.path.startswith(prefix) for prefix in settings.INTERNAL_API_PATH_PREFIXES])
+        is_system = False
+
         # This request is for a private API endpoint
-        behalf = "system" if request.user.system else "principal"
+        if hasattr(request, "user") and request.user:
+            username = request.user.username
+            if username:
+                is_system = request.user.system
+            else:
+                is_system = False
+
+        behalf = "system" if is_system else "principal"
 
         req_sys_counter.labels(
             behalf=behalf,


### PR DESCRIPTION
## Link(s) to Jira
- https://issues.redhat.com/browse/RHCLOUD-36533

## Description of Intent of Change(s)
The what, why and how.
I refactored the process_response to use one block of code for both paths (internal and external endpoints). Before it would shortcut for internal endpoints but the logic for both paths were identical. So i opted for one block.

The `behalf` variable would always be false. Now it uses the same logic as the function `IdentityHeaderMiddleware.log_request` to determine if it should be `system` or `principal`. That is lines 328-339 of the same file.

## Local Testing
How can the feature be exercised?
How can the bug be exploited and fix confirmed?
Is any special local setup required?
I ran the same tests from #779 which is where this functionality originated
## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
