### PR TITLE
Lazily initialize the feature flag client

### DIFF
--- a/rbac/feature_flags.py
+++ b/rbac/feature_flags.py
@@ -59,6 +59,9 @@ class FeatureFlags:
     def is_enabled(self, feature_name, context=None, fallback_function=None):
         """Override of is_enabled for checking flag values."""
         if not self.client:
+            self.initialize()
+
+        if not self.client:
             if fallback_function:
                 logger.warning("FeatureFlags not initialized, using fallback function")
                 return fallback_function(feature_name, context)
@@ -70,8 +73,3 @@ class FeatureFlags:
 
 
 FEATURE_FLAGS = FeatureFlags()
-
-
-def reinit_feature_flags():
-    """Reinitialize feature flags client."""
-    FEATURE_FLAGS.initialize()

--- a/rbac/internal/views.py
+++ b/rbac/internal/views.py
@@ -32,7 +32,7 @@ from django.http import HttpRequest, HttpResponse, JsonResponse
 from django.shortcuts import get_object_or_404
 from django.utils.html import escape
 from django.views.decorators.http import require_http_methods
-from feature_flags import FEATURE_FLAGS, reinit_feature_flags
+from feature_flags import FEATURE_FLAGS
 from google.protobuf import json_format
 from grpc import RpcError
 from internal.errors import SentryDiagnosticError, UserNotFoundError
@@ -92,7 +92,6 @@ PROXY = PrincipalProxy()
 jwt_cache = JWTCache()
 jwt_provider = JWTProvider()
 jwt_manager = JWTManager(jwt_provider, jwt_cache)
-reinit_feature_flags()
 
 
 @contextmanager

--- a/rbac/rbac/settings.py
+++ b/rbac/rbac/settings.py
@@ -333,7 +333,6 @@ else:
     APP_NAME = "rbac"
 
 FEATURE_FLAGS_CACHE_DIR = ENVIRONMENT.get_value("FEATURE_FLAGS_CACHE_DIR", default="/tmp/")
-FEATURE_FLAGS.initialize()
 
 REDIS_SSL = REDIS_PASSWORD is not None
 


### PR DESCRIPTION
## Description of Intent of Change(s)
In order to avoid gunicorn threading issues when initializing the client as is currently the case, this initializes the clietn lazily, when we call `is_enabled` to check a feature's status for the first time.

## Local Testing
How can the feature be exercised?
How can the bug be exploited and fix confirmed?
Is any special local setup required?

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
