### PR TITLE
Fix update rolebindings by subject API to use a supported resource ty…

### DIFF
--- a/rbac/management/role_binding/service.py
+++ b/rbac/management/role_binding/service.py
@@ -655,14 +655,14 @@ class RoleBindingService:
 
         return result
 
+    SUPPORTED_RESOURCE_TYPES = {"workspace"}
+
     def _validate_resource(self, resource_type: str, resource_id: str) -> None:
         """Validate that the resource exists and belongs to this tenant.
 
-        # TODO: Resource validation is workspace-specific because workspace is
-        # the only resource type with a local table. Role bindings can be
-        # created for any resource type, so this lookup needs to be made
-        # generic as more resource
-        # types are supported.
+        Only resource types listed in ``SUPPORTED_RESOURCE_TYPES`` are
+        accepted. To support a new resource type, add it to the set and
+        add an existence check if the type has a local backing table.
 
         Args:
             resource_type: The type of resource (e.g., ``"workspace"``)
@@ -670,7 +670,7 @@ class RoleBindingService:
 
         Raises:
             RequiredFieldError: If resource_type or resource_id is empty
-            InvalidFieldError: If resource_type is not supported
+            InvalidFieldError: If resource_type is not in SUPPORTED_RESOURCE_TYPES
             NotFoundError: If the resource cannot be found for this tenant
         """
         if not resource_type:
@@ -679,11 +679,16 @@ class RoleBindingService:
         if not resource_id:
             raise RequiredFieldError("resource_id")
 
+        if resource_type not in self.SUPPORTED_RESOURCE_TYPES:
+            raise InvalidFieldError(
+                "resource_type",
+                f"Unsupported resource type: '{resource_type}'. "
+                f"Supported types: {', '.join(sorted(self.SUPPORTED_RESOURCE_TYPES))}",
+            )
+
         if resource_type == "workspace":
             if not Workspace.objects.exists_for_tenant(resource_id, tenant=self.tenant):
                 raise NotFoundError(resource_type, resource_id)
-        else:
-            raise InvalidFieldError("resource_type", f"Unsupported resource type: '{resource_type}'")
 
     def _get_roles(self, role_ids: list[str]) -> list[RoleV2]:
         """Get assignable roles by their UUIDs, validating all exist.

--- a/tests/management/role_binding/test_service.py
+++ b/tests/management/role_binding/test_service.py
@@ -528,6 +528,53 @@ class RoleBindingServiceTests(IdentityRequest):
         parent_binding.delete()
         parent_group.delete()
 
+    def test_validate_resource_accepts_supported_types(self):
+        """Test that _validate_resource accepts all SUPPORTED_RESOURCE_TYPES."""
+        resources_by_type = {
+            "workspace": str(self.workspace.id),
+        }
+        for resource_type in RoleBindingService.SUPPORTED_RESOURCE_TYPES:
+            with self.subTest(resource_type=resource_type):
+                resource_id = resources_by_type.get(resource_type, "some-id")
+                self.service._validate_resource(resource_type, resource_id)
+
+    def test_validate_resource_rejects_unsupported_types(self):
+        """Test that _validate_resource raises InvalidFieldError for unsupported types."""
+        from management.exceptions import InvalidFieldError
+
+        unsupported_types = ["host", "project", "inventory", ""]
+        for resource_type in unsupported_types:
+            if not resource_type:
+                continue
+            with self.subTest(resource_type=resource_type):
+                with self.assertRaises(InvalidFieldError) as context:
+                    self.service._validate_resource(resource_type, "some-id")
+
+                self.assertEqual(context.exception.field, "resource_type")
+                self.assertIn(resource_type, str(context.exception))
+                for supported in sorted(RoleBindingService.SUPPORTED_RESOURCE_TYPES):
+                    self.assertIn(supported, str(context.exception))
+
+    def test_validate_resource_rejects_missing_required_fields(self):
+        """Test that _validate_resource raises RequiredFieldError for empty type or id."""
+        from management.exceptions import RequiredFieldError
+
+        test_cases = [
+            ("empty_resource_type", "", str(self.workspace.id)),
+            ("empty_resource_id", "workspace", ""),
+        ]
+        for description, resource_type, resource_id in test_cases:
+            with self.subTest(case=description):
+                with self.assertRaises(RequiredFieldError):
+                    self.service._validate_resource(resource_type, resource_id)
+
+    def test_validate_resource_rejects_nonexistent_workspace(self):
+        """Test that _validate_resource raises NotFoundError for unknown workspace."""
+        from management.exceptions import NotFoundError
+
+        with self.assertRaises(NotFoundError):
+            self.service._validate_resource("workspace", "00000000-0000-0000-0000-000000000000")
+
     def test_get_role_bindings_works_without_tenant_mapping(self):
         """Test that role binding queries work when tenant has no TenantMapping.
 


### PR DESCRIPTION
…pe array to control what resources to create rolebindings for

## Link(s) to Jira
-

## Description of Intent of Change(s)
The what, why and how.

## Local Testing
How can the feature be exercised?
How can the bug be exploited and fix confirmed?
Is any special local setup required?

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Restrict role binding resource validation to an explicit set of supported resource types and ensure unsupported or invalid resources are rejected with clear errors.

Bug Fixes:
- Disallow creation or update of role bindings for unsupported resource types by validating against a defined supported type set.
- Ensure missing resource type or ID and non-existent workspace resources are rejected with appropriate error types.

Enhancements:
- Introduce a SUPPORTED_RESOURCE_TYPES set and clarify documentation for extending resource validation.

Tests:
- Add unit tests covering accepted resource types, unsupported types, missing fields, and non-existent workspaces for role binding resource validation.