### PR TITLE
Update renovate.json to try to disable the pr creation of the sc branch

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,8 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "pipenv": {
-    "enabled": false
-  },
   "baseBranches": [
     "master"
   ]

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,5 +2,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "pipenv": {
     "enabled": false
-  }
+  },
+  "baseBranches": [
+    "master"
+  ]
 }


### PR DESCRIPTION
Testing to see whether adding this renovate.json will disable the dependency updates for the security compliance branch

Related PR: https://github.com/RedHatInsights/cloudwatch-aggregator/pull/269/files

## Summary by Sourcery

CI:
- Update .github/renovate.json to ignore the sc branch for dependency updates