### PR TITLE
RHCLOUD-43407: Add API to migrate an individual custom role

### DIFF
--- a/rbac/internal/urls.py
+++ b/rbac/internal/urls.py
@@ -98,6 +98,7 @@ urlpatterns = [
     path("api/utils/resource_definitions/", views.correct_resource_definitions),
     path("api/utils/principal/", views.principal_removal),
     path("api/utils/user_lookup/", views.user_lookup),
+    path("api/utils/migrate_role/<role_uuid>/", views.migrate_role),
     path("api/relations/lookup_resource/", views.lookup_resource),
     path("api/relations/check_relation/", views.check_relation),
     path("api/relations/read_tuples/", views.read_tuples),

--- a/rbac/internal/views.py
+++ b/rbac/internal/views.py
@@ -2059,7 +2059,7 @@ def migrate_role(request, role_uuid):
 
             relations_dual_write_handler = RelationApiDualWriteHandler(
                 role=role,
-                event_type=ReplicationEventType.UPDATE_CUSTOM_ROLE,
+                event_type=ReplicationEventType.MIGRATE_CUSTOM_ROLE,
                 tenant=role.tenant,
             )
 


### PR DESCRIPTION
## Link(s) to Jira
[RHCLOUD-43407](https://issues.redhat.com/browse/RHCLOUD-43407)

## Description of Intent of Change(s)
We had a role during the stage migration that needs to be re-migrated due to a configuration issue, so add an API to do exactly that.

## Summary by Sourcery

Add an internal API to migrate individual custom roles via RelationApiDualWriteHandler, including validation of system roles and replication settings, error handling, and corresponding tests

New Features:
- Introduce a POST /_private/api/utils/migrate_role/{role_uuid}/ endpoint to manually migrate a custom role

Enhancements:
- Disallow migrating system roles and enforce replication flag before processing
- Return binding_mappings in the JSON response upon successful migration
- Handle gRPC and unexpected errors with appropriate HTTP status codes

Tests:
- Add unit tests for successful migration, replication-disabled rejection, and system role rejection

[RHCLOUD-43407]: https://redhat.atlassian.net/browse/RHCLOUD-43407?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ