### PR TITLE
[RHCLOUD-40691] Replace null value for HBI ungrouped workspace

### DIFF
--- a/rbac/migration_tool/sharedSystemRolesReplicatedRoleBindings.py
+++ b/rbac/migration_tool/sharedSystemRolesReplicatedRoleBindings.py
@@ -111,7 +111,7 @@ def v1_role_to_v2_bindings(
                 if not isinstance(attri_filter["value"], list):
                     # Override operation as "equal" if value is not a list
                     attri_filter["operation"] = "equal"
-                elif attri_filter["value"] == [] or attri_filter["value"] == [None]:
+                elif attri_filter["value"] == []:
                     # Skip empty values
                     continue
 
@@ -122,9 +122,14 @@ def v1_role_to_v2_bindings(
             if not is_for_enabled_resource(resource_type):
                 continue
             for resource_id in values_from_attribute_filter(attri_filter):
-                # TODO: Need to bind against "ungrouped hosts" for inventory
                 if resource_id is None:
-                    raise ValueError(f"Resource ID is None for {resource_def}")
+                    if resource_type != ("rbac", "workspace"):
+                        raise ValueError(f"Resource ID is None for {resource_def}")
+                    ungrouped_ws = Workspace.objects.filter(
+                        type=Workspace.Types.UNGROUPED_HOSTS, tenant=v1_role.tenant
+                    ).first()
+                    if not ungrouped_ws:
+                        continue
                 add_element(perm_groupings, V2boundresource(resource_type, resource_id), v2_perm, collection=set)
         if default:
             add_element(


### PR DESCRIPTION
## Link(s) to Jira
- https://issues.redhat.com/browse/RHCLOUD-40691

## Description of Intent of Change(s)
The null value is causing issues when gathering the info for dual-write replication

## Local Testing
Unit test

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Enable handling of null workspace IDs by mapping them to the tenant’s ungrouped hosts workspace during v1 to v2 role binding migration and update logic

Enhancements:
- Map None resource IDs to the ungrouped hosts workspace instead of erroring during migration
- Simplify attributeFilter value checks to skip only empty lists and not [None]

Tests:
- Add unit test to verify role updates handle null workspace IDs and replicate correctly