### PR TITLE
fix(workspaces): return validation errors instead of 403 for invalid parent in POST/MOVE

### DIFF
--- a/rbac/management/permissions/workspace_access.py
+++ b/rbac/management/permissions/workspace_access.py
@@ -28,6 +28,7 @@ in management/workspace/filters.py.
 """
 
 import logging
+import uuid as uuid_module
 
 from feature_flags import FEATURE_FLAGS
 from management.permissions.system_user_utils import SystemUserAccessResult, check_system_user_access
@@ -156,13 +157,14 @@ class WorkspaceAccessPermission(permissions.BasePermission):
         # For create operations, check permission on parent workspace (ws_id)
         # ws_id is the parent workspace ID where the new workspace will be created
         if view.action == "create":
-            if not is_user_allowed_v2(request, perm, ws_id):
-                return False
-            return True
+            return self._check_create_permission_v2(request, perm, ws_id)
 
-        # For move operations, check target workspace access
-        # Source workspace access is handled by FilterBackend
+        # For move operations, check source and target workspace access
         if view.action == "move":
+            # Check source workspace access first
+            if not self._check_move_source_access_v2(request, perm, ws_id):
+                return False
+            # Then check target workspace access
             return self._check_move_target_access_v2(request)
 
         # For list/detail operations, allow request to proceed
@@ -213,6 +215,99 @@ class WorkspaceAccessPermission(permissions.BasePermission):
 
         return True
 
+    def _user_has_any_create_permission_v2(self, request) -> bool:
+        """
+        Check if the user has 'create' permission on any workspace.
+
+        Uses a list-style Kessel check (StreamedListObjects) and inspects
+        has_real_workspace_access to distinguish genuine permissions from
+        fallback workspaces (root, default, ungrouped).
+
+        Args:
+            request: The HTTP request object
+
+        Returns:
+            bool: True if user has create permission on at least one workspace
+        """
+        is_user_allowed_v2(request, "create", None)
+        return getattr(request, "has_real_workspace_access", False)
+
+    def _check_create_permission_v2(self, request, perm, ws_id) -> bool:
+        """
+        Check create permission with parent_id pre-validation.
+
+        Ensures that validation errors (invalid UUID, non-existent parent, root parent)
+        are returned to users who have create capability, rather than being masked by
+        a 403 from the Kessel check on an invalid parent workspace.
+
+        - Invalid UUID parent_id: always return True (all users get 400 from view validation)
+        - Non-existent or root parent: check general create capability; write-capable users
+          see the validation error, read-only users get 403
+        - Valid parent: normal Kessel permission check on that parent
+        """
+        from management.workspace.model import Workspace
+
+        parent_id = request.data.get("parent_id")
+
+        if parent_id:
+            # Validate UUID format - if invalid, skip permission check entirely.
+            # Invalid UUID is a format error, not a security concern.
+            try:
+                uuid_module.UUID(str(parent_id))
+            except (ValueError, AttributeError):
+                return True
+
+            # Check if parent exists and is a valid type for creating children
+            parent_ws = Workspace.objects.filter(id=parent_id, tenant=request.tenant).only("type").first()
+
+            if parent_ws is None or parent_ws.type == Workspace.Types.ROOT:
+                # Parent doesn't exist or is root (invalid for child creation).
+                # Check if user has create permission on any workspace.
+                # Write-capable users will see the validation error (400/404).
+                # Read-only users get 403.
+                return self._user_has_any_create_permission_v2(request)
+
+        # Valid parent (or no parent specified, defaults handled by ws_id) - normal check
+        if not is_user_allowed_v2(request, perm, ws_id):
+            return False
+        return True
+
+    def _check_move_source_access_v2(self, request, perm, ws_id) -> bool:
+        """
+        Check source workspace access for move operations in V2 mode.
+
+        If the source workspace is a root workspace (which cannot be moved),
+        checks general create capability so that write-capable users see
+        the validation error (400) instead of 403.
+
+        Args:
+            request: The HTTP request object
+            perm: The permission to check (e.g. 'create')
+            ws_id: The source workspace ID from workspace_from_request
+
+        Returns:
+            bool: True if the user has permission on the source workspace
+        """
+        from management.workspace.model import Workspace
+
+        if ws_id:
+            try:
+                uuid_module.UUID(str(ws_id))
+            except (ValueError, AttributeError):
+                return True
+
+            source_ws = Workspace.objects.filter(id=ws_id, tenant=request.tenant).only("type").first()
+
+            if source_ws is not None and source_ws.type == Workspace.Types.ROOT:
+                # Root workspace cannot be moved - check general create capability
+                # so write-capable users see the 400 validation error
+                return self._user_has_any_create_permission_v2(request)
+
+            if not is_user_allowed_v2(request, perm, ws_id):
+                return False
+
+        return True
+
     def _get_target_workspace_id(self, request) -> str | None:
         """
         Get and validate the target workspace ID from request body.
@@ -248,16 +343,32 @@ class WorkspaceAccessPermission(permissions.BasePermission):
         In V2, we use the Inventory API to check if the user has 'create' permission
         on the target workspace (from SpiceDB schema: create, view, edit, move, delete).
 
+        If the target is root workspace (invalid move target), checks general create
+        capability so write-capable users see the validation error (400) instead of 403.
+
         Args:
             request: The HTTP request object
 
         Returns:
             bool: True if the user has 'create' permission on target workspace
         """
+        from management.workspace.model import Workspace
+
         target_workspace_id = self._get_target_workspace_id(request)
         if target_workspace_id is None:
             # Let validation handle missing/invalid parent_id
             return True
+
+        # Pre-validate target: if it doesn't exist or is root, check general capability
+        target_ws = Workspace.objects.filter(id=target_workspace_id, tenant=request.tenant).only("type").first()
+
+        if target_ws is None or target_ws.type == Workspace.Types.ROOT:
+            # Target doesn't exist or is root (invalid move target).
+            # Write-capable users should see the validation error, not 403.
+            if self._user_has_any_create_permission_v2(request):
+                return True
+            self.message = TARGET_WORKSPACE_ACCESS_DENIED_MESSAGE
+            return False
 
         # V2: Check 'create' permission on target workspace via Inventory API
         if not is_user_allowed_v2(request, "create", target_workspace_id):

--- a/rbac/management/workspace/filters.py
+++ b/rbac/management/workspace/filters.py
@@ -71,6 +71,16 @@ class WorkspaceAccessFilterBackend(filters.BaseFilterBackend):
         # Determine the relation/permission and workspace_id based on action
         relation = permission_from_request(request, view)
         action = getattr(view, "action", None)
+
+        # For move action, use 'view' for source workspace visibility check.
+        # The actual move permission (create) is checked by WorkspaceAccessPermission
+        # for both source and target workspaces. Using 'view' here ensures that
+        # workspaces visible to the user (including root via fallback) are not
+        # filtered out, so the service layer can return proper validation errors
+        # (e.g., "cannot move root workspace") instead of 404.
+        if action == "move":
+            relation = "view"
+
         workspace_id = str(view.kwargs.get("pk")) if action in self.DETAIL_ACTIONS else None
 
         # Call is_user_allowed_v2 - handles both list and detail cases

--- a/rbac/management/workspace/view.py
+++ b/rbac/management/workspace/view.py
@@ -244,9 +244,14 @@ class WorkspaceViewSet(WorkspaceObjectAccessMixin, BaseV2ViewSet):
 
         Note: Access checks for both source and target workspaces are handled by
         WorkspaceAccessPermission.has_permission() before this method is called.
+        Source workspace visibility is checked by WorkspaceAccessFilterBackend
+        via get_object() below.
         """
-        target_workspace_id = self._parent_id_query_param_validation(request)
+        # Get source workspace first - this triggers FilterBackend access check.
+        # Must happen before target validation so that users without access to
+        # the source workspace get 404 (not a validation error for the target).
         workspace = self.get_object()
+        target_workspace_id = self._parent_id_query_param_validation(request)
         serializer = self.get_serializer(workspace)
         return serializer.move(workspace, target_workspace_id)
 

--- a/tests/management/workspace/test_workspace_inventory_access.py
+++ b/tests/management/workspace/test_workspace_inventory_access.py
@@ -625,6 +625,13 @@ class WorkspaceInventoryAccessV2Tests(TransactionIdentityRequest):
         mock_response.allowed = allowed_pb2.Allowed.ALLOWED_TRUE
         mock_stub.CheckForUpdate.return_value = mock_response
 
+        # Mock StreamedListObjects to return the default workspace (user has create permission)
+        # This is needed because the permission class uses a list-style check to verify
+        # the user has create capability when the parent_id is invalid/non-existent.
+        mock_list_response = MagicMock(object=MagicMock(resource_id=str(self.default_workspace.id)))
+        mock_list_response.pagination = None
+        mock_stub.StreamedListObjects.side_effect = lambda *args, **kwargs: iter([mock_list_response])
+
         with patch(
             "kessel.inventory.v1beta2.inventory_service_pb2_grpc.KesselInventoryServiceStub",
             return_value=mock_stub,


### PR DESCRIPTION
## Link(s) to Jira
- 

## Description of Intent of Change(s)

### Problem
When creating or moving workspaces with an invalid `parent_id` (bad UUID, non-existent workspace, or root workspace), the V2 permission check returned **403 Forbidden** instead of the appropriate validation error (**400 Bad Request** or **404 Not Found**). This happened because the Kessel/SpiceDB permission check was performed against the invalid parent workspace, which always fails — masking the real validation errors that write-capable users should see.

**Affected test cases:** 3.03, 3.16, 3.17, 7.04, 7.09, 7.14

### Root Cause
The permission layer (`WorkspaceAccessPermission`) was passing raw user-provided `parent_id` values directly to `is_user_allowed_v2()`, which queries Kessel. When the workspace doesn't exist in Kessel, or is a root workspace (where `create` is never granted), the check returns `False` → 403 — before the view layer can validate the request and return the proper error.

### Fix
Three coordinated changes ensure the correct error is returned:

1. **Permission class** (`workspace_access.py`): Adds parent pre-validation before the Kessel check:
   - **Invalid UUID** → always passes permission (all users see 400 from view validation)
   - **Non-existent / root parent** → checks user's *general* create capability via `StreamedListObjects`; write-capable users see the validation error, read-only users still get 403
   - **Valid parent** → normal Kessel permission check (unchanged)
   - Also adds source workspace permission check for move operations

2. **FilterBackend** (`filters.py`): For `move` action, uses `'view'` relation for source workspace visibility instead of `'create'`. This prevents root workspace from being filtered out (it's accessible via fallback), allowing the service layer to return proper validation errors like "cannot move root workspace".

3. **View** (`view.py`): Reorders `_move_atomic()` to call `get_object()` before `_parent_id_query_param_validation()`, ensuring source workspace access is checked before target validation runs.

### Behavior Matrix (after fix)

| Scenario | Write-capable user | Read-only user |
|----------|-------------------|----------------|
| POST + invalid UUID parent | 400 (Invalid UUID) | 400 (Invalid UUID) |
| POST + non-existent parent | 400 (Parent not found) | 403 (Forbidden) |
| POST + root parent | 400 (Invalid parent) | 403 (Forbidden) |
| MOVE + root target | 400 (Invalid parent) | 403 (Forbidden) |
| MOVE + root source | 400 (Cannot move) | 403 (Forbidden) |

## Local Testing

1. Run workspace-specific tests:
```bash
tox -e py312 -- tests/management/workspace/test_workspace_inventory_access tests/management/workspace/test_filters
```

2. Verify linter and type checks:
```bash
tox -e lint -e mypy
```

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [x] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [ ] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices

## Summary by Sourcery

Adjust workspace permission and filtering logic so invalid or disallowed parent workspaces surface correct validation errors instead of generic 403 responses when creating or moving workspaces.

Bug Fixes:
- Ensure workspace creation with invalid, non-existent, or root parent IDs returns appropriate 400/404 validation errors rather than 403 Forbidden for users with create capability.
- Ensure move operations involving root source or target workspaces return the correct validation errors for write-capable users instead of being masked by 403 responses.
- Prevent root workspaces from being filtered out during move operations so that domain-specific validation errors (such as cannot move root) are returned instead of 404.

Enhancements:
- Refine V2 permission checks to distinguish between general create capability and per-workspace access, including dedicated helpers for create and move source/target checks.
- Adjust move view flow so source workspace access is resolved before validating the target workspace, aligning responses for users lacking source access.

Tests:
- Extend workspace inventory access tests to cover the new parent validation and list-style permission checks for invalid parent scenarios.