### PR TITLE
RHCLOUD-40939 - read_tuples input validation

### DIFF
--- a/rbac/internal/schemas.py
+++ b/rbac/internal/schemas.py
@@ -19,6 +19,29 @@ ENTITY_SCHEMA = {
     "required": ["type", "id"],
 }
 
+SUBJECT_FILTER_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "subject_type": {"type": "string"},
+        "subject_namespace": {"type": "string"},
+        "subject_id": {"type": "string"},
+        "relation": {"type": "string"},
+    },
+    "required": ["subject_type", "subject_namespace", "subject_id"],
+}
+
+FILTER_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "resource_id": {"type": "string"},
+        "resource_type": {"type": "string"},
+        "resource_namespace": {"type": "string"},
+        "relation": {"type": "string"},
+        "subject_filter": SUBJECT_FILTER_SCHEMA,
+    },
+    "required": ["resource_id", "resource_type", "resource_namespace", "relation", "subject_filter"],
+}
+
 RELATIONS_TOOL_INPUT_SCHEMAS = [
     # "api/relations/lookup_resource/"
     {
@@ -49,9 +72,16 @@ RELATIONS_TOOL_INPUT_SCHEMAS = [
         },
         "required": ["resource", "relation", "subject"],
     },
+    # "api/relations/read_tuples/"
+    {
+        "type": "object",
+        "properties": {"filter": FILTER_SCHEMA},
+        "required": ["filter"],
+    },
 ]
 
 RELATION_INPUT_SCHEMAS = {
     "lookup_resources": RELATIONS_TOOL_INPUT_SCHEMAS[0],
     "check_relation": RELATIONS_TOOL_INPUT_SCHEMAS[1],
+    "read_tuples": RELATIONS_TOOL_INPUT_SCHEMAS[2],
 }

--- a/rbac/internal/views.py
+++ b/rbac/internal/views.py
@@ -1538,6 +1538,9 @@ def read_tuples(request):
     # Parse JSON data from the POST request body
     req_data = json.loads(request.body)
 
+    if not validate_relations_input("read_tuples", req_data):
+        return JsonResponse({"detail": "Invalid request body provided in request to read_tuples."}, status=500)
+
     # Request parameters for read tuples on relations api from post request
     resource_namespace = req_data["filter"]["resource_namespace"]
     resource_type = req_data["filter"]["resource_type"]
@@ -1546,7 +1549,7 @@ def read_tuples(request):
     subject_namespace = req_data["filter"]["subject_filter"]["subject_namespace"]
     subject_type = req_data["filter"]["subject_filter"]["subject_type"]
     subject_id = req_data["filter"]["subject_filter"]["subject_id"]
-    subject_relation = req_data["filter"]["subject_filter"]["relation"]
+    subject_relation = req_data.get("filter", {}).get("subject_filter", {}).get("relation") or None
     token = jwt_manager.get_jwt_from_redis()
 
     try:


### PR DESCRIPTION
## Link(s) to Jira
https://issues.redhat.com/browse/RHCLOUD-40939

## Description of Intent of Change(s)
Body validation for the read_tuples internal relations endpoint

## Local Testing
How can the feature be exercised?
How can the bug be exploited and fix confirmed?
Is any special local setup required?

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Add JSON schema-based input validation to the internal read_tuples relations endpoint, register the new schemas, and improve error handling for malformed requests.

New Features:
- Define SUBJECT_FILTER_SCHEMA and FILTER_SCHEMA to formalize request body structure for read_tuples

Enhancements:
- Add read_tuples schema entry to RELATIONS_TOOL_INPUT_SCHEMAS and RELATION_INPUT_SCHEMAS mappings
- Invoke validate_relations_input in the read_tuples view to reject invalid request bodies with a 500 response
- Default the subject_filter.relation to None when missing to prevent KeyError