### PR TITLE
refactoring for open api spec for internal endpoint /_s2s/workspaces/ungrouped/

### DIFF
--- a/rbac/internal/specs/openapi.json
+++ b/rbac/internal/specs/openapi.json
@@ -2168,12 +2168,12 @@
       }
     },
     "/_s2s/workspaces/ungrouped/": {
-      "post": {
+      "get": {
         "tags": [
           "V2", "Workspace"
         ],
-        "summary": "Get or create ungrouped hosts workspace",
-        "description": "ungrouped hosts workspace.",
+        "summary": "Get or create ungrouped hosts workspace.",
+        "description": "Get or create ungrouped hosts workspace.",
         "operationId": "GetUngrouped",
         "responses": {
           "201": {

--- a/rbac/internal/views.py
+++ b/rbac/internal/views.py
@@ -1312,7 +1312,11 @@ def principal_removal(request):
 
 
 def retrieve_ungrouped_workspace(request):
-    """GET or create ungrouped workspace for HBI."""
+    """
+    GET or create ungrouped workspace for HBI.
+
+    GET /_private/_s2s/workspaces/ungrouped/
+    """
     if request.method != "GET":
         return HttpResponse("Invalid request method, only GET is allowed.", status=405)
 


### PR DESCRIPTION
## Summary by Sourcery

Update OpenAPI specification and documentation for the internal ungrouped workspace endpoint

Enhancements:
- Improved documentation for the internal endpoint that retrieves or creates ungrouped workspaces

Documentation:
- Updated docstring for the retrieve_ungrouped_workspace function to clarify the endpoint path