### PR TITLE
fix typo in the open api spec for internal endpoint /api/utils/role/ (remove role from rbac db)

### DIFF
--- a/rbac/internal/specs/openapi.json
+++ b/rbac/internal/specs/openapi.json
@@ -958,7 +958,7 @@
         }
       }
     },
-    "/api/utils/roles/": {
+    "/api/utils/role/": {
       "delete": {
         "tags": [
           "Role"


### PR DESCRIPTION
internal endpoint: https://github.com/RedHatInsights/insights-rbac/blob/8ab44910e0ec69f3fe3e61ddbef25aba50084b79/rbac/internal/urls.py#L80

