### PR TITLE
remove print() from tests

### DIFF
--- a/tests/management/group/test_view.py
+++ b/tests/management/group/test_view.py
@@ -3687,8 +3687,6 @@ class GroupViewsetTests(IdentityRequest):
         url = url_base + f"&username_only=true"
         response = client.get(url, **self.headers)
 
-        print(response.json())
-
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data.get("data").get("serviceAccounts")), sa_count)
         self.assertEqual(len(response.data.get("data").get("users")), user_count)

--- a/tests/management/workspace/test_view.py
+++ b/tests/management/workspace/test_view.py
@@ -557,9 +557,7 @@ class WorkspaceTestsCreateUpdateDelete(WorkspaceViewTests):
         standard_workspace = Workspace.objects.create(**workspace_data)
         standard_id = standard_workspace.id
 
-        print("root", self.root_workspace.id)
         for ws_id in invalid_id, default_id, standard_id:
-            print(ws_id)
             test_data = {"name": "New Workspace Name", "parent_id": ws_id}
             response = client.put(url, test_data, format="json", **self.headers)
             self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
## Summary by Sourcery

Remove extraneous print statements from existing tests to clean up test output

Tests:
- Remove print() calls from group view tests
- Remove print() calls from workspace view tests