### PR TITLE
Bootstrap tenant if not exist

### DIFF
--- a/tests/internal/test_views.py
+++ b/tests/internal/test_views.py
@@ -3188,6 +3188,7 @@ class InternalS2SViewsetTests(IdentityRequest):
         self.assertEqual(ungrouped_hosts_data["type"], Workspace.Types.UNGROUPED_HOSTS)
         self.assertEqual(ungrouped_hosts_data["name"], Workspace.SpecialNames.UNGROUPED_HOSTS)
 
+
 def valid_destructive_time():
     return datetime.now(timezone.utc).replace(tzinfo=pytz.UTC) + timedelta(hours=1)
 


### PR DESCRIPTION
## Link(s) to Jira
- None

## Description of Intent of Change(s)
Orgs does not exist
            - Some tenants are misssing due to no users, hence no sync into RBAC
            - or org type is not correctly set in IT, no events sent to RBAC.

## Local Testing
unit test

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Bootstrap tenants that do not yet exist when retrieving an ungrouped workspace, ensuring default and ungrouped workspaces are initialized and returning a 201 response

Enhancements:
- Use get_or_create for Tenant in retrieve_ungrouped_workspace and invoke V2TenantBootstrapService.bootstrap_tenant when a new tenant is created

Tests:
- Add unit test to verify tenant auto-creation, workspace initialization (default and ungrouped), and correct API response for a new tenant