### PR TITLE
Use latest rbac quay repo

### DIFF
--- a/deploy/rbac-clowdapp.yml
+++ b/deploy/rbac-clowdapp.yml
@@ -1045,7 +1045,7 @@ objects:
 parameters:
 - description: Image name
   name: IMAGE
-  value: quay.io/cloudservices/rbac
+  value: quay.io/redhat-services-prod/hcc-accessmanagement-tenant/insights-rbac
 - description: Determines Clowder deployment
   name: CLOWDER_ENABLED
   value: "true"


### PR DESCRIPTION
The latest quay repo has been switched to quay.io/redhat-services-prod/hcc-accessmanagement-tenant/insights-rbac:latest

Have to update it in the clowder for ephemeral envs.

## Summary by Sourcery

Deployment:
- Update the image repository for RBAC service in Clowder deployment configuration to use the new production repository