### PR TITLE
[RHCLOUD-37851] /principals/ endpoint and 'usernames' query param improvement

### DIFF
--- a/rbac/management/principal/view.py
+++ b/rbac/management/principal/view.py
@@ -127,6 +127,7 @@ class PrincipalView(APIView):
 
         elif principal_type == SA_KEY:
             resp, usernames_filter = self.service_accounts_from_it_service(request, user, query_params, options)
+
         status_code = resp.get("status_code")
         response_data = {}
         if status_code == status.HTTP_200_OK:
@@ -166,7 +167,7 @@ class PrincipalView(APIView):
     def users_from_proxy(self, user, query_params, options, limit, offset):
         """Format principal request for proxy and return prepped result."""
         proxy = PrincipalProxy()
-        usernames = query_params.get(USERNAMES_KEY)
+        usernames = query_params.get(USERNAMES_KEY, "").replace(" ", "")
         email = query_params.get(EMAIL_KEY)
         match_criteria = validate_and_get_key(query_params, MATCH_CRITERIA_KEY, VALID_MATCH_VALUE, "exact")
         options["username_only"] = validate_and_get_key(query_params, USERNAME_ONLY_KEY, VALID_BOOLEAN_VALUE, "false")
@@ -210,7 +211,7 @@ class PrincipalView(APIView):
         options["username_only"] = validate_and_get_key(
             query_params, USERNAME_ONLY_KEY, VALID_BOOLEAN_VALUE, required=False
         )
-        options["usernames"] = query_params.get(USERNAMES_KEY)
+        options["usernames"] = query_params.get(USERNAMES_KEY, "").replace(" ", "")
 
         # Fetch the service accounts from IT.
         token_validator = ITSSOTokenValidator()


### PR DESCRIPTION
## Link(s) to Jira
- [RHCLOUD-37851](https://issues.redhat.com/browse/RHCLOUD-37851)

## Description of Intent of Change(s)
- add usernames filter in the links that are part of the response for the service account queries
- trim the space character from the value of the `usernames` query param when filtering by usernames

## Local Testing
list user based principals or service accounts and test the filtering by usernames
- `GET /api/rbac/v1/principals/?usernames=<username1>,<username2>&type=service-account`
- `GET /api/rbac/v1/principals/?usernames=<username1>,<username2>`

check the links in the response contains the usernames filter

for example for service accounts with usernames `sa1`, `sa2`:
`GET /api/rbac/v1/principals/?usernames=sa1,sa2&type=service-account`

and the response can be like this:
(before this change the links didn't contain the usernames filter)
```
{
    "meta": {
        "count": 2,
        "limit": 10,
        "offset": 0
    },
    "links": {
        "first": "/api/rbac/v1/principals/?limit=10&offset=0&usernames=sa1,sa2",
        "next": null,
        "previous": null,
        "last": "/api/rbac/v1/principals/?limit=10&offset=0&usernames=sa1,sa2"
    },
    "data": [
        {
            "type": "service-account",
            "username": "sa1",
            ...
        },
        {
            "type": "service-account",
            "username": "sa2",
            ...
        }
    ]
}
```

then try to add space after comma between 2 usernames and check that you still get same response
(before not all usernames were recognised because of the additional space)

for example these requests will return same response
- `GET /api/rbac/v1/principals/?usernames=<username1>,<username2>`
- `GET /api/rbac/v1/principals/?usernames=<username1>, <username2>` (with 1 space chars after comma)
- `GET /api/rbac/v1/principals/?usernames=<username1>,  <username2>` (with 2 space chars after comma)
