### PR TITLE
[WIP] Test adding new version of the openapi spec (v1.1)

### DIFF
--- a/docs/source/specs/v1.1/openapi.json
+++ b/docs/source/specs/v1.1/openapi.json
@@ -1,9 +1,9 @@
 {
   "openapi": "3.0.0",
   "info": {
-    "description": "**DEPRECATED**: This version (1.0.0) of the API is deprecated. Please use version 1.1.0 instead. The API for Role Based Access Control.",
-    "version": "1.0.0",
-    "title": "Role Based Access Control (DEPRECATED - Use v1.1)",
+    "description": "The API for Role Based Access Control.",
+    "version": "1.1.0",
+    "title": "Role Based Access Control",
     "license": {
       "name": "AGPL-3.0",
       "url": "https://opensource.org/licenses/AGPL-3.0"
@@ -782,12 +782,12 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/PrincipalPagination"
-                    },
+                  "anyOf": [
                     {
                       "$ref": "#/components/schemas/ServiceAccountPagination"
+                    },
+                    {
+                      "$ref": "#/components/schemas/PrincipalPagination"
                     },
                     {
                       "$ref": "#/components/schemas/AllPrincipalsPagination"
@@ -1428,7 +1428,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "$ref": "#/components/schemas/PrincipalPagination"
                     },
@@ -3012,6 +3012,16 @@
             "type": "integer",
             "format": "int64",
             "example": 30
+          },
+          "limit": {
+            "type": "integer",
+            "format": "int64",
+            "example": 10
+          },
+          "offset": {
+            "type": "integer",
+            "format": "int64",
+            "example": 0
           }
         }
       },
@@ -3123,7 +3133,7 @@
             "type": "boolean"
           },
           "external_source_id": {
-            "oneOf": [
+            "anyOf": [
               {
                 "type": "string"
               },
@@ -3132,6 +3142,11 @@
               }
             ],
             "example": "1"
+          },
+          "org_id": {
+            "type": "string",
+            "example": "12345",
+            "nullable": true
           }
         }
       },
@@ -3181,7 +3196,7 @@
               "data": {
                 "type": "array",
                 "items": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "$ref": "#/components/schemas/Principal"
                     },
@@ -3314,13 +3329,20 @@
                   "serviceAccounts": {
                     "type": "array",
                     "items": {
-                      "$ref": "#/components/schemas/ServiceAccount"
+                      "anyOf": [
+                        {
+                          "$ref": "#/components/schemas/ServiceAccount"
+                        },
+                        {
+                          "$ref": "#/components/schemas/PrincipalMinimal"
+                        }
+                      ]
                     }
                   },
                   "users": {
                     "type": "array",
                     "items": {
-                      "oneOf": [
+                      "anyOf": [
                         {
                           "$ref": "#/components/schemas/Principal"
                         },
@@ -3331,7 +3353,7 @@
                     }
                   }
                 },
-                "oneOf": [
+                "anyOf": [
                   {
                     "required": [
                       "serviceAccounts"
@@ -3561,7 +3583,7 @@
         ]
       },
       "CrossAccountRequestDetail": {
-        "oneOf": [
+        "anyOf": [
           {
             "$ref": "#/components/schemas/CrossAccountRequestDetailByAccount"
           },
@@ -3624,7 +3646,7 @@
               "data": {
                 "type": "array",
                 "items": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "$ref": "#/components/schemas/CrossAccountRequestByAccount"
                     },
@@ -3871,21 +3893,21 @@
         ]
       },
       "ResourceDefinitionFilter": {
-          "oneOf": [
-              {
-                "$ref": "#/components/schemas/ResourceDefinitionFilterOperationEqual"
-              },
-              {
-                "$ref": "#/components/schemas/ResourceDefinitionFilterOperationIn"
-              }
-          ]
-     },
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/ResourceDefinitionFilterOperationEqual"
+          },
+          {
+            "$ref": "#/components/schemas/ResourceDefinitionFilterOperationIn"
+          }
+        ]
+      },
       "ResourceDefinitionFilterOperationEqual": {
         "type": "object",
         "required": [
-            "key",
-            "operation",
-            "value"
+          "key",
+          "operation",
+          "value"
         ],
         "properties": {
           "key": {
@@ -3908,9 +3930,9 @@
       "ResourceDefinitionFilterOperationIn": {
         "type": "object",
         "required": [
-            "key",
-            "operation",
-            "value"
+          "key",
+          "operation",
+          "value"
         ],
         "properties": {
           "key": {
@@ -3929,7 +3951,11 @@
               "type": "string",
               "nullable": true
             },
-            "example": ["value1", null, "value2"]
+            "example": [
+              "value1",
+              null,
+              "value2"
+            ]
           }
         }
       },

--- a/rbac/api/openapi/view.py
+++ b/rbac/api/openapi/view.py
@@ -35,6 +35,9 @@ OPENAPI_FILE_NAME = "openapi.json"
 OPENAPI_V2_FILE_PATH = os.path.join(BASE_DIR, "..", "docs/source/specs/v2")
 OPENAPI_V2_FILE_NAME = "openapi.json"
 
+OPENAPI_V1_1_FILE_PATH = os.path.join(BASE_DIR, "..", "docs/source/specs/v1.1")
+OPENAPI_V1_1_FILE_NAME = "openapi.json"
+
 
 @api_view(["GET"])
 @permission_classes((permissions.AllowAny,))
@@ -106,6 +109,45 @@ def openapi_v2(request):
                 "errors": [
                     {
                         "detail": "V2 OpenAPI specification file contains invalid JSON.",
+                        "status": "500",
+                    }
+                ]
+            },
+            status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        )
+
+
+@api_view(["GET"])
+@permission_classes((permissions.AllowAny,))
+@renderer_classes((JSONRenderer,))
+def openapi_v1_1(request):
+    """Provide the V1.1 openapi information."""
+    openapidoc = os.path.join(OPENAPI_V1_1_FILE_PATH, OPENAPI_V1_1_FILE_NAME)
+
+    try:
+        with open(openapidoc, encoding="utf-8") as api_file:
+            data = json.load(api_file)
+            return Response(data)
+    except FileNotFoundError:
+        logger.error(f"V1.1 OpenAPI specification file not found at {openapidoc}")
+        return Response(
+            {
+                "errors": [
+                    {
+                        "detail": "V1.1 OpenAPI specification file not found.",
+                        "status": "500",
+                    }
+                ]
+            },
+            status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        )
+    except json.JSONDecodeError as e:
+        logger.error(f"Invalid JSON in V1.1 OpenAPI specification file: {e}")
+        return Response(
+            {
+                "errors": [
+                    {
+                        "detail": "V1.1 OpenAPI specification file contains invalid JSON.",
                         "status": "500",
                     }
                 ]

--- a/rbac/api/urls.py
+++ b/rbac/api/urls.py
@@ -17,7 +17,7 @@
 from django.urls import include, path
 from rest_framework.routers import DefaultRouter
 
-from api.views import CrossAccountRequestViewSet, openapi, status
+from api.views import CrossAccountRequestViewSet, openapi, openapi_v1_1, status
 
 ROUTER = DefaultRouter()
 ROUTER.register(r"cross-account-requests", CrossAccountRequestViewSet, basename="cross")
@@ -26,5 +26,6 @@ ROUTER.register(r"cross-account-requests", CrossAccountRequestViewSet, basename=
 urlpatterns = [
     path("status/", status, name="server-status"),
     path("openapi.json", openapi, name="openapi"),
+    path("v1.1/openapi.json", openapi_v1_1, name="openapi_v1_1"),
     path("", include(ROUTER.urls)),
 ]

--- a/rbac/api/views.py
+++ b/rbac/api/views.py
@@ -19,5 +19,5 @@
 # flake8: noqa
 # pylint: disable=unused-import
 from api.status.view import status
-from api.openapi.view import openapi
+from api.openapi.view import openapi, openapi_v1_1
 from api.cross_access.view import CrossAccountRequestViewSet


### PR DESCRIPTION
## Link(s) to Jira
-

## Description of Intent of Change(s)
We want to update our openapi spec to use anyOf instead of oneOf. In order to not break other teams that are currently using our openapi spec, we need to cut a new version (v1.1) of the spec. 

## Local Testing
1. Pull this branch
2. Bring up the server as normal locally
```
make reinitdb
make serve
```
check that both v1 and v1.1 are available: 
http://localhost:8000/api/rbac/v1/openapi.json 
http://localhost:8000/api/rbac/v1/v1.1/openapi.json (will this path be a problem?... should we change it)? 

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Introduce a new versioned (v1.1) OpenAPI specification endpoint alongside v1 to enable anyOf-based schema support while preserving backwards compatibility

New Features:
- Serve an independent v1.1 OpenAPI JSON endpoint for the updated specification

Enhancements:
- Define path constants and implement dedicated view with error handling for the v1.1 spec endpoint

Documentation:
- Add the v1.1 OpenAPI specification file under docs/source/specs/v1.1