### PR TITLE
[RHCLOUD-39048] fix the error message for invalid 'type' and 'principal_type' query param value

### DIFF
--- a/rbac/management/utils.py
+++ b/rbac/management/utils.py
@@ -271,7 +271,7 @@ def validate_and_get_key(params, query_key, valid_values, default_value=None, re
     elif value.lower() not in valid_values:
         key = "detail"
         message = "{} query parameter value '{}' is invalid. {} are valid inputs.".format(
-            query_key, value, valid_values
+            query_key, value, [str(v) for v in valid_values]
         )
         raise serializers.ValidationError({key: _(message)})
     return value.lower()

--- a/tests/management/test_utils.py
+++ b/tests/management/test_utils.py
@@ -19,6 +19,7 @@ import uuid
 
 from api.models import Tenant, User
 from management.models import Access, Group, Permission, Principal, Policy, Role
+from management.principal.view import VALID_PRINCIPAL_TYPE_VALUE
 from management.utils import (
     access_for_principal,
     get_principal_from_request,
@@ -363,3 +364,22 @@ class UtilsTests(IdentityRequest):
 
         result = validate_and_get_key(params, query_key, valid_values, default_value=default_value, required=required)
         self.assertEqual(result, default_value)
+
+    def test_validate_and_get_key_param_invalid_type_query_param(self):
+        """
+        Test we get error with missing required query parameter value
+        as strings for 'type' query param which values are class instances.
+        """
+        query_key = "type"
+        query_value = "foo"
+        params = {query_key: query_value}
+        valid_values = VALID_PRINCIPAL_TYPE_VALUE
+        default_value = "user"
+        required = False
+        with self.assertRaises(serializers.ValidationError) as assertion:
+            validate_and_get_key(params, query_key, valid_values, default_value, required)
+
+        expected_err = (
+            f"type query parameter value 'foo' is invalid. {[str(v) for v in valid_values]} are valid inputs."
+        )
+        self.assertEqual(assertion.exception.detail.get("detail"), expected_err)


### PR DESCRIPTION
## Link(s) to Jira
- [RHCLOUD-39048](https://issues.redhat.com/browse/RHCLOUD-39048)

## Description of Intent of Change(s)
if you send request to list principals with invalid `type` value, the response contains `Principal.Types.SERVICE_ACCOUNT` for `service-account` value and similar for `user` value
```
{
    "errors": [
        {
            "detail": "type query parameter value 'foo' is invalid. [Principal.Types.SERVICE_ACCOUNT, Principal.Types.USER, 'all'] are valid inputs.",
            "source": "detail",
            "status": "400"
        }
    ]
}
```

this PR adds logic to convert values into strings
```
{
    "errors": [
        {
            "detail": "type query parameter value 'foo' is invalid. ['service-account', 'user', 'all'] are valid inputs.",
            "source": "detail",
            "status": "400"
        }
    ]
}
```

## Local Testing
send request `GET /principals/?type=foo`
send request `GET /groups/<uuid>/principals/?principal_type=foo`

