### PR TITLE
RHCLOUD-40635 | refactor: make the UMB certificates' secret optional

### DIFF
--- a/deploy/rbac-clowdapp.yml
+++ b/deploy/rbac-clowdapp.yml
@@ -96,6 +96,7 @@ objects:
           name: model-access-permissions
         - name: umb-certificates
           secret:
+            optional: true
             secretName: it-umb-key-pair
         resources:
           limits:


### PR DESCRIPTION
## Link(s) to Jira
- [[RHCLOUD-40635]](https://issues.redhat.com/browse/RHCLOUD-40635)

## Description of Intent of Change(s)
Some environments do not use the UMB queue and therefore they do not need the certificates, so having the secret as mandatory is causing issues.