### PR TITLE
Bump Kafka resources version

### DIFF
--- a/deploy/kafka-connect.yml
+++ b/deploy/kafka-connect.yml
@@ -52,7 +52,7 @@ objects:
         requests:
           cpu: 250m
           memory: 600Mi
-      version: 3.7.0
+      version: 3.9.0
       template:
         perPodService:
           metadata:
@@ -111,7 +111,7 @@ objects:
           - name: rh-registry-pull
           - name: quay.io
     image: quay.io/redhat-user-workloads/hcm-eng-prod-tenant/kafka-connect/kafka-connect:7d45fd8
-    version: 3.7.0
+    version: 3.9.0
     replicas: 1
     bootstrapServers: rbac-kafka-kafka-bootstrap:9092
     resources:


### PR DESCRIPTION
## Link(s) to Jira
-

## Description of Intent of Change(s)
The what, why and how.
The version 3.7.0 is not supported anymore. This PR bumps the versions to a supported version
## Local Testing
How can the feature be exercised?
How can the bug be exploited and fix confirmed?
Is any special local setup required?

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Bump Kafka Connect resource versions to a supported release

Enhancements:
- Update Kafka Connect CR version from 3.7.0 to 3.9.0 in deploy/kafka-connect.yml
- Update Kafka Connect image version field from 3.7.0 to 3.9.0