### PR TITLE
fix typo and remove not needed brackets

### DIFF
--- a/rbac/internal/views.py
+++ b/rbac/internal/views.py
@@ -922,7 +922,7 @@ def clean_binding_mapping(request, binding_id):
                     .exists()
                 ):
                     raise Exception(
-                        f"User(s) {mapping.mappings['users']} are still related to approved cross account reqeusts."
+                        f"User(s) {mapping.mappings['users']} are still related to approved cross account requests."
                     )
                 # After migration, if it is still old format with duplication, means
                 # it only binds with expired cars, which we can remove

--- a/rbac/management/workspace/view.py
+++ b/rbac/management/workspace/view.py
@@ -75,7 +75,7 @@ class WorkspaceViewSet(BaseV2ViewSet):
         if parent_id and tenant:
             if not Workspace.objects.filter(id=parent_id, tenant=tenant).exists():
                 raise serializers.ValidationError(
-                    {"parent_id": (f"Parent workspace '{parent_id}' doesn't exist in tenant")}
+                    {"parent_id": f"Parent workspace '{parent_id}' doesn't exist in tenant"}
                 )
         return super().create(request=request, args=args, kwargs=kwargs)
 


### PR DESCRIPTION
## Summary by Sourcery

Fix a typo in the cross-account request exception and simplify the ValidationError dict formatting by removing redundant parentheses

Bug Fixes:
- Correct typo in exception message from "reqeusts" to "requests"

Enhancements:
- Remove unnecessary parentheses around f-string in ValidationError payload