### PR TITLE
[RHCLOUD-42298] fix the seeding group job - filter roles only for given tenant

### DIFF
--- a/rbac/management/group/view.py
+++ b/rbac/management/group/view.py
@@ -1331,7 +1331,7 @@ class GroupViewSet(
                     remove_roles(group, role_ids, request.tenant, request.user)
 
                 # Save the information to audit logs
-                roles = _roles_by_query_or_ids(role_ids)
+                roles = _roles_by_query_or_ids(role_ids, request.tenant)
                 for role_info in roles:
                     auditlog = AuditLog()
                     auditlog.log_group_remove(

--- a/tests/management/group/test_view.py
+++ b/tests/management/group/test_view.py
@@ -34,6 +34,7 @@ from api.cross_access.model import CrossAccountRequest
 from api.cross_access.util import check_cross_request_expiry
 from api.models import Tenant, User
 from management.cache import TenantCache
+from management.group.definer import add_roles
 from management.group.serializer import GroupInputSerializer
 from management.models import (
     Access,
@@ -2035,6 +2036,70 @@ class GroupViewsetTests(IdentityRequest):
         self.assertIsNotNone(al_dict_description)
         self.assertEqual(al_dict_resource, "group")
         self.assertEqual(al_dict_action, "remove")
+
+    def test_remove_group_roles_tenant_isolation(self):
+        """Test that group role removal properly filters by tenant."""
+        # Create group with a role of the same name in different tenants
+        tenant_a = self.tenant
+        tenant_b = Tenant.objects.create(tenant_name="tenant_b", org_id="222222")
+        bootstrap_service = V2TenantBootstrapService(NoopReplicator())
+        bootstrap_service.bootstrap_tenant(tenant_b)
+
+        role_name = "test_remove_group_roles_tenant_isolation"
+        role_a = Role.objects.create(name=role_name, tenant=tenant_a)
+        role_b = Role.objects.create(name=role_name, tenant=tenant_b)
+        group_a = Group.objects.create(name="group_a", tenant=tenant_a)
+        group_b = Group.objects.create(name="group_b", tenant=tenant_b)
+
+        roles = Role.objects.filter(name=role_name)
+        add_roles(group_a, roles, tenant_a)
+        add_roles(group_b, roles, tenant_b)
+
+        # Try to remove role by ID - should remove the correct role from tenant A
+        url = reverse("v1_management:group-roles", kwargs={"uuid": group_a.uuid})
+        url = f"{url}?roles={role_a.uuid}"
+        client = APIClient()
+        response = client.delete(url, format="json", **self.headers)
+
+        # Should successfully remove the role from tenant A
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertCountEqual([], list(group_a.roles()))
+
+        # The role from tenant B should still exist and not be affected
+        self.assertTrue(Role.objects.filter(name=role_name, tenant=tenant_b).exists())
+        tenant_b_role = Role.objects.get(name=role_name, tenant=tenant_b)
+        self.assertEqual(tenant_b_role.name, role_name)
+
+    def test_add_group_roles_tenant_isolation(self):
+        """Test that group role addition properly filters by tenant."""
+        # Create test data
+        tenant_a = self.tenant
+        tenant_b = Tenant.objects.create(tenant_name="tenant_b", org_id="333333")
+        bootstrap_service = V2TenantBootstrapService(NoopReplicator())
+        bootstrap_service.bootstrap_tenant(tenant_b)
+
+        role_name = "test_add_group_roles_tenant_isolation"
+        role_a = Role.objects.create(name=role_name, tenant=tenant_a)
+        role_b = Role.objects.create(name=role_name, tenant=tenant_b)
+        group_a = Group.objects.create(name="group_a", tenant=tenant_a)
+
+        # Add a role from tenant A to group A (2 roles with the same name exist)
+        url = reverse("v1_management:group-roles", kwargs={"uuid": group_a.uuid})
+        client = APIClient()
+        request_body = {"roles": [str(role_a.uuid)]}
+        response = client.post(url, request_body, format="json", **self.headers)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        group_roles_after_add = list(group_a.roles())
+        self.assertIn(role_a, group_roles_after_add)
+
+        # The role from Tenant B should still exist separately and not be affected
+        self.assertTrue(Role.objects.filter(name=role_name, tenant=tenant_b).exists())
+        tenant_b_role = Role.objects.get(name=role_name, tenant=tenant_b)
+        self.assertEqual(tenant_b_role.name, role_name)
+
+        # The group should not have the role from Tenant B
+        self.assertNotIn(tenant_b_role, group_roles_after_add)
 
     def test_remove_admin_default_group_roles(self):
         """Test that admin_default groups' roles are protected from removal"""


### PR DESCRIPTION
## Link(s) to Jira
- [RHCLOUD-42298](https://issues.redhat.com/browse/RHCLOUD-42298)

## Description of Intent of Change(s)
The group seeding job is currently failing on stage and prod:
```
[2025-09-16 19:13:16,037] INFO: *** Seeding groups... ***
[2025-09-16 19:13:16,037] INFO: Seeding group changes.
[2025-09-16 19:13:16,045] INFO: Group Default access already exists for tenant None.
[2025-09-16 19:13:16,079] ERROR: Error encountered during group seeding {'roles': ErrorDetail(string='Role with id Role object (154569) does not exist.', code='invalid')}.
[2025-09-16 19:13:16,206] INFO: *** Group seeding completed. ***
```

it is because the job calls [_roles_by_query_or_ids](https://github.com/RedHatInsights/insights-rbac/blob/042732647cef0e345af9a14bb3ec847926f9f81b/rbac/management/group/definer.py#L254) function that filter roles by names ... but there can be a case when we have in database roles with same name for different tenants ... that is ok because the uniqueness is forced only within a tenant ... we just need to filter by tenant

## Local Testing
create custom role with same name as already existing system role that belongs to the default group

run seeding locally and check the output
```
ACCESS_CACHE_CONNECT_SIGNALS=False MAX_SEED_THREADS=2 ./rbac/manage.py seeds --groups
```
expected output looks like this
```
GLITCHTIP_DSN was not set, skipping Glitchtip initialization.
[2025-09-17 16:42:05,527] INFO: *** Seeding groups... ***
[2025-09-17 16:42:05,527] INFO: Seeding group changes.
[2025-09-17 16:42:05,557] INFO: Group Default access already exists for public tenant.
[2025-09-17 16:42:05,625] INFO: Finished seeding default group Default access.
[2025-09-17 16:42:05,627] INFO: Group Default admin access already exists for public tenant.
[2025-09-17 16:42:05,656] INFO: Finished seeding default org admin group Default access.
[2025-09-17 16:42:05,658] INFO: Finished seeding group.
[2025-09-17 16:42:05,658] INFO: *** Group seeding completed. ***
```

## Summary by Sourcery

Introduce tenant-based filtering for role queries in group seeding functions and streamline group creation logic for default and admin groups

Bug Fixes:
- restrict _roles_by_query_or_ids to return only roles in the specified tenant to prevent cross-tenant role assignments
- invoke remove_roles in update_group_roles only when there are roles to remove

Enhancements:
- extend _roles_by_query_or_ids signature to accept tenant and update add_roles/remove_roles callers accordingly
- simplify tuple unpacking for Group.get_or_create in seed_group
- standardize logger usage and update default admin group comment