### PR TITLE
[RHCLOUD-39586] Do not allow deletion of non standard types of workspace

### DIFF
--- a/rbac/management/workspace/view.py
+++ b/rbac/management/workspace/view.py
@@ -106,6 +106,10 @@ class WorkspaceViewSet(BaseV2ViewSet):
     def destroy(self, request, *args, **kwargs):
         """Delete a workspace."""
         instance = self.get_object()
+        if instance.type != Workspace.Types.STANDARD:
+            message = f"Unable to delete {instance.type} workspace"
+            error = {"workspace": [_(message)]}
+            raise serializers.ValidationError(error)
         if Workspace.objects.filter(parent=instance, tenant=instance.tenant).exists():
             message = "Unable to delete due to workspace dependencies"
             error = {"workspace": [_(message)]}

--- a/tests/management/workspace/test_view.py
+++ b/tests/management/workspace/test_view.py
@@ -683,6 +683,49 @@ class WorkspaceViewTestsV2Enabled(WorkspaceViewTests):
         self.assertEqual(status_code, 403)
         self.assertEqual(response.get("content-type"), "application/problem+json")
 
+    def test_delete_workspace_with_dependencies(self):
+        workspace_data = {
+            "name": "Workspace for delete",
+            "description": "Workspace for delete - description",
+            "tenant_id": self.tenant.id,
+            "parent_id": self.root_workspace.id,
+        }
+        workspace = Workspace.objects.create(**workspace_data)
+        dependent = Workspace.objects.create(
+            name="Dependent Workspace",
+            tenant=self.tenant,
+            type="standard",
+            parent_id=workspace.id,
+        )
+        url = reverse("v2_management:workspace-detail", kwargs={"pk": workspace.id})
+        client = APIClient()
+        test_headers = self.headers.copy()
+        test_headers["HTTP_ACCEPT"] = "application/problem+json"
+        response = client.delete(url, None, format="json", **test_headers)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        detail = response.data.get("detail")
+        self.assertEqual(detail, "Unable to delete due to workspace dependencies")
+
+    def test_delete_workspace_with_non_standard_types(self):
+        # Root workspace can't be deleted
+        url = reverse("v2_management:workspace-detail", kwargs={"pk": self.root_workspace.id})
+        client = APIClient()
+        test_headers = self.headers.copy()
+        test_headers["HTTP_ACCEPT"] = "application/problem+json"
+        response = client.delete(url, None, format="json", **test_headers)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        detail = response.data.get("detail")
+        self.assertEqual(detail, "Unable to delete root workspace")
+
+        # Default workspace can't be deleted
+        url = reverse("v2_management:workspace-detail", kwargs={"pk": self.default_workspace.id})
+        response = client.delete(url, None, format="json", **test_headers)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        detail = response.data.get("detail")
+        self.assertEqual(detail, "Unable to delete default workspace")
+
 
 @override_settings(V2_APIS_ENABLED=True)
 class TestsList(WorkspaceViewTests):


### PR DESCRIPTION
## Link(s) to Jira
- https://issues.redhat.com/browse/RHCLOUD-39586

## Description of Intent of Change(s)
We should not allow the standard types to be deleted

## Local Testing
Unit test

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Implement restrictions on workspace deletion to prevent removing non-standard workspace types

New Features:
- Add validation to prevent deletion of root and default workspaces

Bug Fixes:
- Prevent deletion of workspaces with existing dependencies
- Block deletion of non-standard workspace types

Tests:
- Add test cases for workspace deletion restrictions
- Verify deletion prevention for root, default, and dependent workspaces