### PR TITLE
Revert "Merge pull request #1788 from lpichler/init_feature_flags_in_app_init"

### DIFF
--- a/rbac/management/apps.py
+++ b/rbac/management/apps.py
@@ -20,7 +20,6 @@ import sys
 
 from django.apps import AppConfig
 from django.db.utils import OperationalError, ProgrammingError
-from feature_flags import FEATURE_FLAGS
 from management.seeds import group_seeding, permission_seeding, role_seeding
 
 from rbac.settings import GROUP_SEEDING_ENABLED, PERMISSION_SEEDING_ENABLED, ROLE_SEEDING_ENABLED
@@ -46,7 +45,6 @@ class ManagementConfig(AppConfig):
             if GROUP_SEEDING_ENABLED:
                 group_seeding()
 
-            FEATURE_FLAGS.initialize()
         except (OperationalError, ProgrammingError) as op_error:
             if "no such table" in str(op_error) or "does not exist" in str(op_error):
                 # skip this if we haven't created tables yet.

--- a/rbac/rbac/settings.py
+++ b/rbac/rbac/settings.py
@@ -37,6 +37,8 @@ from boto3 import client as boto_client
 from corsheaders.defaults import default_headers
 from dateutil.parser import parse as parse_dt
 from app_common_python import LoadedConfig, KafkaTopics
+from feature_flags import FEATURE_FLAGS
+
 
 # Database
 # https://docs.djangoproject.com/en/2.0/ref/settings/#databases
@@ -273,7 +275,6 @@ LOGGING = {
         "rbac": {"handlers": LOGGING_HANDLERS, "level": RBAC_LOGGING_LEVEL},
         "management": {"handlers": LOGGING_HANDLERS, "level": RBAC_LOGGING_LEVEL},
         "migration_tool": {"handlers": LOGGING_HANDLERS, "level": RBAC_LOGGING_LEVEL},
-        "feature_flags": {"handlers": LOGGING_HANDLERS, "level": RBAC_LOGGING_LEVEL},
     },
 }
 
@@ -331,6 +332,7 @@ else:
     APP_NAME = "rbac"
 
 FEATURE_FLAGS_CACHE_DIR = ENVIRONMENT.get_value("FEATURE_FLAGS_CACHE_DIR", default="/tmp/")
+FEATURE_FLAGS.initialize()
 
 REDIS_SSL = REDIS_PASSWORD is not None
 

--- a/tests/test_feature_flags.py
+++ b/tests/test_feature_flags.py
@@ -24,8 +24,8 @@ class FeatureFlagsTest(TestCase):
 
     def test_feature_flags_client(self):
         """Test that we can initialize feature flags with defaults."""
-        FEATURE_FLAGS.initialize()
         client = FEATURE_FLAGS.client
+        FEATURE_FLAGS.initialize()
         self.assertEqual(client.unleash_url, "http://localhost:4242/api")
         self.assertEqual(client.unleash_app_name, "rbac")
         self.assertEqual(FEATURE_FLAGS.is_enabled("foo"), False)


### PR DESCRIPTION
This reverts commit 3895d9a0d726cec0299abe67652433e5d43eab3e, reversing
changes made to a5c67611da3d1f65387606552012895a4ae88907.

## Link(s) to Jira
-

## Description of Intent of Change(s)
The what, why and how.

## Local Testing
How can the feature be exercised?
How can the bug be exploited and fix confirmed?
Is any special local setup required?

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Revert the previous change that initialized feature flags in the Django app ready hook by moving initialization back into the settings module, removing the custom feature_flags logger, and updating tests accordingly.

Enhancements:
- Relocate FEATURE_FLAGS.initialize() from management.apps.ready to rbac settings on import
- Remove the feature_flags logger entry from the logging configuration
- Update tests to initialize FEATURE_FLAGS after accessing the client