### PR TITLE
fix typo in the RelationApiDualWriteWorkspaceHandler

### DIFF
--- a/rbac/internal/views.py
+++ b/rbac/internal/views.py
@@ -59,7 +59,7 @@ from management.utils import (
     get_principal,
     groups_for_principal,
 )
-from management.workspace.relation_api_dual_write_workspace_handler import RelationApiDualWriteWorkspacepHandler
+from management.workspace.relation_api_dual_write_workspace_handler import RelationApiDualWriteWorkspaceHandler
 from management.workspace.serializer import WorkspaceSerializer
 from rest_framework import status
 
@@ -1418,7 +1418,7 @@ def retrieve_ungrouped_workspace(request):
                     name=Workspace.SpecialNames.UNGROUPED_HOSTS,
                     parent=default,
                 )
-                dual_write_handler = RelationApiDualWriteWorkspacepHandler(
+                dual_write_handler = RelationApiDualWriteWorkspaceHandler(
                     ungrouped_hosts, ReplicationEventType.CREATE_WORKSPACE
                 )
                 dual_write_handler.replicate_new_workspace()

--- a/rbac/management/workspace/relation_api_dual_write_workspace_handler.py
+++ b/rbac/management/workspace/relation_api_dual_write_workspace_handler.py
@@ -35,7 +35,7 @@ from migration_tool.utils import create_relationship
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
 
-class RelationApiDualWriteWorkspacepHandler(BaseRelationApiDualWriteHandler):
+class RelationApiDualWriteWorkspaceHandler(BaseRelationApiDualWriteHandler):
     """Class to handle Dual Write for group bindings and membership."""
 
     workspace: Workspace

--- a/rbac/management/workspace/service.py
+++ b/rbac/management/workspace/service.py
@@ -19,7 +19,7 @@ from django.core.exceptions import ValidationError
 from django.db import transaction
 from management.models import Workspace
 from management.relation_replicator.relation_replicator import ReplicationEventType
-from management.workspace.relation_api_dual_write_workspace_handler import RelationApiDualWriteWorkspacepHandler
+from management.workspace.relation_api_dual_write_workspace_handler import RelationApiDualWriteWorkspaceHandler
 from rest_framework import serializers
 
 from api.models import Tenant
@@ -38,7 +38,7 @@ class WorkspaceService:
                     parent_id = default.id
                 parent = Workspace.objects.get(id=parent_id)
                 workspace = Workspace.objects.create(**validated_data, tenant=parent.tenant)
-                dual_write_handler = RelationApiDualWriteWorkspacepHandler(
+                dual_write_handler = RelationApiDualWriteWorkspaceHandler(
                     workspace, ReplicationEventType.CREATE_WORKSPACE
                 )
                 dual_write_handler.replicate_new_workspace()
@@ -63,7 +63,7 @@ class WorkspaceService:
                 raise serializers.ValidationError("Can't update the 'parent_id' on a workspace directly")
             setattr(instance, attr, value)
         instance.save()
-        dual_write_handler = RelationApiDualWriteWorkspacepHandler(instance, ReplicationEventType.UPDATE_WORKSPACE)
+        dual_write_handler = RelationApiDualWriteWorkspaceHandler(instance, ReplicationEventType.UPDATE_WORKSPACE)
         dual_write_handler.replicate_updated_workspace(instance.parent)
         return instance
 
@@ -74,7 +74,7 @@ class WorkspaceService:
         if Workspace.objects.filter(parent=instance, tenant=instance.tenant).exists():
             raise serializers.ValidationError("Unable to delete due to workspace dependencies")
 
-        dual_write_handler = RelationApiDualWriteWorkspacepHandler(instance, ReplicationEventType.DELETE_WORKSPACE)
+        dual_write_handler = RelationApiDualWriteWorkspaceHandler(instance, ReplicationEventType.DELETE_WORKSPACE)
         dual_write_handler.replicate_deleted_workspace()
         instance.delete()
 


### PR DESCRIPTION
## Summary by Sourcery

Fix typo in the dual-write workspace handler class name and its references

Bug Fixes:
- Rename RelationApiDualWriteWorkspacepHandler to RelationApiDualWriteWorkspaceHandler in service and view modules
- Rename the class definition in relation_api_dual_write_workspace_handler.py to drop the extra 'p'