### PR TITLE
[RHCLOUD-37825] github action to check if the PR contains some fixup commits that is needed to resolve before the merge

### DIFF
--- a/.github/workflows/block-fixup-commit-merge.yml
+++ b/.github/workflows/block-fixup-commit-merge.yml
@@ -1,0 +1,15 @@
+name: Git Checks
+
+on: pull_request
+
+jobs:
+  message-check:
+    name: Block Autosquash Commits
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Block Autosquash Commits
+        uses: skjnldsv/block-fixup-merge-action@v2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
[RHCLOUD-37825](https://issues.redhat.com/browse/RHCLOUD-37825)

adds new GH action to avoid to merge the PR with the fixup commits
https://github.com/skjnldsv/block-fixup-merge-action