### PR TITLE
fix config for labeler github action

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -6,4 +6,4 @@ security-compliance:
 
 # Add "bot" label to any PR where the head branch name starts with "konflux" or "dependabot"
 bot:
- - head_branch: ['^konflux/', '^dependabot/']
+ - head-branch: ['^konflux/', '^dependabot/']


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Use the correct `head-branch` key in the GitHub Actions labeler configuration