### PR TITLE
[RHCLOUD-27273] Update resource definitions internal endpoint

### DIFF
--- a/rbac/internal/specs/openapi.json
+++ b/rbac/internal/specs/openapi.json
@@ -2210,6 +2210,17 @@
         "summary": "Get incorrect resource definitions.",
         "description": "Get resource definitions with incorrect attribute filters. Attribute filters with lists must use 'in' operation. Those with a single string must use 'equal'.",
         "operationId": "GetIncorrectResourceDefinitions",
+        "parameters": [
+          {
+            "name": "detail",
+            "in": "query",
+            "description": "Optional flag. If true, returns a list of resource definition objects. If false or omitted, returns only the count.",
+            "required": false,
+            "schema":{
+              "type": "boolean"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "The number of resource definitions that would be corrected."
@@ -2243,6 +2254,17 @@
         "summary": "Fix incorrect resource definitions.",
         "description": "Fix resource definitions with incorrect attribute filters. Attribute filters with lists must use 'in' operation. Those with a single string must use 'equal'.",
         "operationId": "FixIncorrectResourceDefinitions",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "query",
+            "description": "Resource definition id.",
+            "required": false,
+            "schema":{
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "The number of resource definitions that were corrected."

--- a/rbac/internal/views.py
+++ b/rbac/internal/views.py
@@ -74,7 +74,6 @@ from api.tasks import (
 )
 from api.utils import RESOURCE_MODEL_MAPPING, get_resources
 
-
 logger = logging.getLogger(__name__)
 TENANTS = TenantCache()
 PROXY = PrincipalProxy()
@@ -1184,7 +1183,12 @@ def correct_resource_definitions(request):
     Attribute filters with lists must use 'in' operation. Those with a single string must use 'equal'
 
     GET /_private/api/utils/resource_definitions/
+        query param 'detail=false' (default) to get resource definitions count
+        query param 'detail=true' to get resource definitions objects
+
     PATCH /_private/api/utils/resource_definitions/
+        query param 'id=<resource_definitions_id>' to fix only 1 resource definition
+        you can identify 'id' by GET request with 'detail=true' query param
     """
     list_query = """ FROM management_resourcedefinition
                 WHERE "attributeFilter"->>'operation' = 'equal'
@@ -1193,9 +1197,31 @@ def correct_resource_definitions(request):
     string_query = """ from management_resourcedefinition WHERE "attributeFilter"->>'operation' = 'in'
                 AND jsonb_typeof("attributeFilter"->'value') = 'string';"""
 
-    if request.method == "GET":
-        with connection.cursor() as cursor:
+    query_params = request.GET
 
+    if request.method == "GET":
+        detail = query_params.get("detail") == "true"
+        if detail:
+            with connection.cursor() as cursor:
+                cursor.execute("SELECT *" + list_query)
+                list_rows = cursor.fetchall()
+
+                cursor.execute("SELECT *" + string_query)
+                string_rows = cursor.fetchall()
+
+                response = [
+                    {
+                        "id": row[0],
+                        "attributeFilter": json.loads(row[1]),
+                        "access_id": row[2],
+                        "tenant_id": row[3],
+                    }
+                    for row in list_rows + string_rows
+                ]
+
+            return HttpResponse(json.dumps(response), content_type="application/json", status=200)
+
+        with connection.cursor() as cursor:
             cursor.execute("SELECT COUNT(*)" + list_query)
             count = cursor.fetchone()[0]
 
@@ -1203,15 +1229,23 @@ def correct_resource_definitions(request):
             count += cursor.fetchone()[0]
 
         return HttpResponse(f"{count} resource definitions would be corrected", status=200)
+
     elif request.method == "PATCH":
+        resource_definition_id = query_params.get("id")
+
+        if resource_definition_id:
+            resource_definition = get_object_or_404(ResourceDefinition, id=resource_definition_id)
+            resource_definition.attributeFilter = normalize_attribute_filter(resource_definition.attributeFilter)
+            resource_definition.save()
+            return HttpResponse(f"Resource definition id = {resource_definition_id} updated.", status=200)
+
         count = 0
         with connection.cursor() as cursor:
-
             cursor.execute("SELECT id " + list_query)
             result = cursor.fetchall()
             for id in result:
                 resource_definition = ResourceDefinition.objects.get(id=id[0])
-                resource_definition.attributeFilter["operation"] = "in"
+                resource_definition.attributeFilter = normalize_attribute_filter(resource_definition.attributeFilter)
                 resource_definition.save()
                 count += 1
 
@@ -1219,13 +1253,27 @@ def correct_resource_definitions(request):
             result = cursor.fetchall()
             for id in result:
                 resource_definition = ResourceDefinition.objects.get(id=id[0])
-                resource_definition.attributeFilter["operation"] = "equal"
+                resource_definition.attributeFilter = normalize_attribute_filter(resource_definition.attributeFilter)
                 resource_definition.save()
                 count += 1
 
         return HttpResponse(f"Updated {count} bad resource definitions", status=200)
 
     return HttpResponse('Invalid method, only "GET" or "PATCH" are allowed.', status=405)
+
+
+def normalize_attribute_filter(attribute_filter):
+    """For Attribute Filter set valid 'operation' or convert 'value' from string into list."""
+    op = attribute_filter.get("operation")
+    value = attribute_filter.get("value")
+    if op == "equal" and isinstance(value, list):
+        attribute_filter["operation"] = "in"
+    elif op == "in" and isinstance(value, str):
+        if "," in value:
+            attribute_filter["value"] = [item.strip() for item in value.split(",")]
+        else:
+            attribute_filter["operation"] = "equal"
+    return attribute_filter
 
 
 def username_lower(request):


### PR DESCRIPTION
## Link(s) to Jira
- [RHCLOUD-27273](https://issues.redhat.com/browse/RHCLOUD-27273)

## Description of Intent of Change(s)
example of incorrect resource definitions
```
{"attributeFilter": {"key": "key1_id", "operation": "equal", "value": ["value1", "value2"]}},
{"attributeFilter": {"key": "key2_id", "operation": "in", "value": "value1, value2"}},
{"attributeFilter": {"key": "key3_id", "operation": "in", "value": "string"}},
```
**before the change**
- `GET /api/utils/resource_definitions/` returned count of incorrect resource definitions
- `PATCH /api/utils/resource_definitions/` fixed all incorrect resource definitions
  - if the `value` is list/array and the `operation` is "equal", then the `operation` is changed into "in"
  - if the `value` is string and the `operation` is "in", then the `operation` is changed into "equal"

**after the change**
- `GET /api/utils/resource_definitions/` returns count of incorrect resource definitions
  - with query parameter `detail=true` the endpoint returns list of resource definition objects -> you can see the resource definitions before the change and double check there is no unexpected data

- `PATCH /api/utils/resource_definitions/` fixes all incorrect resource definitions
  - if the `value` is list/array, the `operation` should be "in"
  - if the `value` is string, the `operation` should be "equal"
  - if the `value` is string as a list of items separated by comma, then the `value` should be converted into list

additionally for the PATCH endpoint you can use `id` query param to fix only 1 resource definitions -> the id can be identified with GET request with `detail=true` query param

## Local Testing
create few incorrect resource definitions in your RBAC local db and send GET request without/with the `detail` query param
```
GET /api/utils/resource_definitions/
GET /api/utils/resource_definitions/?detail=true
```

then try to fix the resource definitions with PATCH request
```
PATCH /api/utils/resource_definitions/
PATCH /api/utils/resource_definitions/?id=<resource_definition_id>
```

## Checklist
- [x] api spec update
- [x] unit tests
- [x] confluence documentation

## Summary by Sourcery

Update the internal endpoint for resource definitions to improve handling of attribute filter operations and values

New Features:
- Add support for retrieving detailed resource definition information using 'detail=true' query parameter
- Implement ability to fix a specific resource definition by ID using 'id' query parameter

Enhancements:
- Improve resource definition validation by correcting operation and value types
- Add more flexible handling of string and list values in attribute filters

Tests:
- Add comprehensive test cases for new resource definition endpoint functionality
- Create tests for retrieving and patching resource definitions with different scenarios