### PR TITLE
[RHCLOUD-37831] Add ungrouped hosts when bootstrapping tenant

### DIFF
--- a/deploy/add_ungrouped_hosts_workspace.yml
+++ b/deploy/add_ungrouped_hosts_workspace.yml
@@ -1,0 +1,19 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: add-ungrouped-hosts-workspace
+objects:
+- apiVersion: cloud.redhat.com/v1alpha1
+  kind: ClowdJobInvocation
+  metadata:
+    labels:
+      app: rbac
+    name: add-ungrouped-hosts-workspace-${RUN_NUMBER}
+  spec:
+    appName: rbac
+    jobs:
+      - add-ungrouped-hosts
+parameters:
+- name: RUN_NUMBER
+  description: Used to track and re-run the job
+  value: '1'

--- a/deploy/rbac-clowdapp.yml
+++ b/deploy/rbac-clowdapp.yml
@@ -806,6 +806,22 @@ objects:
           volumeMounts:
           - mountPath: /tmp
             name: users-data
+      - name: add-ungrouped-hosts
+        podSpec:
+          image: quay.io/cloudservices/rbac:latest
+          command:
+            - /opt/rbac/rbac/manage.py
+            - add_ungrouped_hosts
+            - --batch_size
+            - ${FILLING_UNGROUPED_HOSTS_BATCH_SIZE}
+          env: *job_common_env_vars
+          resources:
+            limits:
+              cpu: 300m
+              memory: 1Gi
+            requests:
+              cpu: 50m
+              memory: 512Mi
 
 - apiVersion: v1
   kind: ConfigMap
@@ -1205,3 +1221,6 @@ parameters:
 - name: USER_ID_POPULATOR_BATCH_SIZE
   description: The number of user records to process in each batch
   value: '90'
+- name: FILLING_UNGROUPED_HOSTS_BATCH_SIZE
+  description: The number of tenants to process in each batch
+  value: '900'

--- a/rbac/management/management/commands/add_ungrouped_hosts.py
+++ b/rbac/management/management/commands/add_ungrouped_hosts.py
@@ -1,0 +1,25 @@
+"""Import user data command."""
+
+import logging
+
+from django.core.management.base import BaseCommand
+from management.management.commands.utils import add_ungrouped_hosts_for_tenants
+
+logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
+
+
+class Command(BaseCommand):
+    """Command class for importing tenant and user data into database."""
+
+    help = "Import tenant and user data into db"
+
+    def add_arguments(self, parser):
+        """Add arguments to command."""
+        parser.add_argument("--batch_size", default=1000, help="The number of records to process as a batch")
+
+    def handle(self, *args, **options):
+        """Handle method for command."""
+        logger.info("*** Adding ungrouped hosts for tenants... ***")
+        batch_size = int(options["batch_size"])
+        add_ungrouped_hosts_for_tenants(batch_size)
+        logger.info("*** Adding ungrouped hosts finished for all tenants. ***")

--- a/rbac/management/relation_replicator/relation_replicator.py
+++ b/rbac/management/relation_replicator/relation_replicator.py
@@ -59,6 +59,7 @@ class ReplicationEventType(str, Enum):
     EXPIRE_CROSS_ACCOUNT_REQUEST = "expire_cross_account_request"
     MIGRATE_CROSS_ACCOUNT_REQUEST = "migrate_cross_account_request"
     DELETE_BINDING_MAPPINGS = "delete_binding_mappings"
+    ADD_UNGROUPED_HOSTS = "add_ungrouped_hosts"
 
 
 class ReplicationEvent:

--- a/tests/api/test_utils.py
+++ b/tests/api/test_utils.py
@@ -21,7 +21,7 @@ class TestAPIUtils(TestCase):
 
         migration_resource_deletion("workspace", org_id_2)
         self.assertFalse(Workspace.objects.filter(tenant=another_tenant).exists())
-        self.assertEqual(Workspace.objects.filter(tenant=tenant).count(), 2)
+        self.assertEqual(Workspace.objects.filter(tenant=tenant).count(), 2 + 1)  # ungrouped_hosts
 
         migration_resource_deletion("workspace", None)
         self.assertFalse(Workspace.objects.exists())

--- a/tests/management/group/test_view.py
+++ b/tests/management/group/test_view.py
@@ -271,8 +271,8 @@ class GroupViewsetTests(IdentityRequest):
         Principal.objects.all().delete()
         Role.objects.all().delete()
         Policy.objects.all().delete()
-        Workspace.objects.filter(parent__isnull=False).delete()
-        Workspace.objects.filter(parent__isnull=True).delete()
+        while Workspace.objects.first():
+            Workspace.objects.filter(children=None).delete()
 
     @patch(
         "management.principal.proxy.PrincipalProxy.request_filtered_principals",
@@ -3545,8 +3545,8 @@ class GroupViewNonAdminTests(IdentityRequest):
         Access.objects.all().delete()
         Role.objects.all().delete()
         Policy.objects.all().delete()
-        Workspace.objects.filter(parent__isnull=False).delete()
-        Workspace.objects.filter(parent__isnull=True).delete()
+        while Workspace.objects.first():
+            Workspace.objects.filter(children=None).delete()
 
     @staticmethod
     def _create_group_with_user_access_administrator_role(tenant: Tenant) -> Group:

--- a/tests/management/principal/test_cleaner.py
+++ b/tests/management/principal/test_cleaner.py
@@ -845,7 +845,7 @@ class PrincipalUMBTestsWithV2TenantBootstrap(PrincipalUMBTests):
         mapping = TenantMapping.objects.get(tenant=tenant)
         self.assertIsNotNone(mapping)
         workspaces = list(Workspace.objects.filter(tenant=tenant))
-        self.assertEqual(len(workspaces), 2)
+        self.assertEqual(len(workspaces), 2 + 1)  # ungrouped_hosts
         default = Workspace.objects.default(tenant=tenant)
         self.assertIsNotNone(default)
         root = Workspace.objects.root(tenant=tenant)

--- a/tests/management/tenant/test_model.py
+++ b/tests/management/tenant/test_model.py
@@ -283,7 +283,7 @@ class V2TenantBootstrapServiceTest(TestCase):
         # o1 is already bootstrapped, should get 0
         # existing unbootstrapped custom group tenants get 6
         # new or otherwise unbootstrapped tenants get 9
-        num_tenant_bootstrapping_tuples = 0 + 9 + 6 + 9
+        num_tenant_bootstrapping_tuples = 0 + 9 + 6 + 9 + 3  # ungrouped_hosts
 
         self.assertEquals(num_group_membership_tuples + num_tenant_bootstrapping_tuples, self.tuples.count_tuples())
 
@@ -480,7 +480,7 @@ class V2TenantBootstrapServiceTest(TestCase):
         tenant = Tenant.objects.get(org_id=org_id)
         mapping = TenantMapping.objects.get(tenant=tenant)
         workspaces = list(Workspace.objects.filter(tenant=tenant))
-        self.assertEqual(len(workspaces), 2)
+        self.assertEqual(len(workspaces), 2 + 1)  # ungrouped hosts
         default = Workspace.objects.default(tenant=tenant)
         root = Workspace.objects.root(tenant=tenant)
 

--- a/tests/rbac/test_middleware.py
+++ b/tests/rbac/test_middleware.py
@@ -705,7 +705,7 @@ class V2RbacTenantMiddlewareTest(RbacTenantMiddlewareTest):
             mapping = TenantMapping.objects.get(tenant=tenant)
             self.assertIsNotNone(mapping)
             workspaces = list(Workspace.objects.filter(tenant=tenant))
-            self.assertEqual(len(workspaces), 2)
+            self.assertEqual(len(workspaces), 2 + 1)  # ungrouped hosts
             default = Workspace.objects.default(tenant=tenant)
             self.assertIsNotNone(default)
             root = Workspace.objects.root(tenant=tenant)
@@ -811,7 +811,7 @@ class V2RbacTenantMiddlewareTest(RbacTenantMiddlewareTest):
             mapping = TenantMapping.objects.get(tenant=tenant)
             self.assertIsNotNone(mapping)
             workspaces = list(Workspace.objects.filter(tenant=tenant))
-            self.assertEqual(len(workspaces), 2)
+            self.assertEqual(len(workspaces), 2 + 1)  # ungrouped hosts
             default = Workspace.objects.default(tenant=tenant)
             self.assertIsNotNone(default)
             root = Workspace.objects.root(tenant=tenant)


### PR DESCRIPTION
## Link(s) to Jira
- https://issues.redhat.com/browse/RHCLOUD-37831

## Description of Intent of Change(s)
Create a workspace for HBI team to put ungrouped hosts temporary

## Local Testing
Unit test

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
