### PR TITLE
[RHCLOUD-37288] add option to list both principal types in one query to the /principals/ endpoint

### DIFF
--- a/docs/source/specs/openapi.json
+++ b/docs/source/specs/openapi.json
@@ -650,7 +650,8 @@
               "type": "string",
               "enum": [
                 "service-account",
-                "user"
+                "user",
+                "all"
               ]
             }
           }
@@ -667,6 +668,9 @@
                     },
                     {
                       "$ref": "#/components/schemas/ServiceAccountPagination"
+                    },
+                    {
+                      "$ref": "#/components/schemas/AllPrincipalsPagination"
                     }
                   ]
                 }
@@ -3124,6 +3128,63 @@
             }
           }
         }
+      },
+      "AllPrincipalsPagination": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ListPagination"
+          },
+          {
+            "type": "object",
+            "required": [
+              "data"
+            ],
+            "properties": {
+              "data": {
+                "type": "object",
+                "properties": {
+                  "serviceAccounts": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/ServiceAccount"
+                    }
+                  },
+                  "users": {
+                    "type": "array",
+                    "items": {
+                      "oneOf": [
+                        {
+                          "$ref": "#/components/schemas/Principal"
+                        },
+                        {
+                          "$ref": "#/components/schemas/PrincipalMinimal"
+                        }
+                      ]
+                    }
+                  }
+                },
+                "oneOf": [
+                  {
+                    "required": [
+                      "serviceAccounts"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "users"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "serviceAccounts",
+                      "users"
+                    ]
+                  }
+                ]
+              }
+            }
+          }
+        ]
       },
       "Group": {
         "required": [

--- a/rbac/management/principal/view.py
+++ b/rbac/management/principal/view.py
@@ -295,7 +295,7 @@ class PrincipalView(APIView):
         if usernames_filter and user_resp["data"]:
             userCount += len(user_resp["data"])
         elif user_resp["data"]:
-            userCount += user_resp.get("data").get("userCount")
+            userCount += int(user_resp.get("data").get("userCount"))
         userCount += sa_resp.get("saCount")
 
         # Put together the response


### PR DESCRIPTION
## Link(s) to Jira
- [RHCLOUD-37288](https://issues.redhat.com/browse/RHCLOUD-37288)
- [RHCLOUD-38309](https://issues.redhat.com/browse/RHCLOUD-38309)

## Description of Intent of Change(s)
the `/principals/` endpoint allows to list the user based principals with `type=user` query param (default option)
you can list service account based principals with `type=service-account` query param
this PR adds third option `type=all` to list both principal types in one query:
- first we list service accounts if present
- then we list user based principals
- the filtering with `usernames` query param is working too (you can combine usernames of both principal types)
- the access token is needed for the query (same as for `type=service-account`)

example of the response:
```
{
    "meta": {
        "count": 86,
        "limit": 2,
        "offset": 2
    },
    "links": {
        "first": "/api/rbac/v1/principals/?limit=2&offset=0",
        "next": "/api/rbac/v1/principals/?limit=2&offset=4",
        "previous": "/api/rbac/v1/principals/?limit=2&offset=0",
        "last": "/api/rbac/v1/principals/?limit=2&offset=84"
    },
    "data": {
        "serviceAccounts": [
            {
                "type": "service-account",
                "username": "service-account-de4c127a-f818-4ead-b5b9-1fef9b597513"
                ...
            }
        ],
        "users": [
            {
                "username": "my_user_principal",
                ...
            }
        ]
    }
}
```

## Local Testing
use tenant with few user based principals and service accounts and test queries with(out) the `type` query param
```
GET /api/rbac/v1/principals/
GET /api/rbac/v1/principals/?type=user
GET /api/rbac/v1/principals/?type=service-account
GET /api/rbac/v1/principals/?type=all
```

for example if `GET /api/rbac/v1/principals/` returns 10 user based principals and `GET /api/rbac/v1/principals/?type=service-account` returns 3 service accounts, then `GET /api/rbac/v1/principals/?type=all` should return 13 principals (both types)

try combinations of limit and offset to check that pagination is working as expected

for example if your tenant contains 3 SA (service accounts) and 4 U (user based principals) then with `limit=2` and `offset=0` you get this pagination:
```
page 1 -> 2 SA
page 2 -> 1 SA + 1 U
page 3 -> 2 U
page 4 -> 1 U
```

## Checklist
- [x] open api spec updated
- [x] unit tests
- [x] added the ACs in the ticket


