### PR TITLE
[RHCLOUD-32232] Pass client IDs when requesting service accounts (take 2)

### DIFF
--- a/rbac/management/group/view.py
+++ b/rbac/management/group/view.py
@@ -615,7 +615,7 @@ class GroupViewSet(
             # those clients.
             it_service_accounts = it_service.request_service_accounts(
                 bearer_token=user.bearer_token,
-                client_ids=[specified_sa["clientId"] for specified_sa in service_accounts]
+                client_ids=[specified_sa["clientId"] for specified_sa in service_accounts],
             )
 
             # Organize them by their client ID.

--- a/rbac/management/group/view.py
+++ b/rbac/management/group/view.py
@@ -611,7 +611,12 @@ class GroupViewSet(
         # want to skip calling IT
         it_service = ITService()
         if not settings.IT_BYPASS_IT_CALLS:
-            it_service_accounts = it_service.request_service_accounts(bearer_token=user.bearer_token)
+            # We are only interested in the clients with IDs that have been passed to us, so we specifically request
+            # those clients.
+            it_service_accounts = it_service.request_service_accounts(
+                bearer_token=user.bearer_token,
+                client_ids=[specified_sa["clientId"] for specified_sa in service_accounts]
+            )
 
             # Organize them by their client ID.
             it_service_accounts_by_client_ids: dict[str, dict] = {}

--- a/rbac/management/principal/it_service.py
+++ b/rbac/management/principal/it_service.py
@@ -128,6 +128,8 @@ class ITService:
         if not bearer_token:
             raise MissingAuthorizationError()
 
+        # Prevent this from resulting in an overly long URL if too many client IDs are passed.
+        # request_service_accounts handles batching the IDs as needed.
         if len(client_ids) > IT_SERVICE_ACCOUNT_CLIENT_ID_BATCH_SIZE:
             raise ValueError("Request for too many client IDs.")
 
@@ -152,8 +154,6 @@ class ITService:
                 # tests only sees the last value for the offset when attempting to fetch multiple pages.
                 parameters = {"first": offset, "max": limit}
 
-                # Prevent this from resulting in an overly long URL if too many client IDs are passed.
-                # request_service_accounts handles batching the IDs as needed.
                 if client_ids:
                     parameters["clientId"] = client_ids
 

--- a/rbac/management/principal/it_service.py
+++ b/rbac/management/principal/it_service.py
@@ -18,6 +18,7 @@
 
 import itertools
 import logging
+import math
 import time
 import uuid
 from typing import Any, Iterable, Optional, Tuple
@@ -142,7 +143,7 @@ class ITService:
                 client_ids
             ) <= 2 * IT_SERVICE_ACCOUNT_MAX_CLIENT_IDS or self._it_service_account_count_at_least(
                 bearer_token=bearer_token,
-                count=int(len(client_ids) * IT_SERVICE_ACCOUNT_BATCH_SIZE / IT_SERVICE_ACCOUNT_MAX_CLIENT_IDS),
+                count=math.ceil(len(client_ids) / IT_SERVICE_ACCOUNT_MAX_CLIENT_IDS) * IT_SERVICE_ACCOUNT_BATCH_SIZE,
             )
 
             if use_remote_client_ids:

--- a/rbac/management/principal/it_service.py
+++ b/rbac/management/principal/it_service.py
@@ -272,30 +272,11 @@ class ITService:
             service_account_principals = service_account_principals.order_by("username")
         else:
             service_account_principals = service_account_principals.order_by("-username")
-
-        # Put the service accounts in a dict by for a quicker search.
-        sap_dict: dict[str, Principal] = self._service_accounts_by_id(service_account_principals)
-
-        if not settings.IT_BYPASS_IT_CALLS:
-            # Below, in _merge_principals_it_service_accounts, we take the intersection of the principals in the database
-            # and the principals returned by IT. So, we are only interested in any principals that already exist in the
-            # database, and the keys of sap_dict are thus all of the client_ids we're interested in.
-            it_service_accounts = self.request_service_accounts(
-                bearer_token=user.bearer_token,
-                client_ids=list(sap_dict.keys()),
-            )
-        else:
-            # If we are in an ephemeral or test environment, we will take all the service accounts of the user that are
-            # stored in the database and generate a mocked response for them, simulating that IT has the corresponding
-            # service account to complement the information.
-            it_service_accounts = self._get_mock_service_accounts(
-                service_account_principals=service_account_principals,
-            )
-
-        # Filter the incoming service accounts. Also, transform them to the payload we will
-        # be returning.
-        service_accounts: list[dict] = self._merge_principals_it_service_accounts(
-            service_account_principals=sap_dict, it_service_accounts=it_service_accounts, options=options
+            
+        service_accounts = self._filtered_service_accounts(
+            user=user,
+            service_account_principals=service_account_principals,
+            options=options,
         )
 
         # We always set a default offset and a limit if the user doesn't specify them, so it is safe to simply put the
@@ -370,35 +351,15 @@ class ITService:
                     service_account_id__contains=principal_username
                 )
 
-        service_accounts: list[dict] = []
-
         # We do not need to make a request from IT if only usernames are requested.
         if username_only == "true":
             # Grab the service account usernames
             service_accounts = [{"username": sa.username} for sa in group_service_account_principals]
         else:
-            # Put the service accounts in a dict by for a quicker search.
-            sap_dict: dict[str, Principal] = self._service_accounts_by_id(group_service_account_principals)
-
-            it_service_accounts: list[dict[str, Union[str, int]]] = []
-
-            # We might want to bypass calls to the IT service on ephemeral or test environments.
-            if not settings.IT_BYPASS_IT_CALLS:
-                it_service_accounts = self.request_service_accounts(
-                    bearer_token=user.bearer_token,
-                    client_ids=list(sap_dict.keys()),
-                )
-            else:
-                # If we are in an ephemeral or test environment, we will take all the service accounts of the user that
-                # are stored in the database and generate a mocked response for them, simulating that IT has the
-                # corresponding service account to complement the information.
-                it_service_accounts = self._get_mock_service_accounts(
-                    service_account_principals=group_service_account_principals
-                )
-
-            # Filter the incoming service accounts. Also, transform them to the payload we will be returning.
-            service_accounts = self._merge_principals_it_service_accounts(
-                service_account_principals=sap_dict, it_service_accounts=it_service_accounts, options=options
+            service_accounts = self._filtered_service_accounts(
+                user=user,
+                service_account_principals=group_service_account_principals,
+                options=options,
             )
 
         # If either the description or name filters were specified, we need to only keep the service accounts that
@@ -561,7 +522,7 @@ class ITService:
 
         return service_accounts
 
-    def _get_mock_service_accounts(self, service_account_principals: list[Principal]) -> list[dict]:
+    def _get_mock_service_accounts(self, service_account_principals: Iterable[Principal]) -> list[dict]:
         """Mock an IT service call which returns service accounts. Useful for development or testing."""
         mocked_service_accounts: list[dict] = []
         for sap in service_account_principals:
@@ -581,3 +542,37 @@ class ITService:
             )
 
         return mocked_service_accounts
+    
+    def _filtered_service_accounts(self, user: User, service_account_principals: Iterable[Principal], options: dict) -> list[dict]:
+        """Retrieves the service accounts accessible to the provided user, then filters them so that only those that
+        exist locally (as provided in the service_account_principals argument) remain.
+
+        service_account_principals must consist solely of Principals that represent service accounts (i.e. have a
+        service_account_id). The options argument has the same meaning as in _merge_principals_it_service_accounts."""
+
+        # Put the service accounts in a dict by for a quicker search.
+        sap_dict: dict[str, Principal] = self._service_accounts_by_id(service_account_principals)
+
+        if not settings.IT_BYPASS_IT_CALLS:
+            # Below, in _merge_principals_it_service_accounts, we take the intersection of the principals in the database
+            # and the principals returned by IT. So, we are only interested in any principals that already exist in the
+            # database, and the keys of sap_dict are thus all of the client_ids we're interested in.
+            it_service_accounts = self.request_service_accounts(
+                bearer_token=user.bearer_token,
+                client_ids=list(sap_dict.keys()),
+            )
+        else:
+            # If we are in an ephemeral or test environment, we will take all the service accounts of the user that are
+            # stored in the database and generate a mocked response for them, simulating that IT has the corresponding
+            # service account to complement the information.
+            it_service_accounts = self._get_mock_service_accounts(
+                service_account_principals=service_account_principals,
+            )
+
+        # Filter the incoming service accounts. Also, transform them to the payload we will be returning.
+        return self._merge_principals_it_service_accounts(
+            service_account_principals=sap_dict,
+            it_service_accounts=it_service_accounts,
+            options=options,
+        )
+

--- a/rbac/management/principal/it_service.py
+++ b/rbac/management/principal/it_service.py
@@ -100,7 +100,12 @@ class ITService:
 
     @it_request_all_service_accounts_time_tracking.time()
     def request_service_accounts(self, bearer_token: str, client_ids: Optional[Iterable[str]] = None) -> list[dict]:
-        """Request the service accounts for a tenant and returns the entire list that IT has."""
+        """
+        Request the service accounts for a tenant.
+
+        If client_ids is None or empty, request all of the service accounts that IT has. Otherwise, request only the
+        service accounts with the specified IDs.
+        """
         if client_ids is not None:
             client_ids = set(client_ids)
 
@@ -123,14 +128,19 @@ class ITService:
         )
 
     def _request_service_accounts_batch(self, bearer_token: str, client_ids: Optional[list[str]] = None) -> list[dict]:
-        """Request a single batch of the service accounts for a tenant and returns the entire list that IT has."""
+        """
+        Request a single batch of service accounts for a tenant and return the list that IT has.
+
+        Here, a "batch" is a set of client IDs to request. If client_ids is None, all service accounts are requested
+        from IT. client_ids shall have size no greater than IT_SERVICE_ACCOUNT_CLIENT_ID_BATCH_SIZE.
+        """
         # We cannot talk to IT if we don't have a bearer token.
         if not bearer_token:
             raise MissingAuthorizationError()
 
         # Prevent this from resulting in an overly long URL if too many client IDs are passed.
         # request_service_accounts handles batching the IDs as needed.
-        if len(client_ids) > IT_SERVICE_ACCOUNT_CLIENT_ID_BATCH_SIZE:
+        if (client_ids is not None) and (len(client_ids) > IT_SERVICE_ACCOUNT_CLIENT_ID_BATCH_SIZE):
             raise ValueError("Request for too many client IDs.")
 
         received_service_accounts: list[dict] = []
@@ -145,7 +155,7 @@ class ITService:
             # service accounts. If it equals the limit, that means that there are more pages to fetch.
             parameters: dict[str, Union[int, list[str]]] = {"first": offset, "max": limit}
             # If we were given client IDs to filter the collection with, do it!
-            if client_ids:
+            if client_ids is not None:
                 parameters["clientId"] = client_ids
 
             continue_fetching: bool = True
@@ -154,7 +164,7 @@ class ITService:
                 # tests only sees the last value for the offset when attempting to fetch multiple pages.
                 parameters = {"first": offset, "max": limit}
 
-                if client_ids:
+                if client_ids is not None:
                     parameters["clientId"] = client_ids
 
                 # Call IT.

--- a/rbac/management/principal/it_service.py
+++ b/rbac/management/principal/it_service.py
@@ -20,7 +20,7 @@ import itertools
 import logging
 import time
 import uuid
-from typing import Any, Iterable, Optional, Tuple, Union
+from typing import Any, Iterable, Optional, Tuple
 
 import requests
 from django.conf import settings
@@ -114,8 +114,6 @@ class ITService:
         if not bearer_token:
             raise MissingAuthorizationError()
 
-        LOGGER.info(f"request_service_accounts: client_ids={client_ids}")
-
         if client_ids is not None:
             client_ids = set(client_ids)
 
@@ -188,8 +186,6 @@ class ITService:
         assert client_ids is None or len(client_ids) > 0
         assert client_ids is None or len(client_ids) <= IT_SERVICE_ACCOUNT_MAX_CLIENT_IDS
 
-        LOGGER.info(f"service accounts request: client_ids={client_ids}, offset={offset}, limit={limit}")
-
         parameters: dict[str, int | list[str]] = {"first": offset, "max": limit}
 
         if client_ids is not None:
@@ -234,13 +230,6 @@ class ITService:
             offset = 0
             limit = IT_SERVICE_ACCOUNT_BATCH_SIZE
 
-            # If the offset is zero, that means that we need to call the service at least once to get the first
-            # service accounts. If it equals the limit, that means that there are more pages to fetch.
-            parameters: dict[str, Union[int, list[str]]] = {"first": offset, "max": limit}
-            # If we were given client IDs to filter the collection with, do it!
-            if client_ids is not None:
-                parameters["clientId"] = client_ids
-
             continue_fetching: bool = True
             while continue_fetching:
                 body_contents = self._request_service_accounts_raw(
@@ -251,7 +240,7 @@ class ITService:
                 )
 
                 # Merge the previously received service accounts with the new ones.
-                received_service_accounts = received_service_accounts + body_contents
+                received_service_accounts.extend(body_contents)
 
                 # Reassess if we need to keep fetching pages from IT. They don't return page metadata, so we need to
                 # keep looping until the incoming body is an empty array.

--- a/rbac/management/principal/it_service.py
+++ b/rbac/management/principal/it_service.py
@@ -16,6 +16,7 @@
 #
 """Class to manage interactions with the IT service accounts service."""
 
+import itertools
 import logging
 import time
 import uuid
@@ -39,6 +40,9 @@ KEY_SERVICE_ACCOUNT = "service-account-"
 
 # IT path to fetch the service accounts.
 IT_PATH_GET_SERVICE_ACCOUNTS = "/service_accounts/v1"
+
+# Maximum number of service accounts to request from IT at once.
+IT_SERVICE_ACCOUNT_BATCH_SIZE = 100
 
 # Set up the metrics for the IT calls.
 it_request_all_service_accounts_time_tracking = Histogram(
@@ -95,8 +99,29 @@ class ITService:
         self.it_url = f"{self.protocol}://{self.host}:{self.port}{self.base_path}{IT_PATH_GET_SERVICE_ACCOUNTS}"
 
     @it_request_all_service_accounts_time_tracking.time()
-    def request_service_accounts(self, bearer_token: str, client_ids: Optional[list[str]] = None) -> list[dict]:
+    def request_service_accounts(self, bearer_token: str, client_ids: Optional[Iterable[str]] = None) -> list[dict]:
         """Request the service accounts for a tenant and returns the entire list that IT has."""
+        if client_ids:
+            unique_ids = set(client_ids)
+            results: list[dict] = []
+
+            for batch in itertools.batched(unique_ids, IT_SERVICE_ACCOUNT_BATCH_SIZE):
+                results.extend(
+                    self._request_service_accounts_batch(
+                        bearer_token=bearer_token,
+                        client_ids=list(batch),
+                    )
+                )
+
+            return results
+
+        return self._request_service_accounts_batch(
+            bearer_token=bearer_token,
+            client_ids=None,
+        )
+
+    def _request_service_accounts_batch(self, bearer_token: str, client_ids: Optional[list[str]] = None) -> list[dict]:
+        """Request a single batch of the service accounts for a tenant and returns the entire list that IT has."""
         # We cannot talk to IT if we don't have a bearer token.
         if not bearer_token:
             raise MissingAuthorizationError()
@@ -107,7 +132,7 @@ class ITService:
         try:
             # Define some sane initial values.
             offset = 0
-            limit = 100
+            limit = IT_SERVICE_ACCOUNT_BATCH_SIZE
 
             # If the offset is zero, that means that we need to call the service at least once to get the first
             # service accounts. If it equals the limit, that means that there are more pages to fetch.
@@ -121,7 +146,13 @@ class ITService:
                 # Recreate the parameters dictionary every time since otherwise the "assert_has_calls" statement of the
                 # tests only sees the last value for the offset when attempting to fetch multiple pages.
                 parameters = {"first": offset, "max": limit}
+
+                # Prevent this from resulting in an overly long URL if too many client IDs are passed.
+                # request_service_accounts handles batching the IDs as needed.
                 if client_ids:
+                    if len(client_ids) > IT_SERVICE_ACCOUNT_BATCH_SIZE:
+                        raise ValueError("Request for too many client IDs.")
+
                     parameters["clientId"] = client_ids
 
                 # Call IT.
@@ -563,7 +594,7 @@ class ITService:
             # exist in the database, and the keys of sap_dict are thus all of the client_ids we're interested in.
             it_service_accounts = self.request_service_accounts(
                 bearer_token=user.bearer_token,
-                client_ids=list(sap_dict.keys()),
+                client_ids=sap_dict.keys(),
             )
         else:
             # If we are in an ephemeral or test environment, we will take all the service accounts of the user that are

--- a/rbac/management/principal/it_service.py
+++ b/rbac/management/principal/it_service.py
@@ -18,6 +18,7 @@
 
 import logging
 import time
+from typing import Iterable
 import uuid
 from typing import Any, Optional, Tuple, Union
 
@@ -216,23 +217,15 @@ class ITService:
         if settings.IT_BYPASS_IT_CALLS:
             return True
         else:
-            # In theory, we should be able to pass the client ID to the function below to just get the specified
-            # service account and check if it is present or not. However, due to a bug, we need to fetch the whole
-            # collection for now. More details in https://issues.redhat.com/browse/RHCLOUD-31265 .
-            service_accounts: list[dict] = self.request_service_accounts(bearer_token=user.bearer_token)
+            service_accounts: list[dict] = self.request_service_accounts(
+                bearer_token=user.bearer_token,
+                client_ids=[client_id],
+            )
 
-            for sa in service_accounts:
-                if client_id == sa.get("clientId"):
-                    return True
-
-            return False
+            return len(service_accounts) > 0
 
     def get_service_accounts(self, user: User, options: dict[str, Any] = {}) -> Tuple[list[dict], int]:
         """Request and returns the service accounts for the given tenant."""
-        # We might want to bypass calls to the IT service on ephemeral or test environments.
-        it_service_accounts: list[dict] = []
-        if not settings.IT_BYPASS_IT_CALLS:
-            it_service_accounts = self.request_service_accounts(bearer_token=user.bearer_token)
 
         # Get the service accounts from the database. The weird filter is to fetch the service accounts depending on
         # the account number or the organization ID the user gave.
@@ -280,18 +273,24 @@ class ITService:
         else:
             service_account_principals = service_account_principals.order_by("-username")
 
-        # If we are in an ephemeral or test environment, we will take all the service accounts of the user that are
-        # stored in the database and generate a mocked response for them, simulating that IT has the corresponding
-        # service account to complement the information.
-        if settings.IT_BYPASS_IT_CALLS:
-            it_service_accounts = self._get_mock_service_accounts(
-                service_account_principals=service_account_principals
-            )
-
         # Put the service accounts in a dict by for a quicker search.
-        sap_dict: dict[str, Principal] = {}
-        for sap in service_account_principals:
-            sap_dict[sap.service_account_id] = sap
+        sap_dict: dict[str, Principal] = self._service_accounts_by_id(service_account_principals)
+
+        if not settings.IT_BYPASS_IT_CALLS:
+            # Below, in _merge_principals_it_service_accounts, we take the intersection of the principals in the database
+            # and the principals returned by IT. So, we are only interested in any principals that already exist in the
+            # database, and the keys of sap_dict are thus all of the client_ids we're interested in.
+            it_service_accounts = self.request_service_accounts(
+                bearer_token=user.bearer_token,
+                client_ids=list(sap_dict.keys()),
+            )
+        else:
+            # If we are in an ephemeral or test environment, we will take all the service accounts of the user that are
+            # stored in the database and generate a mocked response for them, simulating that IT has the corresponding
+            # service account to complement the information.
+            it_service_accounts = self._get_mock_service_accounts(
+                service_account_principals=service_account_principals,
+            )
 
         # Filter the incoming service accounts. Also, transform them to the payload we will
         # be returning.
@@ -343,12 +342,6 @@ class ITService:
     def get_service_accounts_group(self, group: Group, user: User, options: dict[str, Any] = {}) -> list[dict]:
         """Get the service accounts for the given group."""
         username_only: str = options.get("username_only", "false")
-        # We might want to bypass calls to the IT service
-        #        - on ephemeral or test environments
-        #        - when query param username_only == 'true'
-        it_service_accounts: list[dict[str, Union[str, int]]] = []
-        if not settings.IT_BYPASS_IT_CALLS and username_only == "false":
-            it_service_accounts = self.request_service_accounts(bearer_token=user.bearer_token)
 
         # Fetch the service accounts from the group.
         group_service_account_principals = group.principals.filter(type=Principal.Types.SERVICE_ACCOUNT)
@@ -377,24 +370,32 @@ class ITService:
                     service_account_id__contains=principal_username
                 )
 
-        # If we are in an ephemeral or test environment, we will take all the service accounts of the user that are
-        # stored in the database and generate a mocked response for them, simulating that IT has the corresponding
-        # service account to complement the information.
-        if settings.IT_BYPASS_IT_CALLS:
-            it_service_accounts = self._get_mock_service_accounts(
-                service_account_principals=group_service_account_principals
-            )
-
-        # Put the service accounts in a dict by for a quicker search.
-        sap_dict: dict[str, Principal] = {}
-        for sap in group_service_account_principals:
-            sap_dict[sap.service_account_id] = sap
-
         service_accounts: list[dict] = []
+
+        # We do not need to make a request from IT if only usernames are requested.
         if username_only == "true":
             # Grab the service account usernames
             service_accounts = [{"username": sa.username} for sa in group_service_account_principals]
         else:
+            # Put the service accounts in a dict by for a quicker search.
+            sap_dict: dict[str, Principal] = self._service_accounts_by_id(group_service_account_principals)
+
+            it_service_accounts: list[dict[str, Union[str, int]]] = []
+
+            # We might want to bypass calls to the IT service on ephemeral or test environments.
+            if not settings.IT_BYPASS_IT_CALLS:
+                it_service_accounts = self.request_service_accounts(
+                    bearer_token=user.bearer_token,
+                    client_ids=list(sap_dict.keys()),
+                )
+            else:
+                # If we are in an ephemeral or test environment, we will take all the service accounts of the user that
+                # are stored in the database and generate a mocked response for them, simulating that IT has the
+                # corresponding service account to complement the information.
+                it_service_accounts = self._get_mock_service_accounts(
+                    service_account_principals=group_service_account_principals
+                )
+
             # Filter the incoming service accounts. Also, transform them to the payload we will be returning.
             service_accounts = self._merge_principals_it_service_accounts(
                 service_account_principals=sap_dict, it_service_accounts=it_service_accounts, options=options
@@ -510,6 +511,25 @@ class ITService:
         service_account["type"] = "service-account"
 
         return service_account
+
+    def _service_accounts_by_id(self, principals: Iterable[Principal]) -> dict[str, Principal]:
+        """Transforms an iterable of Principals, each of which must represent a service account, into a dict keyed
+        by service_account_id.
+
+        Raises a ValueError if any Principal does not have a service_account_id."""
+
+        sap_dict: dict[str, Principal] = {}
+
+        for principal in principals:
+            account_id = principal.service_account_id
+
+            if account_id is None or account_id == "":
+                raise ValueError(
+                    f"Expected Principal to have service_account_id set, but it did not. Principal UUID: {principal.uuid}")
+
+            sap_dict[account_id] = principal
+
+        return sap_dict
 
     def _merge_principals_it_service_accounts(
         self, service_account_principals: dict[str, Principal], it_service_accounts: list[dict], options: dict

--- a/rbac/management/principal/it_service.py
+++ b/rbac/management/principal/it_service.py
@@ -101,11 +101,13 @@ class ITService:
     @it_request_all_service_accounts_time_tracking.time()
     def request_service_accounts(self, bearer_token: str, client_ids: Optional[Iterable[str]] = None) -> list[dict]:
         """Request the service accounts for a tenant and returns the entire list that IT has."""
+        if client_ids is not None:
+            client_ids = set(client_ids)
+
         if client_ids:
-            unique_ids = set(client_ids)
             results: list[dict] = []
 
-            for batch in itertools.batched(unique_ids, IT_SERVICE_ACCOUNT_BATCH_SIZE):
+            for batch in itertools.batched(client_ids, IT_SERVICE_ACCOUNT_BATCH_SIZE):
                 results.extend(
                     self._request_service_accounts_batch(
                         bearer_token=bearer_token,

--- a/rbac/management/principal/it_service.py
+++ b/rbac/management/principal/it_service.py
@@ -107,8 +107,8 @@ class ITService:
         """
         Request the service accounts for a tenant.
 
-        If client_ids is None or empty, request all of the service accounts that IT has. Otherwise, request only the
-        service accounts with the specified IDs.
+        If client_ids is None, request all of the service accounts that IT has. Otherwise, request only the service
+        accounts with the specified IDs.
         """
         # We cannot talk to IT if we don't have a bearer token.
         if not bearer_token:

--- a/rbac/management/principal/it_service.py
+++ b/rbac/management/principal/it_service.py
@@ -42,7 +42,8 @@ KEY_SERVICE_ACCOUNT = "service-account-"
 IT_PATH_GET_SERVICE_ACCOUNTS = "/service_accounts/v1"
 
 # Maximum number of different service account client IDs to request from IT at once.
-IT_SERVICE_ACCOUNT_CLIENT_ID_BATCH_SIZE = 100
+# This is a limit set by the IT service.
+IT_SERVICE_ACCOUNT_CLIENT_ID_BATCH_SIZE = 10
 
 # Set up the metrics for the IT calls.
 it_request_all_service_accounts_time_tracking = Histogram(

--- a/rbac/management/principal/it_service.py
+++ b/rbac/management/principal/it_service.py
@@ -41,9 +41,12 @@ KEY_SERVICE_ACCOUNT = "service-account-"
 # IT path to fetch the service accounts.
 IT_PATH_GET_SERVICE_ACCOUNTS = "/service_accounts/v1"
 
+# Maximum number of service accounts to request at once. This is a limit set by the IT service.
+IT_SERVICE_ACCOUNT_BATCH_SIZE = 100
+
 # Maximum number of different service account client IDs to request from IT at once.
 # This is a limit set by the IT service.
-IT_SERVICE_ACCOUNT_CLIENT_ID_BATCH_SIZE = 10
+IT_SERVICE_ACCOUNT_MAX_CLIENT_IDS = 10
 
 # Set up the metrics for the IT calls.
 it_request_all_service_accounts_time_tracking = Histogram(
@@ -107,50 +110,129 @@ class ITService:
         If client_ids is None or empty, request all of the service accounts that IT has. Otherwise, request only the
         service accounts with the specified IDs.
         """
-        if client_ids is not None:
-            client_ids = set(client_ids)
-
-        if client_ids:
-            results: list[dict] = []
-
-            for batch in itertools.batched(client_ids, IT_SERVICE_ACCOUNT_CLIENT_ID_BATCH_SIZE):
-                results.extend(
-                    self._request_service_accounts_batch(
-                        bearer_token=bearer_token,
-                        client_ids=list(batch),
-                    )
-                )
-
-            return results
-
-        return self._request_service_accounts_batch(
-            bearer_token=bearer_token,
-            client_ids=None,
-        )
-
-    def _request_service_accounts_batch(self, bearer_token: str, client_ids: Optional[list[str]] = None) -> list[dict]:
-        """
-        Request a single batch of service accounts for a tenant and return the list that IT has.
-
-        Here, a "batch" is a set of client IDs to request. If client_ids is None, all service accounts are requested
-        from IT. client_ids shall have size no greater than IT_SERVICE_ACCOUNT_CLIENT_ID_BATCH_SIZE.
-        """
         # We cannot talk to IT if we don't have a bearer token.
         if not bearer_token:
             raise MissingAuthorizationError()
 
-        # Prevent this from resulting in an overly long URL if too many client IDs are passed.
-        # request_service_accounts handles batching the IDs as needed.
-        if (client_ids is not None) and (len(client_ids) > IT_SERVICE_ACCOUNT_CLIENT_ID_BATCH_SIZE):
-            raise ValueError("Request for too many client IDs.")
+        LOGGER.info(f"request_service_accounts: client_ids={client_ids}")
 
+        if client_ids is not None:
+            client_ids = set(client_ids)
+
+            # If we are filtering by an empty set client IDs, no service accounts will ever match.
+            if len(client_ids) == 0:
+                return []
+
+            # We want to minimize the number of requests we make. At time of writing, we can request up to 100 service
+            # accounts at once. However, we can only specify at most 10 client IDs as query parameters.
+            #
+            # So, if we make requests with client IDs, we make ceil(len(client_ids) / 10) requests. If we make requests
+            # without client IDs, we make ceil([# of service accounts in IT] / 100) requests. So, we should only pass
+            # client IDs if the number of IDs is less than 1/10 of all service accounts in IT.
+            #
+            # Unfortunately, we have no way to make an educated guess with only RBAC's database, since RBAC's database
+            # is not necessarily in sync with IT. (For instance, stage has a tenant with ~7000 service accounts in
+            # RBAC's database but only 13 in IT.) So, we make a single request in order to determine which strategy is
+            # better (by determining if the number of service accounts in IT is more than 10 times the number of client
+            # IDs).
+            #
+            # As a special case, if we would have to make two or fewer requests using client IDs (i.e. if we care about
+            # fewer than 20 client IDs), then we can always just do that, since we'd always be making at least two
+            # requests anyway (one to see how many service accounts exist and at least one to actually fetch them).
+
+            use_remote_client_ids = len(
+                client_ids
+            ) <= 2 * IT_SERVICE_ACCOUNT_MAX_CLIENT_IDS or self._it_service_account_count_at_least(
+                bearer_token=bearer_token,
+                count=int(len(client_ids) * IT_SERVICE_ACCOUNT_BATCH_SIZE / IT_SERVICE_ACCOUNT_MAX_CLIENT_IDS),
+            )
+
+            if use_remote_client_ids:
+                results: list[dict] = []
+
+                for batch in itertools.batched(client_ids, IT_SERVICE_ACCOUNT_MAX_CLIENT_IDS):
+                    results.extend(
+                        self._request_service_accounts_transformed(
+                            bearer_token=bearer_token,
+                            client_ids=list(batch),
+                        )
+                    )
+
+                return results
+            else:
+                # Request every service account and filter them locally.
+                return [
+                    account
+                    for account in self._request_service_accounts_transformed(
+                        bearer_token=bearer_token, client_ids=None
+                    )
+                    if account["clientId"] in client_ids
+                ]
+
+        # Here, we have no client IDs to worry about, so just request every service account.
+        return self._request_service_accounts_transformed(
+            bearer_token=bearer_token,
+            client_ids=None,
+        )
+
+    def _request_service_accounts_raw(
+        self, bearer_token: str, client_ids: Optional[list[str]], offset: int, limit: int
+    ) -> list[dict]:
+        """
+        Make a single request to IT's service accounts API and return the result.
+
+        This function does not perform any form of iteration or processing of the results. It assumes that its inputs
+        have already been validated. client_ids shall have size no greater than IT_SERVICE_ACCOUNT_MAX_CLIENT_IDS.
+        """
+        assert bearer_token
+        assert client_ids is None or len(client_ids) > 0
+        assert client_ids is None or len(client_ids) <= IT_SERVICE_ACCOUNT_MAX_CLIENT_IDS
+
+        LOGGER.info(f"service accounts request: client_ids={client_ids}, offset={offset}, limit={limit}")
+
+        parameters: dict[str, int | list[str]] = {"first": offset, "max": limit}
+
+        if client_ids is not None:
+            parameters["clientId"] = client_ids
+
+        # Call IT.
+        response = requests.get(
+            url=self.it_url,
+            headers={"Authorization": f"Bearer {bearer_token}"},
+            params=parameters,
+            timeout=self.it_request_timeout,
+        )
+
+        # Save the metrics for the successful call. Successful does not mean that we received an OK response,
+        # but that we were able to reach IT's SSO instead and get a response from them.
+        it_request_status_count.labels(method="GET", status=response.status_code).inc()
+
+        if not status.is_success(response.status_code):
+            LOGGER.error(
+                "Unexpected status code '%s' received from IT when fetching service accounts. " "Response body: %s",
+                response.status_code,
+                response.content,
+            )
+
+            raise UnexpectedStatusCodeFromITError()
+
+        # Extract the body contents.
+        return response.json()
+
+    def _request_service_accounts_transformed(self, bearer_token: str, client_ids: Optional[list[str]]) -> list[dict]:
+        """
+        Request service accounts for a tenant and return the list that IT has (optionally filtering by client ID).
+
+        If client_ids is None, all service accounts are requested from IT. This assumes that bearer_token and client_ids
+        have already been validated. client_ids shall have size no greater than IT_SERVICE_ACCOUNT_MAX_CLIENT_IDS.
+        """
         received_service_accounts: list[dict] = []
 
         # Attempt fetching all the service accounts for the tenant.
         try:
             # Define some sane initial values.
             offset = 0
-            limit = 100
+            limit = IT_SERVICE_ACCOUNT_BATCH_SIZE
 
             # If the offset is zero, that means that we need to call the service at least once to get the first
             # service accounts. If it equals the limit, that means that there are more pages to fetch.
@@ -161,37 +243,12 @@ class ITService:
 
             continue_fetching: bool = True
             while continue_fetching:
-                # Recreate the parameters dictionary every time since otherwise the "assert_has_calls" statement of the
-                # tests only sees the last value for the offset when attempting to fetch multiple pages.
-                parameters = {"first": offset, "max": limit}
-
-                if client_ids is not None:
-                    parameters["clientId"] = client_ids
-
-                # Call IT.
-                response = requests.get(
-                    url=self.it_url,
-                    headers={"Authorization": f"Bearer {bearer_token}"},
-                    params=parameters,
-                    timeout=self.it_request_timeout,
+                body_contents = self._request_service_accounts_raw(
+                    bearer_token=bearer_token,
+                    client_ids=client_ids,
+                    offset=offset,
+                    limit=limit,
                 )
-
-                # Save the metrics for the successful call. Successful does not mean that we received an OK response,
-                # but that we were able to reach IT's SSO instead and get a response from them.
-                it_request_status_count.labels(method="GET", status=response.status_code).inc()
-
-                if not status.is_success(response.status_code):
-                    LOGGER.error(
-                        "Unexpected status code '%s' received from IT when fetching service accounts. "
-                        "Response body: %s",
-                        response.status_code,
-                        response.content,
-                    )
-
-                    raise UnexpectedStatusCodeFromITError()
-
-                # Extract the body contents.
-                body_contents = response.json()
 
                 # Merge the previously received service accounts with the new ones.
                 received_service_accounts = received_service_accounts + body_contents
@@ -233,6 +290,22 @@ class ITService:
             service_accounts.append(self._transform_incoming_payload(incoming_service_account))
 
         return service_accounts
+
+    def _it_service_account_count_at_least(self, bearer_token: str, count: int) -> bool:
+        """Determine whether IT has at least count service accounts."""
+        if count <= 0:
+            return True
+
+        # IT returns an empty array when offset is at least as many accounts as exist. (For example, if there are 10
+        # accounts, requesting an offset of 10 will return an empty array because there is no account at 0-based index
+        # 10.) In order to detect whether an Nth account exists, we need to request offset (N-1). The subtraction is
+        # safe because we have just ensured that count > 0.
+
+        body_contents = self._request_service_accounts_raw(
+            bearer_token=bearer_token, client_ids=None, offset=(count - 1), limit=1
+        )
+
+        return len(body_contents) > 0
 
     def is_service_account_valid_by_client_id(self, user: User, service_account_client_id: str) -> bool:
         """Check if the specified service account is valid."""

--- a/rbac/management/principal/it_service.py
+++ b/rbac/management/principal/it_service.py
@@ -550,7 +550,7 @@ class ITService:
         options: dict,
     ) -> list[dict]:
         """
-        Retrieve the service accounts accessible to use that exist both locally nad in IT.
+        Retrieve the service accounts accessible to use that exist both locally and in IT.
 
         service_account_principals must consist solely of Principals that represent service accounts (i.e. have a
         service_account_id). The options argument has the same meaning as in _merge_principals_it_service_accounts.

--- a/rbac/management/principal/it_service.py
+++ b/rbac/management/principal/it_service.py
@@ -130,10 +130,10 @@ class ITService:
             # client IDs if the number of IDs is less than 1/10 of all service accounts in IT.
             #
             # Unfortunately, we have no way to make an educated guess with only RBAC's database, since RBAC's database
-            # is not necessarily in sync with IT. (For instance, stage has a tenant with ~7000 service accounts in
-            # RBAC's database but only 13 in IT.) So, we make a single request in order to determine which strategy is
-            # better (by determining if the number of service accounts in IT is more than 10 times the number of client
-            # IDs).
+            # is not necessarily in sync with IT. (For instance, at time of writing, stage has a tenant with ~7000
+            # service accounts in RBAC's database but only 13 in IT.) So, we make a single request in order to
+            # determine which strategy is better (by determining if the number of service accounts in IT is more than
+            # 10 times the number of client IDs).
             #
             # As a special case, if we would have to make two or fewer requests using client IDs (i.e. if we care about
             # fewer than 20 client IDs), then we can always just do that, since we'd always be making at least two

--- a/rbac/management/principal/it_service.py
+++ b/rbac/management/principal/it_service.py
@@ -349,7 +349,7 @@ class ITService:
                     service_account_id__contains=principal_username
                 )
 
-        # We do not need to make a request from IT if only usernames are requested.
+        # We do not need to make a request to IT if only usernames are requested.
         if username_only == "true":
             # Grab the service account usernames
             service_accounts = [{"username": sa.username} for sa in group_service_account_principals]

--- a/rbac/management/principal/it_service.py
+++ b/rbac/management/principal/it_service.py
@@ -41,8 +41,8 @@ KEY_SERVICE_ACCOUNT = "service-account-"
 # IT path to fetch the service accounts.
 IT_PATH_GET_SERVICE_ACCOUNTS = "/service_accounts/v1"
 
-# Maximum number of service accounts to request from IT at once.
-IT_SERVICE_ACCOUNT_BATCH_SIZE = 100
+# Maximum number of different service account client IDs to request from IT at once.
+IT_SERVICE_ACCOUNT_CLIENT_ID_BATCH_SIZE = 100
 
 # Set up the metrics for the IT calls.
 it_request_all_service_accounts_time_tracking = Histogram(
@@ -107,7 +107,7 @@ class ITService:
         if client_ids:
             results: list[dict] = []
 
-            for batch in itertools.batched(client_ids, IT_SERVICE_ACCOUNT_BATCH_SIZE):
+            for batch in itertools.batched(client_ids, IT_SERVICE_ACCOUNT_CLIENT_ID_BATCH_SIZE):
                 results.extend(
                     self._request_service_accounts_batch(
                         bearer_token=bearer_token,
@@ -134,7 +134,7 @@ class ITService:
         try:
             # Define some sane initial values.
             offset = 0
-            limit = IT_SERVICE_ACCOUNT_BATCH_SIZE
+            limit = 100
 
             # If the offset is zero, that means that we need to call the service at least once to get the first
             # service accounts. If it equals the limit, that means that there are more pages to fetch.
@@ -152,7 +152,7 @@ class ITService:
                 # Prevent this from resulting in an overly long URL if too many client IDs are passed.
                 # request_service_accounts handles batching the IDs as needed.
                 if client_ids:
-                    if len(client_ids) > IT_SERVICE_ACCOUNT_BATCH_SIZE:
+                    if len(client_ids) > IT_SERVICE_ACCOUNT_CLIENT_ID_BATCH_SIZE:
                         raise ValueError("Request for too many client IDs.")
 
                     parameters["clientId"] = client_ids

--- a/rbac/management/principal/it_service.py
+++ b/rbac/management/principal/it_service.py
@@ -222,7 +222,7 @@ class ITService:
                 client_ids=[client_id],
             )
 
-            return len(service_accounts) > 0
+            return any("clientId" in account and account["clientId"] == client_id for account in service_accounts)
 
     def get_service_accounts(self, user: User, options: dict[str, Any] = {}) -> Tuple[list[dict], int]:
         """Request and returns the service accounts for the given tenant."""
@@ -575,4 +575,3 @@ class ITService:
             it_service_accounts=it_service_accounts,
             options=options,
         )
-

--- a/rbac/management/principal/it_service.py
+++ b/rbac/management/principal/it_service.py
@@ -128,6 +128,9 @@ class ITService:
         if not bearer_token:
             raise MissingAuthorizationError()
 
+        if len(client_ids) > IT_SERVICE_ACCOUNT_CLIENT_ID_BATCH_SIZE:
+            raise ValueError("Request for too many client IDs.")
+
         received_service_accounts: list[dict] = []
 
         # Attempt fetching all the service accounts for the tenant.
@@ -152,9 +155,6 @@ class ITService:
                 # Prevent this from resulting in an overly long URL if too many client IDs are passed.
                 # request_service_accounts handles batching the IDs as needed.
                 if client_ids:
-                    if len(client_ids) > IT_SERVICE_ACCOUNT_CLIENT_ID_BATCH_SIZE:
-                        raise ValueError("Request for too many client IDs.")
-
                     parameters["clientId"] = client_ids
 
                 # Call IT.

--- a/rbac/management/principal/it_service.py
+++ b/rbac/management/principal/it_service.py
@@ -221,7 +221,7 @@ class ITService:
                 client_ids=[client_id],
             )
 
-            return any("clientId" in account and account["clientId"] == client_id for account in service_accounts)
+            return any(client_id == account.get("clientId") for account in service_accounts)
 
     def get_service_accounts(self, user: User, options: dict[str, Any] = {}) -> Tuple[list[dict], int]:
         """Request and returns the service accounts for the given tenant."""

--- a/rbac/management/principal/it_service.py
+++ b/rbac/management/principal/it_service.py
@@ -18,9 +18,8 @@
 
 import logging
 import time
-from typing import Iterable
 import uuid
-from typing import Any, Optional, Tuple, Union
+from typing import Any, Iterable, Optional, Tuple, Union
 
 import requests
 from django.conf import settings
@@ -226,7 +225,6 @@ class ITService:
 
     def get_service_accounts(self, user: User, options: dict[str, Any] = {}) -> Tuple[list[dict], int]:
         """Request and returns the service accounts for the given tenant."""
-
         # Get the service accounts from the database. The weird filter is to fetch the service accounts depending on
         # the account number or the organization ID the user gave.
         service_account_principals = Principal.objects.filter(type=Principal.Types.SERVICE_ACCOUNT).filter(
@@ -272,7 +270,7 @@ class ITService:
             service_account_principals = service_account_principals.order_by("username")
         else:
             service_account_principals = service_account_principals.order_by("-username")
-            
+
         service_accounts = self._filtered_service_accounts(
             user=user,
             service_account_principals=service_account_principals,
@@ -474,11 +472,11 @@ class ITService:
         return service_account
 
     def _service_accounts_by_id(self, principals: Iterable[Principal]) -> dict[str, Principal]:
-        """Transforms an iterable of Principals, each of which must represent a service account, into a dict keyed
-        by service_account_id.
+        """
+        Transform an iterable of service account Principals into a dict keyed by service_account_id.
 
-        Raises a ValueError if any Principal does not have a service_account_id."""
-
+        Raises a ValueError if any Principal does not have a service_account_id.
+        """
         sap_dict: dict[str, Principal] = {}
 
         for principal in principals:
@@ -486,7 +484,9 @@ class ITService:
 
             if account_id is None or account_id == "":
                 raise ValueError(
-                    f"Expected Principal to have service_account_id set, but it did not. Principal UUID: {principal.uuid}")
+                    "Expected Principal to have service_account_id set, but it did not."
+                    + f"Principal UUID: {principal.uuid}",
+                )
 
             sap_dict[account_id] = principal
 
@@ -542,21 +542,25 @@ class ITService:
             )
 
         return mocked_service_accounts
-    
-    def _filtered_service_accounts(self, user: User, service_account_principals: Iterable[Principal], options: dict) -> list[dict]:
-        """Retrieves the service accounts accessible to the provided user, then filters them so that only those that
-        exist locally (as provided in the service_account_principals argument) remain.
+
+    def _filtered_service_accounts(
+        self,
+        user: User,
+        service_account_principals: Iterable[Principal],
+        options: dict,
+    ) -> list[dict]:
+        """
+        Retrieve the service accounts accessible to use that exist both locally nad in IT.
 
         service_account_principals must consist solely of Principals that represent service accounts (i.e. have a
-        service_account_id). The options argument has the same meaning as in _merge_principals_it_service_accounts."""
-
-        # Put the service accounts in a dict by for a quicker search.
+        service_account_id). The options argument has the same meaning as in _merge_principals_it_service_accounts.
+        """
         sap_dict: dict[str, Principal] = self._service_accounts_by_id(service_account_principals)
 
         if not settings.IT_BYPASS_IT_CALLS:
-            # Below, in _merge_principals_it_service_accounts, we take the intersection of the principals in the database
-            # and the principals returned by IT. So, we are only interested in any principals that already exist in the
-            # database, and the keys of sap_dict are thus all of the client_ids we're interested in.
+            # Below, in _merge_principals_it_service_accounts, we take the intersection of the principals in the
+            # database and the principals returned by IT. So, we are only interested in any principals that already
+            # exist in the database, and the keys of sap_dict are thus all of the client_ids we're interested in.
             it_service_accounts = self.request_service_accounts(
                 bearer_token=user.bearer_token,
                 client_ids=list(sap_dict.keys()),

--- a/tests/management/principal/test_it_service.py
+++ b/tests/management/principal/test_it_service.py
@@ -1857,10 +1857,10 @@ class ITServiceTests(IdentityRequest):
         )
 
         for account in filtered:
-            self.assertEqual(
-                1,
-                len(account),
-                f"Expected each account to have a single key when username_only is true; found {list(account.keys())}.",
+            self.assertCountEqual(
+                ["username"],
+                account.keys(),
+                f"Expected each account to have a single key when username_only is true.",
             )
 
             self.assertIn(account["username"], expected_usernames)

--- a/tests/management/principal/test_it_service.py
+++ b/tests/management/principal/test_it_service.py
@@ -449,7 +449,7 @@ class ITServiceTests(IdentityRequest):
             call=calls[0],
             url=it_url,
             headers={"Authorization": f"Bearer {bearer_token_mock}"},
-            params={"first": 249, "max": 1},
+            params={"first": 299, "max": 1},
             timeout=settings.IT_SERVICE_TIMEOUT_SECONDS,
             client_ids_assert=lambda call_client_ids: self.assertEqual([], call_client_ids),
         )
@@ -524,7 +524,7 @@ class ITServiceTests(IdentityRequest):
             call=calls[0],
             url=it_url,
             headers={"Authorization": f"Bearer {bearer_token_mock}"},
-            params={"first": 449, "max": 1},
+            params={"first": 499, "max": 1},
             timeout=settings.IT_SERVICE_TIMEOUT_SECONDS,
             client_ids_assert=lambda call_client_ids: self.assertEqual([], call_client_ids),
         )

--- a/tests/management/principal/test_it_service.py
+++ b/tests/management/principal/test_it_service.py
@@ -1793,7 +1793,7 @@ class ITServiceTests(IdentityRequest):
         )
 
         self.assertSetEqual(
-            set(principal.service_account_id for principal in principals_tenant_one),
+            {principal.service_account_id for principal in principals_tenant_one},
             set(request_service_accounts.call_args.kwargs["client_ids"]),
             "Expected request_service_accounts to be called with the service_account_ids passed to _filtered_service_accounts.",
         )
@@ -1838,7 +1838,7 @@ class ITServiceTests(IdentityRequest):
 
         # Select one principal to remove in order to ensure that the local and IT account lists are merged properly.
         selected_principals = principals_tenant_one[1:]
-        expected_usernames = set(principal.username for principal in selected_principals)
+        expected_usernames = {principal.username for principal in selected_principals}
 
         request_service_accounts.return_value = self.it_service._get_mock_service_accounts(selected_principals)
 

--- a/tests/management/principal/test_it_service.py
+++ b/tests/management/principal/test_it_service.py
@@ -350,7 +350,8 @@ class ITServiceTests(IdentityRequest):
         parameters = {"first": 0, "max": 100, "clientId": client_ids}
 
         # Assert that the "get" function was called with the expected arguments.
-        get.assert_called_with(
+        self._assert_service_account_call(
+            get,
             url=it_url,
             headers={"Authorization": f"Bearer {bearer_token_mock}"},
             params=parameters,

--- a/tests/management/principal/test_it_service.py
+++ b/tests/management/principal/test_it_service.py
@@ -369,7 +369,7 @@ class ITServiceTests(IdentityRequest):
     @mock.patch("management.principal.it_service.requests.get")
     def test_request_service_accounts_single_page(self, get: mock.Mock):
         """Test that the function under test can handle fetching a single page of service accounts from IT"""
-        # Create the mocked response from IT.
+        # Create a fake IT service with service accounts.
         mocked_service_accounts = self._create_mock_it_service_accounts(5)
         requested_service_accounts = mocked_service_accounts[0:3]
 
@@ -413,7 +413,7 @@ class ITServiceTests(IdentityRequest):
     @mock.patch("management.principal.it_service.requests.get")
     def test_request_service_accounts_client_ids_small(self, get: mock.Mock):
         """Test that the function under test uses client IDs when few service accounts are needed."""
-        # Create the mocked response from IT.
+        # Create a fake IT service with service accounts.
         mocked_service_accounts = self._create_mock_it_service_accounts(400)
         requested_service_accounts = mocked_service_accounts[0:5]
 
@@ -487,7 +487,7 @@ class ITServiceTests(IdentityRequest):
     @mock.patch("management.principal.it_service.requests.get")
     def test_request_service_accounts_client_ids_large(self, get: mock.Mock):
         """Test that the function under test uses client IDs when few service accounts are needed."""
-        # Create the mocked response from IT.
+        # Create a fake IT service with service accounts.
         mocked_service_accounts = self._create_mock_it_service_accounts(400)
         requested_service_accounts = mocked_service_accounts[0:5]
 
@@ -550,7 +550,7 @@ class ITServiceTests(IdentityRequest):
     @mock.patch("management.principal.it_service.requests.get")
     def test_request_service_accounts_multiple_pages(self, get: mock.Mock):
         """Test that the function under test can handle fetching multiple pages from IT"""
-        # Create the mocked response from IT.
+        # Create a fake IT service with service accounts.
         mocked_service_accounts = self._create_mock_it_service_accounts(300)
 
         # Make sure the "get" function returns multiple pages of service accounts.

--- a/tests/management/principal/test_it_service.py
+++ b/tests/management/principal/test_it_service.py
@@ -590,28 +590,39 @@ class ITServiceTests(IdentityRequest):
         )
 
         # Assert that the "get" function is called with the expected arguments for the multiple pages.
-        # clientId is handled separately.
-        expected_parameters = [
-            {"first": 0, "max": 100},
-            {"first": 100, "max": 100},
-            {"first": 200, "max": 100},
-            {"first": 300, "max": 100},
-        ]
+        parameters_first_call = {"first": 0, "max": 100}
+        parameters_second_call = {"first": 100, "max": 100}
+        parameters_third_call = {"first": 200, "max": 100}
+        parameters_fourth_call = {"first": 300, "max": 100}
 
-        calls = get.call_args_list
-        self.assertEqual(4, len(calls), "Expected 4 requests for IT service accounts.")
-
-        seen_parameters: list[dict] = []
-
-        for index, call in enumerate(calls):
-            self._assert_service_account_call(
-                call=call,
-                client_ids_assert=lambda call_client_ids: self.assertEqual([], call_client_ids),
-                url=it_url,
-                headers={"Authorization": f"Bearer {bearer_token_mock}"},
-                params=expected_parameters[index],
-                timeout=settings.IT_SERVICE_TIMEOUT_SECONDS,
-            )
+        get.assert_has_calls(
+            [
+                mock.call(
+                    url=it_url,
+                    headers={"Authorization": f"Bearer {bearer_token_mock}"},
+                    params=parameters_first_call,
+                    timeout=settings.IT_SERVICE_TIMEOUT_SECONDS,
+                ),
+                mock.call(
+                    url=it_url,
+                    headers={"Authorization": f"Bearer {bearer_token_mock}"},
+                    params=parameters_second_call,
+                    timeout=settings.IT_SERVICE_TIMEOUT_SECONDS,
+                ),
+                mock.call(
+                    url=it_url,
+                    headers={"Authorization": f"Bearer {bearer_token_mock}"},
+                    params=parameters_third_call,
+                    timeout=settings.IT_SERVICE_TIMEOUT_SECONDS,
+                ),
+                mock.call(
+                    url=it_url,
+                    headers={"Authorization": f"Bearer {bearer_token_mock}"},
+                    params=parameters_fourth_call,
+                    timeout=settings.IT_SERVICE_TIMEOUT_SECONDS,
+                ),
+            ]
+        )
 
         # Assert that the payload is correct.
         self._assert_IT_to_RBAC_model_transformations(

--- a/tests/management/principal/test_it_service.py
+++ b/tests/management/principal/test_it_service.py
@@ -377,7 +377,7 @@ class ITServiceTests(IdentityRequest):
 
         bearer_token_mock = "bearer-token-mock"
 
-        client_ids = [str(uuid.uuid4()) for i in range(0, 200)]
+        client_ids = [str(uuid.uuid4()) for _ in range(150)]
 
         # Call the function under test.
         result: list[dict] = self.it_service.request_service_accounts(
@@ -407,11 +407,8 @@ class ITServiceTests(IdentityRequest):
                 call.kwargs["timeout"], settings.IT_SERVICE_TIMEOUT_SECONDS, "Incorrect timeout for call."
             )
 
-            actual_parameters = call.kwargs["params"]
-
-            # Assert that there are the correct number of client IDs.
+            actual_parameters = dict(call.kwargs["params"])
             call_client_ids = actual_parameters["clientId"]
-            self.assertEqual(100, len(call_client_ids))
 
             # Assert that we do not duplicate requested client IDs.
             self.assertTrue(

--- a/tests/management/principal/test_it_service.py
+++ b/tests/management/principal/test_it_service.py
@@ -395,7 +395,7 @@ class ITServiceTests(IdentityRequest):
 
         bearer_token_mock = "bearer-token-mock"
 
-        client_ids = [str(uuid.uuid4()) for _ in range(150)]
+        client_ids = [str(uuid.uuid4()) for _ in range(145)]
 
         # Call the function under test.
         result: list[dict] = self.it_service.request_service_accounts(
@@ -412,7 +412,7 @@ class ITServiceTests(IdentityRequest):
         base_parameters = {"first": 0, "max": 100}
 
         calls = get.call_args_list
-        self.assertEqual(2, len(calls), "Expected two requests to IT to be made.")
+        self.assertEqual(15, len(calls), "Expected two requests to IT to be made.")
 
         seen_client_ids = set()
 

--- a/tests/management/principal/test_it_service.py
+++ b/tests/management/principal/test_it_service.py
@@ -1579,8 +1579,8 @@ class ITServiceTests(IdentityRequest):
 
         # Select one principal to remove in order to ensure that the local and IT account lists are merged properly.
         selected_principals = principals_tenant_one[1:]
-        mocked = self.it_service._get_mock_service_accounts(selected_principals)
-        request_service_accounts.return_value = mocked
+
+        request_service_accounts.return_value = self.it_service._get_mock_service_accounts(selected_principals)
 
         filtered = self.it_service._filtered_service_accounts(
             user=user,
@@ -1640,10 +1640,9 @@ class ITServiceTests(IdentityRequest):
 
         # Select one principal to remove in order to ensure that the local and IT account lists are merged properly.
         selected_principals = principals_tenant_one[1:]
-        mocked = self.it_service._get_mock_service_accounts(selected_principals)
-        request_service_accounts.return_value = mocked
-
         expected_usernames = set(principal.username for principal in selected_principals)
+
+        request_service_accounts.return_value = self.it_service._get_mock_service_accounts(selected_principals)
 
         # request_service_accounts being called with the correct arguments is tested above.
 

--- a/tests/management/principal/test_it_service.py
+++ b/tests/management/principal/test_it_service.py
@@ -16,20 +16,19 @@
 #
 """Test the principal model."""
 
-import requests
 import uuid
-
-from django.conf import settings
-from django.test import override_settings
-
-from management.group.model import Group
-from management.principal.model import Principal
-from management.principal.it_service import ITService, UnexpectedStatusCodeFromITError
-from rest_framework import serializers, status
-from tests.identity_request import IdentityRequest
 from unittest import mock
 
-from api.models import User, Tenant
+import requests
+from django.conf import settings
+from django.test import override_settings
+from management.group.model import Group
+from management.principal.it_service import ITService, UnexpectedStatusCodeFromITError
+from management.principal.model import Principal
+from rest_framework import serializers, status
+from tests.identity_request import IdentityRequest
+
+from api.models import Tenant, User
 
 # IT path to fetch the service accounts.
 IT_PATH_GET_SERVICE_ACCOUNTS = "/service_accounts/v1"
@@ -305,6 +304,22 @@ class ITServiceTests(IdentityRequest):
                 "the time created and created at fields for the RBAC and IT models do not match",
             )
 
+    def _assert_service_account_call(self, mock: mock.Mock, *args, **kwargs):
+        """Assert that a call to IT's service accounts endpoint is as expected."""
+        if "params" in kwargs and "clientId" in kwargs["params"]:
+            # We do not care about the order of client IDs.
+
+            actual_client_ids = mock.call_args.kwargs["params"]["clientId"]
+
+            self.assertCountEqual(actual_client_ids, kwargs["params"]["clientId"], "Client IDs did not match call.")
+
+            # Now that the IDs have been verified, just make the expectation match reality.
+            kwargs = dict(kwargs)
+            kwargs["params"] = dict(kwargs["params"])
+            kwargs["params"]["clientId"] = actual_client_ids
+
+        mock.assert_called_with(*args, **kwargs)
+
     @mock.patch("management.principal.it_service.requests.get")
     def test_request_service_accounts_single_page(self, get: mock.Mock):
         """Test that the function under test can handle fetching a single page of service accounts from IT"""
@@ -341,6 +356,75 @@ class ITServiceTests(IdentityRequest):
             params=parameters,
             timeout=settings.IT_SERVICE_TIMEOUT_SECONDS,
         )
+
+        # Assert that the payload is correct.
+        self._assert_IT_to_RBAC_model_transformations(
+            it_service_accounts=mocked_service_accounts, rbac_service_accounts=result
+        )
+
+    @mock.patch("management.principal.it_service.requests.get")
+    def test_request_service_accounts_batching(self, get: mock.Mock):
+        """Test that the function under test can properly batch requests for large numbers of client IDs."""
+        # Create the mocked response from IT.
+        mocked_service_accounts = self._create_mock_it_service_accounts(5)
+
+        get.__name__ = "get"
+        get.return_value = mock.Mock(
+            json=lambda: mocked_service_accounts,
+            status_code=status.HTTP_200_OK,
+        )
+
+        bearer_token_mock = "bearer-token-mock"
+
+        client_ids = [str(uuid.uuid4()) for i in range(0, 200)]
+
+        # Call the function under test.
+        result: list[dict] = self.it_service.request_service_accounts(
+            bearer_token=bearer_token_mock, client_ids=client_ids
+        )
+
+        # Build IT's URL for the function call's assertion.
+        it_url = (
+            f"{settings.IT_SERVICE_PROTOCOL_SCHEME}://{settings.IT_SERVICE_HOST}:{settings.IT_SERVICE_PORT}"
+            f"{settings.IT_SERVICE_BASE_PATH}{IT_PATH_GET_SERVICE_ACCOUNTS}"
+        )
+
+        # Build the expected parameters to be seen in the "get" function's assertion call, other than clientId.
+        base_parameters = {"first": 0, "max": 100}
+
+        calls = get.call_args_list
+        self.assertEqual(2, len(calls), "Expected two requests to IT to be made.")
+
+        seen_client_ids = set()
+
+        for call in calls:
+            self.assertEqual(call.kwargs["url"], it_url, "Incorrect URL for call.")
+            self.assertEqual(
+                call.kwargs["headers"], {"Authorization": f"Bearer {bearer_token_mock}"}, "Incorrect headers for call."
+            )
+            self.assertEqual(
+                call.kwargs["timeout"], settings.IT_SERVICE_TIMEOUT_SECONDS, "Incorrect timeout for call."
+            )
+
+            actual_parameters = call.kwargs["params"]
+
+            # Assert that there are the correct number of client IDs.
+            call_client_ids = actual_parameters["clientId"]
+            self.assertEqual(100, len(call_client_ids))
+
+            # Assert that we do not duplicate requested client IDs.
+            self.assertTrue(
+                seen_client_ids.isdisjoint(call_client_ids),
+                f"Duplicate client IDs requested. Seen: {seen_client_ids}. This batch: {call_client_ids}.",
+            )
+
+            seen_client_ids.update(call_client_ids)
+
+            # Assert that everything except client IDs matches.
+            actual_parameters.pop("clientId")
+            self.assertDictEqual(base_parameters, actual_parameters)
+
+        self.assertSetEqual(set(client_ids), seen_client_ids, "Expected all client IDs to be requested.")
 
         # Assert that the payload is correct.
         self._assert_IT_to_RBAC_model_transformations(
@@ -395,39 +479,35 @@ class ITServiceTests(IdentityRequest):
         )
 
         # Assert that the "get" function is called with the expected arguments for the multiple pages.
-        parameters_first_call = {"first": 0, "max": 100, "clientId": client_ids}
-        parameters_second_call = {"first": 100, "max": 100, "clientId": client_ids}
-        parameters_third_call = {"first": 200, "max": 100, "clientId": client_ids}
-        parameters_fourth_call = {"first": 300, "max": 100, "clientId": client_ids}
+        # clientId is handled separately.
+        expected_parameters = [
+            {"first": 0, "max": 100},
+            {"first": 100, "max": 100},
+            {"first": 200, "max": 100},
+            {"first": 300, "max": 100},
+        ]
 
-        get.assert_has_calls(
-            [
-                mock.call(
-                    url=it_url,
-                    headers={"Authorization": f"Bearer {bearer_token_mock}"},
-                    params=parameters_first_call,
-                    timeout=settings.IT_SERVICE_TIMEOUT_SECONDS,
-                ),
-                mock.call(
-                    url=it_url,
-                    headers={"Authorization": f"Bearer {bearer_token_mock}"},
-                    params=parameters_second_call,
-                    timeout=settings.IT_SERVICE_TIMEOUT_SECONDS,
-                ),
-                mock.call(
-                    url=it_url,
-                    headers={"Authorization": f"Bearer {bearer_token_mock}"},
-                    params=parameters_third_call,
-                    timeout=settings.IT_SERVICE_TIMEOUT_SECONDS,
-                ),
-                mock.call(
-                    url=it_url,
-                    headers={"Authorization": f"Bearer {bearer_token_mock}"},
-                    params=parameters_fourth_call,
-                    timeout=settings.IT_SERVICE_TIMEOUT_SECONDS,
-                ),
-            ]
-        )
+        calls = get.call_args_list
+        self.assertEqual(4, len(calls), "Expected 4 requests for IT service accounts.")
+
+        seen_parameters: list[dict] = []
+
+        for index, call in enumerate(calls):
+            self.assertEqual(0, len(call.args))
+            self.assertEqual(4, len(call.kwargs))
+
+            self.assertEqual(it_url, call.kwargs["url"])
+            self.assertEqual({"Authorization": f"Bearer {bearer_token_mock}"}, call.kwargs["headers"])
+            self.assertEqual(settings.IT_SERVICE_TIMEOUT_SECONDS, call.kwargs["timeout"])
+
+            params = dict(call.kwargs["params"])
+
+            # Assert that the client IDs are as expected. (Order does not matter.)
+            self.assertCountEqual(client_ids, params["clientId"])
+
+            # Assert that all other parameters match.
+            params.pop("clientId")
+            self.assertEqual(expected_parameters[index], params)
 
         # Assert that the payload is correct.
         self._assert_IT_to_RBAC_model_transformations(
@@ -467,7 +547,8 @@ class ITServiceTests(IdentityRequest):
         parameters = {"first": 0, "max": 100, "clientId": client_ids}
 
         # Assert that the "get" function was called with the expected arguments.
-        get.assert_called_with(
+        self._assert_service_account_call(
+            get,
             url=it_url,
             headers={"Authorization": f"Bearer {bearer_token_mock}"},
             params=parameters,
@@ -506,7 +587,8 @@ class ITServiceTests(IdentityRequest):
         parameters = {"first": 0, "max": 100, "clientId": client_ids}
 
         # Assert that the "get" function was called with the expected arguments.
-        get.assert_called_with(
+        self._assert_service_account_call(
+            get,
             url=it_url,
             headers={"Authorization": f"Bearer {bearer_token_mock}"},
             params=parameters,
@@ -543,7 +625,8 @@ class ITServiceTests(IdentityRequest):
         parameters = {"first": 0, "max": 100, "clientId": client_ids}
 
         # Assert that the "get" function was called with the expected arguments.
-        get.assert_called_with(
+        self._assert_service_account_call(
+            get,
             url=it_url,
             headers={"Authorization": f"Bearer {bearer_token_mock}"},
             params=parameters,

--- a/tests/management/principal/test_it_service.py
+++ b/tests/management/principal/test_it_service.py
@@ -486,7 +486,7 @@ class ITServiceTests(IdentityRequest):
 
     @mock.patch("management.principal.it_service.requests.get")
     def test_request_service_accounts_client_ids_large(self, get: mock.Mock):
-        """Test that the function under test uses client IDs when few service accounts are needed."""
+        """Test that the function under test uses client IDs when many service accounts are needed."""
         # Create a fake IT service with service accounts.
         mocked_service_accounts = self._create_mock_it_service_accounts(400)
         requested_service_accounts = mocked_service_accounts[0:5]

--- a/tests/management/principal/test_it_service.py
+++ b/tests/management/principal/test_it_service.py
@@ -570,19 +570,14 @@ class ITServiceTests(IdentityRequest):
         _is_service_account_valid.assert_called_with(user=user, client_id=str(client_uuid))
 
     @mock.patch("management.principal.it_service.ITService.request_service_accounts")
+    @override_settings(IT_BYPASS_IT_CALLS=True)
     def test_is_service_account_valid_bypass_it_calls(self, _):
         """Test that the function under test assumes service accounts to always be valid when bypassing IT calls."""
-        original_bypass_it_calls_value = settings.IT_BYPASS_IT_CALLS
-        try:
-            settings.IT_BYPASS_IT_CALLS = True
-
-            self.assertEqual(
-                True,
-                self.it_service._is_service_account_valid(user=User(), client_id="mocked-cid"),
-                "when IT calls are bypassed, a service account should always be validated as if it existed",
-            )
-        finally:
-            settings.IT_BYPASS_IT_CALLS = original_bypass_it_calls_value
+        self.assertEqual(
+            True,
+            self.it_service._is_service_account_valid(user=User(), client_id="mocked-cid"),
+            "when IT calls are bypassed, a service account should always be validated as if it existed",
+        )
 
     @mock.patch("management.principal.it_service.ITService.request_service_accounts")
     def test_is_service_account_valid(self, request_service_accounts: mock.Mock):

--- a/tests/management/principal/test_it_service.py
+++ b/tests/management/principal/test_it_service.py
@@ -16,6 +16,7 @@
 #
 """Test the principal model."""
 
+import typing
 import uuid
 from unittest import mock
 
@@ -304,8 +305,25 @@ class ITServiceTests(IdentityRequest):
                 "the time created and created at fields for the RBAC and IT models do not match",
             )
 
-    def _assert_service_account_call(self, mock: mock.Mock, *args, **kwargs):
-        """Assert that a call to IT's service accounts endpoint is as expected."""
+    def _assert_service_account_call(
+        self, call, client_ids_assert: typing.Callable[[list[str]], None], *args, **kwargs
+    ):
+        # This must be checked using client_ids_condition.
+        assert kwargs.get("params", {}).get("clientId") is None
+
+        self.assertEqual(call.args, args, "Incorrect positional arguments for call.")
+
+        call_kwargs: dict[str, typing.Any] = dict(call.kwargs)
+        call_params: dict[str, typing.Any] = dict(call.kwargs.get("params", {}))
+
+        call_client_ids = call_params.pop("clientId", [])
+        call_kwargs["params"] = call_params
+
+        client_ids_assert(call_client_ids)
+        self.assertEqual(kwargs, call_kwargs, "Incorrect keyword arugments for call.")
+
+    def _assert_service_account_mock_called(self, mock: mock.Mock, *args, **kwargs):
+        """Assert that a mock has a call to IT's service accounts endpoint is as expected."""
         if "params" in kwargs and "clientId" in kwargs["params"]:
             # We do not care about the order of client IDs.
 
@@ -350,7 +368,7 @@ class ITServiceTests(IdentityRequest):
         parameters = {"first": 0, "max": 100, "clientId": client_ids}
 
         # Assert that the "get" function was called with the expected arguments.
-        self._assert_service_account_call(
+        self._assert_service_account_mock_called(
             get,
             url=it_url,
             headers={"Authorization": f"Bearer {bearer_token_mock}"},
@@ -399,28 +417,19 @@ class ITServiceTests(IdentityRequest):
         seen_client_ids = set()
 
         for call in calls:
-            self.assertEqual(call.kwargs["url"], it_url, "Incorrect URL for call.")
-            self.assertEqual(
-                call.kwargs["headers"], {"Authorization": f"Bearer {bearer_token_mock}"}, "Incorrect headers for call."
-            )
-            self.assertEqual(
-                call.kwargs["timeout"], settings.IT_SERVICE_TIMEOUT_SECONDS, "Incorrect timeout for call."
-            )
-
-            actual_parameters = dict(call.kwargs["params"])
-            call_client_ids = actual_parameters["clientId"]
-
-            # Assert that we do not duplicate requested client IDs.
-            self.assertTrue(
-                seen_client_ids.isdisjoint(call_client_ids),
-                f"Duplicate client IDs requested. Seen: {seen_client_ids}. This batch: {call_client_ids}.",
+            self._assert_service_account_call(
+                call=call,
+                client_ids_assert=lambda call_client_ids: self.assertTrue(
+                    seen_client_ids.isdisjoint(call_client_ids),
+                    f"Duplicate client IDs requested. Seen: {seen_client_ids}. This batch: {call_client_ids}.",
+                ),
+                url=it_url,
+                headers={"Authorization": f"Bearer {bearer_token_mock}"},
+                params=base_parameters,
+                timeout=settings.IT_SERVICE_TIMEOUT_SECONDS,
             )
 
-            seen_client_ids.update(call_client_ids)
-
-            # Assert that everything except client IDs matches.
-            actual_parameters.pop("clientId")
-            self.assertDictEqual(base_parameters, actual_parameters)
+            seen_client_ids.update(call.kwargs["params"]["clientId"])
 
         self.assertSetEqual(set(client_ids), seen_client_ids, "Expected all client IDs to be requested.")
 
@@ -491,21 +500,14 @@ class ITServiceTests(IdentityRequest):
         seen_parameters: list[dict] = []
 
         for index, call in enumerate(calls):
-            self.assertEqual(0, len(call.args))
-            self.assertEqual(4, len(call.kwargs))
-
-            self.assertEqual(it_url, call.kwargs["url"])
-            self.assertEqual({"Authorization": f"Bearer {bearer_token_mock}"}, call.kwargs["headers"])
-            self.assertEqual(settings.IT_SERVICE_TIMEOUT_SECONDS, call.kwargs["timeout"])
-
-            params = dict(call.kwargs["params"])
-
-            # Assert that the client IDs are as expected. (Order does not matter.)
-            self.assertCountEqual(client_ids, params["clientId"])
-
-            # Assert that all other parameters match.
-            params.pop("clientId")
-            self.assertEqual(expected_parameters[index], params)
+            self._assert_service_account_call(
+                call=call,
+                client_ids_assert=lambda call_client_ids: self.assertCountEqual(client_ids, call_client_ids),
+                url=it_url,
+                headers={"Authorization": f"Bearer {bearer_token_mock}"},
+                params=expected_parameters[index],
+                timeout=settings.IT_SERVICE_TIMEOUT_SECONDS,
+            )
 
         # Assert that the payload is correct.
         self._assert_IT_to_RBAC_model_transformations(
@@ -545,7 +547,7 @@ class ITServiceTests(IdentityRequest):
         parameters = {"first": 0, "max": 100, "clientId": client_ids}
 
         # Assert that the "get" function was called with the expected arguments.
-        self._assert_service_account_call(
+        self._assert_service_account_mock_called(
             get,
             url=it_url,
             headers={"Authorization": f"Bearer {bearer_token_mock}"},
@@ -585,7 +587,7 @@ class ITServiceTests(IdentityRequest):
         parameters = {"first": 0, "max": 100, "clientId": client_ids}
 
         # Assert that the "get" function was called with the expected arguments.
-        self._assert_service_account_call(
+        self._assert_service_account_mock_called(
             get,
             url=it_url,
             headers={"Authorization": f"Bearer {bearer_token_mock}"},
@@ -623,7 +625,7 @@ class ITServiceTests(IdentityRequest):
         parameters = {"first": 0, "max": 100, "clientId": client_ids}
 
         # Assert that the "get" function was called with the expected arguments.
-        self._assert_service_account_call(
+        self._assert_service_account_mock_called(
             get,
             url=it_url,
             headers={"Authorization": f"Bearer {bearer_token_mock}"},

--- a/tests/management/principal/test_it_service.py
+++ b/tests/management/principal/test_it_service.py
@@ -155,7 +155,9 @@ class ITServiceTests(IdentityRequest):
     def _assert_created_sa_and_result_are_same(
         self, created_database_sa_principals: list[Principal], function_result: list[dict]
     ) -> None:
-        """Assert that the "get_service_accounts" function's result is correct
+        """Assert that the returned representation of service accounts matches the Principals found in the database.
+
+        This verifies the output of, e.g., get_service_accounts.
 
         The assertions make sure that the returned results from the function actually match the created service
         account principals in the test.
@@ -1566,6 +1568,105 @@ class ITServiceTests(IdentityRequest):
                 f' "{expected_first_username}" or "{expected_second_username}", got the following service account:'
                 f" {filtered_result}",
             )
+
+    @mock.patch("management.principal.it_service.ITService.request_service_accounts")
+    def test_filtered_service_accounts(self, request_service_accounts: mock.Mock):
+        """Test that the function properly requests service accounts from IT and merges them with local accounts."""
+        user = User()
+        user.bearer_token = "mocked-bt"
+
+        principals_tenant_one, _ = self._create_database_service_account_principals_two_tenants()
+
+        # Select one principal to remove in order to ensure that the local and IT account lists are merged properly.
+        selected_principals = principals_tenant_one[1:]
+        mocked = self.it_service._get_mock_service_accounts(selected_principals)
+        request_service_accounts.return_value = mocked
+
+        filtered = self.it_service._filtered_service_accounts(
+            user=user,
+            service_account_principals=principals_tenant_one,
+            options={},
+        )
+
+        self.assertEqual(
+            1,
+            request_service_accounts.call_count,
+            "Expected request_service_accounts to be called once.",
+        )
+
+        self.assertSetEqual(
+            set(principal.service_account_id for principal in principals_tenant_one),
+            set(request_service_accounts.call_args.kwargs["client_ids"]),
+            "Expected request_service_accounts to be called with the service_account_ids passed to _filtered_service_accounts.",
+        )
+
+        self._assert_created_sa_and_result_are_same(
+            created_database_sa_principals=selected_principals,
+            function_result=filtered,
+        )
+
+    @override_settings(IT_BYPASS_IT_CALLS=True)
+    @mock.patch("management.principal.it_service.ITService.request_service_accounts")
+    def test_filtered_service_accounts_bypass_it(self, request_service_accounts: mock.Mock):
+        """Test that the function does not use request_service_accounts when IT_BYPASS_IT_CALLS is set."""
+        user = User()
+        user.bearer_token = "mocked-bt"
+
+        principals_tenant_one, _ = self._create_database_service_account_principals_two_tenants()
+
+        # When IT_BYPASS_IT_CALLS is set, _filter_service_accounts should return mocked accounts.
+        request_service_accounts.side_effect = lambda **kwargs: self.fail(
+            "Expected request_service_accounts to not be called when IT_BYPASS_IT_CALLS is set."
+        )
+
+        filtered = self.it_service._filtered_service_accounts(
+            user=user,
+            service_account_principals=principals_tenant_one,
+            options={},
+        )
+
+        self._assert_created_sa_and_result_are_same(
+            created_database_sa_principals=principals_tenant_one,
+            function_result=filtered,
+        )
+
+    @mock.patch("management.principal.it_service.ITService.request_service_accounts")
+    def test_filtered_service_accounts_username_only(self, request_service_accounts: mock.Mock):
+        """Test that the function returns only usernames when username_only is true."""
+        user = User()
+        user.bearer_token = "mocked-bt"
+
+        principals_tenant_one, _ = self._create_database_service_account_principals_two_tenants()
+
+        # Select one principal to remove in order to ensure that the local and IT account lists are merged properly.
+        selected_principals = principals_tenant_one[1:]
+        mocked = self.it_service._get_mock_service_accounts(selected_principals)
+        request_service_accounts.return_value = mocked
+
+        expected_usernames = set(principal.username for principal in selected_principals)
+
+        # request_service_accounts being called with the correct arguments is tested above.
+
+        filtered = self.it_service._filtered_service_accounts(
+            user=user,
+            service_account_principals=principals_tenant_one,
+            options={"username_only": "true"},
+        )
+
+        self.assertEqual(
+            len(selected_principals),
+            len(filtered),
+            "Expected the same number of accounts to be returned as provided.",
+        )
+
+        for account in filtered:
+            self.assertEqual(
+                1,
+                len(account),
+                f"Expected each account to have a single key when username_only is true; found {list(account.keys())}.",
+            )
+
+            self.assertIn(account["username"], expected_usernames)
 
     @override_settings(IT_BYPASS_IT_CALLS=True)
     def test_principal_filtering_without_username_match_criteria_exact_skipped(self):


### PR DESCRIPTION
## Link(s) to Jira
https://issues.redhat.com/browse/RHCLOUD-32232
https://issues.redhat.com/browse/RHCLOUD-41806

## Description of Intent of Change(s)
This is an updated version of #1786. #1786 unconditionally attempted to use client IDs when making requests to IT. This ended up [breaking stage](https://issues.redhat.com/browse/RHCLOUD-41814) due to [attempting to make requests to overly long URLs](https://issues.redhat.com/browse/RHCLOUD-41806). #1904 was created to attempt to address this, but #1486 was ultimately instead reverted with #1905 in order to get stage working again as quickly as possible.

In testing, #1904 ended up taking a very long amount of time to fulfill requests that were previously fast. There are multiple potential causes for this. One is having more service accounts in RBAC than IT; one example of this happening was an attempt to iterate the service accounts of a stage tenant with ~7000 service accounts in RBAC but only 13 in IT (which would end up making hundreds of requests instead of one). Additionally, the course of writing #1904, it was discovered that the IT service only allows specifying 10 client IDs at once; this means that 10 times as many requests would need to be made to iterate an entire tenant if passing client IDs.

This PR addresses these issues by determining whether it will take fewer requests to provide client IDs or simply to iterate the entire tenant.

## Local Testing
### How can the feature be exercised?
`tox` can be run to exercise the new tests.

Retrieval against an actual SSO instance can be tested by running the service locally with `IT_SERVICE_HOST=sso.stage.redhat.com` and making a request to `/api/rbac/v1/princpials/?type=service-account` with a `Bearer` token from stage. The various branches for how to actually make the requests can be tested by creating dummy accounts in the local database.

## Notes
PyCCC. (Used in code inherited from #1904.)

## Summary by Sourcery

Optimize IT service account retrieval by dynamically choosing between server-side client ID filtering and full pagination, based on request count estimates, and refactor related logic and tests accordingly.

New Features:
- Dynamically select between fetching all service accounts or batching client ID queries to minimize number of IT requests
- Introduce private helpers (_request_service_accounts_raw, _request_service_accounts_transformed, _it_service_account_count_at_least) to modularize IT API interactions
- Add _filtered_service_accounts and _service_accounts_by_id methods to streamline merging database and IT account lists

Enhancements:
- Define IT_SERVICE_ACCOUNT_BATCH_SIZE and IT_SERVICE_ACCOUNT_MAX_CLIENT_IDS constants to enforce service limits
- Refactor request_service_accounts signature and implementation to support Iterable client ID inputs and batching logic
- Simplify get_service_accounts and get_service_accounts_group by delegating to _filtered_service_accounts and removing inline bypass logic
- Update group view to pass only specified client IDs when requesting service accounts from IT

Tests:
- Add FakeIT fixture and assertion helpers to simulate IT responses and validate request parameters
- Cover new batching logic with tests for small, large, and no-client-ID scenarios, pagination, and bypass mode
- Enhance existing tests to verify strategy selection and correct transformation of IT service account payloads