### PR TITLE
[RHCLOUD-40444] Roles groups in still shows in default platform group

### DIFF
--- a/tests/management/role/test_view.py
+++ b/tests/management/role/test_view.py
@@ -2271,6 +2271,90 @@ class RoleViewsetTests(IdentityRequest):
         access_data[0]["resourceDefinitions"][0]["attributeFilter"]["value"] = [str(ungrouped_hosts_id.id)]
         self.assertEqual(response.data.get("access"), access_data)
 
+    def test_groups_in_only_from_custom_default_group(self):
+        """
+        Test roles being in default groups won't show up
+        when organization has custom default group that doesn't include the role.
+        """
+        # Create a role that will be in public default group but NOT in custom default group
+        test_role_name = "test_role_not_in_custom_default"
+        test_role = Role.objects.create(
+            name=test_role_name,
+            platform_default=True,  # This makes it part of public default group
+            system=True,
+            tenant=self.public_tenant,
+        )
+
+        # Create permission and access for the test role
+        test_permission = Permission.objects.create(permission="test:*:*", tenant=self.public_tenant)
+        Access.objects.create(permission=test_permission, role=test_role, tenant=self.public_tenant)
+
+        # Ensure public default group exists, or create it
+        public_default_group, created = Group.objects.get_or_create(
+            platform_default=True,
+            tenant=self.public_tenant,
+            defaults={"name": "Default access", "description": "Default access group", "system": True},
+        )
+
+        # Create a policy for the public default group if it doesn't have one
+        public_default_policy, policy_created = Policy.objects.get_or_create(
+            group=public_default_group,
+            defaults={
+                "name": f"System Policy for Group {public_default_group.uuid}",
+                "system": True,
+                "tenant": self.public_tenant,
+            },
+        )
+
+        # Add our test role to the public default group
+        public_default_policy.roles.add(test_role)
+
+        # Create a CUSTOM default group for our tenant that explicitly EXCLUDES the test role
+        custom_default_group = Group.objects.create(
+            name="Custom default access",
+            platform_default=True,
+            system=False,  # Custom groups are not system groups
+            tenant=self.tenant,
+        )
+
+        # Create a policy for the custom default group that does NOT include our test role
+        custom_default_policy = Policy.objects.create(
+            name="Custom default policy", system=True, tenant=self.tenant, group=custom_default_group
+        )
+        # Intentionally NOT adding test_role to this policy
+        # Only add existing roles that should be in custom default
+        custom_default_policy.roles.add(self.defRole)  # Add a different role
+
+        # Now test the groups_in API
+        url = f"{URL}?add_fields=groups_in,groups_in_count"
+        client = APIClient()
+        response = client.get(url, **self.headers)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response_data = response.data.get("data")
+
+        # Find our test role in the response
+        test_role_response = next(
+            (role for role in response_data if role["name"] == test_role_name),
+            None,
+        )
+
+        # Assert that our test role is in the response
+        self.assertIsNotNone(test_role_response, f"Test role '{test_role_name}' not found in API response")
+
+        groups_in = test_role_response.get("groups_in", [])
+        group_names = [group["name"] for group in groups_in]
+
+        # CORRECT BEHAVIOR: groups_in should be empty since:
+        # - Role is NOT in the custom default group for this tenant
+        # - Should not fall back to public default group when custom exists
+        self.assertEqual(
+            len(groups_in),
+            0,
+            f"Role '{test_role_name}' incorrectly shows as being in groups: {group_names}. "
+            f"Expected empty list since role is not in custom default group and should not fall back to public default.",
+        )
+
 
 class RoleViewNonAdminTests(IdentityRequest):
     """Test the role view for nonadmin user."""


### PR DESCRIPTION
## Link(s) to Jira
- https://issues.redhat.com/browse/RHCLOUD-40444

## Description of Intent of Change(s)
There is a bug in the fall back situation when roles is not in custom default group. It falls back to check platform default group, but that doesn't make sense because the custom default group should be the only source of truth if it presents

## Local Testing
Unit test

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Prevent roles from incorrectly appearing in public default groups when a tenant has its own custom default groups by updating the fallback logic and adding a dedicated unit test

Bug Fixes:
- Fix obtain_groups_in to prefer tenant custom default groups over public defaults for both platform and admin default groups, preventing unintended fallbacks

Tests:
- Add unit test verifying roles excluded from tenant’s custom default group do not fall back to public default group