### PR TITLE
[RHCLOUD-39819] Workspace validation error fix

### DIFF
--- a/rbac/management/workspace/model.py
+++ b/rbac/management/workspace/model.py
@@ -76,7 +76,7 @@ class Workspace(TenantAwareModel):
         """Validate the model."""
         if self.type == self.Types.ROOT:
             if self.parent is not None:
-                raise ValidationError({"root_parent": "Root workspace must not have a parent."})
+                raise serializers.ValidationError({"root_parent": "Root workspace must not have a parent."})
         elif self.parent is None:
             if self.type == self.Types.STANDARD:
                 if self.parent_id is None:
@@ -86,9 +86,9 @@ class Workspace(TenantAwareModel):
             else:
                 raise ValidationError({"workspace": f"{self.type} workspaces must have a parent workspace."})
         elif self.type == self.Types.DEFAULT and self.parent.type != self.Types.ROOT:
-            raise ValidationError({"default_parent": "Default workspace must have a root parent."})
+            raise serializers.ValidationError({"default_parent": "Default workspace must have a root parent."})
         elif self.id == self.parent_id:
-            raise serializers.ValidationError({"parent_id": ("The parent_id and id values must not be the same.")})
+            raise serializers.ValidationError({"parent_id": "The parent_id and id values must not be the same."})
 
     def ancestors(self):
         """Return a list of ancestors for a Workspace instance."""

--- a/tests/management/workspace/test_model.py
+++ b/tests/management/workspace/test_model.py
@@ -21,6 +21,7 @@ from tests.identity_request import IdentityRequest
 
 from django.core.exceptions import ValidationError
 from django.db.models import ProtectedError
+from rest_framework import serializers
 
 
 class WorkspaceBaseTestCase(IdentityRequest):
@@ -290,7 +291,7 @@ class Types(WorkspaceBaseTestCase):
             Workspace.objects.create(name="Default", type=Workspace.Types.DEFAULT, tenant=tenant)
 
         default = Workspace.objects.create(name="Default", type=Workspace.Types.DEFAULT, tenant=tenant, parent=root)
-        with self.assertRaises(ValidationError) as assertion:
+        with self.assertRaises(serializers.ValidationError) as assertion:
             root.parent = default
             root.save()
             self.assertEqual(


### PR DESCRIPTION
## Link(s) to Jira
- [RHCLOUD-39819](https://issues.redhat.com/browse/RHCLOUD-39819)

## Description of Intent of Change(s)
use the `ValidationError` from the `rest framework` because the original `ValidationError` comes from `django.core.exceptions `and was not recognised when we call the [exception_handler](https://github.com/RedHatInsights/insights-rbac/blob/7107b955d2835ef65e546238e8e5144312b0bb9f/rbac/api/common/exception_handler.py#L92)

https://www.django-rest-framework.org/api-guide/exceptions/#exception-handling-in-rest-framework-views 

## Local Testing
try to change the parent_id of root or default workspace
```
PUT /api/rbac/v2/workspaces/<root_workspace_id>/
{
    "name": "Workspace name",
    "parent_id": <valid_workspace_id>
}
```
the expected response is 400 Bad Request
```
{
    "status": 400,
    "detail": "Can't update the 'parent_id' on a workspace directly",
    "instance": "/api/rbac/v2/workspaces/<workspace_id>/"
}
```

## Summary by Sourcery

Use Django REST Framework ValidationError for workspace parent validation and add tests to enforce parent_id constraints on root and default workspaces

Bug Fixes:
- Ensure workspace validation errors are recognized by the exception handler by switching to DRF ValidationError

Enhancements:
- Replace django.core.exceptions.ValidationError with rest_framework.serializers.ValidationError in workspace model validation

Tests:
- Add API tests to verify 400 responses when updating root or default workspace parent_id incorrectly
- Update model tests to expect serializers.ValidationError for parent constraint violations