### PR TITLE
Fix parent missing when importing groups data

### DIFF
--- a/rbac/internal/views.py
+++ b/rbac/internal/views.py
@@ -1378,7 +1378,10 @@ def retrieve_ungrouped_workspace(request):
             if not ungrouped_hosts.exists():
                 default = Workspace.objects.get(tenant=tenant, type=Workspace.Types.DEFAULT)
                 ungrouped_hosts, _ = Workspace.objects.get_or_create(
-                    tenant=tenant, type=Workspace.Types.UNGROUPED_HOSTS, name="Ungrouped Hosts", parent=default
+                    tenant=tenant,
+                    type=Workspace.Types.UNGROUPED_HOSTS,
+                    name=Workspace.SpecialNames.UNGROUPED_HOSTS,
+                    parent=default,
                 )
                 dual_write_handler = RelationApiDualWriteWorkspacepHandler(
                     ungrouped_hosts, ReplicationEventType.CREATE_WORKSPACE

--- a/rbac/management/management/commands/utils.py
+++ b/rbac/management/management/commands/utils.py
@@ -179,7 +179,7 @@ def batch_import_workspace(records):
             is_ungrouped = record["ungrouped"].lower() == "true"
             parent = parent_workspace_dict[record["org_id"]]
             if is_ungrouped:
-                ws_name = "Ungrouped Hosts"
+                ws_name = Workspace.SpecialNames.UNGROUPED_HOSTS
                 workspace_type = Workspace.Types.UNGROUPED_HOSTS
             else:
                 ws_name = record["name"]

--- a/rbac/management/management/commands/utils.py
+++ b/rbac/management/management/commands/utils.py
@@ -191,6 +191,7 @@ def batch_import_workspace(records):
                     name=record["name"],
                     tenant=tenant_dict[record["org_id"]],
                     type=workspace_type,
+                    parent=parent,
                     created=record["created_on"],
                     modified=record["modified_on"],
                 )

--- a/rbac/management/management/commands/utils.py
+++ b/rbac/management/management/commands/utils.py
@@ -178,17 +178,22 @@ def batch_import_workspace(records):
         for record in records:
             is_ungrouped = record["ungrouped"].lower() == "true"
             parent = parent_workspace_dict[record["org_id"]]
-            workspace_type = Workspace.Types.UNGROUPED_HOSTS if is_ungrouped else Workspace.Types.STANDARD
+            if is_ungrouped:
+                ws_name = "Ungrouped Hosts"
+                workspace_type = Workspace.Types.UNGROUPED_HOSTS
+            else:
+                ws_name = record["name"]
+                workspace_type = Workspace.Types.STANDARD
 
             if record["id"] in existing_wss_dict:
                 workspace = existing_wss_dict[record["id"]]
-                workspace.name = record["name"]
+                workspace.name = ws_name
                 workspace.modified = record["modified_on"]
                 workspaces_to_update.append(workspace)
             else:
                 workspace = Workspace(
                     id=record["id"],
-                    name=record["name"],
+                    name=ws_name,
                     tenant=tenant_dict[record["org_id"]],
                     type=workspace_type,
                     parent=parent,

--- a/rbac/management/tenant_service/v2.py
+++ b/rbac/management/tenant_service/v2.py
@@ -76,7 +76,10 @@ class V2TenantBootstrapService:
         tenant = Tenant.objects.get(org_id=org_id)
         default = Workspace.objects.get(tenant=tenant, type=Workspace.Types.DEFAULT)
         ungrouped_hosts, _ = Workspace.objects.get_or_create(
-            tenant=tenant, type=Workspace.Types.UNGROUPED_HOSTS, name="Ungrouped Hosts", parent=default
+            tenant=tenant,
+            type=Workspace.Types.UNGROUPED_HOSTS,
+            name=Workspace.SpecialNames.UNGROUPED_HOSTS,
+            parent=default,
         )
 
         relationship = create_relationship(
@@ -572,12 +575,12 @@ class V2TenantBootstrapService:
     def _built_in_workspaces(self, tenant: Tenant) -> tuple[Workspace, Workspace, list[Relationship]]:
         relationships = []
 
-        root = Workspace(tenant=tenant, type=Workspace.Types.ROOT, name="Root Workspace")
+        root = Workspace(tenant=tenant, type=Workspace.Types.ROOT, name=Workspace.SpecialNames.ROOT)
         default = Workspace(
             parent_id=root.id,
             tenant=tenant,
             type=Workspace.Types.DEFAULT,
-            name="Default Workspace",
+            name=Workspace.SpecialNames.DEFAULT,
         )
 
         root_workspace_id = root.id

--- a/rbac/management/workspace/model.py
+++ b/rbac/management/workspace/model.py
@@ -30,6 +30,11 @@ from api.models import TenantAwareModel
 class Workspace(TenantAwareModel):
     """A workspace."""
 
+    class SpecialNames:
+        DEFAULT = "Default Workspace"
+        ROOT = "Root Workspace"
+        UNGROUPED_HOSTS = "Ungrouped Hosts"
+
     class Types(models.TextChoices):
         STANDARD = "standard"
         DEFAULT = "default"

--- a/tests/management/management/commands/test_utils.py
+++ b/tests/management/management/commands/test_utils.py
@@ -296,6 +296,8 @@ a210f23c-f2d2-40c6-b47c-43fa1bgg814a,0dffe7e11-c56e-4fcb-b7a6-66db2e013983
             [(workspace_id_1, str(defaults[0].id)), (workspace_id_2, str(defaults[1].id))],
         )
         self.assertEqual(Workspace.objects.filter(id__in=[workspace_id_1, workspace_id_2]).count(), 2)
+        self.assertEqual(Workspace.objects.get(id=workspace_id_1).parent, defaults[0])
+        self.assertEqual(Workspace.objects.get(id=workspace_id_2).parent, defaults[1])
         # Should be idempotent
         updated_name = "updated_name"
         updated_time = "2026-03-18 15:19:53.509206+00:00"

--- a/tests/management/management/commands/test_utils.py
+++ b/tests/management/management/commands/test_utils.py
@@ -298,9 +298,13 @@ a210f23c-f2d2-40c6-b47c-43fa1bgg814a,0dffe7e11-c56e-4fcb-b7a6-66db2e013983
         self.assertEqual(Workspace.objects.filter(id__in=[workspace_id_1, workspace_id_2]).count(), 2)
         self.assertEqual(Workspace.objects.get(id=workspace_id_1).parent, defaults[0])
         self.assertEqual(Workspace.objects.get(id=workspace_id_2).parent, defaults[1])
+        self.assertEqual(Workspace.objects.get(id=workspace_id_2).type, Workspace.Types.UNGROUPED_HOSTS)
+        self.assertEqual(Workspace.objects.get(id=workspace_id_2).name, "Ungrouped Hosts")
         # Should be idempotent
         updated_name = "updated_name"
         updated_time = "2026-03-18 15:19:53.509206+00:00"
+        records[0]["name"] = updated_name
+        records[0]["modified_on"] = updated_time
         records[1]["name"] = updated_name
         records[1]["modified_on"] = updated_time
         mock_bss.create_workspace_relationships.reset_mock()
@@ -309,6 +313,9 @@ a210f23c-f2d2-40c6-b47c-43fa1bgg814a,0dffe7e11-c56e-4fcb-b7a6-66db2e013983
             mock_bss.create_workspace_relationships.call_args[0][0],
             [(workspace_id_1, str(defaults[0].id)), (workspace_id_2, str(defaults[1].id))],
         )
-        updated_ws = Workspace.objects.get(id=workspace_id_2)
-        self.assertEqual(updated_ws.name, updated_name)
-        self.assertEqual(updated_ws.modified, datetime.fromisoformat(updated_time))
+        updated_ws_1 = Workspace.objects.get(id=workspace_id_1)
+        self.assertEqual(updated_ws_1.name, updated_name)
+        self.assertEqual(updated_ws_1.modified, datetime.fromisoformat(updated_time))
+        updated_ws_2 = Workspace.objects.get(id=workspace_id_2)
+        self.assertEqual(updated_ws_2.name, "Ungrouped Hosts")
+        self.assertEqual(updated_ws_2.modified, datetime.fromisoformat(updated_time))


### PR DESCRIPTION
The parent is missing when bulk importing workspaces

## Summary by Sourcery

Assign the parent workspace during batch import.

Bug Fixes:
- Ensure the parent workspace is correctly assigned when batch importing workspaces using `batch_import_workspace` utility function.

Tests:
- Add assertions to verify the parent workspace is set correctly after batch import.