### PR TITLE
RHCLOUD-42282 - Add check for root workspace for check_workspace endpoint with test

### DIFF
--- a/rbac/internal/views.py
+++ b/rbac/internal/views.py
@@ -1851,13 +1851,24 @@ def check_workspace_relation(request, workspace_uuid):
         workspace_parent_id = str(workspace.parent.id) if workspace.parent else None
         workspace_uuid_str = str(workspace_uuid)
         try:
-            workspace_correct = WorkspaceRelationChecker.check_workspace(workspace_uuid, workspace_parent_id)
-            workspace_check_response = {
-                "org_id": workspace.tenant.org_id,
-                "workspace_id": workspace_uuid_str,
-                "workspace_parent_id": workspace_parent_id,
-                "workspace_relation_correct": workspace_correct,
-            }
+            if workspace.type != Workspace.Types.ROOT:
+                workspace_correct = WorkspaceRelationChecker.check_workspace(workspace_uuid, workspace_parent_id)
+                workspace_check_response = {
+                    "org_id": workspace.tenant.org_id,
+                    "workspace_id": workspace_uuid_str,
+                    "workspace_parent_id": workspace_parent_id,
+                    "workspace_relation_correct": workspace_correct,
+                }
+            else:
+                return JsonResponse(
+                    {
+                        "detail": (
+                            "Root workspace provided — this is not a valid input as it does not have a parent "
+                            "workspace. Request skipped."
+                        )
+                    },
+                    status=400,
+                )
         except RpcError as e:
             return JsonResponse(
                 {"detail": "gRPC error occurred during inventory workspace relation check", "error": str(e)},


### PR DESCRIPTION
## Link(s) to Jira
https://issues.redhat.com/browse/RHCLOUD-42282

## Description of Intent of Change(s)
It is not possible to check on the root workspace if provided to check_workspace endpoint as it does not have a parent workspace. 

We need to add a check that returns a correct response incases where root workspace uuid is provided to avoid null error.

## Local Testing
How can the feature be exercised?
How can the bug be exploited and fix confirmed?
Is any special local setup required?

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
