### PR TITLE
[RHCLOUD-40233] add service account into a group - fix the status code for not existing uuid

### DIFF
--- a/rbac/management/group/view.py
+++ b/rbac/management/group/view.py
@@ -833,15 +833,15 @@ class GroupViewSet(
                             ]
                         },
                     )
-                except ServiceAccountNotFoundError as sanfe:
+                except ServiceAccountNotFoundError as err:
                     return Response(
-                        status=status.HTTP_400_BAD_REQUEST,
+                        status=status.HTTP_404_NOT_FOUND,
                         data={
                             "errors": [
                                 {
-                                    "detail": str(sanfe),
-                                    "source": "group",
-                                    "status": str(status.HTTP_400_BAD_REQUEST),
+                                    "detail": str(err),
+                                    "source": "groups",
+                                    "status": str(status.HTTP_404_NOT_FOUND),
                                 }
                             ]
                         },

--- a/rbac/management/group/view.py
+++ b/rbac/management/group/view.py
@@ -827,7 +827,7 @@ class GroupViewSet(
                             "errors": [
                                 {
                                     "detail": str(ipe),
-                                    "status": status.HTTP_403_FORBIDDEN,
+                                    "status": str(status.HTTP_403_FORBIDDEN),
                                     "source": "groups",
                                 }
                             ]

--- a/tests/management/group/test_view.py
+++ b/tests/management/group/test_view.py
@@ -3692,6 +3692,23 @@ class GroupViewsetTests(IdentityRequest):
         self.assertEqual(len(response.data.get("data").get("users")), user_count)
         self.assertEqual(int(response.data.get("meta").get("count")), sa_count + user_count)
 
+    @override_settings(IT_BYPASS_TOKEN_VALIDATION=True)
+    @patch("management.principal.it_service.ITService.request_service_accounts")
+    def test_add_group_principals_service_account_not_found(self, sa_mock):
+        """Test adding the service account with not existing uuid returns 404 Bad Request."""
+        sa_mock.return_value = []
+
+        client = APIClient()
+        url = reverse("v1_management:group-principals", kwargs={"uuid": self.group.uuid})
+
+        # Valid but not existing UUID
+        uuid = uuid4()
+        request_body = {"principals": [{"clientId": uuid, "type": "service-account"}]}
+        response = client.post(url, request_body, format="json", **self.headers)
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(response.json().get("errors")[0].get("detail"), f"Service account(s) {{'{uuid}'}} not found.")
+
 
 class GroupViewNonAdminTests(IdentityRequest):
     """Test the group view for nonadmin user."""


### PR DESCRIPTION
[RHCLOUD-40233](https://issues.redhat.com/browse/RHCLOUD-40233)


query bellow returns now 400

this PR will change it to return 404

```
POST /api/rbac/v1/groups/<group_id>/principals/
{
    "principals": [
        {
            "clientId": "66a9986a-a265-4a11-88e8-d853a0a557f4",
            "type": "service-account"
        }
    ]
}
```
where client id is valid but not existing uuid

## Summary by Sourcery

Return 404 Not Found when attempting to add a non-existent service account to a group and align error response formatting and tests accordingly.

Bug Fixes:
- Change ServiceAccountNotFoundError handler to return HTTP 404 instead of 400.
- Standardize forbidden error responses to use string status codes.

Enhancements:
- Correct error payload source field from "group" to "groups" in service-account errors.

Tests:
- Add test to verify adding a non-existent service account returns 404.