### PR TITLE
/principals/ endpoint tests

### DIFF
--- a/rbac/management/principal/view.py
+++ b/rbac/management/principal/view.py
@@ -278,7 +278,7 @@ class PrincipalView(APIView):
         if sa_resp.get("status_code") != status.HTTP_200_OK:
             return sa_resp, ""
 
-        # Calculate new limit and offset for the user base principals query
+        # Calculate new limit and offset for the user based principals query
         sa_count_total = sa_resp.get("saCount")
         sa_count = len(sa_resp.get("data", []))
 

--- a/tests/management/principal/test_view.py
+++ b/tests/management/principal/test_view.py
@@ -960,6 +960,10 @@ class PrincipalViewsetTests(IdentityRequest):
 
         cross_account_principal.delete()
 
+
+class PrincipalViewsetServiceAccountTests(IdentityRequest):
+    """Tests the principal view set - only service accounts tests"""
+
     @override_settings(IT_BYPASS_TOKEN_VALIDATION=True)
     @patch("management.principal.it_service.ITService.request_service_accounts")
     def test_principal_service_account_filter_by_name(self, mock_request):
@@ -2552,6 +2556,10 @@ class PrincipalViewsetTests(IdentityRequest):
         # The function is called three times in this test.
         self.assertEqual(mock_request.call_count, 3)
 
+
+class PrincipalViewsetAllTypesTests(IdentityRequest):
+    """Tests the principal view set - only tests with 'type=all' query param."""
+
     @override_settings(IT_BYPASS_TOKEN_VALIDATION=True)
     @patch("management.principal.proxy.PrincipalProxy.request_principals")
     @patch("management.principal.it_service.ITService.get_service_accounts")
@@ -2764,7 +2772,7 @@ class PrincipalViewsetTests(IdentityRequest):
         client = APIClient()
         url = f"{reverse('v1_management:principals')}?type=all&username_only=true"
         response = client.get(url, **self.headers)
-        print(response.data)
+
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data.get("data")), 2)
         for key in response.data.get("data").keys():

--- a/tests/management/principal/test_view.py
+++ b/tests/management/principal/test_view.py
@@ -960,6 +960,18 @@ class PrincipalViewsetTests(IdentityRequest):
 
         cross_account_principal.delete()
 
+    def test_read_principal_invalid_type(self):
+        """Test that an invalid principal's type returns an error response."""
+        invalid_type = "invalid_value"
+        client = APIClient()
+        url = f"{reverse('v1_management:principals')}?type={invalid_type}"
+        response = client.get(url, **self.headers)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        error_message = response.json().get("errors")[0].get("detail")
+        expected_substring = f"type query parameter value '{invalid_type}' is invalid."
+        self.assertIn(expected_substring, error_message)
+
 
 class PrincipalViewsetServiceAccountTests(IdentityRequest):
     """Tests the principal view set - only service accounts tests"""


### PR DESCRIPTION
[RHCLOUD-29404](https://issues.redhat.com/browse/RHCLOUD-29404) - ticket for the SA tests

Principal view tests improvements/refactoring - changes split in commits
- test to list principal usernames only without cross account users
- split principal tests into separate categories (created classes for Service Accounts specific tests and All types queries specific tests)
- test data creation moved from tests into setUp() method
- test for invalid value for "type" query param and list principals
- test for read filtered list of SA usernames
- test for read filtered list of both principal types 
- test for read filtered list of both principal types - username only
- test with 100 principals
- test with 30 principals to test the pagination
- test with 30 principals to test the pagination - username only
- test for all principal types when SA doesnt exist