### PR TITLE
[RHCLOUD-39826] Validation for name/description for default/root ungrouped workspaces

### DIFF
--- a/rbac/management/workspace/service.py
+++ b/rbac/management/workspace/service.py
@@ -56,6 +56,8 @@ class WorkspaceService:
 
     def update(self, instance: Workspace, validated_data: dict) -> Workspace:
         """Update workspace."""
+        if instance.type in (Workspace.Types.ROOT, Workspace.Types.UNGROUPED_HOSTS):
+            raise serializers.ValidationError(f"The {instance.type} workspace cannot be updated.")
         for attr, value in validated_data.items():
             if self._parent_id_attr_update(attr, value, instance):
                 raise serializers.ValidationError("Can't update the 'parent_id' on a workspace directly")

--- a/tests/management/workspace/test_service.py
+++ b/tests/management/workspace/test_service.py
@@ -40,6 +40,9 @@ class WorkspaceServiceTestBase(TestCase):
         cls.standard_child_workspace = Workspace.objects.create(
             name="Standard Child", type=Workspace.Types.STANDARD, tenant=cls.tenant, parent=cls.standard_workspace
         )
+        cls.ungrouped_workspace = Workspace.objects.create(
+            name="Ungrouped", type=Workspace.Types.UNGROUPED_HOSTS, tenant=cls.tenant, parent=cls.default_workspace
+        )
 
 
 class WorkspaceServiceCreateTests(WorkspaceServiceTestBase):
@@ -94,15 +97,37 @@ class WorkspaceServiceUpdateTests(WorkspaceServiceTestBase):
             self.service.update(self.standard_workspace, validated_data)
         self.assertIn("Can't update the 'parent_id' on a workspace directly", str(context.exception))
 
+    def test_update_root_workspace(self):
+        """Test we cannot update the root workspace."""
+        validated_data = {"name": "Bar Name", "description": "Bar Desc"}
+        with self.assertRaises(serializers.ValidationError) as context:
+            self.service.update(self.root_workspace, validated_data)
+        self.assertIn("The root workspace cannot be updated.", str(context.exception))
+
+    def test_update_default_workspace(self):
+        """Test we can update the default workspace."""
+        validated_data = {"name": "Default new name", "description": "Default new description"}
+        updated_instance = self.service.update(self.default_workspace, validated_data)
+        self.assertEqual(updated_instance.name, validated_data["name"])
+        self.assertEqual(updated_instance.description, validated_data["description"])
+
+    def test_update_ungrouped_workspace(self):
+        """Test we cannot update the ungrouped workspace."""
+        validated_data = {"name": "Bar Name", "description": "Bar Desc"}
+        with self.assertRaises(serializers.ValidationError) as context:
+            self.service.update(self.ungrouped_workspace, validated_data)
+        self.assertIn("The ungrouped-hosts workspace cannot be updated.", str(context.exception))
+
 
 class WorkspaceServiceDestroyTests(WorkspaceServiceTestBase):
     """Tests for the destroy method"""
 
     def test_destroy_non_standard(self):
         """Test the destroy method on non-standard workspaces"""
-        with self.assertRaises(serializers.ValidationError) as context:
-            self.service.destroy(self.default_workspace)
-        self.assertIn(f"Unable to delete {self.default_workspace.type} workspace", str(context.exception))
+        for workspace in (self.default_workspace, self.root_workspace, self.ungrouped_workspace):
+            with self.assertRaises(serializers.ValidationError) as context:
+                self.service.destroy(workspace)
+            self.assertIn(f"Unable to delete {workspace.type} workspace", str(context.exception))
 
     def test_destroy_when_parent(self):
         """Test the destroy method on parent workspaces"""

--- a/tests/management/workspace/test_view.py
+++ b/tests/management/workspace/test_view.py
@@ -57,7 +57,9 @@ class WorkspaceViewTests(IdentityRequest):
 
 
 @override_settings(V2_APIS_ENABLED=True)
-class WorkspaceViewTestsV2Enabled(WorkspaceViewTests):
+class WorkspaceTestsCreateUpdateDelete(WorkspaceViewTests):
+    """Tests for create/update/delete workspaces."""
+
     def setUp(self):
         super().setUp()
         self.root_workspace = Workspace.objects.create(
@@ -69,6 +71,7 @@ class WorkspaceViewTestsV2Enabled(WorkspaceViewTests):
             tenant=self.tenant,
             type=Workspace.Types.DEFAULT,
             name="Default Workspace",
+            description="Default Description",
             parent_id=self.root_workspace.id,
         )
         self.standard_workspace = Workspace.objects.create(
@@ -77,6 +80,13 @@ class WorkspaceViewTestsV2Enabled(WorkspaceViewTests):
             tenant=self.tenant,
             parent=self.default_workspace,
             type=Workspace.Types.STANDARD,
+        )
+        self.ungrouped_workspace = Workspace.objects.create(
+            name="Ungrouped Hosts Workspace",
+            description="Ungrouped Hosts Workspace - description",
+            tenant=self.tenant,
+            parent=self.default_workspace,
+            type=Workspace.Types.UNGROUPED_HOSTS,
         )
         self.tuples = InMemoryTuples()
         self.in_memory_replicator = InMemoryRelationReplicator(self.tuples)
@@ -438,7 +448,7 @@ class WorkspaceViewTestsV2Enabled(WorkspaceViewTests):
         self.assertEqual(status_code, 403)
         self.assertEqual(response.get("content-type"), "application/problem+json")
 
-    def test_update_root_workspace_fail(self):
+    def test_update_root_workspace_parent_id_fail(self):
         """Test we cannot update parent id for root workspace."""
         client = APIClient()
         url = reverse("v2_management:workspace-detail", kwargs={"pk": self.root_workspace.id})
@@ -460,9 +470,77 @@ class WorkspaceViewTestsV2Enabled(WorkspaceViewTests):
             response = client.put(url, test_data, format="json", **self.headers)
             self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
             resp_body = json.loads(response.content.decode())
-            self.assertEqual(resp_body.get("detail"), "Can't update the 'parent_id' on a workspace directly")
+            self.assertEqual(resp_body.get("detail"), "The root workspace cannot be updated.")
 
-    def test_update_default_workspace_fail(self):
+    def test_update_root_workspace_name_description_fail(self):
+        """Test we cannot update name and/or description for root workspace."""
+        client = APIClient()
+        url = reverse("v2_management:workspace-detail", kwargs={"pk": self.root_workspace.id})
+
+        # Test data cases:
+        #    - name and description update,
+        #    - only name update
+        #    - only description update (name without change but must be present because the field is required)
+        test_data_cases = [
+            {"name": "New name", "description": "New description"},
+            {"name": "New name"},
+            {"name": self.root_workspace.name, "description": "New description"},
+        ]
+
+        for test_data in test_data_cases:
+            for method in ("put", "patch"):  # try to update via PUT and PATCH endpoint
+                response = getattr(client, method)(url, test_data, format="json", **self.headers)
+                self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+                resp_body = json.loads(response.content.decode())
+                self.assertEqual(resp_body.get("detail"), "The root workspace cannot be updated.")
+
+    def test_update_ungrouped_workspace_parent_id_fail(self):
+        """Test we cannot update parent id for ungrouped workspace."""
+        client = APIClient()
+        url = reverse("v2_management:workspace-detail", kwargs={"pk": self.ungrouped_workspace.id})
+
+        # Test with not existing uuid, with ungrouped workspace's own id, with existing workspace id
+        invalid_id = "a5b82afe-a74a-4d4d-98e5-f49ea78e5910"
+        ungrouped_id = self.ungrouped_workspace.id
+        workspace_data = {
+            "name": "Workspace name",
+            "description": "Workspace description",
+            "tenant_id": self.tenant.id,
+            "parent_id": self.standard_workspace.id,
+        }
+        standard_workspace = Workspace.objects.create(**workspace_data)
+        standard_id = standard_workspace.id
+
+        for ws_id in invalid_id, ungrouped_id, standard_id:
+            test_data = {"name": "New Workspace Name", "parent_id": ws_id}
+            response = client.put(url, test_data, format="json", **self.headers)
+            self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+            resp_body = json.loads(response.content.decode())
+            self.assertEqual(resp_body.get("detail"), "The ungrouped-hosts workspace cannot be updated.")
+
+    def test_update_ungrouped_workspace_name_description_fail(self):
+        """Test we cannot update name and/or description for ungrouped workspace."""
+        client = APIClient()
+        url = reverse("v2_management:workspace-detail", kwargs={"pk": self.ungrouped_workspace.id})
+
+        # Test data cases:
+        #    - name and description update,
+        #    - only name update
+        #    - only description update (name without change but must be present because the field is required)
+        test_data_cases = [
+            {"name": "New name", "description": "New description"},
+            {"name": "New name"},
+            {"name": self.root_workspace.name, "description": "New description"},
+        ]
+
+        for test_data in test_data_cases:
+            for method in ("put", "patch"):  # try to update via PUT and PATCH endpoint
+                response = getattr(client, method)(url, test_data, format="json", **self.headers)
+                self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+                resp_body = json.loads(response.content.decode())
+                self.assertEqual(resp_body.get("detail"), "The ungrouped-hosts workspace cannot be updated.")
+
+    def test_update_default_workspace_parent_id_fail(self):
         """Test we cannot update parent id for default workspace."""
         client = APIClient()
         url = reverse("v2_management:workspace-detail", kwargs={"pk": self.default_workspace.id})
@@ -487,6 +565,36 @@ class WorkspaceViewTestsV2Enabled(WorkspaceViewTests):
             self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
             resp_body = json.loads(response.content.decode())
             self.assertEqual(resp_body.get("detail"), "Can't update the 'parent_id' on a workspace directly")
+
+    def test_update_default_workspace_name_description(self):
+        """Test we can update name and/or description for default workspace."""
+        client = APIClient()
+        url = reverse("v2_management:workspace-detail", kwargs={"pk": self.default_workspace.id})
+
+        # Test data cases:
+        #    - name and description update,
+        #    - only name update
+        #    - only description update (name without change but must be present because the field is required)
+        test_data_cases = [
+            {"name": "New name", "description": "New description"},
+            {"name": "New name", "description": self.default_workspace.description},
+            {"name": self.default_workspace.name, "description": "New description"},
+        ]
+
+        for test_data in test_data_cases:
+            for method in ("put", "patch"):  # try to update via PUT and PATCH endpoint
+                response = getattr(client, method)(url, test_data, format="json", **self.headers)
+                self.assertEqual(response.status_code, status.HTTP_200_OK)
+                resp_body = response.json()
+                self.assertEqual(resp_body.get("id"), str(self.default_workspace.id))
+                self.assertEqual(resp_body.get("name"), test_data["name"])
+                self.assertEqual(resp_body.get("description"), test_data["description"])
+                self.assertEqual(resp_body.get("type"), Workspace.Types.DEFAULT)
+                self.assertEqual(resp_body.get("parent_id"), str(self.default_workspace.parent_id))
+
+                # After test set the default values back
+                self.default_workspace.name = "Default"
+                self.default_workspace.description = "Default description"
 
     def test_edit_workspace_disregard_type(self):
         """Test for creating a workspace."""
@@ -715,13 +823,13 @@ class WorkspaceViewTestsV2Enabled(WorkspaceViewTests):
         self.assertEqual(detail, "Unable to delete due to workspace dependencies")
 
     def test_delete_workspace_with_non_standard_types(self):
+        """Test the non-standard (root, default, ungrouped-hosts) workspaces cannot be deleted."""
+        client = APIClient()
         # Root workspace can't be deleted
         url = reverse("v2_management:workspace-detail", kwargs={"pk": self.root_workspace.id})
-        client = APIClient()
         test_headers = self.headers.copy()
         test_headers["HTTP_ACCEPT"] = "application/problem+json"
         response = client.delete(url, None, format="json", **test_headers)
-
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         detail = response.data.get("detail")
         self.assertEqual(detail, "Unable to delete root workspace")
@@ -733,9 +841,16 @@ class WorkspaceViewTestsV2Enabled(WorkspaceViewTests):
         detail = response.data.get("detail")
         self.assertEqual(detail, "Unable to delete default workspace")
 
+        # Ungrouped workspace can't be deleted
+        url = reverse("v2_management:workspace-detail", kwargs={"pk": self.ungrouped_workspace.id})
+        response = client.delete(url, None, format="json", **test_headers)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        detail = response.data.get("detail")
+        self.assertEqual(detail, "Unable to delete ungrouped-hosts workspace")
+
 
 @override_settings(V2_APIS_ENABLED=True)
-class TestsList(WorkspaceViewTests):
+class WorkspaceTestsList(WorkspaceViewTests):
     """Tests for listing workspaces."""
 
     def setUp(self):


### PR DESCRIPTION
## Link(s) to Jira
- [RHCLOUD-39826](https://issues.redhat.com/browse/RHCLOUD-39826)

## Description of Intent of Change(s)

- The root workspace cannot be deleted or renamed.
- The default workspace cannot be deleted but it can be renamed.
- The ungrouped workspace cannot be deleted and it cannot be renamed.

this PR adds validation to prevent the root and ungrouped workspaces to be updated

the validation to prevent deletion is already [in place](https://github.com/RedHatInsights/insights-rbac/blob/77c15fbb8186e2ca89f451b08da3759da261cc92/rbac/management/workspace/service.py#L70) 

## Local Testing
**try to remove the root, default and ungrouped-hosts workspace**
```
DELETE /api/rbac/v2/workspaces/<workspace_id>/
```
example of the expected response:
```
{
    "status": 400,
    "detail": "Unable to delete default workspace",
    "instance": "/api/rbac/v2/workspaces/0196c988-bccd-76c3-a1b7-1a9c488f27d0/"
}
```

**try to update name and/or description of root or ungrouped-hosts workspace**
```
PUT /api/rbac/v2/workspaces/<workspace_id>/
PATCH /api/rbac/v2/workspaces/<workspace_id>/
{
  "name": "New name",
  "description": "New description"
}
```
example of the expected response:
```
{
    "status": 400,
    "detail": "The root workspace cannot be updated.",
    "instance": "/api/rbac/v2/workspaces/0196c988-bccc-7da3-a217-0baa6cec8043/"
}
```

**it is still possible to update name and/or description of default and standard workspace
it is still possible to remove the standard workspace**

## Summary by Sourcery

Enforce validation rules preventing name or description changes on root and ungrouped-hosts workspaces while retaining deletion guards, allow renaming of the default workspace, and add comprehensive view and service tests for these behaviors.

Enhancements:
- Prevent renaming or updating description of root and ungrouped-hosts workspaces
- Allow name and description updates for the default workspace

Tests:
- Add view tests to verify root and ungrouped-hosts workspaces cannot be updated
- Add view tests to verify default workspace name/description updates succeed
- Extend delete tests to cover ungrouped-hosts workspace deletion restriction
- Add service layer tests enforcing update restrictions for root and ungrouped-hosts workspaces
- Combine destroy tests for non-standard workspaces into a single loop

Chores:
- Rename test class for clarity