### PR TITLE
add pull request labeler github action

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,9 @@
+# Docs: https://github.com/marketplace/actions/labeler
+
+# Add "security-compliance" label to any PR that is opened against the "security-compliance" branch
+security-compliance:
+ - base-branch: 'security-compliance'
+
+# Add "bot" label to any PR where the head branch name starts with "konflux" or "dependabot"
+bot:
+ - head_branch: ['^konflux/', '^dependabot/']

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,12 @@
+name: "Pull Request Labeler"
+on:
+- pull_request_target
+
+jobs:
+  labeler:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v5


### PR DESCRIPTION
**Github Action Pull Request Labeler**
https://github.com/marketplace/actions/labeler

the file `.github/labeler.yml` contains a list of labels and config options to match and apply the label

## Summary by Sourcery

Introduce a GitHub Actions workflow to auto-label pull requests based on branch patterns.

Enhancements:
- Apply "security-compliance" label to PRs targeting the security-compliance branch.
- Apply "bot" label to PRs from branches beginning with "konflux" or "dependabot".

CI:
- Add Pull Request Labeler workflow using actions/labeler.