### PR TITLE
[RHCLOUD-39213] Clean relationships of permission deletion in seeding

### DIFF
--- a/rbac/management/role/definer.py
+++ b/rbac/management/role/definer.py
@@ -230,7 +230,8 @@ def seed_permissions():
         logger.info(f"Removing the following permissions(s): {perms_to_delete.values()}")
         # Actually remove perms no longer in DB
         with transaction.atomic():
-            perms_to_delete.delete()
+            for permission in perms_to_delete:
+                delete_permission(permission)
 
 
 def delete_permission(permission: Permission):


### PR DESCRIPTION
## Link(s) to Jira
- https://issues.redhat.com/browse/RHCLOUD-39213

## Description of Intent of Change(s)
Gracefully handles the deletion of permission in seeding job

## Local Testing
Unit tests

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Handle permission deletions gracefully in the seeding job by introducing per-permission cleanup logic and adding test coverage for deleting stale permissions and related replication data.

Enhancements:
- Refactor seed_permissions to delete each stale permission via delete_permission helper instead of bulk removal

Tests:
- Add test_seed_permissions_delete_permission to ensure stale permissions and their associated relation tuples are removed during seeding