### PR TITLE
[RHCLOUD-39820] migrate to the open api specification version 3.1.1

### DIFF
--- a/docs/source/specs/openapi.json
+++ b/docs/source/specs/openapi.json
@@ -1,5 +1,5 @@
 {
-  "openapi": "3.0.0",
+  "openapi": "3.1.1",
   "info": {
     "description": "The API for Role Based Access Control.",
     "version": "1.0.0",
@@ -3856,15 +3856,13 @@
           "value": {
             "oneOf": [
               {
-                "type": "string",
-                "example": "123456",
-                "nullable": true
+                "type": ["string", "null"],
+                "example": "123456"
               },
               {
                 "type": "array",
                 "items": {
-                  "type": "string",
-                  "nullable": true
+                  "type": ["string", "null"]
                 },
                 "example": ["value1", null, "value2"]
               }


### PR DESCRIPTION
[RHCLOUD-39820](https://issues.redhat.com/browse/RHCLOUD-39820)

Migrate to the open api specification version 3.1.1 that will allow us use new features introduced in this version as https://github.com/RedHatInsights/insights-rbac/pull/1418#issuecomment-2569611683

## Summary by Sourcery

Documentation:
- Upgrade OpenAPI specification file to version 3.1.1