### PR TITLE
add tearDown() method in the ServiceToServiceWithToken class

### DIFF
--- a/tests/rbac/test_middleware.py
+++ b/tests/rbac/test_middleware.py
@@ -599,6 +599,9 @@ class ServiceToServiceWithToken(IdentityRequest):
         patch_token_validator.start()
         self.addCleanup(patch_token_validator.stop)
 
+    def tearDown(self):
+        Tenant.objects.all().delete()
+
     def test_no_identity_or_token_returns_401(self):
         url = reverse("v1_management:group-list")
         client = APIClient()


### PR DESCRIPTION
TL;DR
test sometimes fail because Tenant objects are not removed after test run (because of order of tests)

--------------------------

in https://github.com/RedHatInsights/insights-rbac/pull/1750 the test class `ServiceToServiceWithToken` was introduced
with following tests:

1. `test_valid_token_and_org_via_token_instead_of_header_returns_200`
2. `test_valid_token_but_invalid_org_via_token_instead_of_header_returns_404`

in tests is created tenant with expected (for test 1) and not expected (for test 2) org id
the test then check the token send with request contains correct org id

but 

because the Tenant object are not removed after test then sometimes when test 2 is triggered after test 1, the tenant from test 1 with correct org id exists in the database and then the test 2 fails

adding the `tearDown()` method will remove Tenant objects after test run