### PR TITLE
[RHCLOUD-39098] fix for list principals usernames_only

### DIFF
--- a/rbac/management/principal/proxy.py
+++ b/rbac/management/principal/proxy.py
@@ -161,7 +161,7 @@ class PrincipalProxy:  # pylint: disable=too-few-public-methods
         """Send request to proxy service."""
         metrics_method = method.__name__.upper()
         if params and params.get("username_only") == "true":
-            principals = Principal.objects.filter(type="user", tenant__org_id=org_id)
+            principals = Principal.objects.filter(type="user", tenant__org_id=org_id, cross_account=False)
             offset = params.get("offset", 0)
             limit = params.get("limit", StandardResultsSetPagination.default_limit)
             userList = [dict(username=principal.username) for principal in principals]
@@ -171,7 +171,7 @@ class PrincipalProxy:  # pylint: disable=too-few-public-methods
         if settings.BYPASS_BOP_VERIFICATION:
             to_return = []
             if data is None:
-                for principal in Principal.objects.filter(type="user", tenant__org_id=org_id):
+                for principal in Principal.objects.filter(type="user", tenant__org_id=org_id, cross_account=False):
                     to_return.append(
                         dict(
                             username=principal.username,

--- a/rbac/management/principal/proxy.py
+++ b/rbac/management/principal/proxy.py
@@ -162,6 +162,8 @@ class PrincipalProxy:  # pylint: disable=too-few-public-methods
         metrics_method = method.__name__.upper()
         if params and params.get("username_only") == "true":
             principals = Principal.objects.filter(type="user", tenant__org_id=org_id, cross_account=False)
+            if data and "users" in data:
+                principals = principals.filter(username__in=data["users"])
             offset = params.get("offset", 0)
             limit = params.get("limit", StandardResultsSetPagination.default_limit)
             userList = [dict(username=principal.username) for principal in principals]

--- a/rbac/management/principal/proxy.py
+++ b/rbac/management/principal/proxy.py
@@ -161,7 +161,7 @@ class PrincipalProxy:  # pylint: disable=too-few-public-methods
         """Send request to proxy service."""
         metrics_method = method.__name__.upper()
         if params and params.get("username_only") == "true":
-            principals = Principal.objects.filter(type="user")
+            principals = Principal.objects.filter(type="user", tenant__org_id=org_id)
             offset = params.get("offset", 0)
             limit = params.get("limit", StandardResultsSetPagination.default_limit)
             userList = [dict(username=principal.username) for principal in principals]
@@ -171,7 +171,7 @@ class PrincipalProxy:  # pylint: disable=too-few-public-methods
         if settings.BYPASS_BOP_VERIFICATION:
             to_return = []
             if data is None:
-                for principal in Principal.objects.filter(type="user"):
+                for principal in Principal.objects.filter(type="user", tenant__org_id=org_id):
                     to_return.append(
                         dict(
                             username=principal.username,
@@ -269,7 +269,9 @@ class PrincipalProxy:  # pylint: disable=too-few-public-methods
         params = self._create_params(limit, offset, options)
         url = "{}://{}:{}{}{}".format(self.protocol, self.host, self.port, self.path, account_principals_path)
 
-        return self._request_principals(url, params=params, org_id_filter=False, method=method, data=payload)
+        return self._request_principals(
+            url, org_id=org_id, params=params, org_id_filter=False, method=method, data=payload
+        )
 
     def request_filtered_principals(self, principals, org_id=None, limit=None, offset=None, options={}):
         """Request specific principals for an account."""

--- a/tests/management/group/test_view.py
+++ b/tests/management/group/test_view.py
@@ -2562,7 +2562,7 @@ class GroupViewsetTests(IdentityRequest):
             al_response = al_client.get(al_url, **self.headers)
             retrieve_data = al_response.data.get("data")
             al_list = retrieve_data
-            print(al_list)
+
             for al_record in al_list:
                 if al_record["action"] == "remove":
                     al_dict = al_record

--- a/tests/management/group/test_view.py
+++ b/tests/management/group/test_view.py
@@ -1881,7 +1881,7 @@ class GroupViewsetTests(IdentityRequest):
         return_value={"status_code": 200, "data": [{"username": "test_user"}]},
     )
     def test_principal_get_ordering_nonusername_fail(self, mock_request):
-        """Test that passing a username order_by parameter calls the proxy correctly."""
+        """Test that passing a username order_by parameter with invalid value returns 400."""
         url = f"{reverse('v1_management:group-principals', kwargs={'uuid': self.group.uuid})}?order_by=best_joke"
         client = APIClient()
         response = client.get(url, **self.headers)

--- a/tests/management/group/test_view.py
+++ b/tests/management/group/test_view.py
@@ -3425,6 +3425,47 @@ class GroupViewsetTests(IdentityRequest):
         self.assertEqual(int(response.data.get("meta").get("count")), 0)
         self.assertEqual(len(response.data.get("data")), 0)
 
+    def test_get_group_user_principals_username_only(self):
+        """Test we can list only usernames for principals in a group."""
+        # Create a group with 2 user based principals
+        group_name = "TestGroup"
+        group = Group.objects.create(name=group_name, tenant=self.tenant)
+        principal1 = Principal.objects.create(tenant=self.tenant, username="user1")
+        principal2 = Principal.objects.create(tenant=self.tenant, username="user2")
+        group.principals.add(principal1, principal2)
+
+        # Test that /groups/{uuid}/principals/?username_only=true returns correct data with default limit and offset
+        base_url = f"{reverse('v1_management:group-principals', kwargs={'uuid': group.uuid})}"
+        url = base_url + "?username_only=true"
+        client = APIClient()
+        response = client.get(url, **self.headers)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(int(response.data.get("meta").get("count")), 2)
+        self.assertEqual(int(response.data.get("meta").get("limit")), 10)
+        self.assertEqual(int(response.data.get("meta").get("offset")), 0)
+        self.assertEqual(len(response.data.get("data")), 2)
+
+        # Test that /groups/{uuid}/principals/?username_only=true returns correct data for given offset and limit
+        test_data = [
+            {"limit": 10, "offset": 2, "expected_data_count": 0},
+            {"limit": 10, "offset": 1, "expected_data_count": 1},
+            {"limit": 1, "offset": 0, "expected_data_count": 1},
+        ]
+        for item in test_data:
+            limit = item["limit"]
+            offset = item["offset"]
+            expected_data_count = item["expected_data_count"]
+            url = base_url + f"?username_only=true&limit={limit}&offset={offset}"
+            client = APIClient()
+            response = client.get(url, **self.headers)
+
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            self.assertEqual(int(response.data.get("meta").get("count")), 2)
+            self.assertEqual(int(response.data.get("meta").get("limit")), limit)
+            self.assertEqual(int(response.data.get("meta").get("offset")), offset)
+            self.assertEqual(len(response.data.get("data")), expected_data_count)
+
 
 class GroupViewNonAdminTests(IdentityRequest):
     """Test the group view for nonadmin user."""

--- a/tests/management/principal/test_view.py
+++ b/tests/management/principal/test_view.py
@@ -131,6 +131,17 @@ class PrincipalViewsetTests(IdentityRequest):
         self.principal = Principal(username="test_user", tenant=self.tenant)
         self.principal.save()
 
+        # Create second tenant with 2 user based principals
+        customer_data = self._create_customer_data()
+        self.tenant_B = Tenant.objects.create(
+            tenant_name="tenantB",
+            account_id=customer_data["account_id"],
+            org_id=customer_data["org_id"],
+            ready=True,
+        )
+        self.principal_B1 = Principal.objects.create(username="test_user_B1", tenant=self.tenant_B)
+        self.principal_B2 = Principal.objects.create(username="test_user_B2", tenant=self.tenant_B)
+
     def tearDown(self):
         """Tear down principal viewset tests."""
         Principal.objects.all().delete()
@@ -199,6 +210,9 @@ class PrincipalViewsetTests(IdentityRequest):
         self.assertCountEqual(list(principal.keys()), ["username"])
         self.assertIsNotNone(principal.get("username"))
         self.assertEqual(principal.get("username"), self.principal.username)
+
+        # Check we list only 1 principal even we have 3 in db (rest 2 belongs to different tenant)
+        self.assertEqual(len(Principal.objects.all()), 3)
 
     @override_settings(BYPASS_BOP_VERIFICATION=True)
     def test_read_principal_list_username_only_false_success(self):


### PR DESCRIPTION
## Link(s) to Jira
- [RHCLOUD-39098](https://issues.redhat.com/browse/RHCLOUD-39098)

## Description of Intent of Change(s)

1. fix the principal filter queryset to include the tenant (before we get all principals from DB = cca 780,000 in production)
2. fix the principal filter queryset to exclude cross account principals
3. add condition to filter principals by specified set of usernames = used for listing principals in the group (accidentally removed here https://github.com/RedHatInsights/insights-rbac/pull/1558)

the missing tenant (1) has been present for long time (> 2 years) but due to the additional condition (3) and the fact that the majority of requests was to list usernames only within a group, the RBAC service was still able to process them, however without the filter condition (3), we experienced a massive increase in memory usage during the production release

with this change we will be able to proceed with the production release without the memory usage issue, additionally we expect latency improvement in the `/groups/uuid/principals/` endpoint too - because of (1)


## Local testing
affected queries:
- `GET /principals/?username_only=true`
- `GET /groups/<uuid>/principals/?username_only=true`

in both cases, the BOP calls is expected to be skipped, and records should be returned from the RBAC database

since we have a cleaning job in place, the response should not differ significantly from queries without the `username_only=true` parameter

we need to ensure these queries are working as expected:
- `GET /principals/` returns all user based principals within the tenant from BOP
- `GET /principals/?username_only=true` returns all user based principals within the tenant, but only usernames from RBAC DB
- `GET /groups/<uuid>/principals/` returns the user based principals that belongs to the group (all principals belong to the correct tenant) 
- `GET /groups/<uuid>/principals/?username_only=true` returns the user based principals that belongs to the group, but only usernames from RBAC DB (all principals belong to the correct tenant)

responses do not contain cross account principals

everything should work for service accounts queries too (with username_only=true we skip the IT call as we do for user based principals but without the cleaning job the service accounts are not removed from db = we need some solution asap)
- `GET /principals/?type=service-account`
- `GET /principals/?type=service-account&username_only=true`
- `GET /groups/<uuid>/principals/?principal_type=service-account`
- `GET /groups/<uuid>/principals/?principal_type=service-account&username_only=true`

everything should work for all principals queries too (this is working now only for listing all principals within the tenant, for listing principals in a group will be added here https://github.com/RedHatInsights/insights-rbac/pull/1567)
- `GET /principals/?type=all`
- `GET /principals/?type=all&username_only=true`

we need to ensure the `GET /principals/` query is working with `usernames` query parameter, for example:
- `GET /principals/?usernames=<username1>,<username2>` 
- `GET /principals/?username_only=true&usernames=<username1>,<username2>` 

we need to ensure the `GET /groups/<uuid>/principals/` query is working with `principal_username` query parameter, for example:
- `GET /groups/<uuid>/principals/?principal_username=<value>`
- `GET /groups/<uuid>/principals/?username_only=true&principal_username=<value>`

