### PR TITLE
RHCLOUD-41806: Revert "RHCLOUD-32232 Pass client ids when making requests to IT"

### DIFF
--- a/rbac/management/group/view.py
+++ b/rbac/management/group/view.py
@@ -553,12 +553,7 @@ class GroupViewSet(
         # want to skip calling IT
         it_service = ITService()
         if not settings.IT_BYPASS_IT_CALLS:
-            # We are only interested in the clients with IDs that have been passed to us, so we specifically request
-            # those clients.
-            it_service_accounts = it_service.request_service_accounts(
-                bearer_token=user.bearer_token,
-                client_ids=[specified_sa["clientId"] for specified_sa in service_accounts],
-            )
+            it_service_accounts = it_service.request_service_accounts(bearer_token=user.bearer_token)
 
             # Organize them by their client ID.
             it_service_accounts_by_client_ids: dict[str, dict] = {}

--- a/rbac/management/principal/it_service.py
+++ b/rbac/management/principal/it_service.py
@@ -18,7 +18,7 @@
 import logging
 import time
 import uuid
-from typing import Any, Iterable, Optional, Tuple, Union
+from typing import Any, Optional, Tuple, Union
 
 import requests
 from django.conf import settings
@@ -215,15 +215,24 @@ class ITService:
         if settings.IT_BYPASS_IT_CALLS:
             return True
         else:
-            service_accounts: list[dict] = self.request_service_accounts(
-                bearer_token=user.bearer_token,
-                client_ids=[client_id],
-            )
+            # In theory, we should be able to pass the client ID to the function below to just get the specified
+            # service account and check if it is present or not. However, due to a bug, we need to fetch the whole
+            # collection for now. More details in https://issues.redhat.com/browse/RHCLOUD-31265 .
+            service_accounts: list[dict] = self.request_service_accounts(bearer_token=user.bearer_token)
 
-            return any(client_id == account.get("clientId") for account in service_accounts)
+            for sa in service_accounts:
+                if client_id == sa.get("clientId"):
+                    return True
+
+            return False
 
     def get_service_accounts(self, user: User, options: dict[str, Any] = {}) -> Tuple[list[dict], int]:
         """Request and returns the service accounts for the given tenant."""
+        # We might want to bypass calls to the IT service on ephemeral or test environments.
+        it_service_accounts: list[dict] = []
+        if not settings.IT_BYPASS_IT_CALLS:
+            it_service_accounts = self.request_service_accounts(bearer_token=user.bearer_token)
+
         # Get the service accounts from the database. The weird filter is to fetch the service accounts depending on
         # the account number or the organization ID the user gave.
         service_account_principals = Principal.objects.filter(type=Principal.Types.SERVICE_ACCOUNT).filter(
@@ -270,10 +279,23 @@ class ITService:
         else:
             service_account_principals = service_account_principals.order_by("-username")
 
-        service_accounts = self._filtered_service_accounts(
-            user=user,
-            service_account_principals=service_account_principals,
-            options=options,
+        # If we are in an ephemeral or test environment, we will take all the service accounts of the user that are
+        # stored in the database and generate a mocked response for them, simulating that IT has the corresponding
+        # service account to complement the information.
+        if settings.IT_BYPASS_IT_CALLS:
+            it_service_accounts = self._get_mock_service_accounts(
+                service_account_principals=service_account_principals
+            )
+
+        # Put the service accounts in a dict by for a quicker search.
+        sap_dict: dict[str, Principal] = {}
+        for sap in service_account_principals:
+            sap_dict[sap.service_account_id] = sap
+
+        # Filter the incoming service accounts. Also, transform them to the payload we will
+        # be returning.
+        service_accounts: list[dict] = self._merge_principals_it_service_accounts(
+            service_account_principals=sap_dict, it_service_accounts=it_service_accounts, options=options
         )
 
         # We always set a default offset and a limit if the user doesn't specify them, so it is safe to simply put the
@@ -320,6 +342,12 @@ class ITService:
     def get_service_accounts_group(self, group: Group, user: User, options: dict[str, Any] = {}) -> list[dict]:
         """Get the service accounts for the given group."""
         username_only: str = options.get("username_only", "false")
+        # We might want to bypass calls to the IT service
+        #        - on ephemeral or test environments
+        #        - when query param username_only == 'true'
+        it_service_accounts: list[dict[str, Union[str, int]]] = []
+        if not settings.IT_BYPASS_IT_CALLS and username_only == "false":
+            it_service_accounts = self.request_service_accounts(bearer_token=user.bearer_token)
 
         # Fetch the service accounts from the group.
         group_service_account_principals = group.principals.filter(type=Principal.Types.SERVICE_ACCOUNT)
@@ -348,15 +376,27 @@ class ITService:
                     service_account_id__contains=principal_username
                 )
 
-        # We do not need to make a request to IT if only usernames are requested.
+        # If we are in an ephemeral or test environment, we will take all the service accounts of the user that are
+        # stored in the database and generate a mocked response for them, simulating that IT has the corresponding
+        # service account to complement the information.
+        if settings.IT_BYPASS_IT_CALLS:
+            it_service_accounts = self._get_mock_service_accounts(
+                service_account_principals=group_service_account_principals
+            )
+
+        # Put the service accounts in a dict by for a quicker search.
+        sap_dict: dict[str, Principal] = {}
+        for sap in group_service_account_principals:
+            sap_dict[sap.service_account_id] = sap
+
+        service_accounts: list[dict] = []
         if username_only == "true":
             # Grab the service account usernames
             service_accounts = [{"username": sa.username} for sa in group_service_account_principals]
         else:
-            service_accounts = self._filtered_service_accounts(
-                user=user,
-                service_account_principals=group_service_account_principals,
-                options=options,
+            # Filter the incoming service accounts. Also, transform them to the payload we will be returning.
+            service_accounts = self._merge_principals_it_service_accounts(
+                service_account_principals=sap_dict, it_service_accounts=it_service_accounts, options=options
             )
 
         # If either the description or name filters were specified, we need to only keep the service accounts that
@@ -470,27 +510,6 @@ class ITService:
 
         return service_account
 
-    def _service_accounts_by_id(self, principals: Iterable[Principal]) -> dict[str, Principal]:
-        """
-        Transform an iterable of service account Principals into a dict keyed by service_account_id.
-
-        Raises a ValueError if any Principal does not have a service_account_id.
-        """
-        sap_dict: dict[str, Principal] = {}
-
-        for principal in principals:
-            account_id = principal.service_account_id
-
-            if account_id is None or account_id == "":
-                raise ValueError(
-                    "Expected Principal to have service_account_id set, but it did not."
-                    + f"Principal UUID: {principal.uuid}",
-                )
-
-            sap_dict[account_id] = principal
-
-        return sap_dict
-
     def _merge_principals_it_service_accounts(
         self, service_account_principals: dict[str, Principal], it_service_accounts: list[dict], options: dict
     ) -> list[dict]:
@@ -521,7 +540,7 @@ class ITService:
 
         return service_accounts
 
-    def _get_mock_service_accounts(self, service_account_principals: Iterable[Principal]) -> list[dict]:
+    def _get_mock_service_accounts(self, service_account_principals: list[Principal]) -> list[dict]:
         """Mock an IT service call which returns service accounts. Useful for development or testing."""
         mocked_service_accounts: list[dict] = []
         for sap in service_account_principals:
@@ -541,40 +560,3 @@ class ITService:
             )
 
         return mocked_service_accounts
-
-    def _filtered_service_accounts(
-        self,
-        user: User,
-        service_account_principals: Iterable[Principal],
-        options: dict,
-    ) -> list[dict]:
-        """
-        Retrieve the service accounts accessible to use that exist both locally and in IT.
-
-        service_account_principals must consist solely of Principals that represent service accounts (i.e. have a
-        service_account_id). The options argument has the same meaning as in _merge_principals_it_service_accounts.
-        """
-        sap_dict: dict[str, Principal] = self._service_accounts_by_id(service_account_principals)
-
-        if not settings.IT_BYPASS_IT_CALLS:
-            # Below, in _merge_principals_it_service_accounts, we take the intersection of the principals in the
-            # database and the principals returned by IT. So, we are only interested in any principals that already
-            # exist in the database, and the keys of sap_dict are thus all of the client_ids we're interested in.
-            it_service_accounts = self.request_service_accounts(
-                bearer_token=user.bearer_token,
-                client_ids=list(sap_dict.keys()),
-            )
-        else:
-            # If we are in an ephemeral or test environment, we will take all the service accounts of the user that are
-            # stored in the database and generate a mocked response for them, simulating that IT has the corresponding
-            # service account to complement the information.
-            it_service_accounts = self._get_mock_service_accounts(
-                service_account_principals=service_account_principals,
-            )
-
-        # Filter the incoming service accounts. Also, transform them to the payload we will be returning.
-        return self._merge_principals_it_service_accounts(
-            service_account_principals=sap_dict,
-            it_service_accounts=it_service_accounts,
-            options=options,
-        )

--- a/tests/management/principal/test_it_service.py
+++ b/tests/management/principal/test_it_service.py
@@ -154,9 +154,7 @@ class ITServiceTests(IdentityRequest):
     def _assert_created_sa_and_result_are_same(
         self, created_database_sa_principals: list[Principal], function_result: list[dict]
     ) -> None:
-        """Assert that the returned representation of service accounts matches the Principals found in the database.
-
-        This verifies the output of, e.g., get_service_accounts.
+        """Assert that the "get_service_accounts" function's result is correct
 
         The assertions make sure that the returned results from the function actually match the created service
         account principals in the test.
@@ -571,14 +569,19 @@ class ITServiceTests(IdentityRequest):
         _is_service_account_valid.assert_called_with(user=user, client_id=str(client_uuid))
 
     @mock.patch("management.principal.it_service.ITService.request_service_accounts")
-    @override_settings(IT_BYPASS_IT_CALLS=True)
     def test_is_service_account_valid_bypass_it_calls(self, _):
         """Test that the function under test assumes service accounts to always be valid when bypassing IT calls."""
-        self.assertEqual(
-            True,
-            self.it_service._is_service_account_valid(user=User(), client_id="mocked-cid"),
-            "when IT calls are bypassed, a service account should always be validated as if it existed",
-        )
+        original_bypass_it_calls_value = settings.IT_BYPASS_IT_CALLS
+        try:
+            settings.IT_BYPASS_IT_CALLS = True
+
+            self.assertEqual(
+                True,
+                self.it_service._is_service_account_valid(user=User(), client_id="mocked-cid"),
+                "when IT calls are bypassed, a service account should always be validated as if it existed",
+            )
+        finally:
+            settings.IT_BYPASS_IT_CALLS = original_bypass_it_calls_value
 
     @mock.patch("management.principal.it_service.ITService.request_service_accounts")
     def test_is_service_account_valid(self, request_service_accounts: mock.Mock):
@@ -1567,104 +1570,6 @@ class ITServiceTests(IdentityRequest):
                 f' "{expected_first_username}" or "{expected_second_username}", got the following service account:'
                 f" {filtered_result}",
             )
-
-    @mock.patch("management.principal.it_service.ITService.request_service_accounts")
-    def test_filtered_service_accounts(self, request_service_accounts: mock.Mock):
-        """Test that the function properly requests service accounts from IT and merges them with local accounts."""
-        user = User()
-        user.bearer_token = "mocked-bt"
-
-        principals_tenant_one, _ = self._create_database_service_account_principals_two_tenants()
-
-        # Select one principal to remove in order to ensure that the local and IT account lists are merged properly.
-        selected_principals = principals_tenant_one[1:]
-
-        request_service_accounts.return_value = self.it_service._get_mock_service_accounts(selected_principals)
-
-        filtered = self.it_service._filtered_service_accounts(
-            user=user,
-            service_account_principals=principals_tenant_one,
-            options={},
-        )
-
-        self.assertEqual(
-            1,
-            request_service_accounts.call_count,
-            "Expected request_service_accounts to be called once.",
-        )
-
-        self.assertSetEqual(
-            set(principal.service_account_id for principal in principals_tenant_one),
-            set(request_service_accounts.call_args.kwargs["client_ids"]),
-            "Expected request_service_accounts to be called with the service_account_ids passed to _filtered_service_accounts.",
-        )
-
-        self._assert_created_sa_and_result_are_same(
-            created_database_sa_principals=selected_principals,
-            function_result=filtered,
-        )
-
-    @override_settings(IT_BYPASS_IT_CALLS=True)
-    @mock.patch("management.principal.it_service.ITService.request_service_accounts")
-    def test_filtered_service_accounts_bypass_it(self, request_service_accounts: mock.Mock):
-        """Test that the function does not use request_service_accounts when IT_BYPASS_IT_CALLS is set."""
-        user = User()
-        user.bearer_token = "mocked-bt"
-
-        principals_tenant_one, _ = self._create_database_service_account_principals_two_tenants()
-
-        # When IT_BYPASS_IT_CALLS is set, _filter_service_accounts should return mocked accounts.
-        request_service_accounts.side_effect = lambda **kwargs: self.fail(
-            "Expected request_service_accounts to not be called when IT_BYPASS_IT_CALLS is set."
-        )
-
-        filtered = self.it_service._filtered_service_accounts(
-            user=user,
-            service_account_principals=principals_tenant_one,
-            options={},
-        )
-
-        self._assert_created_sa_and_result_are_same(
-            created_database_sa_principals=principals_tenant_one,
-            function_result=filtered,
-        )
-
-    @mock.patch("management.principal.it_service.ITService.request_service_accounts")
-    def test_filtered_service_accounts_username_only(self, request_service_accounts: mock.Mock):
-        """Test that the function returns only usernames when username_only is true."""
-        user = User()
-        user.bearer_token = "mocked-bt"
-
-        principals_tenant_one, _ = self._create_database_service_account_principals_two_tenants()
-
-        # Select one principal to remove in order to ensure that the local and IT account lists are merged properly.
-        selected_principals = principals_tenant_one[1:]
-        expected_usernames = set(principal.username for principal in selected_principals)
-
-        request_service_accounts.return_value = self.it_service._get_mock_service_accounts(selected_principals)
-
-        # request_service_accounts being called with the correct arguments is tested above.
-
-        filtered = self.it_service._filtered_service_accounts(
-            user=user,
-            service_account_principals=principals_tenant_one,
-            options={"username_only": "true"},
-        )
-
-        self.assertEqual(
-            len(selected_principals),
-            len(filtered),
-            "Expected the same number of accounts to be returned as provided.",
-        )
-
-        for account in filtered:
-            self.assertEqual(
-                1,
-                len(account),
-                f"Expected each account to have a single key when username_only is true; found {list(account.keys())}.",
-            )
-
-            self.assertIn(account["username"], expected_usernames)
 
     @override_settings(IT_BYPASS_IT_CALLS=True)
     def test_principal_filtering_without_username_match_criteria_exact_skipped(self):


### PR DESCRIPTION
Reverts RedHatInsights/insights-rbac#1786, since it is [breaking stage](https://issues.redhat.com/browse/RHCLOUD-41806).

This is ideally a temporary fix until #1904 is merged.

## Summary by Sourcery

Revert the client ID filtering in IT service requests and associated code and tests, restoring the original behavior of fetching all service accounts until the new implementation is ready.

Enhancements:
- Revert passing specific client_ids to ITService.request_service_accounts
- Remove deprecated helper methods _filtered_service_accounts and _service_accounts_by_id

Tests:
- Restore original test logic for bypassing IT calls and remove overridden settings decorator