### PR TITLE
RHCLOUD-40242 | feature: forbid creating workspaces with an 'ungrouped' parent workspace

### DIFF
--- a/rbac/management/workspace/view.py
+++ b/rbac/management/workspace/view.py
@@ -21,9 +21,9 @@ from management.base_viewsets import BaseV2ViewSet
 from management.permissions.workspace_access import WorkspaceAccessPermission
 from management.utils import validate_and_get_key
 from management.workspace.service import WorkspaceService
-from rest_framework import serializers
 from rest_framework.filters import OrderingFilter
 from rest_framework.permissions import SAFE_METHODS
+
 
 from .model import Workspace
 from .serializer import WorkspaceSerializer, WorkspaceWithAncestrySerializer
@@ -69,14 +69,6 @@ class WorkspaceViewSet(BaseV2ViewSet):
 
     def create(self, request, *args, **kwargs):
         """Create a Workspace."""
-        tenant = request.tenant
-        parent_id = request.data.get("parent_id")
-
-        if parent_id and tenant:
-            if not Workspace.objects.filter(id=parent_id, tenant=tenant).exists():
-                raise serializers.ValidationError(
-                    {"parent_id": f"Parent workspace '{parent_id}' doesn't exist in tenant"}
-                )
         return super().create(request=request, args=args, kwargs=kwargs)
 
     def retrieve(self, request, *args, **kwargs):


### PR DESCRIPTION
## Link(s) to Jira
- [[RHCLOUD-40242]](https://issues.redhat.com/browse/RHCLOUD-40242)

## Description of Intent of Change(s)
Ungrouped workspaces should not have any descendants, because they eventually will get removed and having them would complicate the removal.

## Local Testing
### How can the feature be exercised?

1. Create a workspace in the database with an `ungrouped-hosts` type.
2. Send a `POST /workspaces/` request with the following payload:

```json
{
    "name": "New Workspace",
    "description": "New Workspace - description",
    "tenant_id": "${YOUR_TENANT_ID}",
    "parent_id": "${RECENTLY_CREATED_UNGROUPED_WORKSPACE_ID}"
}
```

## Checklist
- [x] if API spec changes are required, is the spec updated?
- [x] are theses changes covered by unit tests?

## Summary by Sourcery

Enforce that workspaces of type 'ungrouped-hosts' cannot have child workspaces by adding validation in the create API and corresponding tests.

Enhancements:
- Add validation to verify parent workspace existence and forbid parents of type 'ungrouped-hosts' during workspace creation.

Tests:
- Add unit test to ensure creating a workspace with an 'ungrouped-hosts' parent returns a 400 error.