### PR TITLE
[RHCLOUD-38719] Populate null values for resource definitions

### DIFF
--- a/rbac/internal/views.py
+++ b/rbac/internal/views.py
@@ -30,9 +30,9 @@ from django.http import HttpRequest, HttpResponse, JsonResponse
 from django.shortcuts import get_object_or_404
 from django.utils.html import escape
 from internal.errors import SentryDiagnosticError, UserNotFoundError
-from internal.utils import delete_bindings
+from internal.utils import delete_bindings, get_or_create_ungrouped_workspace
 from management.cache import TenantCache
-from management.models import BindingMapping, Group, Permission, Principal, ResourceDefinition, Role, Workspace
+from management.models import BindingMapping, Group, Permission, Principal, ResourceDefinition, Role
 from management.principal.proxy import (
     API_TOKEN_HEADER,
     CLIENT_ID_HEADER,
@@ -59,7 +59,6 @@ from management.utils import (
     get_principal,
     groups_for_principal,
 )
-from management.workspace.relation_api_dual_write_workspace_handler import RelationApiDualWriteWorkspacepHandler
 from management.workspace.serializer import WorkspaceSerializer
 from rest_framework import status
 
@@ -1372,23 +1371,7 @@ def retrieve_ungrouped_workspace(request):
     try:
         with transaction.atomic():
             tenant = Tenant.objects.get(org_id=org_id)
-            ungrouped_hosts = Workspace.objects.select_for_update().filter(
-                tenant=tenant, type=Workspace.Types.UNGROUPED_HOSTS
-            )
-            if not ungrouped_hosts.exists():
-                default = Workspace.objects.get(tenant=tenant, type=Workspace.Types.DEFAULT)
-                ungrouped_hosts, _ = Workspace.objects.get_or_create(
-                    tenant=tenant,
-                    type=Workspace.Types.UNGROUPED_HOSTS,
-                    name=Workspace.SpecialNames.UNGROUPED_HOSTS,
-                    parent=default,
-                )
-                dual_write_handler = RelationApiDualWriteWorkspacepHandler(
-                    ungrouped_hosts, ReplicationEventType.CREATE_WORKSPACE
-                )
-                dual_write_handler.replicate_new_workspace()
-            else:
-                ungrouped_hosts = ungrouped_hosts.get()
+            ungrouped_hosts = get_or_create_ungrouped_workspace(tenant)
             data = WorkspaceSerializer(ungrouped_hosts).data
             return HttpResponse(json.dumps(data), content_type="application/json", status=201)
     except Exception as e:

--- a/rbac/management/management/commands/import_workspace_data.py
+++ b/rbac/management/management/commands/import_workspace_data.py
@@ -3,7 +3,7 @@
 import logging
 
 from django.core.management.base import BaseCommand
-from management.management.commands.utils import download_data_from_S3, populate_workspace_data
+from management.management.commands.utils import backfill_null_value, download_data_from_S3, populate_workspace_data
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 FILE_NAME = "groups_data.csv"
@@ -22,3 +22,6 @@ class Command(BaseCommand):
         logger.info("*** Processing workspace data file... ***")
         populate_workspace_data(FILE_NAME)
         logger.info("*** Data population completed. ***")
+        logger.info("*** Backfilling null values. ***")
+        backfill_null_value()
+        logger.info("*** Backfilling completed. ***")

--- a/rbac/management/management/commands/utils.py
+++ b/rbac/management/management/commands/utils.py
@@ -21,11 +21,12 @@ import os
 import boto3
 from botocore.exceptions import ClientError
 from django.db import IntegrityError, transaction
-from management.principal.model import Principal
-from management.role.relation_api_dual_write_handler import OutboxReplicator
+from internal.utils import get_or_create_ungrouped_workspace
+from management.models import Principal, ResourceDefinition, Role, Workspace
+from management.relation_replicator.relation_replicator import ReplicationEventType
+from management.role.relation_api_dual_write_handler import OutboxReplicator, RelationApiDualWriteHandler
 from management.tenant_mapping.model import logger
 from management.tenant_service.v2 import V2TenantBootstrapService
-from management.workspace.model import Workspace
 
 
 from api.models import Tenant, User
@@ -205,3 +206,46 @@ def batch_import_workspace(records):
         Workspace.objects.bulk_create(workspaces)
         Workspace.objects.bulk_update(workspaces_to_update, ["name", "modified"])
         BOOT_STRAP_SERVICE.create_workspace_relationships(pairs)
+
+
+def _replace_null_value_in_resourcedef(rd: ResourceDefinition):
+    updated = False
+    if rd.attributeFilter["operation"] == "in":
+        for value in rd.attributeFilter["value"]:
+            if value is None:
+                rd.attributeFilter["value"].remove(value)
+                ungrouped_ws = get_or_create_ungrouped_workspace(rd.tenant)
+                rd.attributeFilter["value"].append(str(ungrouped_ws.id))
+                updated = True
+    else:  # operation is "equals"
+        if rd.attributeFilter["value"] is None:
+            ungrouped_ws = get_or_create_ungrouped_workspace(rd.tenant)
+            rd.attributeFilter["value"] = str(ungrouped_ws.id)
+            updated = True
+    return updated
+
+
+def backfill_null_value():
+    """Backfill null values of the resource definition for inventory."""
+    # Backfill null values for workspaces
+    for rd in ResourceDefinition.objects.filter(attributeFilter__key="group.id"):
+        updated = _replace_null_value_in_resourcedef(rd)
+
+        if updated:
+            with transaction.atomic():
+                rd.save()
+                role = rd.access.role
+                # Update all resource definitions for the role
+                for access in role.access.all():
+                    for rd in access.resourceDefinitions.all():
+                        updated = _replace_null_value_in_resourcedef(rd)
+                        if updated:
+                            rd.save()
+                logger.info(f"Migrating role: {role.name} with UUID {role.uuid}.")
+                # Requery and lock role
+                role = Role.objects.select_for_update().get(pk=role.id)
+                dual_write_handler = RelationApiDualWriteHandler(
+                    role, ReplicationEventType.MIGRATE_CUSTOM_ROLE, OutboxReplicator()
+                )
+                dual_write_handler.prepare_for_update()
+                dual_write_handler.replicate_new_or_updated_role(role)

--- a/rbac/management/workspace/relation_api_dual_write_workspace_handler.py
+++ b/rbac/management/workspace/relation_api_dual_write_workspace_handler.py
@@ -35,7 +35,7 @@ from migration_tool.utils import create_relationship
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
 
-class RelationApiDualWriteWorkspacepHandler(BaseRelationApiDualWriteHandler):
+class RelationApiDualWriteWorkspaceHandler(BaseRelationApiDualWriteHandler):
     """Class to handle Dual Write for group bindings and membership."""
 
     workspace: Workspace

--- a/rbac/management/workspace/serializer.py
+++ b/rbac/management/workspace/serializer.py
@@ -18,7 +18,7 @@
 """Serializer for workspace management."""
 from django.db import transaction
 from management.relation_replicator.relation_replicator import ReplicationEventType
-from management.workspace.relation_api_dual_write_workspace_handler import RelationApiDualWriteWorkspacepHandler
+from management.workspace.relation_api_dual_write_workspace_handler import RelationApiDualWriteWorkspaceHandler
 from rest_framework import serializers
 
 from .model import Workspace
@@ -55,9 +55,7 @@ class WorkspaceSerializer(serializers.ModelSerializer):
 
         with transaction.atomic():
             workspace = Workspace.objects.create(**validated_data)
-            dual_write_handler = RelationApiDualWriteWorkspacepHandler(
-                workspace, ReplicationEventType.CREATE_WORKSPACE
-            )
+            dual_write_handler = RelationApiDualWriteWorkspaceHandler(workspace, ReplicationEventType.CREATE_WORKSPACE)
             dual_write_handler.replicate_new_workspace()
         return workspace
 
@@ -68,7 +66,7 @@ class WorkspaceSerializer(serializers.ModelSerializer):
             instance = Workspace.objects.select_for_update().filter(id=instance.id).get()
             previous_parent = instance.parent
             instance = super().update(instance, validated_data)
-            dual_write_handler = RelationApiDualWriteWorkspacepHandler(instance, ReplicationEventType.UPDATE_WORKSPACE)
+            dual_write_handler = RelationApiDualWriteWorkspaceHandler(instance, ReplicationEventType.UPDATE_WORKSPACE)
             dual_write_handler.replicate_updated_workspace(previous_parent)
         return instance
 

--- a/rbac/management/workspace/view.py
+++ b/rbac/management/workspace/view.py
@@ -23,7 +23,7 @@ from management.base_viewsets import BaseV2ViewSet
 from management.permissions import WorkspaceAccessPermission
 from management.relation_replicator.relation_replicator import ReplicationEventType
 from management.utils import validate_and_get_key, validate_uuid
-from management.workspace.relation_api_dual_write_workspace_handler import RelationApiDualWriteWorkspacepHandler
+from management.workspace.relation_api_dual_write_workspace_handler import RelationApiDualWriteWorkspaceHandler
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
 from rest_framework.filters import OrderingFilter
@@ -117,7 +117,7 @@ class WorkspaceViewSet(BaseV2ViewSet):
         with transaction.atomic():
             instance = Workspace.objects.select_for_update().filter(id=instance.id).get()
             response = super().destroy(request=request, args=args, kwargs=kwargs)
-            dual_write_handler = RelationApiDualWriteWorkspacepHandler(instance, ReplicationEventType.DELETE_WORKSPACE)
+            dual_write_handler = RelationApiDualWriteWorkspaceHandler(instance, ReplicationEventType.DELETE_WORKSPACE)
             dual_write_handler.replicate_deleted_workspace()
         return response
 


### PR DESCRIPTION
## Link(s) to Jira
- https://issues.redhat.com/browse/RHCLOUD-38719

## Description of Intent of Change(s)
HBI team says there are some other services need to make the work around. It would be better for us to fix it on our side.

## Local Testing
Unit tests

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Implement a mechanism to backfill null values in resource definitions for workspaces, specifically handling ungrouped hosts scenarios

New Features:
- Add functionality to replace null workspace values with ungrouped hosts workspace ID

Enhancements:
- Create a utility function to get or create ungrouped workspace for a tenant
- Modify resource definition handling to automatically populate null workspace values

Tests:
- Add comprehensive test cases for backfilling null workspace values
- Test scenarios with existing and non-existing ungrouped hosts workspaces