### PR TITLE
Revert "Revert "RHCLOUD-42150 - Update Inventory API endpoints using authentication provided by Kesse…""

### DIFF
--- a/deploy/rbac-clowdapp.yml
+++ b/deploy/rbac-clowdapp.yml
@@ -453,8 +453,23 @@ objects:
                 optional: true
           - name: RELATION_API_SERVER
             value: ${RELATION_API_SERVER}
+            # Inventory API variables
+          - name: INVENTORY_API_CLIENT_ID
+            valueFrom:
+              secretKeyRef:
+                key: rbac-client-id
+                name: service-accounts
+                optional: true
+          - name: INVENTORY_API_CLIENT_SECRET
+            valueFrom:
+              secretKeyRef:
+                key: rbac-client-secret
+                name: service-accounts
+                optional: true
           - name: INVENTORY_API_SERVER
             value: ${INVENTORY_API_SERVER}
+          - name: INVENTORY_API_TOKEN_URL
+            value: ${INVENTORY_API_TOKEN_URL}
           - name: SCOPES
             value: ${SCOPES}
           - name: TOKEN_GRANT_TYPE
@@ -1519,6 +1534,9 @@ parameters:
 - name: INVENTORY_API_SERVER
   description: The gRPC API server to use for inventory api
   value: "localhost:9000"
+- name: INVENTORY_API_TOKEN_URL
+  description: The SSO token url to use for inventory api
+  value: "https://sso.stage.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token"
 - name: REPLICATION_TO_RELATION_ENABLED
   description: Enable replication to Relation API
   value: "False"

--- a/rbac/internal/utils.py
+++ b/rbac/internal/utils.py
@@ -18,9 +18,7 @@
 """Utilities for Internal RBAC use."""
 import json
 import logging
-from contextlib import contextmanager
 
-import grpc
 import jsonschema
 from django.conf import settings
 from django.db import transaction
@@ -37,13 +35,6 @@ from api.models import User
 
 
 logger = logging.getLogger(__name__)
-
-
-@contextmanager
-def create_client_channel(addr):
-    """Create secure channel for grpc requests."""
-    secure_channel = grpc.insecure_channel(addr)
-    yield secure_channel
 
 
 def build_internal_user(request, json_rh_auth):

--- a/rbac/internal/views.py
+++ b/rbac/internal/views.py
@@ -19,9 +19,7 @@
 import json
 import logging
 import uuid
-from contextlib import contextmanager
 
-import grpc
 import requests
 from core.utils import destructive_ok
 from django.conf import settings
@@ -88,6 +86,8 @@ from management.tasks import (
 )
 from management.tenant_service.v2 import V2TenantBootstrapService
 from management.utils import (
+    create_client_channel,
+    create_client_channel_inventory,
     get_principal,
     groups_for_principal,
 )
@@ -117,13 +117,6 @@ BootstrappedTenantChecker = BootstrappedTenantInventoryChecker()
 GroupPrincipalChecker = GroupPrincipalInventoryChecker()
 WorkspaceRelationChecker = WorkspaceRelationInventoryChecker()
 RoleRelationChecker = RoleRelationInventoryChecker()
-
-
-@contextmanager
-def create_client_channel(addr):
-    """Create secure channel for grpc requests."""
-    secure_channel = grpc.insecure_channel(addr)
-    yield secure_channel
 
 
 def tenant_is_modified(tenant_name=None, org_id=None):
@@ -1733,10 +1726,9 @@ def check_inventory(request):
     subject_resource_id = req_data["subject"]["resource"]["resource_id"]
     subject_resource_type = req_data["subject"]["resource"]["resource_type"]
     subject_resource_reporter_type = req_data["subject"]["resource"]["reporter"]["type"]
-    token = jwt_manager.get_jwt_from_redis()
 
     try:
-        with create_client_channel(settings.INVENTORY_API_SERVER) as channel:
+        with create_client_channel_inventory(settings.INVENTORY_API_SERVER) as channel:
             stub = inventory_service_pb2_grpc.KesselInventoryServiceStub(channel)
 
             resource_ref = resource_reference_pb2.ResourceReference(
@@ -1758,9 +1750,7 @@ def check_inventory(request):
             relation=resource_relation,
             object=resource_ref,
         )
-        # Pass JWT token in metadata
-        metadata = [("authorization", f"Bearer {token}")]
-        response = stub.Check(request, metadata=metadata)
+        response = stub.Check(request)
 
         if response:
             response_to_dict = json_format.MessageToDict(response)

--- a/rbac/management/inventory_checker/inventory_api_check.py
+++ b/rbac/management/inventory_checker/inventory_api_check.py
@@ -32,7 +32,7 @@ from kessel.inventory.v1beta2 import (
 )
 from kessel.inventory.v1beta2.check_request_pb2 import CheckRequest
 from management.cache import JWTCache
-from management.utils import create_client_channel
+from management.utils import create_client_channel_inventory
 
 jwt_cache = JWTCache()
 jwt_provider = JWTProvider()
@@ -49,16 +49,13 @@ class InventoryApiBaseChecker:
 
         Accepts either a single check request or list of check requests.
         """
-        token = jwt_manager.get_jwt_from_redis()
-
         if isinstance(checks, CheckRequest):
             checks = [checks]
 
-            with create_client_channel(settings.INVENTORY_API_SERVER) as channel:
+            with create_client_channel_inventory(settings.INVENTORY_API_SERVER) as channel:
                 stub = inventory_service_pb2_grpc.KesselInventoryServiceStub(channel)
-                metadata = [("authorization", f"Bearer {token}")]
 
-                responses = [stub.Check(req, metadata=metadata) for req in checks]
+                responses = [stub.Check(req) for req in checks]
                 return all(self._is_allowed(res) for res in responses)
         return False
 

--- a/rbac/rbac/settings.py
+++ b/rbac/rbac/settings.py
@@ -527,6 +527,13 @@ TOKEN_GRANT_TYPE = ENVIRONMENT.get_value("TOKEN_GRANT_TYPE", default="client_cre
 RELATION_API_SERVER = ENVIRONMENT.get_value("RELATION_API_SERVER", default="localhost:9000")
 RELATIONS_API_CLIENT_ID = ENVIRONMENT.get_value("RELATION_API_CLIENT_ID", default="")
 RELATIONS_API_CLIENT_SECRET = ENVIRONMENT.get_value("RELATION_API_CLIENT_SECRET", default="")
+INVENTORY_API_CLIENT_ID = ENVIRONMENT.get_value("INVENTORY_API_CLIENT_ID", default="")
+INVENTORY_API_CLIENT_SECRET = ENVIRONMENT.get_value("INVENTORY_API_CLIENT_SECRET", default="")
+INVENTORY_API_TOKEN_URL = ENVIRONMENT.get_value(
+    "INVENTORY_API_TOKEN_URL",
+    default="https://sso.stage.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token",
+)
+INVENTORY_API_LOCAL = ENVIRONMENT.bool("INVENTORY_API_LOCAL", default=True)
 INVENTORY_API_SERVER = ENVIRONMENT.get_value("INVENTORY_API_SERVER", default="localhost:9000")
 ENV_NAME = ENVIRONMENT.get_value("ENV_NAME", default="stage")
 

--- a/tests/internal/test_views.py
+++ b/tests/internal/test_views.py
@@ -3972,7 +3972,7 @@ class InternalInventoryViewsetTests(BaseInternalViewsetTests):
     """Test the /_private/api/inventory/ endpoints from internal viewset."""
 
     @patch("internal.jwt_utils.JWTProvider.get_jwt_token", return_value={"access_token": "mocked_valid_token"})
-    @patch("internal.views.create_client_channel")
+    @patch("management.utils.create_client_channel")
     def test_check_inventory(self, mock_create_channel, mock_get_token):
         """Test a request to check inventory endpoint returns the correct response."""
 
@@ -4003,7 +4003,7 @@ class InternalInventoryViewsetTests(BaseInternalViewsetTests):
             self.assertEqual(response_body["allowed"], True)
 
     @patch("internal.jwt_utils.JWTProvider.get_jwt_token", return_value={"access_token": "mocked_valid_token"})
-    @patch("internal.views.create_client_channel", side_effect=RpcError("Simulated GRPC error"))
+    @patch("management.utils.create_client_channel", side_effect=RpcError("Simulated GRPC error"))
     def test_check_inventory_grpc_error(self, mock_channel, mock_token):
         """Test a request to check inventory endpoint returns the correct response in case of grpc error."""
 
@@ -4029,7 +4029,7 @@ class InternalInventoryViewsetTests(BaseInternalViewsetTests):
         self.assertEqual(response_body["detail"], "Error occurred in gRPC call")
         self.assertEqual(response_body["error"], "Simulated GRPC error")
 
-    @patch("internal.views.create_client_channel", side_effect=Exception("Simulated internal error"))
+    @patch("internal.utils.create_client_channel", side_effect=Exception("Simulated internal error"))
     def test_check_inventory_error(self, mock_channel):
         """Test a request to check inventory endpoint returns the correct response in case of an error."""
 
@@ -4055,7 +4055,7 @@ class InternalInventoryViewsetTests(BaseInternalViewsetTests):
         self.assertEqual(response_body["error"], "Simulated internal error")
 
     @patch("internal.jwt_utils.JWTProvider.get_jwt_token", return_value={"access_token": "mocked_valid_token"})
-    @patch("internal.views.create_client_channel")
+    @patch("management.utils.create_client_channel")
     def test_check_inventory_invalid_body(self, mock_create_channel, mock_get_token):
         """Test a request to check inventory endpoint returns the correct response in case of input validation failure."""
 


### PR DESCRIPTION
Reverts RedHatInsights/insights-rbac#2011

## Summary by Sourcery

Reapply OAuth2-based authentication for Inventory API by introducing a new secure gRPC channel context manager, updating settings and deployment config for OAuth credentials, replacing manual JWT metadata injection, and adjusting related code paths and tests.

Enhancements:
- Introduce create_client_channel_inventory to establish a TLS+OAuth2-secured gRPC channel for the Inventory API
- Remove manual JWT metadata handling and rely on composite channel credentials for authentication
- Add settings and environment variables for Inventory API client ID, client secret, token URL, and a local development flag
- Refactor internal views and inventory checker to use the new secure channel context manager
- Update deployment manifest to supply Inventory API OAuth credentials and token URL
- Adjust tests to mock and patch the new create_client_channel utility in management.utils