### PR TITLE
query param validation: use the default value if the query param is provided without a value

### DIFF
--- a/rbac/management/utils.py
+++ b/rbac/management/utils.py
@@ -239,6 +239,8 @@ def validate_and_get_key(params, query_key, valid_values, default_value=None, re
             key = "detail"
             message = "Query parameter '{}' is required.".format(query_key)
             raise serializers.ValidationError({key: _(message)})
+        if default_value:
+            return default_value.lower()
         return None
 
     elif value.lower() not in valid_values:

--- a/tests/management/test_utils.py
+++ b/tests/management/test_utils.py
@@ -27,11 +27,14 @@ from management.utils import (
     roles_for_principal,
     account_id_for_tenant,
     get_principal,
+    validate_and_get_key,
 )
 from tests.identity_request import IdentityRequest
 
 from unittest import mock
 from unittest.mock import Mock
+
+from rest_framework import serializers
 
 SERVICE_ACCOUNT_KEY = "service-account"
 
@@ -264,3 +267,82 @@ class UtilsTests(IdentityRequest):
         created_principal = Principal.objects.get(username=username)
         self.assertEqual(created_principal.type, "user")
         self.assertEqual(created_principal.username, username)
+
+    def test_validate_and_get_key_success(self):
+        """Test we can validate the query param value."""
+        query_key = "type"
+        query_value = "service-account"
+        params = {query_key: query_value}
+        valid_values = ["user", "service-account"]
+        default_value = "user"
+        required = False
+        result = validate_and_get_key(params, query_key, valid_values, default_value, required)
+
+        self.assertEqual(result, query_value)
+
+    def test_validate_and_get_key_invalid(self):
+        """Test we get error with invalid query param value."""
+        query_key = "type"
+        query_value = "foo"
+        params = {query_key: query_value}
+        valid_values = ["user", "service-account"]
+        default_value = "user"
+        required = False
+        with self.assertRaises(serializers.ValidationError) as assertion:
+            validate_and_get_key(params, query_key, valid_values, default_value, required)
+
+        expected_err = (
+            f"{query_key} query parameter value '{query_value}' is invalid. {valid_values} are valid inputs."
+        )
+        self.assertEqual(assertion.exception.detail.get("detail"), expected_err)
+
+    def test_validate_and_get_key_required_invalid(self):
+        """Test we get error with missing required query parameter value."""
+        query_key = "type"
+        params = {}
+        valid_values = ["user", "service-account"]
+        required = True
+        with self.assertRaises(serializers.ValidationError) as assertion:
+            validate_and_get_key(params, query_key, valid_values, required=required)
+
+        expected_err = f"Query parameter '{query_key}' is required."
+        self.assertEqual(assertion.exception.detail.get("detail"), expected_err)
+
+    def test_validate_and_get_key_required_success(self):
+        """Test we get the default value if the mandatory parameter is not provided."""
+        query_key = "type"
+        params = {}
+        valid_values = ["user", "service-account"]
+        default_value = "user"
+        required = True
+
+        result = validate_and_get_key(params, query_key, valid_values, default_value=default_value, required=required)
+        self.assertEqual(result, default_value)
+
+    def test_validate_and_get_key_param_not_provided(self):
+        """Test we get None if the optional parameter is not provided (without default value)."""
+        query_key = "type"
+        params = {}
+        valid_values = ["user", "service-account"]
+        required = False
+
+        result = validate_and_get_key(params, query_key, valid_values, required=required)
+        self.assertIsNone(result)
+
+    def test_validate_and_get_key_param_default_value(self):
+        """Test we get the default value if the optional parameter is not provided."""
+        query_key = "type"
+        params = {}
+        valid_values = ["user", "service-account"]
+        default_value = "user"
+        required = False
+
+        result = validate_and_get_key(params, query_key, valid_values, default_value=default_value, required=required)
+        self.assertEqual(result, default_value)
+
+        # The default value is used even if the query key is part of the request
+        # for example /principals/?type=
+        params = {query_key: ""}
+
+        result = validate_and_get_key(params, query_key, valid_values, default_value=default_value, required=required)
+        self.assertEqual(result, default_value)


### PR DESCRIPTION
in utils we have a function for query params validation `validate_and_get_key()`
one case can be that the query param is provided without a value, for example `GET /principals/?type=`
= the value is `""` (empty string) and the default value is not used

I think in that case we should return the default value

and I noticed we don't have tests for this function so I wrote few 😉 
