### PR TITLE
principal_type query param refactoring

### DIFF
--- a/rbac/management/group/view.py
+++ b/rbac/management/group/view.py
@@ -801,6 +801,7 @@ class GroupViewSet(
             request.query_params,
             PRINCIPAL_TYPE_KEY,
             VALID_PRINCIPAL_TYPE_VALUE,
+            default_value=Principal.Types.USER,
             required=False,
         )
 

--- a/tests/management/group/test_view.py
+++ b/tests/management/group/test_view.py
@@ -1348,7 +1348,7 @@ class GroupViewsetTests(IdentityRequest):
                 "sort_order": None,
                 "username_only": "false",
                 "admin_only": True,
-                "principal_type": None,
+                "principal_type": "user",
             },
         )
 
@@ -1821,7 +1821,7 @@ class GroupViewsetTests(IdentityRequest):
             options={
                 "sort_order": None,
                 "username_only": "false",
-                "principal_type": None,
+                "principal_type": "user",
             },
             org_id=self.customer_data["org_id"],
         )
@@ -1845,7 +1845,7 @@ class GroupViewsetTests(IdentityRequest):
             options={
                 "sort_order": None,
                 "username_only": "false",
-                "principal_type": None,
+                "principal_type": "user",
             },
             org_id=self.customer_data["org_id"],
         )
@@ -1869,7 +1869,7 @@ class GroupViewsetTests(IdentityRequest):
             options={
                 "sort_order": "asc",
                 "username_only": "false",
-                "principal_type": None,
+                "principal_type": "user",
             },
             org_id=self.customer_data["org_id"],
         )


### PR DESCRIPTION
- set the constants for the `principal_type` query param 
- set the default value (`user`) for the `principal_type` query param