### PR TITLE
fix(permissions): return 403 instead of 404 for denied V2 workspace detail operations

### DIFF
--- a/rbac/management/permissions/workspace_access.py
+++ b/rbac/management/permissions/workspace_access.py
@@ -28,9 +28,11 @@ in management/workspace/filters.py.
 """
 
 import logging
+import uuid
 
 from feature_flags import FEATURE_FLAGS
 from management.permissions.system_user_utils import SystemUserAccessResult, check_system_user_access
+from management.utils import validate_uuid
 from management.workspace.utils import (
     is_user_allowed_v1,
     is_user_allowed_v2,
@@ -118,18 +120,16 @@ class WorkspaceAccessPermission(permissions.BasePermission):
 
     def _has_permission_v2(self, request, view, perm, ws_id) -> bool:
         """
-        V2 permission check - coarse-grained for create/move, FilterBackend for detail/list.
-
-        The WorkspaceAccessFilterBackend handles access filtering for list/detail operations
-        via queryset. This ensures consistent 404 behavior for both non-existing and
-        inaccessible workspaces (prevents existence leakage).
+        V2 permission check using Inventory API.
 
         This permission class handles:
         - System user bypass/denial
         - Create operation: check 'create' permission on parent workspace
-        - Move operation: check 'create' permission on target workspace
+        - Move operation: check 'create' permission on target workspace + source access
+        - Detail operations (retrieve, update, partial_update, destroy): check access
+          and return 403 if denied (prevents leaking resource existence via 404)
 
-        For list/detail operations, allow the request to proceed and let the
+        For list operations, allow the request to proceed and let the
         FilterBackend handle access via queryset filtering.
         """
         # For system users (s2s communication), bypass v2 access checks and rely on user.admin
@@ -161,15 +161,26 @@ class WorkspaceAccessPermission(permissions.BasePermission):
             return True
 
         # For move operations, check target workspace access
-        # Source workspace access is handled by FilterBackend
+        # Source workspace access is checked below as a detail action
         if view.action == "move":
-            return self._check_move_target_access_v2(request)
+            if not self._check_move_target_access_v2(request):
+                return False
 
-        # For list/detail operations, allow request to proceed
+        # For detail operations, check access and return 403 if denied
+        # This prevents leaking resource existence via 404
+        if view.action in ("retrieve", "update", "partial_update", "destroy", "move"):
+            # Validate UUID before access check — raises ValidationError (400) for invalid UUIDs
+            # rather than bypassing the permission check entirely
+            if ws_id is not None:
+                validate_uuid(str(ws_id), "workspace uuid validation")
+            if not is_user_allowed_v2(request, perm, ws_id):
+                return False
+            return True
+
+        # For list operations, allow request to proceed
         # FilterBackend handles access filtering via queryset
-        # For list: users with no real workspace access get fallback workspaces
+        # Users with no real workspace access get fallback workspaces
         # (root, default, ungrouped) via FilterBackend instead of 403
-        # This ensures 404 for both non-existing and inaccessible workspaces
         return True
 
     def _has_permission_v1(self, request, view, ws_id) -> bool:
@@ -227,8 +238,6 @@ class WorkspaceAccessPermission(permissions.BasePermission):
         Returns:
             str: The valid UUID string, or None if missing/invalid (let validation handle it)
         """
-        import uuid
-
         # Only check request.data (POST body) - aligns with view's source of truth
         target_workspace_id = request.data.get("parent_id")
         if not target_workspace_id:

--- a/rbac/management/workspace/filters.py
+++ b/rbac/management/workspace/filters.py
@@ -60,9 +60,9 @@ class WorkspaceAccessFilterBackend(filters.BaseFilterBackend):
           - None: StreamedListObjects, sets request.permission_tuples
           - Specified: CheckForUpdate
 
-        This ensures consistent 404 behavior:
-        - If workspace doesn't exist: 404 (standard DRF behavior)
-        - If workspace exists but user can't access: 404 (prevents existence leakage)
+        For V2 detail actions, access is checked by WorkspaceAccessPermission
+        (returning 403 if denied), so this filter passes the queryset through.
+        For V2 list actions, this filter restricts the queryset to accessible workspaces.
         """
         # Skip filtering if V2 access check is disabled (fall back to v1 behavior)
         if not FEATURE_FLAGS.is_workspace_access_check_v2_enabled():
@@ -71,27 +71,25 @@ class WorkspaceAccessFilterBackend(filters.BaseFilterBackend):
         # Determine the relation/permission and workspace_id based on action
         relation = permission_from_request(request, view)
         action = getattr(view, "action", None)
-        workspace_id = str(view.kwargs.get("pk")) if action in self.DETAIL_ACTIONS else None
 
-        # Call is_user_allowed_v2 - handles both list and detail cases
-        # Side effect: when workspace_id is None (list actions), is_user_allowed_v2 sets
-        # request.permission_tuples with accessible workspace IDs, used for filtering below
+        # For detail actions, access is already checked by WorkspaceAccessPermission
+        # (returning 403 if denied). No need to re-check here.
+        if action in self.DETAIL_ACTIONS:
+            return queryset
+
+        # For list actions, call is_user_allowed_v2 to get accessible workspace IDs
+        # Side effect: is_user_allowed_v2 sets request.permission_tuples
         try:
-            has_access = is_user_allowed_v2(request, relation, workspace_id)
+            has_access = is_user_allowed_v2(request, relation, None)
         except Exception as e:
             logger.exception(
-                "Exception in is_user_allowed_v2: user=%s, org_id=%s, workspace_id=%s, relation=%s, error=%s",
+                "Exception in is_user_allowed_v2: user=%s, org_id=%s, relation=%s, error=%s",
                 getattr(request.user, "username", "unknown"),
                 getattr(request.user, "org_id", "unknown"),
-                workspace_id,
                 relation,
                 str(e),
             )
             return queryset.none()
-
-        # For detail actions: filter to specific workspace if access granted
-        if workspace_id:
-            return queryset.filter(id=workspace_id) if has_access else queryset.none()
 
         # For list actions: check access decision first, then filter by permission_tuples
         if not has_access:

--- a/rbac/management/workspace/view.py
+++ b/rbac/management/workspace/view.py
@@ -60,9 +60,8 @@ class WorkspaceViewSet(WorkspaceObjectAccessMixin, BaseV2ViewSet):
     A viewset that provides default `create()`, `destroy` and `retrieve()`.
 
     Access control is handled by:
-    - WorkspaceAccessPermission: Coarse-grained endpoint access
-    - WorkspaceAccessFilterBackend: Queryset filtering via Kessel Inventory API
-    - WorkspaceObjectAccessMixin: 404 for inaccessible workspaces (no existence leak)
+    - WorkspaceAccessPermission: Access checks (403 for denied detail operations)
+    - WorkspaceAccessFilterBackend: Queryset filtering for list operations via Kessel Inventory API
     """
 
     permission_classes = (WorkspaceAccessPermission,)

--- a/tests/management/workspace/test_filters.py
+++ b/tests/management/workspace/test_filters.py
@@ -90,42 +90,42 @@ class WorkspaceAccessFilterBackendUnitTests(TransactionTestCase):
 
     @patch("management.workspace.filters.is_user_allowed_v2")
     @patch("management.workspace.filters.FEATURE_FLAGS")
-    def test_detail_action_uses_workspace_id(self, mock_flags, mock_is_user_allowed_v2):
-        """FilterBackend uses workspace_id for detail actions (CheckForUpdate)."""
+    def test_detail_action_skips_access_check(self, mock_flags, mock_is_user_allowed_v2):
+        """FilterBackend skips access check for detail actions (handled by permission class)."""
         mock_flags.is_workspace_access_check_v2_enabled.return_value = True
-        mock_is_user_allowed_v2.return_value = True
 
         request = Mock(tenant=Mock())
         request.method = "GET"
         queryset = Mock()
         view = Mock(action="retrieve", kwargs={"pk": "ws-123"})
 
-        self.filter_backend.filter_queryset(request, queryset, view)
+        result = self.filter_backend.filter_queryset(request, queryset, view)
 
-        # Should call is_user_allowed_v2 with specific workspace_id
-        mock_is_user_allowed_v2.assert_called_once()
-        call_args = mock_is_user_allowed_v2.call_args
-        self.assertEqual(call_args[0][2], "ws-123")  # target_workspace should be ws-123
+        # Should NOT call is_user_allowed_v2 — permission class handles detail access
+        mock_is_user_allowed_v2.assert_not_called()
 
-        # Should filter queryset to just that workspace
-        queryset.filter.assert_called_once()
+        # Should return queryset unchanged
+        self.assertEqual(result, queryset)
 
     @patch("management.workspace.filters.is_user_allowed_v2")
     @patch("management.workspace.filters.FEATURE_FLAGS")
-    def test_detail_action_returns_empty_when_access_denied(self, mock_flags, mock_is_user_allowed_v2):
-        """Detail action returns empty queryset when access is denied."""
+    def test_detail_action_skips_access_check_for_write_actions(self, mock_flags, mock_is_user_allowed_v2):
+        """FilterBackend skips access check for all detail actions (update, destroy, move)."""
         mock_flags.is_workspace_access_check_v2_enabled.return_value = True
-        mock_is_user_allowed_v2.return_value = False
 
-        request = Mock(tenant=Mock())
-        request.method = "GET"
-        queryset = Mock()
-        view = Mock(action="retrieve", kwargs={"pk": "ws-123"})
+        for action in ("retrieve", "update", "partial_update", "destroy", "move"):
+            mock_is_user_allowed_v2.reset_mock()
+            request = Mock(tenant=Mock())
+            request.method = "PUT"
+            queryset = Mock()
+            view = Mock(action=action, kwargs={"pk": "ws-123"})
 
-        self.filter_backend.filter_queryset(request, queryset, view)
+            result = self.filter_backend.filter_queryset(request, queryset, view)
 
-        # Should return empty queryset
-        queryset.none.assert_called_once()
+            # Should NOT call is_user_allowed_v2
+            mock_is_user_allowed_v2.assert_not_called()
+            # Should return queryset unchanged
+            self.assertEqual(result, queryset)
 
     @patch("management.workspace.filters.is_user_allowed_v2")
     @patch("management.workspace.filters.FEATURE_FLAGS")
@@ -207,10 +207,9 @@ class WorkspaceAccessFilterBackendUnitTests(TransactionTestCase):
 
     @patch("management.workspace.filters.is_user_allowed_v2")
     @patch("management.workspace.filters.FEATURE_FLAGS")
-    def test_detail_actions_include_all_detail_types(self, mock_flags, mock_is_user_allowed_v2):
-        """All detail action types use CheckForUpdate via is_user_allowed_v2 with workspace_id."""
+    def test_detail_actions_skip_filter_for_all_types(self, mock_flags, mock_is_user_allowed_v2):
+        """All detail action types skip FilterBackend access check (handled by permission class)."""
         mock_flags.is_workspace_access_check_v2_enabled.return_value = True
-        mock_is_user_allowed_v2.return_value = True
 
         detail_actions = ["retrieve", "update", "partial_update", "destroy", "move"]
 
@@ -222,15 +221,15 @@ class WorkspaceAccessFilterBackendUnitTests(TransactionTestCase):
             queryset = Mock()
             view = Mock(action=action, kwargs={"pk": "ws-456"})
 
-            self.filter_backend.filter_queryset(request, queryset, view)
+            result = self.filter_backend.filter_queryset(request, queryset, view)
 
-            # Should call is_user_allowed_v2 with workspace_id for all detail actions
-            mock_is_user_allowed_v2.assert_called_once()
-            call_args = mock_is_user_allowed_v2.call_args
+            # Should NOT call is_user_allowed_v2 — permission class handles detail access
+            mock_is_user_allowed_v2.assert_not_called()
+            # Should return queryset unchanged
             self.assertEqual(
-                call_args[0][2],
-                "ws-456",
-                f"Action {action} should pass workspace_id to is_user_allowed_v2",
+                result,
+                queryset,
+                f"Action {action} should return queryset unchanged",
             )
 
 
@@ -336,8 +335,8 @@ class WorkspaceFilterBackendIntegrationTests(TransactionIdentityRequest):
         "feature_flags.FEATURE_FLAGS.is_workspace_access_check_v2_enabled",
         return_value=True,
     )
-    def test_detail_returns_404_for_inaccessible_workspace(self, mock_flag, mock_channel):
-        """Test that detail endpoint returns 404 for inaccessible workspace (no existence leak)."""
+    def test_detail_returns_403_for_inaccessible_workspace(self, mock_flag, mock_channel):
+        """Test that detail endpoint returns 403 for inaccessible workspace."""
         mock_stub = MagicMock()
         mock_channel.return_value.__enter__.return_value = MagicMock()
 
@@ -360,9 +359,9 @@ class WorkspaceFilterBackendIntegrationTests(TransactionIdentityRequest):
             client = APIClient()
             response = client.get(url, format="json", **headers)
 
-            # Should return 404 (not 403) to prevent existence leakage
-            # User cannot distinguish between non-existing and inaccessible workspaces
-            self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+            # Should return 403 Forbidden when user lacks permission
+            # Access check happens in WorkspaceAccessPermission before resource lookup
+            self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
             # Verify CheckForUpdate was called (not StreamedListObjects)
             mock_stub.CheckForUpdate.assert_called()

--- a/tests/management/workspace/test_workspace_inventory_access.py
+++ b/tests/management/workspace/test_workspace_inventory_access.py
@@ -446,10 +446,10 @@ class WorkspaceInventoryAccessV2Tests(TransactionIdentityRequest):
     def test_workspace_access_denied(self, mock_flag, mock_channel):
         """Test workspace access is denied when Inventory API returns not allowed.
 
-        Returns 404 (not 403) to prevent existence leakage - user cannot distinguish
-        between a non-existing workspace and one they don't have access to.
+        Returns 403 Forbidden when the user lacks permission to access the workspace.
+        The access check happens in WorkspaceAccessPermission before resource lookup.
         """
-        # Mock Inventory API - FilterBackend uses CheckForUpdate for detail actions
+        # Mock Inventory API - permission class uses CheckForUpdate for detail actions
         mock_stub = MagicMock()
         mock_channel.return_value.__enter__.return_value = MagicMock()
 
@@ -474,8 +474,8 @@ class WorkspaceInventoryAccessV2Tests(TransactionIdentityRequest):
             client = APIClient()
             response = client.get(url, format="json", **headers)
 
-            # Should return 404 (not 403) to prevent existence leakage
-            self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+            # Should return 403 Forbidden when user lacks permission
+            self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
             # Verify CheckForUpdate was called for detail action
             mock_stub.CheckForUpdate.assert_called()
@@ -863,10 +863,10 @@ class WorkspaceInventoryAccessV2Tests(TransactionIdentityRequest):
     def test_workspace_update_access_denied(self, mock_flag, mock_channel):
         """Test workspace update is denied when Inventory API returns not allowed.
 
-        Returns 404 (not 403) to prevent existence leakage - user cannot distinguish
-        between a non-existing workspace and one they don't have access to.
+        Returns 403 Forbidden when the user lacks permission to update the workspace.
+        The access check happens in WorkspaceAccessPermission before resource lookup.
         """
-        # Mock Inventory API - FilterBackend uses CheckForUpdate for detail actions
+        # Mock Inventory API - permission class uses CheckForUpdate for detail actions
         mock_stub = MagicMock()
         mock_channel.return_value.__enter__.return_value = MagicMock()
 
@@ -896,9 +896,8 @@ class WorkspaceInventoryAccessV2Tests(TransactionIdentityRequest):
             client = APIClient()
             response = client.put(url, updated_data, format="json", **headers)
 
-            # Should return 404 (not 403) to prevent existence leakage
-            # User cannot tell if workspace doesn't exist or they lack access
-            self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+            # Should return 403 Forbidden when user lacks permission
+            self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
             # Verify CheckForUpdate was called for detail action
             mock_stub.CheckForUpdate.assert_called()
@@ -1038,8 +1037,8 @@ class WorkspaceInventoryAccessV2Tests(TransactionIdentityRequest):
             client = APIClient()
             response = client.patch(url, updated_data, format="json", **headers)
 
-            # Should return 404 (not 403) to prevent existence leakage
-            self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+            # Should return 403 Forbidden when user lacks permission
+            self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
             # Verify CheckForUpdate was called for detail action
             mock_stub.CheckForUpdate.assert_called()
@@ -1104,10 +1103,10 @@ class WorkspaceInventoryAccessV2Tests(TransactionIdentityRequest):
     def test_workspace_delete_access_denied(self, mock_flag, mock_channel):
         """Test workspace deletion is denied when user lacks permissions.
 
-        Returns 404 (not 403) to prevent existence leakage - user cannot distinguish
-        between a non-existing workspace and one they don't have access to.
+        Returns 403 Forbidden when the user lacks permission to delete the workspace.
+        The access check happens in WorkspaceAccessPermission before resource lookup.
         """
-        # Mock Inventory API - FilterBackend uses CheckForUpdate for detail actions
+        # Mock Inventory API - permission class uses CheckForUpdate for detail actions
         mock_stub = MagicMock()
         mock_channel.return_value.__enter__.return_value = MagicMock()
 
@@ -1132,8 +1131,8 @@ class WorkspaceInventoryAccessV2Tests(TransactionIdentityRequest):
             client = APIClient()
             response = client.delete(url, format="json", **headers)
 
-            # Should return 404 (not 403) to prevent existence leakage
-            self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+            # Should return 403 Forbidden when user lacks permission
+            self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
             # Verify CheckForUpdate was called for detail action
             mock_stub.CheckForUpdate.assert_called()


### PR DESCRIPTION
## Link(s) to Jira
- 

## Description of Intent of Change(s)

### What
Fix V2 workspace access checks for detail operations (GET, PUT, PATCH, DELETE on `/workspaces/{id}/`) to return **403 Forbidden** instead of **404 Not Found** when a user lacks permission.

### Why
Previously, access control for detail operations was handled by `WorkspaceAccessFilterBackend`, which filtered inaccessible workspaces out of the queryset. When a user had no access, DRF's `get_object()` couldn't find the workspace in the filtered queryset and returned 404. This:

1. **Leaks resource existence** — an attacker can distinguish between "workspace doesn't exist" (404) and "workspace exists but I can't access it" (also 404, but should be 403)
2. **Violates the expected API contract** — unauthorized access should return 403 across GET, DELETE, PATCH, PUT, and MOVE operations

### How

**Commit 1 — `fix(permissions)`** (core fix):
- `WorkspaceAccessPermission._has_permission_v2()` now calls `is_user_allowed_v2()` for detail actions (`retrieve`, `update`, `partial_update`, `destroy`, `move`) and returns `False` → **403 Forbidden** when denied
- Invalid UUIDs raise `ValidationError` (400) directly from the permission class instead of bypassing the access check entirely — eliminates a timing side-channel and ensures consistent security enforcement
- Move operations now check both target workspace access AND source workspace access in the permission class

**Commit 2 — `refactor(filters)`** (remove redundant API calls):
- `WorkspaceAccessFilterBackend` no longer performs access checks for V2 detail actions — returns the queryset unchanged since the permission class already handled authorization
- List operations are unchanged — the FilterBackend still handles queryset filtering via `StreamedListObjects`
- Eliminates one redundant Inventory API call per detail request

**Commit 3 — `test(workspace)`** (test updates):
- Filter tests: detail actions no longer call `is_user_allowed_v2` in FilterBackend, return queryset unchanged
- Inventory access tests: denied detail operations now expect 403 instead of 404

### Before → After
| Scenario | Before | After |
|----------|--------|-------|
| Detail operation, access denied | 404 | **403** |
| Detail operation, access allowed | 200 | 200 (unchanged) |
| Detail operation, invalid UUID | 400 (bypass permission check) | 400 (validate in permission class) |
| List operation | Filtered queryset | Filtered queryset (unchanged) |

## Local Testing

1. Enable V2 workspace access checks (feature flag `WORKSPACE_ACCESS_CHECK_V2`)
2. As a non-admin user without workspace permissions, attempt:
   - `GET /api/rbac/v2/workspaces/{id}/` → should return 403
   - `DELETE /api/rbac/v2/workspaces/{id}/` → should return 403
   - `PUT /api/rbac/v2/workspaces/{id}/` → should return 403
   - `PATCH /api/rbac/v2/workspaces/{id}/` → should return 403
3. As an admin user, the same operations should still work normally
4. List operations (`GET /api/rbac/v2/workspaces/`) should be unaffected

## Checklist
- [x] if API spec changes are required, is the spec updated? _(N/A - response codes align with spec)_
- [x] are there any pre/post merge actions required? if so, document here. _(None)_
- [x] are theses changes covered by unit tests?
- [x] if warranted, are documentation changes accounted for? _(docstrings updated)_
- [x] does this require migration changes? _(No)_
  - [ ] if yes, are they backwards compatible?
- [x] is there known, direct impact to dependent teams/components? _(API consumers will see 403 instead of 404 for unauthorized workspace detail access when V2 is enabled)_
  - [x] if yes, how will this be handled? _(Behind V2 feature flag, gradual rollout)_

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [x] Input Validation
- [ ] Output Encoding
- [x] Authentication and Password Management
- [ ] Session Management
- [x] Access Control
- [ ] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices