### PR TITLE
[RHCLOUD-40265] Skipping emitting events for internal admin endpoint of workspace deletion

### DIFF
--- a/rbac/internal/views.py
+++ b/rbac/internal/views.py
@@ -1503,7 +1503,7 @@ def workspace_removal(request):
                     dual_write_handler = RelationApiDualWriteWorkspaceHandler(
                         ws, ReplicationEventType.DELETE_WORKSPACE
                     )
-                    dual_write_handler.replicate_deleted_workspace()
+                    dual_write_handler.replicate_deleted_workspace(skip_ws_events=True)
                     ws.delete()
                 logger.info(f"Deleted workspace id='{ws_id}'")
                 return HttpResponse(f"Workspace with id='{ws_id}' deleted.", content_type="text/plain", status=200)
@@ -1530,7 +1530,7 @@ def workspace_removal(request):
                     dual_write_handler = RelationApiDualWriteWorkspaceHandler(
                         ws, ReplicationEventType.DELETE_WORKSPACE
                     )
-                    dual_write_handler.replicate_deleted_workspace()
+                    dual_write_handler.replicate_deleted_workspace(skip_ws_events=True)
                     ws.delete()
                 if query_params.get("without_child_only", "") == "true":
                     return HttpResponse(

--- a/rbac/management/relation_replicator/relation_replicator.py
+++ b/rbac/management/relation_replicator/relation_replicator.py
@@ -131,6 +131,10 @@ class RelationReplicator(ABC):
         """Replicate the given event to Kessel Relations."""
         pass
 
+    def replicate_workspace(self, event: WorkspaceEvent):
+        """Replicate the given workspace event to Kessel Relations."""
+        pass
+
 
 class PartitionKey(ABC):
     """

--- a/rbac/management/workspace/relation_api_dual_write_workspace_handler.py
+++ b/rbac/management/workspace/relation_api_dual_write_workspace_handler.py
@@ -73,14 +73,14 @@ class RelationApiDualWriteWorkspaceHandler(BaseRelationApiDualWriteHandler):
         self.generate_relations_to_update_workspace(previous_parent)
         self._replicate()
 
-    def replicate_deleted_workspace(self):
+    def replicate_deleted_workspace(self, skip_ws_events: bool = False):
         """Replicate deleted principals into group."""
         if not self.replication_enabled():
             return
         self.generate_relations_to_remove_workspace()
-        self._replicate()
+        self._replicate(skip_ws_events=skip_ws_events)
 
-    def _replicate(self):
+    def _replicate(self, skip_ws_events: bool = False):
         # To avoid Circular Dependency
         from management.workspace.serializer import WorkspaceEventSerializer
 
@@ -97,15 +97,16 @@ class RelationApiDualWriteWorkspaceHandler(BaseRelationApiDualWriteHandler):
                         add=self.relations_to_add,
                     ),
                 )
-            self._replicator.replicate_workspace(
-                WorkspaceEvent(
-                    account_number=self.workspace.tenant.account_id,
-                    org_id=str(self.workspace.tenant.org_id),
-                    workspace=WorkspaceEventSerializer(self.workspace).data,
-                    event_type=self.event_type,
-                    partition_key=PartitionKey.byEnvironment(),
+            if not skip_ws_events:
+                self._replicator.replicate_workspace(
+                    WorkspaceEvent(
+                        account_number=self.workspace.tenant.account_id,
+                        org_id=str(self.workspace.tenant.org_id),
+                        workspace=WorkspaceEventSerializer(self.workspace).data,
+                        event_type=self.event_type,
+                        partition_key=PartitionKey.byEnvironment(),
+                    )
                 )
-            )
         except Exception as e:
             raise DualWriteException(e)
 


### PR DESCRIPTION
## Link(s) to Jira
- https://issues.redhat.com/browse/RHCLOUD-40265

## Description of Intent of Change(s)
We have to re-import the workspace data from HBI.
This endpoint is internal admin tool to clean the workspace data in RBAC. Do not send events to HBI, or they would remove all workspaces on their side

## Local Testing
Unit tests

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Enable conditional suppression of workspace event replication for delete operations in internal destructive APIs

Enhancements:
- Add skip_ws_events parameter to replicate_deleted_workspace and _replicate methods to bypass event emission
- Modify internal workspace_removal view to invoke replicate_deleted_workspace with skip_ws_events=True for destructive deletes

Tests:
- Update delete operation tests to mock replicator methods and assert replicate() is called while replicate_workspace() is not when skip_ws_events is enabled