### PR TITLE
[RHCLOUD-40266]Bootstrap tenants that do not exist in rbac

### DIFF
--- a/rbac/management/management/commands/utils.py
+++ b/rbac/management/management/commands/utils.py
@@ -180,7 +180,9 @@ def batch_import_workspace(records):
             parent = parent_workspace_dict.get(record["org_id"])
             if not parent:
                 logger.warning(f"Missing tenant for org_id: {record['org_id']}")
-                continue
+                bootstrapped_tenant = BOOT_STRAP_SERVICE._get_or_bootstrap_tenant(record["org_id"], ready=True)
+                tenant_dict[record["org_id"]] = bootstrapped_tenant.tenant
+                parent = Workspace.objects.default(tenant=bootstrapped_tenant.tenant)
             if is_ungrouped:
                 ws_name = Workspace.SpecialNames.UNGROUPED_HOSTS
                 workspace_type = Workspace.Types.UNGROUPED_HOSTS


### PR DESCRIPTION
## Link(s) to Jira
- https://issues.redhat.com/browse/RHCLOUD-40266

## Description of Intent of Change(s)
No harm to add more tenants

## Local Testing
Unit tests

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Enable batch_import_workspace to bootstrap tenants missing in RBAC and update tests to verify workspace relationships for newly created tenants

New Features:
- Automatically bootstrap missing tenants during batch_import_workspace

Enhancements:
- Update batch_import_workspace to set parent workspace for newly bootstrapped tenants
- Refine test mocking to target create_workspace_relationships directly

Tests:
- Expand test_batch_import_workspace to cover a third tenant and validate workspace count, parent assignment, type, name, and idempotency