### PR TITLE
[RHCLOUD-40774] Move parent id validation to view in workspace movement

### DIFF
--- a/rbac/management/workspace/service.py
+++ b/rbac/management/workspace/service.py
@@ -23,8 +23,7 @@ from django.db import transaction
 from management.models import Workspace
 from management.relation_replicator.relation_replicator import ReplicationEventType
 from management.workspace.relation_api_dual_write_workspace_handler import RelationApiDualWriteWorkspaceHandler
-from rest_framework import serializers, status
-from rest_framework.response import Response
+from rest_framework import serializers
 
 from api.models import Tenant
 
@@ -103,7 +102,7 @@ class WorkspaceService:
         dual_write_handler.replicate_deleted_workspace()
         instance.delete()
 
-    def move(self, instance: Workspace, new_parent_id: uuid.UUID) -> Response:
+    def move(self, instance: Workspace, new_parent_id: uuid.UUID) -> None:
         """Move a workspace under new parent."""
         new_parent_workspace = self._parent_workspace_validation(new_parent_id, instance)
         self._prevent_moving_workspace_under_itself(new_parent_id, instance)
@@ -112,9 +111,7 @@ class WorkspaceService:
         self._prevent_duplicate_names_under_parent(instance, new_parent_workspace)
         self._enforce_hierarchy_depth(new_parent_id, instance.tenant)
         self._enforce_hierarchy_depth_for_descendants(new_parent_workspace, instance)
-
         # TODO: Implement actual move operation
-        return Response({"id": str(instance.id), "parent_id": str(new_parent_id)}, status=status.HTTP_200_OK)
 
     def _enforce_hierarchy_depth(self, target_parent_id: uuid.UUID, tenant: Tenant) -> None:
         """Enforce hierarchy depth limits on workspaces."""

--- a/rbac/management/workspace/view.py
+++ b/rbac/management/workspace/view.py
@@ -25,11 +25,12 @@ from management.permissions.workspace_access import WorkspaceAccessPermission
 from management.utils import validate_and_get_key
 from management.workspace.service import WorkspaceService
 from management.workspace.utils import is_user_allowed
-from rest_framework import serializers
+from rest_framework import serializers, status
 from rest_framework.decorators import action
 from rest_framework.filters import OrderingFilter
 from rest_framework.permissions import SAFE_METHODS
 from rest_framework.request import Request
+from rest_framework.response import Response
 
 from .model import Workspace
 from .serializer import WorkspaceSerializer, WorkspaceWithAncestrySerializer
@@ -134,7 +135,9 @@ class WorkspaceViewSet(BaseV2ViewSet):
         """Move a workspace under new parent."""
         new_parent_id = self._parent_id_query_param_validation(request)
         self._check_target_workspace_write_access(request, new_parent_id)
-        return self._service.move(self.get_object(), new_parent_id)
+        workspace = self.get_object()
+        self._service.move(self.get_object(), new_parent_id)
+        return Response({"id": str(workspace.id), "parent_id": str(new_parent_id)}, status=status.HTTP_200_OK)
 
     @staticmethod
     def _check_target_workspace_write_access(request, target_workspace_id: uuid.UUID) -> None:


### PR DESCRIPTION
## Link(s) to Jira
-  https://issues.redhat.com/browse/RHCLOUD-40774 (this PR only updated original [PR](https://github.com/RedHatInsights/insights-rbac/pull/1798))

## Description of Intent of Change(s)
- Parent id needs to validated for access check in view layer and this PR move its validation into view.
- Simplify signature of move method in service layer

## Local Testing
How can the feature be exercised?
How can the bug be exploited and fix confirmed?
Is any special local setup required?

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Move parent_id validation from the service layer into the view so that input is validated and access checks occur before invoking the business logic.

Enhancements:
- Add _parent_id_query_param_validation in WorkspaceView to validate and parse parent_id.
- Convert _check_target_workspace_write_access to a static method and perform it in the view.
- Update WorkspaceView.move to use the validated parent_id and call service.move with the parsed UUID.
- Simplify WorkspaceService.move signature to accept the validated parent_id and remove its duplicate validation method.