### PR TITLE
[RHCLOUD-32144] fix serializer selection for routes containing 'roles' substring

### DIFF
--- a/rbac/management/group/view.py
+++ b/rbac/management/group/view.py
@@ -205,9 +205,9 @@ class GroupViewSet(
         """Get serializer based on route."""
         if "principals" in self.request.path:
             return GroupPrincipalInputSerializer
-        if ROLES_KEY in self.request.path and self.request.method == "GET":
+        if ROLES_KEY in self.request.path.split("/") and self.request.method == "GET":
             return GroupRoleSerializerOut
-        if ROLES_KEY in self.request.path:
+        if ROLES_KEY in self.request.path.split("/"):
             return GroupRoleSerializerIn
         if self.request.method in ("POST", "PUT"):
             return GroupInputSerializer


### PR DESCRIPTION
## Link(s) to Jira
- [RHCLOUD-32144](https://issues.redhat.com/browse/RHCLOUD-32144)

## Description of Intent of Change(s)
This PR will fix the [Glitchtip issue ](https://glitchtip.devshift.net/insights/issues/53274?project=38)`TypeError: Object of type Group is not JSON serializable`
![image](https://github.com/user-attachments/assets/15cc427d-1d8b-41c2-879f-fecdbff99153)

The root cause is the incorrect serializer that was selected for the route [here](https://github.com/RedHatInsights/insights-rbac/blob/69c3565fccd9f7465051af5648932401a4e2a9e3/rbac/management/group/view.py#L204) 
(`get_serializer_class()` method in the `GroupViewSet()`).

Previously, the check for `roles` in the route path used a simple substring match, which could lead to incorrect serializer selection if the path contained a username with `roles` as part of it

Now the condition is updated to split the route by `/` and check each part for the `roles` substring.

## Local Testing
use principal with username that contains `roles` substring, e.g. username = `roles_test` and send request to the internal endpoint `GET _private/api/v1/integrations/tenant/<org_id>/principal/{username}/groups/`
