### PR TITLE
[RHCLOUD-38791] List unbootstrapped tenants in internal endpoint

### DIFF
--- a/rbac/internal/specs/openapi.json
+++ b/rbac/internal/specs/openapi.json
@@ -1266,6 +1266,45 @@
         }
       }
     },
+    "/api/utils/bootstrap_pending_tenants/": {
+      "get": {
+        "summary": "List tenants that are not bootstrapped",
+        "description": "Returns a list of tenant IDs that have not yet been bootstrapped.",
+        "operationId": "bootstrapPendingTenants",
+        "responses": {
+          "200": {
+            "description": "Successful response with a list of unbootstrapped tenants.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "org_ids": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "description": "List of unbootstrapped tenant IDs."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Invalid method. Only GET is allowed.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string",
+                  "example": "Invalid method only \"GET\" is allowed."
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/utils/bindings/": {
       "get": {
         "tags": [

--- a/rbac/internal/specs/openapi.json
+++ b/rbac/internal/specs/openapi.json
@@ -1269,7 +1269,7 @@
     "/api/utils/bootstrap_pending_tenants/": {
       "get": {
         "summary": "List tenants that are not bootstrapped",
-        "description": "Returns a list of tenant IDs that have not yet been bootstrapped.",
+        "description": "Returns a list of tenant org IDs that have not yet been bootstrapped.",
         "operationId": "bootstrapPendingTenants",
         "responses": {
           "200": {

--- a/rbac/internal/urls.py
+++ b/rbac/internal/urls.py
@@ -86,6 +86,7 @@ urlpatterns = [
     path("api/utils/bindings/<role_uuid>/", views.list_or_delete_bindings_for_role),
     path("api/utils/binding/<binding_id>/clean/", views.clean_binding_mapping),
     path("api/utils/bootstrap_tenant/", views.bootstrap_tenant),
+    path("api/utils/bootstrap_pending_tenants/", views.bootstrap_pending_tenants),
     path("api/utils/migration_resources/", views.migration_resources),
     path("api/utils/reset_imported_tenants/", views.reset_imported_tenants),
     path("api/utils/resource_definitions/", views.correct_resource_definitions),

--- a/rbac/internal/views.py
+++ b/rbac/internal/views.py
@@ -590,12 +590,14 @@ def bootstrap_pending_tenants(request):
     if request.method != "GET":
         return HttpResponse('Invalid method only "GET" is allowed.', status=405)
 
-    query = """SELECT t.id FROM api_tenant t
+    public_tenant = Tenant.objects.get(tenant_name="public")
+    query = """SELECT t.org_id FROM api_tenant t
                LEFT JOIN management_tenantmapping m
-               ON t.id = m.tenant_id WHERE m.tenant_id IS NULL AND t.id <> 1;
+               ON t.id = m.tenant_id
+               WHERE m.tenant_id IS NULL AND t.id <> %s;
             """
     with connection.cursor() as cursor:
-        cursor.execute(query)
+        cursor.execute(query, [public_tenant.id])
         tenant_ids_to_bootstrap = [str(row[0]) for row in cursor.fetchall()] if cursor.rowcount > 0 else []
 
     response = {"org_ids": tenant_ids_to_bootstrap}

--- a/tests/internal/test_views.py
+++ b/tests/internal/test_views.py
@@ -2105,3 +2105,20 @@ class InternalViewsetResourceDefinitionTests(IdentityRequest):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.content, b"0 resource definitions would be corrected")
+
+    def test_bootstrap_pending_tenants(self):
+        tenant = Tenant.objects.create(org_id="111", account_id="111")
+
+        response = self.client.get(
+            f"/_private/api/utils/bootstrap_pending_tenants/",
+            **self.internal_request.META,
+        )
+
+        expected_json = {
+            "org_ids": sorted([str(self.tenant.id), str(self.test_tenant.id), str(tenant.id)]),
+        }
+
+        response_json = json.loads(response.content)
+        response_json["org_ids"].sort()
+
+        self.assertEqual(response_json, expected_json)

--- a/tests/internal/test_views.py
+++ b/tests/internal/test_views.py
@@ -2115,7 +2115,7 @@ class InternalViewsetResourceDefinitionTests(IdentityRequest):
         )
 
         expected_json = {
-            "org_ids": sorted([str(self.tenant.id), str(self.test_tenant.id), str(tenant.id)]),
+            "org_ids": sorted([str(self.tenant.org_id), str(self.test_tenant.org_id), str(tenant.org_id)]),
         }
 
         response_json = json.loads(response.content)


### PR DESCRIPTION
## Link(s) to Jira
- https://issues.redhat.com/browse/RHCLOUD-38791

## Description of Intent of Change(s)
List unbootstrapped tenants in internal endpoint to reboostrapp them.


## Local Testing
- run rbac server

```
curl -X GET "http://localhost:8000/_private/api/utils/bootstrap_pending_tenants/" \
     -H "x-rh-identity: eyJpZGVudGl0eSI6IHsidHlwZSI6ICJBc3NvY2lhdGUiLCAiYXNzb2NpYXRlIjogeyJlbWFpbCI6ICJ1c2VyQGV4YW1wbGUuY29tIn19fQ==" \
     -H "User-Type: associate"
```

it will list tenants which don't have  associated tenant mapping records, for example:

```
{"org_ids": ["3"]}
```



## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
