### PR TITLE
RHCLOUD-40828 | feature: use feature flags instead of env flags

### DIFF
--- a/rbac/management/access/view.py
+++ b/rbac/management/access/view.py
@@ -16,8 +16,8 @@
 #
 
 """View for principal access."""
-from django.conf import settings
 from django.db.models import Prefetch
+from feature_flags import FEATURE_FLAGS
 from management.cache import AccessCache
 from management.models import Access, ResourceDefinition, Workspace
 from management.querysets import get_access_queryset
@@ -177,8 +177,8 @@ class AccessView(APIView):
 
     def add_ungrouped_hosts_id(self, response, tenant):
         """Add ungrouped hosts id to the data."""
-        if not settings.ADD_UNGROUPED_HOSTS_ID:
-            return
+        if not FEATURE_FLAGS.is_add_ungrouped_hosts_id_enabled():
+            return None
         ungrouped_hosts_id = None
         queried = False
         for access in response.data["data"]:
@@ -196,6 +196,6 @@ class AccessView(APIView):
                         ungrouped_hosts_id = str(ungrouped_workspace.id)
                         if ungrouped_hosts_id not in attribute_filter["value"]:
                             attribute_filter["value"].append(ungrouped_hosts_id)
-                        if settings.REMOVE_NULL_VALUE:
+                        if FEATURE_FLAGS.is_remove_null_value_enabled():
                             attribute_filter["value"].remove(None)
         return response

--- a/rbac/management/role/serializer.py
+++ b/rbac/management/role/serializer.py
@@ -18,6 +18,7 @@
 """Serializer for role management."""
 from django.conf import settings
 from django.utils.translation import gettext as _
+from feature_flags import FEATURE_FLAGS
 from internal.utils import get_or_create_ungrouped_workspace
 from management.models import Group, Workspace
 from management.serializer_override_mixin import SerializerCreateOverrideMixin
@@ -75,7 +76,7 @@ class ResourceDefinitionSerializer(SerializerCreateOverrideMixin, serializers.Mo
     def to_representation(self, instance):
         """Convert the ResourceDefinition instance to a dictionary."""
         serialized_data = super().to_representation(instance)
-        if settings.REMOVE_NULL_VALUE and instance.attributeFilter["key"] == "group.id":
+        if FEATURE_FLAGS.is_remove_null_value_enabled() and instance.attributeFilter["key"] == "group.id":
             value = instance.attributeFilter["value"]
             if isinstance(value, list) and None in value:
                 ungrouped_hosts = get_or_create_ungrouped_workspace(instance.tenant)

--- a/rbac/rbac/middleware.py
+++ b/rbac/rbac/middleware.py
@@ -26,6 +26,7 @@ from django.core.handlers.wsgi import WSGIRequest
 from django.db import IntegrityError, transaction
 from django.http import Http404, HttpResponse, QueryDict
 from django.urls import resolve
+from feature_flags import FEATURE_FLAGS
 from management.authorization.token_validator import ITSSOTokenValidator, TokenValidator
 from management.cache import TenantCache
 from management.models import Principal
@@ -467,7 +468,11 @@ class ReadOnlyApiMiddleware:
         """Determine whether or not to deny v2 writes."""
         resolver = resolve(request.path)
         api_namespace = resolver.app_name if resolver else ""
-        return settings.V2_READ_ONLY_API_MODE and self._is_write_request(request) and api_namespace == "v2_management"
+        return (
+            FEATURE_FLAGS.is_v2_api_read_only_mode_enabled()
+            and self._is_write_request(request)
+            and api_namespace == "v2_management"
+        )
 
     def _read_only_response(self):
         """Return a read-only API error response."""

--- a/tests/rbac/test_middleware.py
+++ b/tests/rbac/test_middleware.py
@@ -1192,17 +1192,17 @@ class RBACReadOnlyApiMiddlewareV2(RBACReadOnlyApiMiddleware):
         super().setUp()
         self.request = self.factory.get("/api/rbac/v2/workspaces/")
 
-    @override_settings(V2_READ_ONLY_API_MODE=True)
-    def test_get_read_only_v2_true(self):
-        """Test GET and V2_READ_ONLY_API_MODE=True."""
+    @patch("rbac.middleware.FEATURE_FLAGS.is_v2_api_read_only_mode_enabled", return_value=True)
+    def test_get_read_only_v2_true(self, ff_is_v2_api_read_only_mode_enabled: Mock):
+        """Test write methods with the "read only V2 API" feature flag enabled."""
         self.request.method = "GET"
         middleware = ReadOnlyApiMiddleware(get_response=Mock(return_value="OK"))
         resp = middleware(self.request)
         self.assertEqual(resp, "OK")
 
-    @override_settings(V2_READ_ONLY_API_MODE=True)
-    def test_write_methods_read_only_v2_true(self):
-        """Test write methods and V2_READ_ONLY_API_MODE=True."""
+    @patch("rbac.middleware.FEATURE_FLAGS.is_v2_api_read_only_mode_enabled", return_value=True)
+    def test_write_methods_read_only_v2_true(self, feature_flags_is_enabled: Mock):
+        """Test write methods with the "read only V2 API" feature flag enabled."""
         for method in self.write_methods:
             self.request.method = method
             middleware = ReadOnlyApiMiddleware(get_response=Mock(return_value="OK"))
@@ -1210,23 +1210,23 @@ class RBACReadOnlyApiMiddlewareV2(RBACReadOnlyApiMiddleware):
             self.assertReadOnlyFailure(resp)
 
     def test_get_read_only_v2_false(self):
-        """Test GET and V2_READ_ONLY_API_MODE=False."""
+        """Test GET with the "read only V2 API" feature flag disabled."""
         self.request.method = "GET"
         middleware = ReadOnlyApiMiddleware(get_response=Mock(return_value="OK"))
         resp = middleware(self.request)
         self.assertEqual(resp, "OK")
 
     def test_write_methods_read_only_v2_false(self):
-        """Test write methods and V2_READ_ONLY_API_MODE=False."""
+        """Test write methods with the "read only V2 API" feature flag disabled."""
         for method in self.write_methods:
             self.request.method = method
             middleware = ReadOnlyApiMiddleware(get_response=Mock(return_value="OK"))
             resp = middleware(self.request)
             self.assertEqual(resp, "OK")
 
-    @override_settings(V2_READ_ONLY_API_MODE=True)
-    def test_write_methods_read_only_v2_true_v1_path(self):
-        """Test write methods and V2_READ_ONLY_API_MODE=False with a v1 API path succeeds."""
+    @patch("rbac.middleware.FEATURE_FLAGS.is_v2_api_read_only_mode_enabled", return_value=True)
+    def test_write_methods_read_only_v2_true_v1_path(self, feature_flags_is_enabled: Mock):
+        """Test write methods with the "read only V2 API" feature flag enabled and with a v1 API path succeeds."""
         for method in self.write_methods:
             self.request.method = method
             self.request.path = "/api/rbac/v1/roles/"


### PR DESCRIPTION
## Link(s) to Jira
- [[RHCLOUD-40828]](https://issues.redhat.com/browse/RHCLOUD-40828)

## Description of Intent of Change(s)
These changes will allow us to enable and disable the following features using Unleash, instead of having to change them via GitOps configurations:

- V2_READ_ONLY_API_MODE
- ADD_UNGROUPED_HOSTS_ID
- REMOVE_NULL_VALUE

## Local Testing
### Is any special local setup required?

You need to run Unleash like so:

```bash
podman run \
    --rm \
    --detach \
    --network host \
    --env DATABASE_HOST=localhost \
    --env DATABASE_NAME=postgres \
    --env DATABASE_USERNAME=postgres \
    --env DATABASE_PASSWORD=postgres \
    --env DATABASE_PORT=5432 \
    --env DATABASE_SSL=false \
    docker.io/unleashorg/unleash-server
```

And then add the toggles defined in the `feature_flags.py` file to Unleash's default project. Once done that you should be able to turn on and off these features and send requests to test how the configuration changes ASAP!

## Checklist
- [x] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?

## Summary by Sourcery

Switch to Unleash for toggling V2 read-only API mode, ungrouped hosts ID inclusion, and null value removal by removing environment flags and updating code, tests, and deployment configuration to use the new feature flag client.

New Features:
- Introduce Unleash feature flags for V2 read-only API mode, adding ungrouped hosts ID, and removing null values

Enhancements:
- Replace legacy environment-based toggles with FEATURE_FLAGS.is_enabled checks in middleware, views, serializers, and settings
- Define centralized feature flag constants in rbac/feature_flags.py

Deployment:
- Remove deprecated environment variables and parameters for the three feature toggles from deploy/rbac-clowdapp.yml

Tests:
- Adapt existing tests to patch FEATURE_FLAGS.is_enabled and add mock_feature_flags utility instead of using override_settings