### PR TITLE
RHCLOUD-40153 | feature: upgrade Python version to 3.12

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.9'
+        python-version: '3.12'
 
     - name: Run Pre-Commit
       uses: pre-commit/action@v3.0.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 default_language_version:
-  python: python3.9
+  python: python3.12
 repos:
 - repo: https://github.com/PyCQA/flake8
   rev: "7.2.0"
@@ -12,7 +12,7 @@ repos:
   rev: 25.1.0
   hooks:
   - id: black
-    args: ["--check", "-l", "119", "-t", "py39", "rbac", "tests", "--diff"]
+    args: ["--check", "-l", "119", "-t", "py312", "rbac", "tests", "--diff"]
     require_serial: true
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v5.0.0

--- a/.tekton/insights-rbac-pull-request.yaml
+++ b/.tekton/insights-rbac-pull-request.yaml
@@ -246,7 +246,7 @@ spec:
             value: $(params.POSTGRESQL_PORT)
           - name: DATABASE_HOST
             value: $(params.DATABASE_HOST)
-          image: registry.access.redhat.com/ubi9/python-39:latest
+          image: registry.access.redhat.com/ubi9/python-312:latest
           name: unit-tests
           script: |
             #!/bin/bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5-1747111267 AS base
 
 USER root
 
-ENV PYTHON_VERSION=3.9 \
+ENV PYTHON_VERSION=3.12 \
     PYTHONUNBUFFERED=1 \
     PYTHONIOENCODING=UTF-8 \
     LC_ALL=en_US.UTF-8 \
@@ -26,8 +26,8 @@ LABEL summary="$SUMMARY" \
       io.k8s.description="$DESCRIPTION" \
       io.k8s.display-name="insights-rbac" \
       io.openshift.expose-services="8080:http" \
-      io.openshift.tags="python,python39,rh-python39" \
-      com.redhat.component="python39-docker" \
+      io.openshift.tags="python,python312,rh-python312" \
+      com.redhat.component="python312-docker" \
       name="insights-rbac" \
       version="1" \
       maintainer="Red Hat Insights"
@@ -37,7 +37,7 @@ LABEL summary="$SUMMARY" \
 # glibc-langpack-en is needed to set locale to en_US and disable warning about it
 # gcc to compile some python packages (e.g. ciso8601)
 # shadow-utils to make useradd available
-RUN INSTALL_PKGS="python3 python3-devel glibc-langpack-en libpq-devel gcc shadow-utils" && \
+RUN INSTALL_PKGS="python3.12 python3.12-devel glibc-langpack-en libpq-devel gcc shadow-utils" && \
     microdnf --nodocs -y upgrade && \
     microdnf -y --setopt=tsflags=nodocs --setopt=install_weak_deps=0 install $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
@@ -51,7 +51,7 @@ ARG USER_ID=1001
 # Create a Python virtual environment for use by any application to avoid
 # potential conflicts with Python packages preinstalled in the main Python
 # installation.
-RUN python3.9 -m venv /pipenv-venv
+RUN python3.12 -m venv /pipenv-venv
 ENV PATH="/pipenv-venv/bin:$PATH"
 # Install pipenv into the virtual env
 RUN \

--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ lint:
 	tox -elint
 
 format:
-	black -t py39 -l 119 rbac tests
+	black -t py312 -l 119 rbac tests
 
 typecheck:
 	mypy --install-types --non-interactive rbac

--- a/Pipfile
+++ b/Pipfile
@@ -58,7 +58,7 @@ pre-commit = "==4.2.0"
 mypy = "==1.15.0"
 
 [requires]
-python_version = "3.9"
+python_version = "3.12"
 
 [pipenv]
 allow_prereleases = true

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "c405ab152ff7ee28839abf1e4230be4c6e261d252efc46f62850fdead80e8f02"
+            "sha256": "e882b7c8392d08121d2966c8d1800a806ec89ba5239a7cae793dbf8f07e08532"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.9"
+            "python_version": "3.12"
         },
         "sources": [
             {
@@ -53,7 +53,7 @@
                 "sha256:39e3809566ff85354557ec2398b55e096c8364bacac9405a7a1fa429e77fe76c",
                 "sha256:d9321a7a3d5a6a5e187e824d2fa0793ce379a202935782d555d6e9d2735677d3"
             ],
-            "markers": "python_version >= '3.8'",
+            "markers": "python_full_version < '3.11.3'",
             "version": "==5.0.1"
         },
         "billiard": {
@@ -70,16 +70,15 @@
                 "sha256:aa1424213678a249fe828fb9345deac5e33f9a2266fd1b23ec72e02857b018a2"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.9'",
             "version": "==1.38.20"
         },
         "botocore": {
             "hashes": [
-                "sha256:29685c91050a870c3809238dc5da1ac65a48a3a20b4bca46b6057dcb6b39c72a",
-                "sha256:a7f818672f10d7a080c2c4558428011c3e0abc1039a047d27ac76ec846158457"
+                "sha256:9788f7efe974328a38cbade64cc0b1e67d27944b899f88cb786ae362973133b6",
+                "sha256:a785d5e9a5eda88ad6ab9ed8b87d1f2ac409d0226bba6ff801c55359e94d91a8"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==1.38.23"
+            "version": "==1.38.27"
         },
         "celery": {
             "hashes": [
@@ -87,7 +86,6 @@
                 "sha256:504a19140e8d3029d5acad88330c541d4c3f64c789d85f94756762d8bca7e706"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.8'",
             "version": "==5.4.0"
         },
         "certifi": {
@@ -168,7 +166,7 @@
                 "sha256:f7f5baafcc48261359e14bcd6d9bff6d4b28d9103847c9e136694cb0501aef87",
                 "sha256:fc48c783f9c87e60831201f2cce7f3b2e4846bf4d8728eabe54d60700b318a0b"
             ],
-            "markers": "python_version >= '3.8'",
+            "markers": "platform_python_implementation != 'PyPy'",
             "version": "==1.17.1"
         },
         "charset-normalizer": {
@@ -302,46 +300,46 @@
         },
         "cryptography": {
             "hashes": [
-                "sha256:057723b79752a142efbc609e90b0dff27b0361ccbee3bd48312d70f5cdf53b78",
-                "sha256:05c2385b1f5c89a17df19900cfb1345115a77168f5ed44bdf6fd3de1ce5cc65b",
-                "sha256:08281de408e7eb71ba3cd5098709a356bfdf65eebd7ee7633c3610f0aa80d79b",
-                "sha256:10d68763892a7b19c22508ab57799c4423c7c8cd61d7eee4c5a6a55a46511949",
-                "sha256:1655d3a76e3dedb683c982a6c3a2cbfae2d08f47a48ec5a3d58db52b3d29ea6f",
-                "sha256:18f8084b7ca3ce1b8d38bdfe33c48116edf9a08b4d056ef4a96dceaa36d8d965",
-                "sha256:2cb03a944a1a412724d15a7c051d50e63a868031f26b6a312f2016965b661942",
-                "sha256:4142e20c29224cec63e9e32eb1e6014fb285fe39b7be66b3564ca978a3a8afe9",
-                "sha256:463096533acd5097f8751115bc600b0b64620c4aafcac10c6d0041e6e68f88fe",
-                "sha256:48caa55c528617fa6db1a9c3bf2e37ccb31b73e098ac2b71408d1f2db551dde4",
-                "sha256:49af56491473231159c98c2c26f1a8f3799a60e5cf0e872d00745b858ddac9d2",
-                "sha256:4cc31c66411e14dd70e2f384a9204a859dc25b05e1f303df0f5326691061b839",
-                "sha256:501de1296b2041dccf2115e3c7d4947430585601b251b140970ce255c5cfb985",
-                "sha256:59c0c8f043dd376bbd9d4f636223836aed50431af4c5a467ed9bf61520294627",
-                "sha256:614bca7c6ed0d8ad1dce683a6289afae1f880675b4090878a0136c3da16bc693",
-                "sha256:61a8b1bbddd9332917485b2453d1de49f142e6334ce1d97b7916d5a85d179c84",
-                "sha256:7429936146063bd1b2cfc54f0e04016b90ee9b1c908a7bed0800049cbace70eb",
-                "sha256:7c73968fbb7698a4c5d6160859db560d3aac160edde89c751edd5a8bc6560c88",
-                "sha256:80303ee6a02ef38c4253160446cbeb5c400c07e01d4ddbd4ff722a89b736d95a",
-                "sha256:965611880c3fa8e504b7458484c0697e00ae6e937279cd6734fdaa2bc954dc49",
-                "sha256:9a900036b42f7324df7c7ad9569eb92ba0b613cf699160dd9c2154b24fd02f8e",
-                "sha256:9cfd1399064b13043082c660ddd97a0358e41c8b0dc7b77c1243e013d305c344",
-                "sha256:a8ec324711596fbf21837d3a5db543937dd84597d364769b46e0102250023f77",
-                "sha256:a9727a21957d3327cf6b7eb5ffc9e4b663909a25fea158e3fcbc49d4cdd7881b",
-                "sha256:b19f4b28dd2ef2e6d600307fee656c00825a2980c4356a7080bd758d633c3a6f",
-                "sha256:b2de529027579e43b6dc1f805f467b102fb7d13c1e54c334f1403ee2b37d0059",
-                "sha256:c0c000c1a09f069632d8a9eb3b610ac029fcc682f1d69b758e625d6ee713f4ed",
-                "sha256:cdafb86eb673c3211accffbffdb3cdffa3aaafacd14819e0898d23696d18e4d3",
-                "sha256:d2a90ce2f0f5b695e4785ac07c19a58244092f3c85d57db6d8eb1a2b26d2aad6",
-                "sha256:d784d57b958ffd07e9e226d17272f9af0c41572557604ca7554214def32c26bf",
-                "sha256:d891942592789fa0ab71b502550bbadb12f540d7413d7d7c4cef4b02af0f5bc6",
-                "sha256:dc7693573f16535428183de8fd27f0ca1ca37a51baa0b41dc5ed7b3d68fe80e2",
-                "sha256:ddb8d01aa900b741d6b7cc585a97aff787175f160ab975e21f880e89d810781a",
-                "sha256:e328357b6bbf79928363dbf13f4635b7aac0306afb7e5ad24d21d0c5761c3253",
-                "sha256:e86c8d54cd19a13e9081898b3c24351683fd39d726ecf8e774aaa9d8d96f5f3a",
-                "sha256:e9e4bdcd70216b08801e267c0b563316b787f957a46e215249921f99288456f9",
-                "sha256:f169469d04a23282de9d0be349499cb6683b6ff1b68901210faacac9b0c24b7d"
+                "sha256:00094838ecc7c6594171e8c8a9166124c1197b074cfca23645cee573910d76bc",
+                "sha256:050ce5209d5072472971e6efbfc8ec5a8f9a841de5a4db0ebd9c2e392cb81972",
+                "sha256:232954730c362638544758a8160c4ee1b832dc011d2c41a306ad8f7cccc5bb0b",
+                "sha256:25286aacb947286620a31f78f2ed1a32cded7be5d8b729ba3fb2c988457639e4",
+                "sha256:2f8f8f0b73b885ddd7f3d8c2b2234a7d3ba49002b0223f58cfde1bedd9563c56",
+                "sha256:38deed72285c7ed699864f964a3f4cf11ab3fb38e8d39cfcd96710cd2b5bb716",
+                "sha256:3ad69eeb92a9de9421e1f6685e85a10fbcfb75c833b42cc9bc2ba9fb00da4710",
+                "sha256:5555365a50efe1f486eed6ac7062c33b97ccef409f5970a0b6f205a7cfab59c8",
+                "sha256:555e5e2d3a53b4fabeca32835878b2818b3f23966a4efb0d566689777c5a12c8",
+                "sha256:57a6500d459e8035e813bd8b51b671977fb149a8c95ed814989da682314d0782",
+                "sha256:5833bb4355cb377ebd880457663a972cd044e7f49585aee39245c0d592904578",
+                "sha256:71320fbefd05454ef2d457c481ba9a5b0e540f3753354fff6f780927c25d19b0",
+                "sha256:7573d9eebaeceeb55285205dbbb8753ac1e962af3d9640791d12b36864065e71",
+                "sha256:92d5f428c1a0439b2040435a1d6bc1b26ebf0af88b093c3628913dd464d13fa1",
+                "sha256:97787952246a77d77934d41b62fb1b6f3581d83f71b44796a4158d93b8f5c490",
+                "sha256:9bb5bf55dcb69f7067d80354d0a348368da907345a2c448b0babc4215ccd3497",
+                "sha256:9cc80ce69032ffa528b5e16d217fa4d8d4bb7d6ba8659c1b4d74a1b0f4235fca",
+                "sha256:9e4253ed8f5948a3589b3caee7ad9a5bf218ffd16869c516535325fece163dcc",
+                "sha256:9eda14f049d7f09c2e8fb411dda17dd6b16a3c76a1de5e249188a32aeb92de19",
+                "sha256:a2b56de3417fd5f48773ad8e91abaa700b678dc7fe1e0c757e1ae340779acf7b",
+                "sha256:af3f92b1dc25621f5fad065288a44ac790c5798e986a34d393ab27d2b27fcff9",
+                "sha256:c5edcb90da1843df85292ef3a313513766a78fbbb83f584a5a58fb001a5a9d57",
+                "sha256:c824c9281cb628015bfc3c59335163d4ca0540d49de4582d6c2637312907e4b1",
+                "sha256:c92519d242703b675ccefd0f0562eb45e74d438e001f8ab52d628e885751fb06",
+                "sha256:ca932e11218bcc9ef812aa497cdf669484870ecbcf2d99b765d6c27a86000942",
+                "sha256:cb6ab89421bc90e0422aca911c69044c2912fc3debb19bb3c1bfe28ee3dff6ab",
+                "sha256:cfd84777b4b6684955ce86156cfb5e08d75e80dc2585e10d69e47f014f0a5342",
+                "sha256:d377dde61c5d67eb4311eace661c3efda46c62113ff56bf05e2d679e02aebb5b",
+                "sha256:d54ae41e6bd70ea23707843021c778f151ca258081586f0cfa31d936ae43d1b2",
+                "sha256:dc10ec1e9f21f33420cc05214989544727e776286c1c16697178978327b95c9c",
+                "sha256:ec21313dd335c51d7877baf2972569f40a4291b76a0ce51391523ae358d05899",
+                "sha256:ec64ee375b5aaa354b2b273c921144a660a511f9df8785e6d1c942967106438e",
+                "sha256:ed43d396f42028c1f47b5fec012e9e12631266e3825e95c00e3cf94d472dac49",
+                "sha256:edd6d51869beb7f0d472e902ef231a9b7689508e83880ea16ca3311a00bf5ce7",
+                "sha256:f22af3c78abfbc7cbcdf2c55d23c3e022e1a462ee2481011d518c7fb9c9f3d65",
+                "sha256:fae1e637f527750811588e4582988932c222f8251f7b7ea93739acb624e1487f",
+                "sha256:fed5aaca1750e46db870874c9c273cd5182a9e9deb16f06f7bdffdb5c2bde4b9"
             ],
             "markers": "python_version >= '3.7' and python_full_version not in '3.9.0, 3.9.1'",
-            "version": "==45.0.2"
+            "version": "==45.0.3"
         },
         "django": {
             "hashes": [
@@ -349,7 +347,6 @@
                 "sha256:b54ac28d6aa964fc7c2f7335138a54d78980232011e0cd2231d04eed393dcb0d"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.8'",
             "version": "==4.2.21"
         },
         "django-cors-headers": {
@@ -358,7 +355,6 @@
                 "sha256:f1c125dcd58479fe7a67fe2499c16ee38b81b397463cf025f0e2c42937421070"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.9'",
             "version": "==4.7.0"
         },
         "django-environ": {
@@ -367,7 +363,6 @@
                 "sha256:92fb346a158abda07ffe6eb23135ce92843af06ecf8753f43adf9d2366dcc0ca"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.9' and python_version < '4'",
             "version": "==0.12.0"
         },
         "django-extensions": {
@@ -376,7 +371,6 @@
                 "sha256:9600b7562f79a92cbf1fde6403c04fee314608fefbb595502e34383ae8203401"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.6'",
             "version": "==3.2.3"
         },
         "django-filter": {
@@ -385,7 +379,6 @@
                 "sha256:ed473b76e84f7e83b2511bb2050c3efb36d135207d0128dfe3ae4b36e3594ba5"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.7'",
             "version": "==22.1"
         },
         "django-prometheus": {
@@ -409,7 +402,6 @@
                 "sha256:f022ff46613584de994c0c6a4aebbace5fd700555fbe9d33b865ebf173eba6c9"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.9'",
             "version": "==3.16.0"
         },
         "djangorestframework-csv": {
@@ -425,7 +417,6 @@
                 "sha256:f6e22d267770b06f797076f49b5fcc9d97108b22f452f5f9ed4b5367b1e61b5b"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.6'",
             "version": "==2.2.0"
         },
         "googleapis-common-protos": {
@@ -491,7 +482,6 @@
                 "sha256:f9c30c464cb2ddfbc2ddf9400287701270fdc0f14be5f08a1e3939f1e749b455"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.9'",
             "version": "==1.71.0"
         },
         "grpcio-status": {
@@ -500,7 +490,6 @@
                 "sha256:843934ef8c09e3e858952887467f8256aac3910c55f077a359a65b2b3cde3e68"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.9'",
             "version": "==1.71.0"
         },
         "grpcio-tools": {
@@ -566,7 +555,6 @@
                 "sha256:f014447a0101dc57e294f6c18ca6b40227a4c90e9bdb586042628030cba004ec"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.7'",
             "version": "==23.0.0"
         },
         "idna": {
@@ -583,7 +571,6 @@
                 "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.7'",
             "version": "==3.1.6"
         },
         "jmespath": {
@@ -600,7 +587,6 @@
                 "sha256:ecf3a5999f89d3a663485ab7c4f633541586d6f44e664ee760197299f39ed51b"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.8'",
             "version": "==1.0.4"
         },
         "kafka-python": {
@@ -700,7 +686,6 @@
                 "sha256:594b45c410d6f4f8888940fe80b5cc2521b305a1fafe1c58609ef715a001f301"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.8'",
             "version": "==0.21.1"
         },
         "prompt-toolkit": {
@@ -713,20 +698,20 @@
         },
         "protobuf": {
             "hashes": [
-                "sha256:13eb236f8eb9ec34e63fc8b1d6efd2777d062fa6aaa68268fb67cf77f6839ad7",
-                "sha256:1832f0515b62d12d8e6ffc078d7e9eb06969aa6dc13c13e1036e39d73bebc2de",
-                "sha256:307ecba1d852ec237e9ba668e087326a67564ef83e45a0189a772ede9e854dd0",
-                "sha256:3fde11b505e1597f71b875ef2fc52062b6a9740e5f7c8997ce878b6009145862",
-                "sha256:476cb7b14914c780605a8cf62e38c2a85f8caff2e28a6a0bad827ec7d6c85d68",
-                "sha256:4f1dfcd7997b31ef8f53ec82781ff434a28bf71d9102ddde14d076adcfc78c99",
-                "sha256:678974e1e3a9b975b8bc2447fca458db5f93a2fb6b0c8db46b6675b5b5346812",
-                "sha256:aec4962f9ea93c431d5714ed1be1c93f13e1a8618e70035ba2b0564d9e633f2e",
-                "sha256:bcefcdf3976233f8a502d265eb65ea740c989bacc6c30a58290ed0e519eb4b8d",
-                "sha256:d7d3f7d1d5a66ed4942d4fefb12ac4b14a29028b209d4bfb25c68ae172059922",
-                "sha256:fd32223020cb25a2cc100366f1dedc904e2d71d9322403224cdde5fdced0dabe"
+                "sha256:3f1c6468a2cfd102ff4703976138844f78ebd1fb45f49011afc5139e9e283079",
+                "sha256:3f76e3a3675b4a4d867b52e4a5f5b78a2ef9565549d4037e06cf7b0942b1d3fc",
+                "sha256:470f3af547ef17847a28e1f47200a1cbf0ba3ff57b7de50d22776607cd2ea353",
+                "sha256:63848923da3325e1bf7e9003d680ce6e14b07e55d0473253a690c3a8b8fd6e61",
+                "sha256:6cf42630262c59b2d8de33954443d94b746c952b01434fc58a417fdbd2e84bd5",
+                "sha256:6f642dc9a61782fa72b90878af134c5afe1917c89a568cd3476d758d3c3a0736",
+                "sha256:7318608d56b6402d2ea7704ff1e1e4597bee46d760e7e4dd42a3d45e24b87f2e",
+                "sha256:bc1463bafd4b0929216c35f437a8e28731a2b7fe3d98bb77a600efced5a15c84",
+                "sha256:e38c5add5a311f2a6eb0340716ef9b039c1dfa428b28f25a7838ac329204a671",
+                "sha256:ef91363ad4faba7b25d844ef1ada59ff1604184c0bcd8b39b8a6bef15e1af238",
+                "sha256:fa18533a299d7ab6c55a238bf8629311439995f2e7eca5caaff08663606e9015"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==5.29.4"
+            "version": "==5.29.5"
         },
         "protoc-gen-validate": {
             "hashes": [
@@ -734,7 +719,6 @@
                 "sha256:7f52989e2f0fd60f140ce55ebe7d361291dd31626ecba2ce8eb4605b7413d393"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.9'",
             "version": "==1.2.1"
         },
         "psycopg2": {
@@ -751,7 +735,6 @@
                 "sha256:c6f7b8561225f9e711a9c47087388a97fdc948211c10a4bccbf0ba68ab7b3b5a"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.8'",
             "version": "==2.9.10"
         },
         "pycparser": {
@@ -768,7 +751,6 @@
                 "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427"
             ],
             "index": "pypi",
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==2.9.0.post0"
         },
         "pytz": {
@@ -785,7 +767,6 @@
                 "sha256:ee7e1056b9aea0f04c6c2ed59452947f34c4940ee025f5dd83e6a6418b6989e4"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.8'",
             "version": "==5.2.1"
         },
         "relations-grpc-clients-python-kessel-project": {
@@ -794,7 +775,6 @@
                 "sha256:ec54158ed4a014c526fc0087de3f3b9d63f591bd9fd4191665dd224fe7886fef"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.9'",
             "version": "==0.3.9"
         },
         "requests": {
@@ -803,7 +783,6 @@
                 "sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.8'",
             "version": "==2.32.3"
         },
         "s3transfer": {
@@ -820,23 +799,22 @@
                 "sha256:c58935bfff8af6a0856d37e8adebdbc7b3281c2b632ec823ef03cd108d216ff0"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.6'",
             "version": "==2.27.0"
         },
         "setuptools": {
             "hashes": [
-                "sha256:49f7af965996f26d43c8ae34539c8d99c5042fbff34302ea151eaa9c207cd257",
-                "sha256:95a60484590d24103af13b686121328cc2736bee85de8936383111e421b9edc0"
+                "sha256:062d34222ad13e0cc312a4c02d73f059e86a4acbfbdea8f8f76b28c99f306922",
+                "sha256:f36b47402ecde768dbfafc46e8e4207b4360c654f1f3bb84475f0a28628fb19c"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==80.8.0"
+            "version": "==80.9.0"
         },
         "six": {
             "hashes": [
                 "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274",
                 "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.17.0"
         },
         "sqlparse": {
@@ -845,7 +823,6 @@
                 "sha256:cf2196ed3418f3ba5de6af7e82c694a9fbdbfecccdfc72e281548517081f16ca"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.8'",
             "version": "==0.5.3"
         },
         "stompest": {
@@ -860,7 +837,7 @@
                 "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d",
                 "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8"
             ],
-            "markers": "python_version >= '3.8'",
+            "markers": "python_version < '3.11'",
             "version": "==4.12.2"
         },
         "tzdata": {
@@ -869,7 +846,6 @@
                 "sha256:a48093786cdcde33cad18c2555e8532f34422074448fbc874186f0abd79565cd"
             ],
             "index": "pypi",
-            "markers": "python_version >= '2'",
             "version": "==2024.2"
         },
         "unicodecsv": {
@@ -884,7 +860,6 @@
                 "sha256:40c2dc0c681e47eb8f90e7e27bf6ff7df2e677421fd46756da1161c39ca70d32"
             ],
             "index": "pypi",
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
             "version": "==1.26.20"
         },
         "uuid-utils": {
@@ -918,7 +893,6 @@
                 "sha256:ffc49c33edf87d1ec8112a9b43e4cf55326877716f929c165a2cc307d31c73d5"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.9'",
             "version": "==0.10.0"
         },
         "validate-email": {
@@ -941,7 +915,6 @@
                 "sha256:c66283efb4af22f1dd7565b12450dad4ef9175878f3d65b56ccff0dcf0a53c28"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.6'",
             "version": "==3.0.0"
         },
         "wcwidth": {
@@ -965,7 +938,6 @@
                 "sha256:a02d6660ad161ff17e3042653c8e3f5ecbb2a2481a006bde125b9efb9a30113a"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.7'",
             "version": "==6.4.0"
         },
         "xmltodict": {
@@ -974,7 +946,6 @@
                 "sha256:aa89e8fd76320154a40d19a0df04a4695fb9dc5ba977cbb68ab3e4eb225e7852"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.4'",
             "version": "==0.13.0"
         }
     },
@@ -1021,7 +992,6 @@
                 "sha256:f3df5f1bf91d36002b0a75389ca8663510cf0531cca8aa5c1ef695b46d98655f"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.9'",
             "version": "==25.1.0"
         },
         "cachetools": {
@@ -1110,7 +1080,7 @@
                 "sha256:f7f5baafcc48261359e14bcd6d9bff6d4b28d9103847c9e136694cb0501aef87",
                 "sha256:fc48c783f9c87e60831201f2cce7f3b2e4846bf4d8728eabe54d60700b318a0b"
             ],
-            "markers": "python_version >= '3.8'",
+            "markers": "platform_python_implementation != 'PyPy'",
             "version": "==1.17.1"
         },
         "cfgv": {
@@ -1314,51 +1284,50 @@
                 "sha256:fd51355ab8a372d89fb0e6a31719e825cf8df8b6724bee942fb5b92c3f016ba3"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.9'",
             "version": "==7.8.2"
         },
         "cryptography": {
             "hashes": [
-                "sha256:057723b79752a142efbc609e90b0dff27b0361ccbee3bd48312d70f5cdf53b78",
-                "sha256:05c2385b1f5c89a17df19900cfb1345115a77168f5ed44bdf6fd3de1ce5cc65b",
-                "sha256:08281de408e7eb71ba3cd5098709a356bfdf65eebd7ee7633c3610f0aa80d79b",
-                "sha256:10d68763892a7b19c22508ab57799c4423c7c8cd61d7eee4c5a6a55a46511949",
-                "sha256:1655d3a76e3dedb683c982a6c3a2cbfae2d08f47a48ec5a3d58db52b3d29ea6f",
-                "sha256:18f8084b7ca3ce1b8d38bdfe33c48116edf9a08b4d056ef4a96dceaa36d8d965",
-                "sha256:2cb03a944a1a412724d15a7c051d50e63a868031f26b6a312f2016965b661942",
-                "sha256:4142e20c29224cec63e9e32eb1e6014fb285fe39b7be66b3564ca978a3a8afe9",
-                "sha256:463096533acd5097f8751115bc600b0b64620c4aafcac10c6d0041e6e68f88fe",
-                "sha256:48caa55c528617fa6db1a9c3bf2e37ccb31b73e098ac2b71408d1f2db551dde4",
-                "sha256:49af56491473231159c98c2c26f1a8f3799a60e5cf0e872d00745b858ddac9d2",
-                "sha256:4cc31c66411e14dd70e2f384a9204a859dc25b05e1f303df0f5326691061b839",
-                "sha256:501de1296b2041dccf2115e3c7d4947430585601b251b140970ce255c5cfb985",
-                "sha256:59c0c8f043dd376bbd9d4f636223836aed50431af4c5a467ed9bf61520294627",
-                "sha256:614bca7c6ed0d8ad1dce683a6289afae1f880675b4090878a0136c3da16bc693",
-                "sha256:61a8b1bbddd9332917485b2453d1de49f142e6334ce1d97b7916d5a85d179c84",
-                "sha256:7429936146063bd1b2cfc54f0e04016b90ee9b1c908a7bed0800049cbace70eb",
-                "sha256:7c73968fbb7698a4c5d6160859db560d3aac160edde89c751edd5a8bc6560c88",
-                "sha256:80303ee6a02ef38c4253160446cbeb5c400c07e01d4ddbd4ff722a89b736d95a",
-                "sha256:965611880c3fa8e504b7458484c0697e00ae6e937279cd6734fdaa2bc954dc49",
-                "sha256:9a900036b42f7324df7c7ad9569eb92ba0b613cf699160dd9c2154b24fd02f8e",
-                "sha256:9cfd1399064b13043082c660ddd97a0358e41c8b0dc7b77c1243e013d305c344",
-                "sha256:a8ec324711596fbf21837d3a5db543937dd84597d364769b46e0102250023f77",
-                "sha256:a9727a21957d3327cf6b7eb5ffc9e4b663909a25fea158e3fcbc49d4cdd7881b",
-                "sha256:b19f4b28dd2ef2e6d600307fee656c00825a2980c4356a7080bd758d633c3a6f",
-                "sha256:b2de529027579e43b6dc1f805f467b102fb7d13c1e54c334f1403ee2b37d0059",
-                "sha256:c0c000c1a09f069632d8a9eb3b610ac029fcc682f1d69b758e625d6ee713f4ed",
-                "sha256:cdafb86eb673c3211accffbffdb3cdffa3aaafacd14819e0898d23696d18e4d3",
-                "sha256:d2a90ce2f0f5b695e4785ac07c19a58244092f3c85d57db6d8eb1a2b26d2aad6",
-                "sha256:d784d57b958ffd07e9e226d17272f9af0c41572557604ca7554214def32c26bf",
-                "sha256:d891942592789fa0ab71b502550bbadb12f540d7413d7d7c4cef4b02af0f5bc6",
-                "sha256:dc7693573f16535428183de8fd27f0ca1ca37a51baa0b41dc5ed7b3d68fe80e2",
-                "sha256:ddb8d01aa900b741d6b7cc585a97aff787175f160ab975e21f880e89d810781a",
-                "sha256:e328357b6bbf79928363dbf13f4635b7aac0306afb7e5ad24d21d0c5761c3253",
-                "sha256:e86c8d54cd19a13e9081898b3c24351683fd39d726ecf8e774aaa9d8d96f5f3a",
-                "sha256:e9e4bdcd70216b08801e267c0b563316b787f957a46e215249921f99288456f9",
-                "sha256:f169469d04a23282de9d0be349499cb6683b6ff1b68901210faacac9b0c24b7d"
+                "sha256:00094838ecc7c6594171e8c8a9166124c1197b074cfca23645cee573910d76bc",
+                "sha256:050ce5209d5072472971e6efbfc8ec5a8f9a841de5a4db0ebd9c2e392cb81972",
+                "sha256:232954730c362638544758a8160c4ee1b832dc011d2c41a306ad8f7cccc5bb0b",
+                "sha256:25286aacb947286620a31f78f2ed1a32cded7be5d8b729ba3fb2c988457639e4",
+                "sha256:2f8f8f0b73b885ddd7f3d8c2b2234a7d3ba49002b0223f58cfde1bedd9563c56",
+                "sha256:38deed72285c7ed699864f964a3f4cf11ab3fb38e8d39cfcd96710cd2b5bb716",
+                "sha256:3ad69eeb92a9de9421e1f6685e85a10fbcfb75c833b42cc9bc2ba9fb00da4710",
+                "sha256:5555365a50efe1f486eed6ac7062c33b97ccef409f5970a0b6f205a7cfab59c8",
+                "sha256:555e5e2d3a53b4fabeca32835878b2818b3f23966a4efb0d566689777c5a12c8",
+                "sha256:57a6500d459e8035e813bd8b51b671977fb149a8c95ed814989da682314d0782",
+                "sha256:5833bb4355cb377ebd880457663a972cd044e7f49585aee39245c0d592904578",
+                "sha256:71320fbefd05454ef2d457c481ba9a5b0e540f3753354fff6f780927c25d19b0",
+                "sha256:7573d9eebaeceeb55285205dbbb8753ac1e962af3d9640791d12b36864065e71",
+                "sha256:92d5f428c1a0439b2040435a1d6bc1b26ebf0af88b093c3628913dd464d13fa1",
+                "sha256:97787952246a77d77934d41b62fb1b6f3581d83f71b44796a4158d93b8f5c490",
+                "sha256:9bb5bf55dcb69f7067d80354d0a348368da907345a2c448b0babc4215ccd3497",
+                "sha256:9cc80ce69032ffa528b5e16d217fa4d8d4bb7d6ba8659c1b4d74a1b0f4235fca",
+                "sha256:9e4253ed8f5948a3589b3caee7ad9a5bf218ffd16869c516535325fece163dcc",
+                "sha256:9eda14f049d7f09c2e8fb411dda17dd6b16a3c76a1de5e249188a32aeb92de19",
+                "sha256:a2b56de3417fd5f48773ad8e91abaa700b678dc7fe1e0c757e1ae340779acf7b",
+                "sha256:af3f92b1dc25621f5fad065288a44ac790c5798e986a34d393ab27d2b27fcff9",
+                "sha256:c5edcb90da1843df85292ef3a313513766a78fbbb83f584a5a58fb001a5a9d57",
+                "sha256:c824c9281cb628015bfc3c59335163d4ca0540d49de4582d6c2637312907e4b1",
+                "sha256:c92519d242703b675ccefd0f0562eb45e74d438e001f8ab52d628e885751fb06",
+                "sha256:ca932e11218bcc9ef812aa497cdf669484870ecbcf2d99b765d6c27a86000942",
+                "sha256:cb6ab89421bc90e0422aca911c69044c2912fc3debb19bb3c1bfe28ee3dff6ab",
+                "sha256:cfd84777b4b6684955ce86156cfb5e08d75e80dc2585e10d69e47f014f0a5342",
+                "sha256:d377dde61c5d67eb4311eace661c3efda46c62113ff56bf05e2d679e02aebb5b",
+                "sha256:d54ae41e6bd70ea23707843021c778f151ca258081586f0cfa31d936ae43d1b2",
+                "sha256:dc10ec1e9f21f33420cc05214989544727e776286c1c16697178978327b95c9c",
+                "sha256:ec21313dd335c51d7877baf2972569f40a4291b76a0ce51391523ae358d05899",
+                "sha256:ec64ee375b5aaa354b2b273c921144a660a511f9df8785e6d1c942967106438e",
+                "sha256:ed43d396f42028c1f47b5fec012e9e12631266e3825e95c00e3cf94d472dac49",
+                "sha256:edd6d51869beb7f0d472e902ef231a9b7689508e83880ea16ca3311a00bf5ce7",
+                "sha256:f22af3c78abfbc7cbcdf2c55d23c3e022e1a462ee2481011d518c7fb9c9f3d65",
+                "sha256:fae1e637f527750811588e4582988932c222f8251f7b7ea93739acb624e1487f",
+                "sha256:fed5aaca1750e46db870874c9c273cd5182a9e9deb16f06f7bdffdb5c2bde4b9"
             ],
             "markers": "python_version >= '3.7' and python_full_version not in '3.9.0, 3.9.1'",
-            "version": "==45.0.2"
+            "version": "==45.0.3"
         },
         "distlib": {
             "hashes": [
@@ -1381,7 +1350,6 @@
                 "sha256:84bcf92bb725dd7341336eea4685df9a364f16f2470c4d29c1d7e6c5fd5a457d"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.7'",
             "version": "==18.13.0"
         },
         "filelock": {
@@ -1398,7 +1366,6 @@
                 "sha256:fa558ae3f6f7dbf2b4f22663e5343b6b6023620461f8d4ff2019ef4b5ee70426"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.9'",
             "version": "==7.2.0"
         },
         "flake8-docstrings": {
@@ -1407,7 +1374,6 @@
                 "sha256:51f2344026da083fc084166a9353f5082b01f72901df422f74b4d953ae88ac75"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.7'",
             "version": "==1.7.0"
         },
         "flake8-import-order": {
@@ -1454,7 +1420,7 @@
                 "sha256:d13b81ad223b890aa16c5471f2ac3056cf76c5f10f82d6f9292f0b415f389000",
                 "sha256:e5dd1551894c77868a30651cef00984d50e1002d06942a7101d34870c5f02afd"
             ],
-            "markers": "python_version >= '3.9'",
+            "markers": "python_version < '3.10'",
             "version": "==8.7.0"
         },
         "jinja2": {
@@ -1463,7 +1429,6 @@
                 "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.7'",
             "version": "==3.1.6"
         },
         "markupsafe": {
@@ -1577,7 +1542,6 @@
                 "sha256:f95579473af29ab73a10bada2f9722856792a36ec5af5399b653aa28360290a5"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.9'",
             "version": "==1.15.0"
         },
         "mypy-extensions": {
@@ -1634,7 +1598,6 @@
                 "sha256:a009ca7205f1eb497d10b845e52c838a98b6cdd2102a6c8e4540e94ee75c58bd"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.9'",
             "version": "==4.2.0"
         },
         "pycodestyle": {
@@ -1691,7 +1654,6 @@
                 "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427"
             ],
             "index": "pypi",
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==2.9.0.post0"
         },
         "pyyaml": {
@@ -1759,23 +1721,22 @@
                 "sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.8'",
             "version": "==2.32.3"
         },
         "setuptools": {
             "hashes": [
-                "sha256:49f7af965996f26d43c8ae34539c8d99c5042fbff34302ea151eaa9c207cd257",
-                "sha256:95a60484590d24103af13b686121328cc2736bee85de8936383111e421b9edc0"
+                "sha256:062d34222ad13e0cc312a4c02d73f059e86a4acbfbdea8f8f76b28c99f306922",
+                "sha256:f36b47402ecde768dbfafc46e8e4207b4360c654f1f3bb84475f0a28628fb19c"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==80.8.0"
+            "version": "==80.9.0"
         },
         "six": {
             "hashes": [
                 "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274",
                 "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.17.0"
         },
         "snowballstemmer": {
@@ -1783,7 +1744,7 @@
                 "sha256:6cd7b3897da8d6c9ffb968a6781fa6532dce9c3618a4b127d920dab764a19064",
                 "sha256:6d5eeeec8e9f84d4d56b847692bacf79bc2c8e90c7f80ca4444ff8b6f2e52895"
             ],
-            "markers": "python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==3.0.1"
         },
         "sphinx": {
@@ -1792,7 +1753,6 @@
                 "sha256:ebf612653238bcc8f4359627a9b7ce44ede6fdd75d9d30f68255c7383d3a6226"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.6'",
             "version": "==4.5.0"
         },
         "sphinx-rtd-theme": {
@@ -1801,7 +1761,6 @@
                 "sha256:590b030c7abb9cf038ec053b95e5380b5c70d61591eb0b552063fbe7c41f0931"
             ],
             "index": "pypi",
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
             "version": "==1.3.0"
         },
         "sphinxcontrib-applehelp": {
@@ -1895,7 +1854,7 @@
                 "sha256:ece47d672db52ac607a3d9599a9d48dcb2f2f735c6c2d1f34130085bb12b112a",
                 "sha256:f4039b9cbc3048b2416cc57ab3bda989a6fcf9b36cf8937f01a6e731b64f80d7"
             ],
-            "markers": "python_version >= '3.8'",
+            "markers": "python_version < '3.11'",
             "version": "==2.2.1"
         },
         "tox": {
@@ -1904,7 +1863,6 @@
                 "sha256:dd67f030317b80722cf52b246ff42aafd3ed27ddf331c415612d084304cf5e52"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.8'",
             "version": "==4.25.0"
         },
         "types-pyyaml": {
@@ -1913,7 +1871,6 @@
                 "sha256:9f21a70216fc0fa1b216a8176db5f9e0af6eb35d2f2932acb87689d03a5bf6ba"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.9'",
             "version": "==6.0.12.20250516"
         },
         "typing-extensions": {
@@ -1921,7 +1878,7 @@
                 "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d",
                 "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8"
             ],
-            "markers": "python_version >= '3.8'",
+            "markers": "python_version < '3.11'",
             "version": "==4.12.2"
         },
         "urllib3": {
@@ -1930,7 +1887,6 @@
                 "sha256:40c2dc0c681e47eb8f90e7e27bf6ff7df2e677421fd46756da1161c39ca70d32"
             ],
             "index": "pypi",
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
             "version": "==1.26.20"
         },
         "virtualenv": {
@@ -1943,11 +1899,11 @@
         },
         "zipp": {
             "hashes": [
-                "sha256:2c9958f6430a2040341a52eb608ed6dd93ef4392e02ffe219417c1b28b5dd1f4",
-                "sha256:ac1bbe05fd2991f160ebce24ffbac5f6d11d83dc90891255885223d42b3cd931"
+                "sha256:dd2f28c3ce4bc67507bfd3781d21b7bb2be31103b51a4553ad7d90b84e57ace5",
+                "sha256:fe208f65f2aca48b81f9e6fd8cf7b8b32c26375266b009b413d45306b6148343"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==3.21.0"
+            "version": "==3.22.0"
         }
     }
 }

--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ More info is available through platformdocs_.
 Getting Started
 ===============
 
-This is a Python project developed using Python 3.9. Make sure you have at least this version installed.
+This is a Python project developed using Python 3.12. Make sure you have at least this version installed.
 
 Additionally, the development environment installation requires the postgresql-devel package installed for your distribution before running properly.
 
@@ -187,7 +187,7 @@ This will rebuild the tox virtual env and then run all tests.
 
 To run unit tests specifically::
 
-    tox -e py39
+    tox -e py312
 
 To lint the code base ::
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,4 +1,4 @@
 [mypy]
-python_version = 3.9
+python_version = 3.12
 ignore_missing_imports = True
 disable_error_code = annotation-unchecked, var-annotated, misc, index

--- a/tests/management/group/test_view.py
+++ b/tests/management/group/test_view.py
@@ -7234,7 +7234,7 @@ class GroupReplicationTests(IdentityRequest):
         response = client.post(url, test_data, format="json", **self.headers)
 
         # Expect no new tuples
-        self.assertEquals(0, self.relations.count_tuples())
+        self.assertEqual(0, self.relations.count_tuples())
 
     @patch("management.relation_replicator.outbox_replicator.OutboxReplicator.replicate")
     def test_remove_role_added_twice_removes_role(self, replicate):

--- a/tests/management/management/commands/test_utils.py
+++ b/tests/management/management/commands/test_utils.py
@@ -80,7 +80,7 @@ class TestProcessBatch(TestCase):
 
         self.assertFalse(Tenant.objects.get(org_id="1000000").ready)
         self.assertFalse(Tenant.objects.get(org_id="10000001").ready)
-        self.assertEquals(2, Tenant.objects.exclude(tenant_name="public").count())
+        self.assertEqual(2, Tenant.objects.exclude(tenant_name="public").count())
 
     def test_existing_unready_tenants_are_kept_unready_but_still_bootstrapped(self):
         Tenant.objects.create(org_id="1000000", ready=False)

--- a/tests/management/role/test_dual_write.py
+++ b/tests/management/role/test_dual_write.py
@@ -340,8 +340,8 @@ class DualWriteGroupTestCase(DualWriteTestCase):
         """Create a group and add users to it."""
         group, principals = self.given_group("g1", ["u1", "u2"])
         tuples = self.tuples.find_tuples(all_of(resource("rbac", "group", group.uuid), relation("member")))
-        self.assertEquals(len(tuples), 2)
-        self.assertEquals({t.subject_id for t in tuples}, {f"localhost/{p.user_id}" for p in principals})
+        self.assertEqual(len(tuples), 2)
+        self.assertEqual({t.subject_id for t in tuples}, {f"localhost/{p.user_id}" for p in principals})
 
     def test_update_group_tuples(self):
         """Update a group by adding and removing users."""
@@ -350,15 +350,15 @@ class DualWriteGroupTestCase(DualWriteTestCase):
         principals += self.given_additional_group_members(group, ["u3"])
 
         tuples = self.tuples.find_tuples(all_of(resource("rbac", "group", group.uuid), relation("member")))
-        self.assertEquals(len(tuples), 3)
-        self.assertEquals({t.subject_id for t in tuples}, {f"localhost/{p.user_id}" for p in principals})
+        self.assertEqual(len(tuples), 3)
+        self.assertEqual({t.subject_id for t in tuples}, {f"localhost/{p.user_id}" for p in principals})
 
         self.given_removed_group_members(group, ["u2"])
         principals = [p for p in principals if p.username != "u2"]
 
         tuples = self.tuples.find_tuples(all_of(resource("rbac", "group", group.uuid), relation("member")))
-        self.assertEquals(len(tuples), 2)
-        self.assertEquals({t.subject_id for t in tuples}, {f"localhost/{p.user_id}" for p in principals})
+        self.assertEqual(len(tuples), 2)
+        self.assertEqual({t.subject_id for t in tuples}, {f"localhost/{p.user_id}" for p in principals})
 
     def test_custom_roles_group_assignments_tuples(self):
         role_1 = self.given_v1_role(
@@ -386,7 +386,7 @@ class DualWriteGroupTestCase(DualWriteTestCase):
             )
         )
 
-        self.assertEquals(len(tuples), 4)
+        self.assertEqual(len(tuples), 4)
         for mapping in mappings:
             for group_from_mapping in mapping["groups"]:
                 tuples = self.tuples.find_tuples(
@@ -396,14 +396,14 @@ class DualWriteGroupTestCase(DualWriteTestCase):
                         subject("rbac", "group", group_from_mapping, "member"),
                     )
                 )
-                self.assertEquals(len(tuples), 1)
-                self.assertEquals(tuples.only.subject_id, mapping["groups"][0])
+                self.assertEqual(len(tuples), 1)
+                self.assertEqual(tuples.only.subject_id, mapping["groups"][0])
 
         self.given_roles_unassigned_from_group(group, [role_1, role_2])
 
         mappings = BindingMapping.objects.filter(role=role_2).all()
         for m in mappings:
-            self.assertEquals(m.mappings["groups"], [])
+            self.assertEqual(m.mappings["groups"], [])
 
         tuples = self.tuples.find_tuples(
             all_of(
@@ -413,7 +413,7 @@ class DualWriteGroupTestCase(DualWriteTestCase):
             )
         )
 
-        self.assertEquals(len(tuples), 0)
+        self.assertEqual(len(tuples), 0)
 
     def test_adding_same_role_again_and_unassign_it_once(self):
         role_test = self.given_v1_role(
@@ -429,7 +429,7 @@ class DualWriteGroupTestCase(DualWriteTestCase):
 
         # See the group bound multiple times
         mappings = BindingMapping.objects.filter(role=role_test).first().mappings
-        self.assertEquals(len(mappings["groups"]), 2)
+        self.assertEqual(len(mappings["groups"]), 2)
         tuples = self.tuples.find_tuples(
             all_of(
                 resource("rbac", "role_binding", mappings["id"]),
@@ -437,7 +437,7 @@ class DualWriteGroupTestCase(DualWriteTestCase):
                 subject("rbac", "group", str(group.uuid), "member"),
             )
         )
-        self.assertEquals(len(tuples), 1)
+        self.assertEqual(len(tuples), 1)
         dual_write_handler = RelationApiDualWriteGroupHandler(
             group,
             ReplicationEventType.UNASSIGN_ROLE,
@@ -447,7 +447,7 @@ class DualWriteGroupTestCase(DualWriteTestCase):
         dual_write_handler.replicate()
 
         mappings = BindingMapping.objects.filter(role=role_test).first().mappings
-        self.assertEquals(len(mappings["groups"]), 1)
+        self.assertEqual(len(mappings["groups"]), 1)
         tuples = self.tuples.find_tuples(
             all_of(
                 resource("rbac", "role_binding", mappings["id"]),
@@ -455,7 +455,7 @@ class DualWriteGroupTestCase(DualWriteTestCase):
                 subject("rbac", "group", str(group.uuid), "member"),
             )
         )
-        self.assertEquals(len(tuples), 1)
+        self.assertEqual(len(tuples), 1)
 
     def test_reset_called_multiple_times_when_role_added_multiple_times(self):
         role_test = self.given_v1_system_role(
@@ -471,7 +471,7 @@ class DualWriteGroupTestCase(DualWriteTestCase):
 
         # See the group bound multiple times
         mappings = BindingMapping.objects.filter(role=role_test).first().mappings
-        self.assertEquals(len(mappings["groups"]), 3)
+        self.assertEqual(len(mappings["groups"]), 3)
         tuples = self.tuples.find_tuples(
             all_of(
                 resource("rbac", "role_binding", mappings["id"]),
@@ -479,7 +479,7 @@ class DualWriteGroupTestCase(DualWriteTestCase):
                 subject("rbac", "group", str(group.uuid), "member"),
             )
         )
-        self.assertEquals(len(tuples), 1)
+        self.assertEqual(len(tuples), 1)
 
         dual_write_handler = RelationApiDualWriteGroupHandler(
             group,
@@ -493,7 +493,7 @@ class DualWriteGroupTestCase(DualWriteTestCase):
         dual_write_handler.replicate()
 
         mappings = BindingMapping.objects.filter(role=role_test).first().mappings
-        self.assertEquals(len(mappings["groups"]), 1)
+        self.assertEqual(len(mappings["groups"]), 1)
         tuples = self.tuples.find_tuples(
             all_of(
                 resource("rbac", "role_binding", mappings["id"]),
@@ -501,7 +501,7 @@ class DualWriteGroupTestCase(DualWriteTestCase):
                 subject("rbac", "group", str(group.uuid), "member"),
             )
         )
-        self.assertEquals(len(tuples), 1)
+        self.assertEqual(len(tuples), 1)
 
     def test_reset_when_role_added_multiple_times(self):
         role_test = self.given_v1_system_role(
@@ -517,7 +517,7 @@ class DualWriteGroupTestCase(DualWriteTestCase):
 
         # See the group bound multiple times
         mappings = BindingMapping.objects.filter(role=role_test).first().mappings
-        self.assertEquals(len(mappings["groups"]), 3)
+        self.assertEqual(len(mappings["groups"]), 3)
         tuples = self.tuples.find_tuples(
             all_of(
                 resource("rbac", "role_binding", mappings["id"]),
@@ -525,7 +525,7 @@ class DualWriteGroupTestCase(DualWriteTestCase):
                 subject("rbac", "group", str(group.uuid), "member"),
             )
         )
-        self.assertEquals(len(tuples), 1)
+        self.assertEqual(len(tuples), 1)
 
         dual_write_handler = RelationApiDualWriteGroupHandler(
             group,
@@ -537,7 +537,7 @@ class DualWriteGroupTestCase(DualWriteTestCase):
         dual_write_handler.replicate()
 
         mappings = BindingMapping.objects.filter(role=role_test).first().mappings
-        self.assertEquals(len(mappings["groups"]), 1)
+        self.assertEqual(len(mappings["groups"]), 1)
         tuples = self.tuples.find_tuples(
             all_of(
                 resource("rbac", "role_binding", mappings["id"]),
@@ -545,7 +545,7 @@ class DualWriteGroupTestCase(DualWriteTestCase):
                 subject("rbac", "group", str(group.uuid), "member"),
             )
         )
-        self.assertEquals(len(tuples), 1)
+        self.assertEqual(len(tuples), 1)
 
     def test_delete_group_removes_group_from_role_bindings(self):
         # Add two groups to two roles
@@ -579,9 +579,9 @@ class DualWriteGroupTestCase(DualWriteTestCase):
             )
         )
 
-        self.assertEquals({t.subject_id for t in tuples}, {str(group_2.uuid)})
+        self.assertEqual({t.subject_id for t in tuples}, {str(group_2.uuid)})
         # 2 resources * 2 roles * 1 group = 4 role bindings
-        self.assertEquals(len(tuples), 4)
+        self.assertEqual(len(tuples), 4)
 
     def test_delete_group_removes_principals(self):
         group, _ = self.given_group("g1", ["u1", "u2"])
@@ -589,7 +589,7 @@ class DualWriteGroupTestCase(DualWriteTestCase):
         self.given_group_removed(group)
 
         tuples = self.tuples.find_tuples(all_of(resource("rbac", "group", group.uuid)))
-        self.assertEquals(len(tuples), 0)
+        self.assertEqual(len(tuples), 0)
 
     def test_delete_group_removes_role_binding_for_system_roles_if_last_group(self):
         role_1 = self.given_v1_role(
@@ -616,7 +616,7 @@ class DualWriteGroupTestCase(DualWriteTestCase):
             )
         )
 
-        self.assertEquals(len(tuples), 0)
+        self.assertEqual(len(tuples), 0)
 
         # But the custom role remains
         tuples = self.tuples.find_tuples(
@@ -628,7 +628,7 @@ class DualWriteGroupTestCase(DualWriteTestCase):
         )
 
         # 2 resources * 1 role
-        self.assertEquals(len(tuples), 2)
+        self.assertEqual(len(tuples), 2)
 
     def test_delete_group_keeps_role_binding_for_system_roles_if_not_last_group(self):
         """Keep the role binding if it still has other groups assigned to it."""
@@ -659,7 +659,7 @@ class DualWriteGroupTestCase(DualWriteTestCase):
             )
         )
 
-        self.assertEquals(len(tuples), 1)
+        self.assertEqual(len(tuples), 1)
 
 
 class DualWriteSystemRolesTestCase(DualWriteTestCase):
@@ -766,7 +766,7 @@ class DualWriteSystemRolesTestCase(DualWriteTestCase):
 
         # check if relations exist in replicator.
         tuples = self.tuples.find_tuples(predicate=resource_type("rbac", "role"))
-        self.assertEquals(len(tuples), 4)
+        self.assertEqual(len(tuples), 4)
 
         parents = [rel.resource_id for rel in tuples if rel.relation == "child" and rel.subject_id == str(role.uuid)]
         self.assertSetEqual(set([admin_default, platform_default]), set(parents))
@@ -782,7 +782,7 @@ class DualWriteSystemRolesTestCase(DualWriteTestCase):
 
         # check if only 2 relations exists in replicator.
         tuples = self.tuples.find_tuples(predicate=resource_type("rbac", "role"))
-        self.assertEquals(len(tuples), 2)
+        self.assertEqual(len(tuples), 2)
         parents = [rel.resource_id for rel in tuples if rel.relation == "child" and rel.subject_id == str(role.uuid)]
         self.assertSetEqual(set([platform_default]), set(parents))
 
@@ -796,7 +796,7 @@ class DualWriteSystemRolesTestCase(DualWriteTestCase):
         dual_write_handler.replicate_update_system_role(role)
 
         tuples = self.tuples.find_tuples(predicate=resource_type("rbac", "role"))
-        self.assertEquals(len(tuples), 0)
+        self.assertEqual(len(tuples), 0)
 
     def test_delete_system_role(self):
         platform_default_group, admin_default_group = seed_group()
@@ -809,7 +809,7 @@ class DualWriteSystemRolesTestCase(DualWriteTestCase):
 
         # check if relations exist in replicator.
         tuples = self.tuples.find_tuples(predicate=resource_type("rbac", "role"))
-        self.assertEquals(len(tuples), 4)
+        self.assertEqual(len(tuples), 4)
         parents = [rel.resource_id for rel in tuples if rel.relation == "child" and rel.subject_id == str(role.uuid)]
         self.assertSetEqual(set([admin_default, platform_default]), set(parents))
 
@@ -818,13 +818,13 @@ class DualWriteSystemRolesTestCase(DualWriteTestCase):
 
         # check if relations do not exist in replicator.
         tuples = self.tuples.find_tuples(predicate=resource_type("rbac", "role"))
-        self.assertEquals(len(tuples), 0)
+        self.assertEqual(len(tuples), 0)
 
         role = self.given_v1_system_role("d_r2", [], platform_default=True)
 
         # Check that it was created as platform default
         tuples = self.tuples.find_tuples(predicate=resource_type("rbac", "role"))
-        self.assertEquals(len(tuples), 1)
+        self.assertEqual(len(tuples), 1)
         parents = [rel.resource_id for rel in tuples if rel.relation == "child" and rel.subject_id == str(role.uuid)]
         self.assertSetEqual(set([platform_default]), set(parents))
 
@@ -834,13 +834,13 @@ class DualWriteSystemRolesTestCase(DualWriteTestCase):
 
         # Check if relations do not exist in replicator.
         tuples = self.tuples.find_tuples(predicate=resource_type("rbac", "role"))
-        self.assertEquals(len(tuples), 0)
+        self.assertEqual(len(tuples), 0)
 
         role = self.given_v1_system_role("d_r3", [], admin_default=True)
 
         # Check that it was created as platform default
         tuples = self.tuples.find_tuples(predicate=resource_type("rbac", "role"))
-        self.assertEquals(len(tuples), 1)
+        self.assertEqual(len(tuples), 1)
         parents = [rel.resource_id for rel in tuples if rel.relation == "child" and rel.subject_id == str(role.uuid)]
         self.assertSetEqual(set([admin_default]), set(parents))
 
@@ -850,14 +850,14 @@ class DualWriteSystemRolesTestCase(DualWriteTestCase):
 
         # Check if relations do not exist in replicator.
         tuples = self.tuples.find_tuples(predicate=resource_type("rbac", "role"))
-        self.assertEquals(len(tuples), 0)
+        self.assertEqual(len(tuples), 0)
 
         # create role with no relations
         role = self.given_v1_system_role("d_r4", [])
 
         # ensure no relations exist in replicator.
         tuples = self.tuples.find_tuples(predicate=resource_type("rbac", "role"))
-        self.assertEquals(len(tuples), 0)
+        self.assertEqual(len(tuples), 0)
 
         # delete system role
         dual_write_handler = SeedingRelationApiDualWriteHandler(replicator=InMemoryRelationReplicator(self.tuples))
@@ -865,7 +865,7 @@ class DualWriteSystemRolesTestCase(DualWriteTestCase):
 
         # check if relations do not exist in replicator.
         tuples = self.tuples.find_tuples(predicate=resource_type("rbac", "role"))
-        self.assertEquals(len(tuples), 0)
+        self.assertEqual(len(tuples), 0)
 
 
 class DualWriteCustomRolesTestCase(DualWriteTestCase):
@@ -1070,7 +1070,7 @@ class DualWriteCrossAccountReqeustTestCase(DualWriteTestCase):
 
         # See the user bound multiple times
         mappings = BindingMapping.objects.filter(role=system_role).first().mappings
-        self.assertEquals(len(mappings["users"]), 2)
+        self.assertEqual(len(mappings["users"]), 2)
         tuples = self.tuples.find_tuples(
             all_of(
                 resource("rbac", "role_binding", mappings["id"]),
@@ -1078,7 +1078,7 @@ class DualWriteCrossAccountReqeustTestCase(DualWriteTestCase):
                 subject("rbac", "principal", f"localhost/{user_id}", ""),
             )
         )
-        self.assertEquals(len(tuples), 1)
+        self.assertEqual(len(tuples), 1)
         dual_write_handler = RelationApiDualWriteCrossAccessHandler(
             car_1,
             ReplicationEventType.EXPIRE_CROSS_ACCOUNT_REQUEST,
@@ -1088,7 +1088,7 @@ class DualWriteCrossAccountReqeustTestCase(DualWriteTestCase):
         dual_write_handler.replicate()
 
         mappings = BindingMapping.objects.filter(role=system_role).first().mappings
-        self.assertEquals(len(mappings["users"]), 1)
+        self.assertEqual(len(mappings["users"]), 1)
         tuples = self.tuples.find_tuples(
             all_of(
                 resource("rbac", "role_binding", mappings["id"]),
@@ -1096,7 +1096,7 @@ class DualWriteCrossAccountReqeustTestCase(DualWriteTestCase):
                 subject("rbac", "principal", f"localhost/{user_id}", ""),
             )
         )
-        self.assertEquals(len(tuples), 1)
+        self.assertEqual(len(tuples), 1)
 
     def test_multiple_cars_for_same_user_and_reset_multiple_times(self):
         user_id_1 = "user_id_1"
@@ -1108,7 +1108,7 @@ class DualWriteCrossAccountReqeustTestCase(DualWriteTestCase):
 
         # See the user bound multiple times
         mappings = BindingMapping.objects.filter(role=system_role).first().mappings
-        self.assertEquals(len(mappings["users"]), 3)
+        self.assertEqual(len(mappings["users"]), 3)
         tuples = self.tuples.find_tuples(
             all_of(
                 resource("rbac", "role_binding", mappings["id"]),
@@ -1116,7 +1116,7 @@ class DualWriteCrossAccountReqeustTestCase(DualWriteTestCase):
                 subject("rbac", "principal", f"localhost/{user_id_1}", ""),
             )
         )
-        self.assertEquals(len(tuples), 1)
+        self.assertEqual(len(tuples), 1)
         tuples = self.tuples.find_tuples(
             all_of(
                 resource("rbac", "role_binding", mappings["id"]),
@@ -1124,7 +1124,7 @@ class DualWriteCrossAccountReqeustTestCase(DualWriteTestCase):
                 subject("rbac", "principal", f"localhost/{user_id_2}", ""),
             )
         )
-        self.assertEquals(len(tuples), 1)
+        self.assertEqual(len(tuples), 1)
 
         # Call reset and there would be only one user in mapping
         dual_write_handler = RelationApiDualWriteCrossAccessHandler(
@@ -1136,7 +1136,7 @@ class DualWriteCrossAccountReqeustTestCase(DualWriteTestCase):
         dual_write_handler.replicate()
 
         mapping = BindingMapping.objects.filter(role=system_role).first()
-        self.assertEquals(mapping.mappings["users"], {str(SourceKey(car_1, car_1.source_pk())): user_id_1})
+        self.assertEqual(mapping.mappings["users"], {str(SourceKey(car_1, car_1.source_pk())): user_id_1})
         tuples = self.tuples.find_tuples(
             all_of(
                 resource("rbac", "role_binding", mapping.mappings["id"]),
@@ -1144,7 +1144,7 @@ class DualWriteCrossAccountReqeustTestCase(DualWriteTestCase):
                 subject("rbac", "principal", f"localhost/{user_id_1}", ""),
             )
         )
-        self.assertEquals(len(tuples), 1)
+        self.assertEqual(len(tuples), 1)
         # user_id_2 is gone because we wipe the old format out
         tuples = self.tuples.find_tuples(
             all_of(
@@ -1153,13 +1153,13 @@ class DualWriteCrossAccountReqeustTestCase(DualWriteTestCase):
                 subject("rbac", "principal", f"localhost/{user_id_2}", ""),
             )
         )
-        self.assertEquals(len(tuples), 0)
+        self.assertEqual(len(tuples), 0)
 
         # Call reset again for car_1, should be the same
         dual_write_handler.generate_relations_reset_roles(car_1.roles.all())
         dual_write_handler.replicate()
         mapping.refresh_from_db()
-        self.assertEquals(mapping.mappings["users"], {str(SourceKey(car_1, car_1.source_pk())): user_id_1})
+        self.assertEqual(mapping.mappings["users"], {str(SourceKey(car_1, car_1.source_pk())): user_id_1})
         tuples = self.tuples.find_tuples(
             all_of(
                 resource("rbac", "role_binding", mapping.mappings["id"]),
@@ -1167,7 +1167,7 @@ class DualWriteCrossAccountReqeustTestCase(DualWriteTestCase):
                 subject("rbac", "principal", f"localhost/{user_id_1}", ""),
             )
         )
-        self.assertEquals(len(tuples), 1)
+        self.assertEqual(len(tuples), 1)
 
         # Call reset for car_2, it will appear in the mapping
         dual_write_handler = RelationApiDualWriteCrossAccessHandler(
@@ -1178,7 +1178,7 @@ class DualWriteCrossAccountReqeustTestCase(DualWriteTestCase):
         dual_write_handler.generate_relations_reset_roles(car_2.roles.all())
         dual_write_handler.replicate()
         mapping.refresh_from_db()
-        self.assertEquals(
+        self.assertEqual(
             mapping.mappings["users"],
             {str(SourceKey(car_1, car_1.source_pk())): user_id_1, str(SourceKey(car_2, car_2.source_pk())): user_id_2},
         )
@@ -1189,7 +1189,7 @@ class DualWriteCrossAccountReqeustTestCase(DualWriteTestCase):
                 subject("rbac", "principal", f"localhost/{user_id_2}", ""),
             )
         )
-        self.assertEquals(len(tuples), 1)
+        self.assertEqual(len(tuples), 1)
 
         # Call reset for car_3, it will appear in the mapping, but relation tuple
         # remains 1 cuase it is still creating relationship for user_id_1
@@ -1201,7 +1201,7 @@ class DualWriteCrossAccountReqeustTestCase(DualWriteTestCase):
         dual_write_handler.generate_relations_reset_roles(car_3.roles.all())
         dual_write_handler.replicate()
         mapping.refresh_from_db()
-        self.assertEquals(
+        self.assertEqual(
             mapping.mappings["users"],
             {
                 str(SourceKey(car_1, car_1.source_pk())): user_id_1,
@@ -1216,7 +1216,7 @@ class DualWriteCrossAccountReqeustTestCase(DualWriteTestCase):
                 subject("rbac", "principal", f"localhost/{user_id_1}", ""),
             )
         )
-        self.assertEquals(len(tuples), 1)
+        self.assertEqual(len(tuples), 1)
 
 
 class RbacFixture:

--- a/tests/management/role/test_view.py
+++ b/tests/management/role/test_view.py
@@ -452,7 +452,7 @@ class RoleViewsetTests(IdentityRequest):
         ]
         workspace = find_in_list(to_add, lambda r: r["resource"]["type"]["name"] == "workspace")
 
-        self.assertEquals(
+        self.assertEqual(
             role_binding,
             workspace["subject"]["subject"]["id"],
             "expected binding to workspace (not to excluded resource)",
@@ -460,7 +460,7 @@ class RoleViewsetTests(IdentityRequest):
 
         role = find_in_list(to_add, lambda r: r["resource"]["type"]["name"] == "role")
 
-        self.assertEquals(role["relation"], "app_all_read", "expected workspace permission")
+        self.assertEqual(role["relation"], "app_all_read", "expected workspace permission")
 
     @patch("management.relation_replicator.outbox_replicator.OutboxReplicator._save_replication_event")
     def test_create_role_with_display_success(self, mock_method):

--- a/tests/management/tenant/test_model.py
+++ b/tests/management/tenant/test_model.py
@@ -286,7 +286,7 @@ class V2TenantBootstrapServiceTest(TestCase):
         # new or otherwise unbootstrapped tenants get 9
         num_tenant_bootstrapping_tuples = 0 + 9 + 6 + 9
 
-        self.assertEquals(num_group_membership_tuples + num_tenant_bootstrapping_tuples, self.tuples.count_tuples())
+        self.assertEqual(num_group_membership_tuples + num_tenant_bootstrapping_tuples, self.tuples.count_tuples())
 
         # Assert user updated for first user with existing tenant
         self.assertAddedToDefaultGroup("localhost/u1", bootstrapped.mapping, and_admin_group=True)  # 2

--- a/tests/management/test_utils.py
+++ b/tests/management/test_utils.py
@@ -398,9 +398,9 @@ class UtilsTests(IdentityRequest):
 
     def test_value_to_list(self):
         """Test returning value to a list"""
-        self.assertEquals(value_to_list(1), [1])
-        self.assertEquals(value_to_list("foo"), ["foo"])
-        self.assertEquals(value_to_list(True), [True])
-        self.assertEquals(value_to_list([1]), [1])
-        self.assertEquals(value_to_list(["foo"]), ["foo"])
-        self.assertEquals(value_to_list([True]), [True])
+        self.assertEqual(value_to_list(1), [1])
+        self.assertEqual(value_to_list("foo"), ["foo"])
+        self.assertEqual(value_to_list(True), [True])
+        self.assertEqual(value_to_list([1]), [1])
+        self.assertEqual(value_to_list(["foo"]), ["foo"])
+        self.assertEqual(value_to_list([True]), [True])

--- a/tests/management/workspace/test_view.py
+++ b/tests/management/workspace/test_view.py
@@ -145,12 +145,12 @@ class WorkspaceTestsCreateUpdateDelete(WorkspaceViewTests):
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         data = response.data
         self.assertEqual(data.get("name"), "New Workspace")
-        self.assertNotEquals(data.get("id"), "")
+        self.assertNotEqual(data.get("id"), "")
         self.assertIsNotNone(data.get("id"))
-        self.assertNotEquals(data.get("created"), "")
-        self.assertNotEquals(data.get("modified"), "")
-        self.assertEquals(data.get("description"), "Workspace")
-        self.assertEquals(data.get("type"), "standard")
+        self.assertNotEqual(data.get("created"), "")
+        self.assertNotEqual(data.get("modified"), "")
+        self.assertEqual(data.get("description"), "Workspace")
+        self.assertEqual(data.get("type"), "standard")
         self.assertEqual(response.get("content-type"), "application/json")
         tuples = self.tuples.find_tuples(
             all_of(
@@ -178,12 +178,12 @@ class WorkspaceTestsCreateUpdateDelete(WorkspaceViewTests):
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         data = response.data
         self.assertEqual(data.get("name"), "Root Peer")
-        self.assertNotEquals(data.get("id"), "")
+        self.assertNotEqual(data.get("id"), "")
         self.assertIsNotNone(data.get("id"))
-        self.assertNotEquals(data.get("created"), "")
-        self.assertNotEquals(data.get("modified"), "")
-        self.assertEquals(data.get("description"), "Workspace")
-        self.assertEquals(data.get("type"), "standard")
+        self.assertNotEqual(data.get("created"), "")
+        self.assertNotEqual(data.get("modified"), "")
+        self.assertEqual(data.get("description"), "Workspace")
+        self.assertEqual(data.get("type"), "standard")
         self.assertEqual(response.get("content-type"), "application/json")
 
     def test_create_workspace_assign_parent_id(self):
@@ -201,13 +201,13 @@ class WorkspaceTestsCreateUpdateDelete(WorkspaceViewTests):
         data = response.data
 
         self.assertEqual(data.get("name"), "New Workspace")
-        self.assertNotEquals(data.get("id"), "")
-        self.assertNotEquals(data.get("parent_id"), data.get("id"))
+        self.assertNotEqual(data.get("id"), "")
+        self.assertNotEqual(data.get("parent_id"), data.get("id"))
         self.assertIsNotNone(data.get("id"))
-        self.assertNotEquals(data.get("created"), "")
-        self.assertNotEquals(data.get("modified"), "")
-        self.assertEquals(data.get("description"), "Workspace")
-        self.assertEquals(data.get("type"), "standard")
+        self.assertNotEqual(data.get("created"), "")
+        self.assertNotEqual(data.get("modified"), "")
+        self.assertEqual(data.get("description"), "Workspace")
+        self.assertEqual(data.get("type"), "standard")
         self.assertEqual(response.get("content-type"), "application/json")
 
     def test_create_workspace_empty_body(self):
@@ -344,16 +344,16 @@ class WorkspaceTestsCreateUpdateDelete(WorkspaceViewTests):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         data = response.data
         self.assertEqual(data.get("name"), "Updated name")
-        self.assertNotEquals(data.get("id"), "")
+        self.assertNotEqual(data.get("id"), "")
         self.assertIsNotNone(data.get("id"))
-        self.assertNotEquals(data.get("created"), "")
-        self.assertNotEquals(data.get("modified"), "")
-        self.assertEquals(data.get("type"), "standard")
-        self.assertEquals(data.get("description"), "Updated description")
+        self.assertNotEqual(data.get("created"), "")
+        self.assertNotEqual(data.get("modified"), "")
+        self.assertEqual(data.get("type"), "standard")
+        self.assertEqual(data.get("description"), "Updated description")
 
         update_workspace = Workspace.objects.filter(id=workspace.id).first()
-        self.assertEquals(update_workspace.name, "Updated name")
-        self.assertEquals(update_workspace.description, "Updated description")
+        self.assertEqual(update_workspace.name, "Updated name")
+        self.assertEqual(update_workspace.description, "Updated description")
         self.assertEqual(response.get("content-type"), "application/json")
 
         self.assertEqual(len(self.tuples), 0)
@@ -411,12 +411,12 @@ class WorkspaceTestsCreateUpdateDelete(WorkspaceViewTests):
         self.assertEqual(data.get("name"), "New Workspace")
         self.assertEqual(data.get("description"), "New Workspace - description")
         self.assertEqual(data.get("id"), str(workspace.id))
-        self.assertNotEquals(data.get("created"), "")
-        self.assertNotEquals(data.get("modified"), "")
-        self.assertEquals(data.get("type"), "standard")
+        self.assertNotEqual(data.get("created"), "")
+        self.assertNotEqual(data.get("modified"), "")
+        self.assertEqual(data.get("type"), "standard")
 
         update_workspace = Workspace.objects.filter(id=workspace.id).first()
-        self.assertEquals(update_workspace.name, "New Workspace")
+        self.assertEqual(update_workspace.name, "New Workspace")
 
     def test_update_workspace_update_parent_id(self):
         """Test for updating a workspace's parent_id."""
@@ -463,14 +463,14 @@ class WorkspaceTestsCreateUpdateDelete(WorkspaceViewTests):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         data = response.data
         self.assertEqual(data.get("name"), "Updated name")
-        self.assertNotEquals(data.get("id"), "")
+        self.assertNotEqual(data.get("id"), "")
         self.assertIsNotNone(data.get("id"))
-        self.assertNotEquals(data.get("created"), "")
-        self.assertNotEquals(data.get("modified"), "")
-        self.assertEquals(data.get("type"), "standard")
+        self.assertNotEqual(data.get("created"), "")
+        self.assertNotEqual(data.get("modified"), "")
+        self.assertEqual(data.get("type"), "standard")
 
         update_workspace = Workspace.objects.filter(id=workspace.id).first()
-        self.assertEquals(update_workspace.name, "Updated name")
+        self.assertEqual(update_workspace.name, "Updated name")
         self.assertEqual(response.get("content-type"), "application/json")
 
     def test_partial_update_workspace_same_tenant_parent_id(self):
@@ -743,14 +743,14 @@ class WorkspaceTestsCreateUpdateDelete(WorkspaceViewTests):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         data = response.data
         self.assertEqual(data.get("name"), "Standard Workspace")
-        self.assertEquals(data.get("description"), "Standard Workspace - description")
-        self.assertNotEquals(data.get("id"), "")
+        self.assertEqual(data.get("description"), "Standard Workspace - description")
+        self.assertNotEqual(data.get("id"), "")
         self.assertIsNotNone(data.get("id"))
-        self.assertNotEquals(data.get("created"), "")
-        self.assertNotEquals(data.get("modified"), "")
+        self.assertNotEqual(data.get("created"), "")
+        self.assertNotEqual(data.get("modified"), "")
         self.assertEqual(response.get("content-type"), "application/json")
         self.assertEqual(data.get("ancestry"), None)
-        self.assertEquals(data.get("type"), "standard")
+        self.assertEqual(data.get("type"), "standard")
         self.assertEqual(response.get("content-type"), "application/json")
 
     def test_get_workspace_with_ancestry(self):
@@ -762,16 +762,16 @@ class WorkspaceTestsCreateUpdateDelete(WorkspaceViewTests):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         data = response.data
         self.assertEqual(data.get("name"), "Standard Workspace")
-        self.assertEquals(data.get("description"), "Standard Workspace - description")
-        self.assertNotEquals(data.get("id"), "")
+        self.assertEqual(data.get("description"), "Standard Workspace - description")
+        self.assertNotEqual(data.get("id"), "")
         self.assertIsNotNone(data.get("id"))
-        self.assertNotEquals(data.get("created"), "")
-        self.assertNotEquals(data.get("modified"), "")
+        self.assertNotEqual(data.get("created"), "")
+        self.assertNotEqual(data.get("modified"), "")
         self.assertEqual(
             data.get("ancestry"),
             [{"name": self.root_workspace.name, "id": str(self.root_workspace.id), "parent_id": None}],
         )
-        self.assertEquals(data.get("type"), "standard")
+        self.assertEqual(data.get("type"), "standard")
         self.assertEqual(response.get("content-type"), "application/json")
         self.assertEqual(data.get("ancestry"), None)
 
@@ -784,11 +784,11 @@ class WorkspaceTestsCreateUpdateDelete(WorkspaceViewTests):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         data = response.data
         self.assertEqual(data.get("name"), "Standard Workspace")
-        self.assertEquals(data.get("description"), "Standard Workspace - description")
-        self.assertNotEquals(data.get("id"), "")
+        self.assertEqual(data.get("description"), "Standard Workspace - description")
+        self.assertNotEqual(data.get("id"), "")
         self.assertIsNotNone(data.get("id"))
-        self.assertNotEquals(data.get("created"), "")
-        self.assertNotEquals(data.get("modified"), "")
+        self.assertNotEqual(data.get("created"), "")
+        self.assertNotEqual(data.get("modified"), "")
         self.assertCountEqual(
             data.get("ancestry"),
             [
@@ -800,7 +800,7 @@ class WorkspaceTestsCreateUpdateDelete(WorkspaceViewTests):
                 },
             ],
         )
-        self.assertEquals(data.get("type"), "standard")
+        self.assertEqual(data.get("type"), "standard")
         self.assertEqual(response.get("content-type"), "application/json")
 
     def test_get_workspace_not_found(self):

--- a/tests/migration_tool/tests_migrate.py
+++ b/tests/migration_tool/tests_migrate.py
@@ -557,7 +557,7 @@ class MigrateTestTupleStore(TestCase):
         )
 
         # Last two are implicit default parent relations – these can be removed
-        self.assertEquals(
+        self.assertEqual(
             1,
             self.relations.count_tuples(
                 all_of(
@@ -568,7 +568,7 @@ class MigrateTestTupleStore(TestCase):
             ),
         )
 
-        self.assertEquals(
+        self.assertEqual(
             1,
             self.relations.count_tuples(
                 all_of(
@@ -579,4 +579,4 @@ class MigrateTestTupleStore(TestCase):
             ),
         )
 
-        self.assertEquals(31, len(self.relations))
+        self.assertEqual(31, len(self.relations))

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = lint, py39, mypy
+envlist = lint, py312, mypy
 skipsdist = True
 
 [flake8]
@@ -58,7 +58,7 @@ setenv =
   PYTHONPATH={toxinidir}
 commands =
   flake8 rbac
-  black --check -t py39 -l 119 rbac tests --diff
+  black --check -t py312 -l 119 rbac tests --diff
 
 [testenv:mypy]
 deps =


### PR DESCRIPTION
## Link(s) to Jira
- [[RHCLOUD-40153]](https://issues.redhat.com/browse/RHCLOUD-40153)

## Description of Intent of Change(s)
The version 3.9 of Python will go out of support relatively soon, so we want to migrate to 3.12 to extend the support for three years.

## Summary by Sourcery

Enhancements:
- Bump required Python version in Pipfile from 3.9 to 3.12