### PR TITLE
[RHCLOUD-37601] Update username_lower endpoint to include also usernames with mixed case 

### DIFF
--- a/tests/internal/test_views.py
+++ b/tests/internal/test_views.py
@@ -1450,6 +1450,9 @@ class InternalViewsetTests(IdentityRequest):
             [
                 Principal(username="12345", tenant=self.tenant),
                 Principal(username="ABCDE", tenant=self.tenant),
+                Principal(username="Xyz", tenant=self.tenant),
+                Principal(username="iJkLm", tenant=self.tenant),
+                Principal(username="i.J.k@.L.m", tenant=self.tenant),
                 Principal(username="user", tenant=self.tenant),
             ]
         )
@@ -1461,7 +1464,8 @@ class InternalViewsetTests(IdentityRequest):
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(
-            response.content.decode(), "Usernames to be updated: ['12345', 'ABCDE'] to ['12345', 'abcde']"
+            response.content.decode(),
+            "Usernames to be updated: ['ABCDE', 'Xyz', 'i.J.k@.L.m', 'iJkLm'] to ['abcde', 'i.j.k@.l.m', 'ijklm', 'xyz']",
         )
 
         response = self.client.post(
@@ -1470,8 +1474,8 @@ class InternalViewsetTests(IdentityRequest):
             content_type="application/json",
         )
         self.assertEqual(response.status_code, 200)
-        usernames = Principal.objects.values_list("username", flat=True)
-        self.assertEqual({"12345", "abcde", "user"}, set(usernames))
+        usernames = Principal.objects.values_list("username", flat=True).order_by("username")
+        self.assertEqual({"12345", "abcde", "i.j.k@.l.m", "ijklm", "user", "xyz"}, set(usernames))
 
 
 class InternalViewsetResourceDefinitionTests(IdentityRequest):


### PR DESCRIPTION
## Link(s) to Jira
- https://issues.redhat.com/browse/RHCLOUD-37601

## Description of Intent of Change(s)
This PR extends this [PR](https://github.com/RedHatInsights/insights-rbac/pull/1472) to include also principals with usernames in mixed case (at least one upper case)
 
## Local Testing
How can the feature be exercised?
How can the bug be exploited and fix confirmed?
Is any special local setup required?

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
