### PR TITLE
Revert "RHCLOUD-42150 - Update Inventory API endpoints using authentication provided by Kesse…"

### DIFF
--- a/deploy/rbac-clowdapp.yml
+++ b/deploy/rbac-clowdapp.yml
@@ -453,23 +453,8 @@ objects:
                 optional: true
           - name: RELATION_API_SERVER
             value: ${RELATION_API_SERVER}
-            # Inventory API variables
-          - name: INVENTORY_API_CLIENT_ID
-            valueFrom:
-              secretKeyRef:
-                key: rbac-client-id
-                name: service-accounts
-                optional: true
-          - name: INVENTORY_API_CLIENT_SECRET
-            valueFrom:
-              secretKeyRef:
-                key: rbac-client-secret
-                name: service-accounts
-                optional: true
           - name: INVENTORY_API_SERVER
             value: ${INVENTORY_API_SERVER}
-          - name: INVENTORY_API_TOKEN_URL
-            value: ${INVENTORY_API_TOKEN_URL}
           - name: SCOPES
             value: ${SCOPES}
           - name: TOKEN_GRANT_TYPE
@@ -1534,9 +1519,6 @@ parameters:
 - name: INVENTORY_API_SERVER
   description: The gRPC API server to use for inventory api
   value: "localhost:9000"
-- name: INVENTORY_API_TOKEN_URL
-  description: The SSO token url to use for inventory api
-  value: "https://sso.stage.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token"
 - name: REPLICATION_TO_RELATION_ENABLED
   description: Enable replication to Relation API
   value: "False"

--- a/rbac/internal/utils.py
+++ b/rbac/internal/utils.py
@@ -18,7 +18,9 @@
 """Utilities for Internal RBAC use."""
 import json
 import logging
+from contextlib import contextmanager
 
+import grpc
 import jsonschema
 from django.conf import settings
 from django.db import transaction
@@ -35,6 +37,13 @@ from api.models import User
 
 
 logger = logging.getLogger(__name__)
+
+
+@contextmanager
+def create_client_channel(addr):
+    """Create secure channel for grpc requests."""
+    secure_channel = grpc.insecure_channel(addr)
+    yield secure_channel
 
 
 def build_internal_user(request, json_rh_auth):

--- a/rbac/management/utils.py
+++ b/rbac/management/utils.py
@@ -26,8 +26,6 @@ import grpc
 from django.conf import settings
 from django.core.exceptions import PermissionDenied
 from django.utils.translation import gettext as _
-from kessel.auth import OAuth2ClientCredentials
-from kessel.grpc import oauth2_call_credentials
 from management.authorization.invalid_token import InvalidTokenError
 from management.authorization.missing_authorization import MissingAuthorizationError
 from management.authorization.token_validator import TokenValidator
@@ -52,35 +50,12 @@ SERVICE_ACCOUNT_KEY = "service-account"
 
 logger = logging.getLogger(__name__)
 
-# Configure OAuth credentials with direct token URL
-inventory_auth_credentials = OAuth2ClientCredentials(
-    client_id=settings.INVENTORY_API_CLIENT_ID,
-    client_secret=settings.INVENTORY_API_CLIENT_SECRET,
-    token_endpoint=settings.INVENTORY_API_TOKEN_URL,  # Direct token endpoint
-)
-
-call_credentials = oauth2_call_credentials(inventory_auth_credentials)
-
 
 @contextmanager
 def create_client_channel(addr):
-    """Create secure channel for grpc requests for relations api."""
+    """Create secure channel for grpc requests."""
     secure_channel = grpc.insecure_channel(addr)
     yield secure_channel
-
-
-@contextmanager
-def create_client_channel_inventory(addr):
-    """Create secure channel for grpc requests for inventory api."""
-    if settings.DEVELOPMENT:  # Flag for local dev (avoids ssl error)
-        channel = grpc.insecure_channel(addr)
-        yield channel
-    else:
-        # Combine with TLS for secure channel
-        ssl_credentials = grpc.ssl_channel_credentials()
-        channel_credentials = grpc.composite_channel_credentials(ssl_credentials, call_credentials)
-        secure_channel = grpc.secure_channel(addr, channel_credentials)
-        yield secure_channel
 
 
 def validate_psk(psk, client_id):

--- a/rbac/rbac/settings.py
+++ b/rbac/rbac/settings.py
@@ -527,13 +527,6 @@ TOKEN_GRANT_TYPE = ENVIRONMENT.get_value("TOKEN_GRANT_TYPE", default="client_cre
 RELATION_API_SERVER = ENVIRONMENT.get_value("RELATION_API_SERVER", default="localhost:9000")
 RELATIONS_API_CLIENT_ID = ENVIRONMENT.get_value("RELATION_API_CLIENT_ID", default="")
 RELATIONS_API_CLIENT_SECRET = ENVIRONMENT.get_value("RELATION_API_CLIENT_SECRET", default="")
-INVENTORY_API_CLIENT_ID = ENVIRONMENT.get_value("INVENTORY_API_CLIENT_ID", default="")
-INVENTORY_API_CLIENT_SECRET = ENVIRONMENT.get_value("INVENTORY_API_CLIENT_SECRET", default="")
-INVENTORY_API_TOKEN_URL = ENVIRONMENT.get_value(
-    "INVENTORY_API_TOKEN_URL",
-    default="https://sso.stage.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token",
-)
-INVENTORY_API_LOCAL = ENVIRONMENT.bool("INVENTORY_API_LOCAL", default=True)
 INVENTORY_API_SERVER = ENVIRONMENT.get_value("INVENTORY_API_SERVER", default="localhost:9000")
 ENV_NAME = ENVIRONMENT.get_value("ENV_NAME", default="stage")
 

--- a/tests/internal/test_views.py
+++ b/tests/internal/test_views.py
@@ -3972,7 +3972,7 @@ class InternalInventoryViewsetTests(BaseInternalViewsetTests):
     """Test the /_private/api/inventory/ endpoints from internal viewset."""
 
     @patch("internal.jwt_utils.JWTProvider.get_jwt_token", return_value={"access_token": "mocked_valid_token"})
-    @patch("management.utils.create_client_channel")
+    @patch("internal.views.create_client_channel")
     def test_check_inventory(self, mock_create_channel, mock_get_token):
         """Test a request to check inventory endpoint returns the correct response."""
 
@@ -4003,7 +4003,7 @@ class InternalInventoryViewsetTests(BaseInternalViewsetTests):
             self.assertEqual(response_body["allowed"], True)
 
     @patch("internal.jwt_utils.JWTProvider.get_jwt_token", return_value={"access_token": "mocked_valid_token"})
-    @patch("management.utils.create_client_channel", side_effect=RpcError("Simulated GRPC error"))
+    @patch("internal.views.create_client_channel", side_effect=RpcError("Simulated GRPC error"))
     def test_check_inventory_grpc_error(self, mock_channel, mock_token):
         """Test a request to check inventory endpoint returns the correct response in case of grpc error."""
 
@@ -4029,7 +4029,7 @@ class InternalInventoryViewsetTests(BaseInternalViewsetTests):
         self.assertEqual(response_body["detail"], "Error occurred in gRPC call")
         self.assertEqual(response_body["error"], "Simulated GRPC error")
 
-    @patch("internal.utils.create_client_channel", side_effect=Exception("Simulated internal error"))
+    @patch("internal.views.create_client_channel", side_effect=Exception("Simulated internal error"))
     def test_check_inventory_error(self, mock_channel):
         """Test a request to check inventory endpoint returns the correct response in case of an error."""
 
@@ -4055,7 +4055,7 @@ class InternalInventoryViewsetTests(BaseInternalViewsetTests):
         self.assertEqual(response_body["error"], "Simulated internal error")
 
     @patch("internal.jwt_utils.JWTProvider.get_jwt_token", return_value={"access_token": "mocked_valid_token"})
-    @patch("management.utils.create_client_channel")
+    @patch("internal.views.create_client_channel")
     def test_check_inventory_invalid_body(self, mock_create_channel, mock_get_token):
         """Test a request to check inventory endpoint returns the correct response in case of input validation failure."""
 


### PR DESCRIPTION
Reverts RedHatInsights/insights-rbac#1955

## Summary by Sourcery

Revert the previous Inventory API OAuth2 integration and restore a simple gRPC client setup, while updating inventory checks to retrieve and pass JWTs from cache and cleaning up related settings, deployment variables, and tests.

Enhancements:
- Simplify inventory client channel creation by removing the specialized OAuth2-based helper and unifying on a basic gRPC channel
- Retrieve JWT from cache and include it as an authorization metadata header on inventory service calls

Tests:
- Adjust mocks to target the correct create_client_channel helper in internal views after the revert

Chores:
- Remove OAuth2 client credentials configuration, related settings and environment variables
- Revert deployment manifest entries for inventory API client ID, secret, and token URL