### PR TITLE
Update kafka-connect repo

### DIFF
--- a/deploy/kafka-connect.yml
+++ b/deploy/kafka-connect.yml
@@ -110,7 +110,7 @@ objects:
           - name: quay-cloudservices-pull
           - name: rh-registry-pull
           - name: quay.io
-    image: quay.io/cloudservices/kafka-connect@sha256:57decfca1b637ecaffeb13ff61309c6578791ae93b0da5ba9b051878928762ac
+    image: quay.io/redhat-user-workloads/hcm-eng-prod-tenant/kafka-connect/kafka-connect@sha256:4bfbb3336a523959bf4db6b8af9cdca680c60e7a0fe490aedc2c22e321d4e11a
     version: 3.7.0
     replicas: 1
     bootstrapServers: rbac-kafka-kafka-bootstrap:9092


### PR DESCRIPTION
## Link(s) to Jira
-

## Description of Intent of Change(s)
Previous quay image repo has been deprecated. Now using the konflux based images

## Local Testing
How can the feature be exercised?
How can the bug be exploited and fix confirmed?
Is any special local setup required?

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Deployment:
- Replace deprecated quay.io/cloudservices kafka-connect image with the konflux-based quay.io/redhat-user-workloads path