### PR TITLE
Update the system-users secret ref

### DIFF
--- a/deploy/rbac-clowdapp.yml
+++ b/deploy/rbac-clowdapp.yml
@@ -1092,7 +1092,7 @@ objects:
 - apiVersion: v1
   kind: Secret
   metadata:
-    name: rbac-system-users
+    name: system-users
   data:
     system-users.json: >-
       ewogICAgImluc2VydF9zdWJfaGVyZSI6IHsKICAgICAgICAiYWRtaW4iOiB0cnVlLAogICAgICAgICJpc19zZXJ2aWNlX2FjY291bnQiOiB0cnVlLAogICAgICAgICJhbGxvd19hbnlfb3JnIjogdHJ1ZQogICAgfQp9Cg==
@@ -1176,7 +1176,7 @@ parameters:
   description: Name of the secret containing PSK configuration.
 - displayName: RBAC system users
   name: RBAC_SYSTEM_USERS
-  value: rbac-system-users
+  value: system-users
   description: >
     Name of the secret containing system user configuration.
     System user configuration JSON defines which users, when identified via JWT authentication,


### PR DESCRIPTION
Updates from `rbac-system-users` to `system-users`. This departs from the `rbac-psks` pattern, but since we'll ideally deprecate that eventually, this is less redundant since the secret is already within the RBAC namespace per env.

This also fixes the current broken ref in stage since Vault has it as `system-users` already.
