### PR TITLE
[RHCLOUD-39213] Internal endpoint to remove relationships

### DIFF
--- a/rbac/internal/urls.py
+++ b/rbac/internal/urls.py
@@ -98,6 +98,7 @@ urlpatterns = [
     path("api/utils/principal/", views.principal_removal),
     path("api/utils/user_lookup/", views.user_lookup),
     path("api/utils/workspace/", views.workspace_removal),
+    path("api/utils/relations_removal/", views.relations_removal),
 ]
 
 urlpatterns.extend(integration_urlpatterns)

--- a/rbac/management/group/relation_api_dual_write_group_handler.py
+++ b/rbac/management/group/relation_api_dual_write_group_handler.py
@@ -72,6 +72,7 @@ class RelationApiDualWriteGroupHandler(RelationApiDualWriteSubjectHandler):
     def _generate_member_relations(self):
         """Generate user-groups relations."""
         relations = []
+
         for principal in self.principals:
             relationship = self.group.relationship_to_principal(principal)
             if relationship is None:

--- a/tests/internal/utils.py
+++ b/tests/internal/utils.py
@@ -1,0 +1,66 @@
+from api.models import Tenant
+from django.urls import reverse
+from management.models import Permission
+from rest_framework.test import APIClient
+
+
+def create_role(role_name, headers, role_display="", in_access_data=None):
+    """Create a role."""
+    access_data = [
+        {
+            "permission": "app:*:*",
+            "resourceDefinitions": [
+                {
+                    "attributeFilter": {
+                        "key": "key1.id",
+                        "operation": "equal",
+                        "value": "value1",
+                    }
+                }
+            ],
+        },
+        {"permission": "app:*:read", "resourceDefinitions": []},
+    ]
+    if in_access_data is not None:
+        access_data = in_access_data
+    else:
+        tenant = Tenant._get_public_tenant()
+        Permission.objects.get_or_create(permission="app:*:*", tenant=tenant)
+        Permission.objects.get_or_create(permission="app:*:read", tenant=tenant)
+    test_data = {
+        "name": role_name,
+        "display_name": role_display,
+        "access": access_data,
+    }
+
+    # create a role
+    client = APIClient()
+    response = client.post(reverse("v1_management:role-list"), test_data, format="json", **headers)
+    return response
+
+
+def create_group(group_name, headers):
+    """Create a group."""
+    test_data = {"name": group_name, "description": "a group!"}
+    url = reverse("v1_management:group-list")
+    client = APIClient()
+    response = client.post(url, test_data, format="json", **headers)
+    return response
+
+
+def add_principal_to_group(group_uuid, username, headers):
+    """Add principal to existing group."""
+    url = reverse("v1_management:group-principals", kwargs={"uuid": group_uuid})
+    client = APIClient()
+    test_data = {"principals": [{"username": username}]}
+    response = client.post(url, test_data, format="json", **headers)
+    return response
+
+
+def add_roles_to_group(group_uuid, role_uuids, headers):
+    """Add role to existing group."""
+    url = reverse("v1_management:group-roles", kwargs={"uuid": group_uuid})
+    client = APIClient()
+    test_data = {"roles": role_uuids}
+    response = client.post(url, test_data, format="json", **headers)
+    return response


### PR DESCRIPTION
## Link(s) to Jira
- https://issues.redhat.com/browse/RHCLOUD-39213

## Description of Intent of Change(s)
The what, why and how.

## Local Testing
How can the feature be exercised?
How can the bug be exploited and fix confirmed?
Is any special local setup required?

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Add an internal DELETE endpoint to handle removal of role-group and user-group relations with request validation, replication handling, and logging.

New Features:
- Add a private DELETE endpoint at `/api/utils/relations_removal/` to remove role-group and user-group relations via query parameters.

Enhancements:
- Enforce HTTP method and query parameter validation with 405 and 400 error responses.
- Log warnings when attempting to remove relations that no longer exist.