### PR TITLE
Openapi v1 anyof

### DIFF
--- a/docs/source/specs/openapi.json
+++ b/docs/source/specs/openapi.json
@@ -3099,6 +3099,11 @@
               }
             ],
             "example": "1"
+          },
+          "org_id": {
+            "type": "string",
+            "example": "12345",
+            "nullable": true
           }
         }
       },
@@ -3148,7 +3153,7 @@
               "data": {
                 "type": "array",
                 "items": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "$ref": "#/components/schemas/Principal"
                     },
@@ -3838,21 +3843,21 @@
         ]
       },
       "ResourceDefinitionFilter": {
-          "oneOf": [
-              {
-                "$ref": "#/components/schemas/ResourceDefinitionFilterOperationEqual"
-              },
-              {
-                "$ref": "#/components/schemas/ResourceDefinitionFilterOperationIn"
-              }
-          ]
-     },
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/ResourceDefinitionFilterOperationEqual"
+          },
+          {
+            "$ref": "#/components/schemas/ResourceDefinitionFilterOperationIn"
+          }
+        ]
+      },
       "ResourceDefinitionFilterOperationEqual": {
         "type": "object",
         "required": [
-            "key",
-            "operation",
-            "value"
+          "key",
+          "operation",
+          "value"
         ],
         "properties": {
           "key": {
@@ -3875,9 +3880,9 @@
       "ResourceDefinitionFilterOperationIn": {
         "type": "object",
         "required": [
-            "key",
-            "operation",
-            "value"
+          "key",
+          "operation",
+          "value"
         ],
         "properties": {
           "key": {
@@ -3896,7 +3901,11 @@
               "type": "string",
               "nullable": true
             },
-            "example": ["value1", null, "value2"]
+            "example": [
+              "value1",
+              null,
+              "value2"
+            ]
           }
         }
       },

--- a/rbac/internal/views.py
+++ b/rbac/internal/views.py
@@ -1848,7 +1848,7 @@ def check_workspace_relation(request, workspace_uuid):
                 status=500,
             )
     elif workspace:
-        workspace_parent_id = str(workspace.parent.id)
+        workspace_parent_id = str(workspace.parent.id) if workspace.parent else None
         workspace_uuid_str = str(workspace_uuid)
         try:
             workspace_correct = WorkspaceRelationChecker.check_workspace(workspace_uuid, workspace_parent_id)


### PR DESCRIPTION
## Link(s) to Jira
-

## Description of Intent of Change(s)
Trying to use OpenAPI Generator to get all classes for interacting with the RBAC v1 API, it was not possible to use `oneOf` for complementary results, in this case `PrincipalMinimal` and `Principal` objects.

And the `/principals` endpoint is now showing `org_id` in the response.

## Local Testing
How can the feature be exercised?
How can the bug be exploited and fix confirmed?
Is any special local setup required?

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Improve API spec compatibility by adjusting principal schema composition and exposing org_id, and fix workspace relation handling to account for absent parent workspaces.

New Features:
- Add org_id field to the /principals endpoint response

Bug Fixes:
- Handle missing parent workspace in check_workspace_relation view by allowing None

Enhancements:
- Replace oneOf with anyOf for principal schemas in the OpenAPI spec