### PR TITLE
Inventory check_workspace split logic for descendants and single check

### DIFF
--- a/rbac/internal/views.py
+++ b/rbac/internal/views.py
@@ -1823,7 +1823,7 @@ def check_workspace_relation(request, workspace_uuid):
         try:
             if workspace_pairs:
                 workspace_uuid = str(workspace_uuid)
-                workspace_descendants_correct = WorkspaceRelationChecker.check_workspace(workspace_pairs)
+                workspace_descendants_correct = WorkspaceRelationChecker.check_workspace_descendants(workspace_pairs)
                 response = {
                     "org_id": workspace.tenant.org_id,
                     "workspace_id": workspace_uuid,

--- a/rbac/management/inventory_checker/inventory_api_check.py
+++ b/rbac/management/inventory_checker/inventory_api_check.py
@@ -202,8 +202,8 @@ class BootstrappedTenantInventoryChecker(InventoryApiBaseChecker):
 class WorkspaceRelationInventoryChecker(InventoryApiBaseChecker):
     """Subclass to check workspace parent relations are correct on inventory api."""
 
-    def check_workspace(self, workspace_pairs):
-        """Core logic to check workspace relation on inventory api."""
+    def check_workspace_descendants(self, workspace_pairs):
+        """Core logic to check workspace descendant relations on inventory api."""
         checks = []
         # Build the check requests for checking parent-child workspace relationship
         for workspace_uuid, workspace_parent_uuid in workspace_pairs:
@@ -228,4 +228,29 @@ class WorkspaceRelationInventoryChecker(InventoryApiBaseChecker):
             logger.warning(f"{workspace_uuid} does not have the expected parent workspace.")
         else:
             logger.info(f"{workspace_uuid} has the correct parent workspace.")
+        return workspace_check
+
+    def check_workspace(self, workspace_id, workspace_parent_id):
+        """Core logic to check workspace relation on inventory api."""
+        # Build the check request for checking parent-child workspace relationship
+        check_request = CheckRequest(
+            object=resource_reference_pb2.ResourceReference(
+                resource_id=workspace_parent_id,
+                resource_type="workspace",
+                reporter=reporter_reference_pb2.ReporterReference(type="rbac"),
+            ),
+            relation="parent",
+            subject=subject_reference_pb2.SubjectReference(
+                resource=resource_reference_pb2.ResourceReference(
+                    resource_id=workspace_id,
+                    resource_type="workspace",
+                    reporter=reporter_reference_pb2.ReporterReference(type="rbac"),
+                )
+            ),
+        )
+        workspace_check = self.check_inventory_core(check_request)
+        if not workspace_check:
+            logger.warning(f"{workspace_id} does not have the expected parent workspace.")
+        else:
+            logger.info(f"{workspace_id} has the correct parent workspace.")
         return workspace_check

--- a/tests/internal/test_views.py
+++ b/tests/internal/test_views.py
@@ -4376,7 +4376,9 @@ class InternalInventoryViewsetTests(BaseInternalViewsetTests):
 
     @patch("internal.jwt_utils.JWTProvider.get_jwt_token", return_value={"access_token": "mocked_valid_token"})
     @patch("management.utils.create_client_channel")
-    @patch("management.inventory_checker.inventory_api_check.WorkspaceRelationInventoryChecker.check_workspace")
+    @patch(
+        "management.inventory_checker.inventory_api_check.WorkspaceRelationInventoryChecker.check_workspace_descendants"
+    )
     @patch("internal.views.check_workspace_relation")
     def test_inventory_workspace_descendants_relation(
         self, mock_workspace_view, mock_check_workspace_relation, mock_create_channel, mock_get_token
@@ -4571,7 +4573,7 @@ class InternalInventoryViewsetTests(BaseInternalViewsetTests):
         )
 
     @patch(
-        "management.inventory_checker.inventory_api_check.WorkspaceRelationInventoryChecker.check_workspace",
+        "management.inventory_checker.inventory_api_check.WorkspaceRelationInventoryChecker.check_workspace_descendants",
         side_effect=RpcError("Simulated GRPC error"),
     )
     def test_inventory_workspace_descendants_relation_grpc_error(self, mock_check_workspace):
@@ -4615,7 +4617,7 @@ class InternalInventoryViewsetTests(BaseInternalViewsetTests):
         self.assertEqual(response_body["error"], "Simulated GRPC error")
 
     @patch(
-        "management.inventory_checker.inventory_api_check.WorkspaceRelationInventoryChecker.check_workspace",
+        "management.inventory_checker.inventory_api_check.WorkspaceRelationInventoryChecker.check_workspace_descendants",
         side_effect=Exception("Simulated internal error"),
     )
     def test_inventory_workspace_descendants_relation_error(self, mock_check_workspace):


### PR DESCRIPTION
## Link(s) to Jira
-

## Description of Intent of Change(s)
For the check_workspace split the logic for descendant checks and single workspace parent child checks into separate functions     as different input is required for performance considerations,

## Local Testing
How can the feature be exercised?
How can the bug be exploited and fix confirmed?
Is any special local setup required?

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
