### PR TITLE
[RHCLOUD-39005] change coverage settings to show HTML report

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,25 +2,17 @@
 [run]
 branch = True
 omit =
-  .tox/*
-  *virtualenv/*
-  *virtualenvs/*
-  *manage.py
-  *database.py
-  *settings.py
-  *urls.py
-  *wsgi.py
-  *migrations/*
-  *tests/*
-  */tests_*.py
-  *provider_interface.py
-  *dev_middleware.py
+  */migrations/*
 
 [paths]
 source = rbac
 
 [report]
 # Regexes for lines to exclude from consideration
+ignore_errors = True
+sort = Cover
+skip_covered = True
+skip_empty = True
 exclude_lines =
     # Have to re-enable the standard pragma
     pragma: no cover
@@ -36,5 +28,3 @@ exclude_lines =
     # Don't complain if non-runnable code isn't run:
     if 0:
     if __name__ == .__main__.:
-
-ignore_errors = True

--- a/.dockerignore
+++ b/.dockerignore
@@ -12,6 +12,7 @@
 !tests/
 !Makefile
 !mypy.ini
+!.coveragerc
 
 # keep the test files out of the final image
 #**/*test*

--- a/tox.ini
+++ b/tox.ini
@@ -44,7 +44,8 @@ deps =
 commands =
   pipenv install
   coverage run {toxinidir}/rbac/manage.py test --failfast -v 2 {posargs: tests/}
-  coverage report --show-missing
+  coverage report
+  coverage html
 
 [testenv:lint]
 deps =


### PR DESCRIPTION
## Link(s) to Jira
- [RHCLOUD-39005](https://issues.redhat.com/browse/RHCLOUD-39005)

## Description of Intent of Change(s)
in RBAC project we use `coverage` package that measures code coverage
- [coverage on Pypi.org](https://pypi.org/project/coverage/)
- [coverage docs](https://coverage.readthedocs.io/en/7.7.1/index.html)

I updated/fixed the settings for `coverage` to exclude only migrations (they are generated by Django) because I think it is worthy to see even for tests or settings py files to see if the code is or is not executed (and it is recommended in documentation)

I updated settings to skip covered files and added html report

now when you run tests via `tox` command, the `coverage` report will be still generated but without missing (not covered) lines because the report with that was quite complicated

now you can find new html report in `htmlcov/index.html`
![image](https://github.com/user-attachments/assets/c93408f8-0501-402f-a267-6447764b30e2)

## Local Testing
run tests via `tox` command, check new report and in the end of report you can find information about HTML report
```
py39 run-test: commands[3] | coverage html
Wrote HTML report to htmlcov/index.html
```
