### PR TITLE
[RHCLOUD-40774] Access check for target workspace for workspace movement

### DIFF
--- a/tests/management/workspace/test_view.py
+++ b/tests/management/workspace/test_view.py
@@ -1832,3 +1832,175 @@ class WorkspaceViewTestsWithPeerRestrictions(WorkspaceViewTests):
 
         self.assertEqual(status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(response.get("content-type"), "application/problem+json")
+
+
+@override_settings(V2_APIS_ENABLED=True)
+class WorkspaceViewAccessCheckTests(WorkspaceViewTests):
+    """Test the access check functionality in the workspace view."""
+
+    def setUp(self):
+        """Set up workspace access check tests."""
+        super().setUp()
+        # Create a unique test workspace that won't conflict with existing names
+        self.test_workspace = self.service.create(
+            name="Test Workspace for Move",
+            description="Test workspace for move operations",
+            tenant=self.tenant,
+            parent=self.standard_workspace,
+            type=Workspace.Types.STANDARD,
+        )
+
+        # Create test users
+        self.user_with_access = {"username": "user_with_access", "email": "user_with_access@example.com"}
+        self.user_without_access = {"username": "user_without_access", "email": "user_without_access@example.com"}
+
+        # Set up access for user_with_access to have write permissions on default_workspace
+        self._setup_access_for_principal(
+            self.user_with_access["username"], "inventory:groups:write", str(self.default_workspace.id)
+        )
+
+        # user_without_access gets no permissions (will fall back to no access)
+
+    def test_move_with_write_access_allowed(self):
+        """Test that move succeeds when user has write access to target workspace."""
+        # Create request context for user with access
+        request_context = self._create_request_context(self.customer_data, self.user_with_access, is_org_admin=False)
+        headers = request_context["request"].META
+
+        # Execute
+        url = reverse("v2_management:workspace-move", kwargs={"pk": self.test_workspace.id})
+        client = APIClient()
+        data = {"parent_id": str(self.default_workspace.id)}
+        response = client.post(url, data, format="json", **headers)
+
+        # Verify
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response_data = response.data
+        self.assertEqual(response_data["id"], str(self.test_workspace.id))
+        self.assertEqual(response_data["parent_id"], str(self.default_workspace.id))
+
+    def test_move_with_write_access_denied(self):
+        """Test that move fails when user lacks write access to target workspace."""
+        # Create request context for user without access
+        request_context = self._create_request_context(
+            self.customer_data, self.user_without_access, is_org_admin=False
+        )
+        headers = request_context["request"].META
+
+        # Execute
+        url = reverse("v2_management:workspace-move", kwargs={"pk": self.test_workspace.id})
+        client = APIClient()
+        data = {"parent_id": str(self.default_workspace.id)}
+        response = client.post(url, data, format="json", **headers)
+
+        # Verify - Should get 403 from WorkspaceAccessPermission class
+        # before our custom validation can return 400
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertIn("You do not have permission to perform this action", str(response.data))
+
+    def test_move_with_admin_access(self):
+        """Test that move succeeds when user is org admin (bypasses access check)."""
+        # Create request context for org admin
+        request_context = self._create_request_context(
+            self.customer_data,
+            self.user_without_access,  # Even user without specific permissions should work as admin
+            is_org_admin=True,
+        )
+        headers = request_context["request"].META
+
+        # Execute
+        url = reverse("v2_management:workspace-move", kwargs={"pk": self.test_workspace.id})
+        client = APIClient()
+        data = {"parent_id": str(self.default_workspace.id)}
+        response = client.post(url, data, format="json", **headers)
+
+        # Verify
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response_data = response.data
+        self.assertEqual(response_data["id"], str(self.test_workspace.id))
+        self.assertEqual(response_data["parent_id"], str(self.default_workspace.id))
+
+    def test_move_missing_parent_id(self):
+        """Test that move fails when parent_id is missing."""
+        request_context = self._create_request_context(self.customer_data, self.user_with_access, is_org_admin=False)
+        headers = request_context["request"].META
+
+        url = reverse("v2_management:workspace-move", kwargs={"pk": self.test_workspace.id})
+        client = APIClient()
+        data = {}
+        response = client.post(url, data, format="json", **headers)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("The 'parent_id' field is required", str(response.data))
+
+    def test_move_invalid_parent_id_uuid(self):
+        """Test that move fails when parent_id is not a valid UUID."""
+        request_context = self._create_request_context(self.customer_data, self.user_with_access, is_org_admin=False)
+        headers = request_context["request"].META
+
+        url = reverse("v2_management:workspace-move", kwargs={"pk": self.test_workspace.id})
+        client = APIClient()
+        data = {"parent_id": "invalid-uuid"}
+        response = client.post(url, data, format="json", **headers)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("not a valid UUID", str(response.data))
+
+    def test_move_with_read_only_access(self):
+        """Test that move fails when user only has read access to target workspace."""
+        # Create user with only read access
+        read_only_user = {"username": "read_only_user", "email": "read_only@example.com"}
+        self._setup_access_for_principal(
+            read_only_user["username"],
+            "inventory:groups:read",  # Only read permission, not write
+            str(self.default_workspace.id),
+        )
+
+        request_context = self._create_request_context(self.customer_data, read_only_user, is_org_admin=False)
+        headers = request_context["request"].META
+
+        # Execute
+        url = reverse("v2_management:workspace-move", kwargs={"pk": self.test_workspace.id})
+        client = APIClient()
+        data = {"parent_id": str(self.default_workspace.id)}
+        response = client.post(url, data, format="json", **headers)
+
+        # Verify - Should get 403 from WorkspaceAccessPermission class
+        # since user only has read access but move requires write
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertIn("You do not have permission to perform this action", str(response.data))
+
+    def test_move_with_wildcard_permission(self):
+        """Test that move succeeds when user has wildcard (*) permission on target workspace."""
+        # Create user with wildcard permission
+        wildcard_user = {"username": "wildcard_user", "email": "wildcard@example.com"}
+        self._setup_access_for_principal(
+            wildcard_user["username"],
+            "inventory:groups:*",  # Wildcard permission includes write
+            str(self.default_workspace.id),
+        )
+
+        request_context = self._create_request_context(self.customer_data, wildcard_user, is_org_admin=False)
+        headers = request_context["request"].META
+
+        # Execute
+        url = reverse("v2_management:workspace-move", kwargs={"pk": self.test_workspace.id})
+        client = APIClient()
+        data = {"parent_id": str(self.default_workspace.id)}
+        response = client.post(url, data, format="json", **headers)
+
+        # Verify
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response_data = response.data
+        self.assertEqual(response_data["id"], str(self.test_workspace.id))
+        self.assertEqual(response_data["parent_id"], str(self.default_workspace.id))
+
+
+class WorkspaceViewTestsV2Disabled(WorkspaceViewTests):
+    def test_get_workspace_list(self):
+        """Test for accessing v2 APIs which should be disabled by default."""
+        url = "/api/rbac/v2/workspaces/"
+        client = APIClient()
+        response = client.get(url, None, format="json", **self.headers)
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)


### PR DESCRIPTION
- **validations for workspace move**
- **add tests for move workspace feature**
- **fixup! validations for workspace move**
- **fixup! validations for workspace move**
- **fixup! validations for workspace move**
- **Access check for parent workspace in workspace move operation**

## Link(s) to Jira
-

## Description of Intent of Change(s)
The what, why and how.

## Local Testing
How can the feature be exercised?
How can the bug be exploited and fix confirmed?
Is any special local setup required?

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Implement a robust workspace "move" feature that allows standard workspaces to be re-parented under a new workspace with full validations and permission checks.

New Features:
- Add POST /move action to re-parent standard workspaces under a new parent

Enhancements:
- Implement service-layer validations for parent ID presence, existence, self-reference, non-standard type, descendant cycles, duplicate names, and hierarchy depth limits
- Extend Workspace model with get_max_descendant_depth and descendants methods for depth calculations
- Enforce write-access checks in the move view before delegating to the service

CI:
- Restrict default tox test suite to management workspace tests in tox.ini

Tests:
- Add comprehensive workspace move tests for success/failure cases, hierarchy depth enforcement, duplicate names, and access control scenarios