### PR TITLE
[WIP] [RHCLOUD-43006] Playbook Dispatcher Permissions Logic 

### DIFF
--- a/rbac/internal/utils.py
+++ b/rbac/internal/utils.py
@@ -200,3 +200,27 @@ def is_str_valid_uuid(uuid_str: str) -> bool:
         return True
     except ValueError:
         return False
+
+
+def get_workspace_id_by_name(workspace_name: str, tenant):
+    """
+    Get workspace ID by workspace name for a given tenant.
+
+    Args:
+        workspace_name: The name of the workspace (e.g., "tasks", "automation")
+        tenant: The tenant object
+
+    Returns:
+        Workspace ID as string if found, None otherwise
+    """
+    from management.workspace.model import Workspace
+
+    try:
+        workspace = Workspace.objects.get(tenant=tenant, name=workspace_name)
+        return str(workspace.id)
+    except Workspace.DoesNotExist:
+        return None
+    except Workspace.MultipleObjectsReturned:
+        # If multiple workspaces have the same name, return the first one
+        workspace = Workspace.objects.filter(tenant=tenant, name=workspace_name).first()
+        return str(workspace.id) if workspace else None

--- a/tests/migration_tool/tests_migrate.py
+++ b/tests/migration_tool/tests_migrate.py
@@ -554,3 +554,178 @@ class MigrateTestTupleStore(TestCase):
         )
 
         self.assertEqual(29, len(self.relations))
+
+    def test_playbook_dispatcher_service_attribute_with_workspace_name(self):
+        """Test that playbook-dispatcher permissions bind to workspace by looking up service name."""
+        # Create a workspace matching the service/application name
+        target_workspace = Workspace.objects.create(
+            name="cost-management",  # Service name matches workspace name
+            tenant=self.o1.tenant,
+            parent=self.o1.default_workspace,
+            type=Workspace.Types.STANDARD,
+        )
+
+        # Create a playbook-dispatcher permission
+        public_tenant = Tenant.objects.get(tenant_name="public")
+        pbd_permission = Permission.objects.create(permission="playbook-dispatcher:run:read", tenant=public_tenant)
+
+        # Create role with service resource definition using service/application name as value
+        role = Role.objects.create(name="pbd_role", tenant=self.o1.tenant)
+        access = Access.objects.create(permission=pbd_permission, role=role, tenant=self.o1.tenant)
+        ResourceDefinition.objects.create(
+            attributeFilter={
+                "key": "service",
+                "operation": "equal",
+                "value": "cost-management",  # Service/application name
+            },
+            access=access,
+            tenant=self.o1.tenant,
+        )
+
+        # Create policy to bind role to group
+        group = self.fixture.new_group("pbd_group", self.o1.tenant, ["pbd_u1"])[0]
+        policy = Policy.objects.create(name="pbd_policy", group=group, tenant=self.o1.tenant)
+        policy.roles.add(role)
+
+        # Clear relations and migrate
+        self.relations.clear()
+        self.o1.tenant.ready = True
+        self.o1.tenant.save()
+
+        migrate_data(orgs=[self.o1.tenant.org_id], write_relationships=InMemoryRelationReplicator(self.relations))
+
+        # Verify permission is bound to the cost-management workspace
+        target_bindings = self.relations.find_tuples(
+            all_of(resource("rbac", "workspace", target_workspace.id), relation("binding"))
+        )
+
+        # Should have a binding with the playbook-dispatcher permission
+        self.assertTrue(
+            target_bindings.traverse_subject(
+                [
+                    all_of(
+                        relation("role"),
+                        self.relations.subject_is_resource_of(relation("playbook_dispatcher_run_read"), only=True),
+                    ),
+                    all_of(relation("subject"), subject("rbac", "group", group.uuid, "member")),
+                ]
+            ),
+            "missing playbook-dispatcher binding to cost-management workspace",
+        )
+
+    def test_playbook_dispatcher_multiple_services(self):
+        """Test playbook-dispatcher permissions with multiple service/application names."""
+        # Create workspaces matching service/application names
+        workspace1 = Workspace.objects.create(
+            name="cost-management",
+            tenant=self.o1.tenant,
+            parent=self.o1.default_workspace,
+            type=Workspace.Types.STANDARD,
+        )
+        workspace2 = Workspace.objects.create(
+            name="advisor", tenant=self.o1.tenant, parent=self.o1.default_workspace, type=Workspace.Types.STANDARD
+        )
+
+        # Create a playbook-dispatcher permission
+        public_tenant = Tenant.objects.get(tenant_name="public")
+        pbd_permission = Permission.objects.create(permission="playbook-dispatcher:run:read", tenant=public_tenant)
+
+        # Create role with multiple service/application names
+        role = Role.objects.create(name="pbd_role", tenant=self.o1.tenant)
+        access = Access.objects.create(permission=pbd_permission, role=role, tenant=self.o1.tenant)
+        ResourceDefinition.objects.create(
+            attributeFilter={
+                "key": "service",
+                "operation": "in",
+                "value": ["cost-management", "advisor"],  # Service/application names
+            },
+            access=access,
+            tenant=self.o1.tenant,
+        )
+
+        # Create policy to bind role to group
+        group = self.fixture.new_group("pbd_group", self.o1.tenant, ["pbd_u1"])[0]
+        policy = Policy.objects.create(name="pbd_policy", group=group, tenant=self.o1.tenant)
+        policy.roles.add(role)
+
+        # Clear relations and migrate
+        self.relations.clear()
+        self.o1.tenant.ready = True
+        self.o1.tenant.save()
+
+        migrate_data(orgs=[self.o1.tenant.org_id], write_relationships=InMemoryRelationReplicator(self.relations))
+
+        # Verify permission is bound to both workspaces
+        workspace1_bindings = self.relations.find_tuples(
+            all_of(resource("rbac", "workspace", workspace1.id), relation("binding"))
+        )
+        workspace2_bindings = self.relations.find_tuples(
+            all_of(resource("rbac", "workspace", workspace2.id), relation("binding"))
+        )
+
+        # Both workspaces should have bindings
+        self.assertTrue(
+            workspace1_bindings.traverse_subject(
+                [
+                    all_of(
+                        relation("role"),
+                        self.relations.subject_is_resource_of(relation("playbook_dispatcher_run_read"), only=True),
+                    ),
+                    all_of(relation("subject"), subject("rbac", "group", group.uuid, "member")),
+                ]
+            ),
+            "missing playbook-dispatcher binding to cost-management workspace",
+        )
+
+        self.assertTrue(
+            workspace2_bindings.traverse_subject(
+                [
+                    all_of(
+                        relation("role"),
+                        self.relations.subject_is_resource_of(relation("playbook_dispatcher_run_read"), only=True),
+                    ),
+                    all_of(relation("subject"), subject("rbac", "group", group.uuid, "member")),
+                ]
+            ),
+            "missing playbook-dispatcher binding to advisor workspace",
+        )
+
+    def test_playbook_dispatcher_invalid_workspace_name_skipped(self):
+        """Test that invalid workspace names in service attribute are skipped with warning."""
+        # Create a playbook-dispatcher permission
+        public_tenant = Tenant.objects.get(tenant_name="public")
+        pbd_permission = Permission.objects.create(permission="playbook-dispatcher:run:read", tenant=public_tenant)
+
+        # Create role with non-existent workspace name
+        role = Role.objects.create(name="pbd_role", tenant=self.o1.tenant)
+        access = Access.objects.create(permission=pbd_permission, role=role, tenant=self.o1.tenant)
+        fake_workspace_name = "nonexistent-workspace"
+        ResourceDefinition.objects.create(
+            attributeFilter={
+                "key": "service",
+                "operation": "equal",
+                "value": fake_workspace_name,
+            },
+            access=access,
+            tenant=self.o1.tenant,
+        )
+
+        # Create policy to bind role to group
+        group = self.fixture.new_group("pbd_group", self.o1.tenant, ["pbd_u1"])[0]
+        policy = Policy.objects.create(name="pbd_policy", group=group, tenant=self.o1.tenant)
+        policy.roles.add(role)
+
+        # Clear relations and migrate
+        self.relations.clear()
+        self.o1.tenant.ready = True
+        self.o1.tenant.save()
+
+        migrate_data(orgs=[self.o1.tenant.org_id], write_relationships=InMemoryRelationReplicator(self.relations))
+
+        # Verify no binding was created for the non-existent workspace
+        # Since the workspace doesn't exist, there should be no bindings at all for this permission
+        # Check that default workspace doesn't have this permission either (it should fall through)
+        pbd_bindings_count = sum(1 for t in self.relations.find_tuples(relation("playbook_dispatcher_run_read")))
+
+        # Should have 0 bindings since workspace wasn't found and it doesn't fall back to default
+        self.assertEqual(pbd_bindings_count, 0, "unexpected binding for non-existent workspace")


### PR DESCRIPTION
## Link(s) to Jira
- https://issues.redhat.com/browse/RHCLOUD-43006

- just an idea of how the permissions migration might work 
- using the value of the resourceDefinitions to find the name of the workspace ID in order to fit it into the V2 schema 
## Description of Intent of Change(s)
The what, why and how.

## Local Testing
How can the feature be exercised?
How can the bug be exploited and fix confirmed?
Is any special local setup required?

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Implement special handling for playbook-dispatcher permissions in the migration tool by resolving the service attributeFilter to workspace bindings, and add utility and tests to support this mapping

Enhancements:
- Extend v1_role_to_v2_bindings to look up workspace IDs by service name and bind playbook-dispatcher permissions to those workspaces, with info and warning logs
- Add get_workspace_id_by_name helper to fetch a workspace ID by name for a given tenant

Tests:
- Add unit tests verifying migration of playbook-dispatcher permissions for a single workspace, multiple workspaces, and skipping invalid workspace names