### PR TITLE
feat: add read-only MCP tools for RBAC endpoints

### DIFF
--- a/rbac/management/mcp_views.py
+++ b/rbac/management/mcp_views.py
@@ -34,15 +34,37 @@ from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.views import View
 from django.views.decorators.csrf import csrf_exempt
+from management.audit_log.view import AuditLogViewSet
+from management.group.view import GroupViewSet
+from management.permission.view import PermissionViewSet
 from management.principal.view import PrincipalView
+from management.role.v2_view import RoleV2ViewSet
+from management.role_binding.view import RoleBindingViewSet
+from management.workspace.view import WorkspaceViewSet
 from mcp.server.fastmcp import FastMCP
 from prometheus_client import Counter, Histogram
 
 from api.common import RH_IDENTITY_HEADER
+from api.cross_access.view import CrossAccountRequestViewSet
+from api.status.view import status as status_view_fn
 
-# Cache the view function — PrincipalView.as_view() returns a new callable each time,
+# Cache view functions — .as_view() returns a new callable each time,
 # but the result is stateless and reusable.
 _principal_view = PrincipalView.as_view()
+_status_view = status_view_fn
+_permission_list_view = PermissionViewSet.as_view({"get": "list"})
+_auditlog_list_view = AuditLogViewSet.as_view({"get": "list"})
+_role_v2_list_view = RoleV2ViewSet.as_view({"get": "list"})
+_role_v2_detail_view = RoleV2ViewSet.as_view({"get": "retrieve"})
+_group_list_view = GroupViewSet.as_view({"get": "list"})
+_group_detail_view = GroupViewSet.as_view({"get": "retrieve"})
+_group_principals_view = GroupViewSet.as_view({"get": "principals"})
+_cross_account_list_view = CrossAccountRequestViewSet.as_view({"get": "list"})
+_cross_account_detail_view = CrossAccountRequestViewSet.as_view({"get": "retrieve"})
+_workspace_list_view = WorkspaceViewSet.as_view({"get": "list"})
+_workspace_detail_view = WorkspaceViewSet.as_view({"get": "retrieve"})
+_role_binding_list_view = RoleBindingViewSet.as_view({"get": "list"})
+_role_binding_by_subject_view = RoleBindingViewSet.as_view({"get": "by_subject"})
 
 logger = logging.getLogger(__name__)
 
@@ -203,6 +225,422 @@ def list_principals(
     if hasattr(response, "data"):
         return json.dumps(response.data, default=str)
     return response.content.decode()
+
+
+def _call_view(request: HttpRequest, view: Callable[..., Any], path: str, query_params: dict[str, str]) -> str:
+    """Call a Django view with cloned request and return the response as a JSON string."""
+    view_request = _clone_request(request, path, data=query_params)
+    response = view(view_request)
+    if hasattr(response, "data"):
+        return json.dumps(response.data, default=str)
+    return response.content.decode()
+
+
+def _call_detail_view(
+    request: HttpRequest,
+    view: Callable[..., Any],
+    path: str,
+    query_params: dict[str, str],
+    **view_kwargs: str,
+) -> str:
+    """Call a Django detail view with cloned request and return the response as a JSON string.
+
+    Pass the lookup kwarg as a keyword argument, e.g. ``pk=value`` or ``uuid=value``.
+    """
+    view_request = _clone_request(request, path, data=query_params)
+    response = view(view_request, **view_kwargs)
+    if hasattr(response, "data"):
+        return json.dumps(response.data, default=str)
+    return response.content.decode()
+
+
+# ┌──────────────────────────────────────────────────────────────────┐
+# │                   MCP Tool → API Endpoint Map                   │
+# ├──────────────────────────┬───────────────────────────────────────┤
+# │ MCP Tool                 │ API Endpoint(s)                      │
+# ├──────────────────────────┼───────────────────────────────────────┤
+# │ hello                    │ (none — in-process greeting)         │
+# │ list_principals          │ GET /api/v1/principals/              │
+# │ get_status               │ GET /api/v1/status/                  │
+# │ list_permissions         │ GET /api/v1/permissions/             │
+# │ list_audit_logs          │ GET /api/v1/auditlogs/               │
+# │ list_roles_v2            │ GET /api/v2/roles/                   │
+# │ get_role_v2              │ GET /api/v2/roles/{uuid}/            │
+# │ list_groups              │ GET /api/v1/groups/                  │
+# │ get_group                │ GET /api/v1/groups/{uuid}/           │
+# │ list_group_principals    │ GET /api/v1/groups/{uuid}/principals/│
+# │ list_cross_account_reqs  │ GET /api/v1/cross-account-requests/  │
+# │ get_cross_account_req    │ GET /api/v1/cross-account-requests/  │
+# │                          │     {uuid}/                          │
+# │ list_workspaces          │ GET /api/v2/workspaces/              │
+# │ get_workspace            │ GET /api/v2/workspaces/{uuid}/       │
+# │ list_role_bindings       │ GET /api/v2/role-bindings/           │
+# │ list_role_bindings_by_   │ GET /api/v2/role-bindings/by-subject/│
+# │   subject                │                                     │
+# └──────────────────────────┴───────────────────────────────────────┘
+
+
+@register_tool(
+    description=(
+        "Get RBAC server status including API version, commit hash, server address, "
+        "platform info, Python version and loaded modules. No authentication required. "
+        "Calls: GET /api/v1/status/"
+    ),
+)
+def get_status(request: HttpRequest) -> str:
+    """Return server status by delegating to the status view."""
+    path = reverse("v1_api:server-status")
+    view_request = _clone_request(request, path)
+    response = _status_view(view_request)
+    if hasattr(response, "data"):
+        return json.dumps(response.data, default=str)
+    return response.content.decode()
+
+
+@register_tool(
+    description=(
+        "List permissions available in RBAC. Supports filtering by application, "
+        "resource_type, verb, and pagination. "
+        "Calls: GET /api/v1/permissions/"
+    ),
+    requires_auth=True,
+)
+def list_permissions(
+    request: HttpRequest,
+    *,
+    application: str = "",
+    resource_type: str = "",
+    verb: str = "",
+    limit: int = 10,
+    offset: int = 0,
+    order_by: str = "",
+) -> str:
+    """List permissions by delegating to PermissionViewSet."""
+    query_params: dict[str, str] = {
+        "limit": str(limit),
+        "offset": str(offset),
+    }
+    if application:
+        query_params["application"] = application
+    if resource_type:
+        query_params["resource_type"] = resource_type
+    if verb:
+        query_params["verb"] = verb
+    if order_by:
+        query_params["order_by"] = order_by
+
+    path = reverse("v1_management:permission-list")
+    return _call_view(request, _permission_list_view, path, query_params)
+
+
+@register_tool(
+    description=(
+        "List audit log entries for the authenticated organization. "
+        "Supports ordering by created, principal_username, resource_type, action. "
+        "Calls: GET /api/v1/auditlogs/"
+    ),
+    requires_auth=True,
+)
+def list_audit_logs(
+    request: HttpRequest,
+    *,
+    limit: int = 10,
+    offset: int = 0,
+    ordering: str = "-created",
+) -> str:
+    """List audit logs by delegating to AuditLogViewSet."""
+    query_params: dict[str, str] = {
+        "limit": str(limit),
+        "offset": str(offset),
+        "ordering": ordering,
+    }
+    path = reverse("v1_management:auditlog-list")
+    return _call_view(request, _auditlog_list_view, path, query_params)
+
+
+@register_tool(
+    description=(
+        "List roles (V2 API). Returns assignable roles for the tenant. "
+        "Supports ordering by name and last_modified. "
+        "Calls: GET /api/v2/roles/"
+    ),
+    requires_auth=True,
+)
+def list_roles_v2(
+    request: HttpRequest,
+    *,
+    limit: int = 10,
+    offset: int = 0,
+) -> str:
+    """List V2 roles by delegating to RoleV2ViewSet."""
+    query_params: dict[str, str] = {
+        "limit": str(limit),
+        "offset": str(offset),
+    }
+    path = reverse("v2_management:roles-list")
+    return _call_view(request, _role_v2_list_view, path, query_params)
+
+
+@register_tool(
+    description="Get details of a specific role by UUID (V2 API). Calls: GET /api/v2/roles/{uuid}/",
+    requires_auth=True,
+)
+def get_role_v2(
+    request: HttpRequest,
+    *,
+    role_uuid: str,
+) -> str:
+    """Get a single V2 role by delegating to RoleV2ViewSet."""
+    path = reverse("v2_management:roles-detail", kwargs={"uuid": role_uuid})
+    return _call_detail_view(request, _role_v2_detail_view, path, {}, uuid=role_uuid)
+
+
+@register_tool(
+    description=(
+        "List groups for the authenticated organization. "
+        "Supports filtering by name and pagination. "
+        "Calls: GET /api/v1/groups/"
+    ),
+    requires_auth=True,
+)
+def list_groups(
+    request: HttpRequest,
+    *,
+    limit: int = 10,
+    offset: int = 0,
+    name: str = "",
+    order_by: str = "",
+) -> str:
+    """List groups by delegating to GroupViewSet."""
+    query_params: dict[str, str] = {
+        "limit": str(limit),
+        "offset": str(offset),
+    }
+    if name:
+        query_params["name"] = name
+    if order_by:
+        query_params["order_by"] = order_by
+
+    path = reverse("v1_management:group-list")
+    return _call_view(request, _group_list_view, path, query_params)
+
+
+@register_tool(
+    description="Get details of a specific group by UUID. Calls: GET /api/v1/groups/{uuid}/",
+    requires_auth=True,
+)
+def get_group(
+    request: HttpRequest,
+    *,
+    group_uuid: str,
+) -> str:
+    """Get a single group by delegating to GroupViewSet."""
+    path = reverse("v1_management:group-detail", kwargs={"uuid": group_uuid})
+    return _call_detail_view(request, _group_detail_view, path, {}, uuid=group_uuid)
+
+
+@register_tool(
+    description="List principals (users) in a specific group. Calls: GET /api/v1/groups/{uuid}/principals/",
+    requires_auth=True,
+)
+def list_group_principals(
+    request: HttpRequest,
+    *,
+    group_uuid: str,
+    limit: int = 10,
+    offset: int = 0,
+    principal_type: str = "",
+) -> str:
+    """List principals in a group by delegating to GroupViewSet.principals."""
+    query_params: dict[str, str] = {
+        "limit": str(limit),
+        "offset": str(offset),
+    }
+    if principal_type:
+        query_params["principal_type"] = principal_type
+
+    path = reverse("v1_management:group-principals", kwargs={"uuid": group_uuid})
+    view_request = _clone_request(request, path, data=query_params)
+    response = _group_principals_view(view_request, uuid=group_uuid)
+    if hasattr(response, "data"):
+        return json.dumps(response.data, default=str)
+    return response.content.decode()
+
+
+@register_tool(
+    description=(
+        "List cross-account requests for the authenticated organization. "
+        "Supports filtering by org_id, status, approved_only. "
+        "Calls: GET /api/v1/cross-account-requests/"
+    ),
+    requires_auth=True,
+)
+def list_cross_account_requests(
+    request: HttpRequest,
+    *,
+    limit: int = 10,
+    offset: int = 0,
+    status: str = "",
+    org_id: str = "",
+    approved_only: str = "",
+    ordering: str = "",
+) -> str:
+    """List cross-account requests by delegating to CrossAccountRequestViewSet."""
+    query_params: dict[str, str] = {
+        "limit": str(limit),
+        "offset": str(offset),
+    }
+    if status:
+        query_params["status"] = status
+    if org_id:
+        query_params["org_id"] = org_id
+    if approved_only:
+        query_params["approved_only"] = approved_only
+    if ordering:
+        query_params["ordering"] = ordering
+
+    path = reverse("v1_api:cross-list")
+    return _call_view(request, _cross_account_list_view, path, query_params)
+
+
+@register_tool(
+    description=(
+        "Get details of a specific cross-account request by its ID. "
+        "Calls: GET /api/v1/cross-account-requests/{request_id}/"
+    ),
+    requires_auth=True,
+)
+def get_cross_account_request(
+    request: HttpRequest,
+    *,
+    request_id: str,
+) -> str:
+    """Get a single cross-account request by delegating to CrossAccountRequestViewSet."""
+    path = reverse("v1_api:cross-detail", kwargs={"pk": request_id})
+    return _call_detail_view(request, _cross_account_detail_view, path, {}, pk=request_id)
+
+
+@register_tool(
+    description=(
+        "List workspaces for the authenticated organization (V2 API). "
+        "Supports ordering by name, created, modified, type. "
+        "Calls: GET /api/v2/workspaces/"
+    ),
+    requires_auth=True,
+)
+def list_workspaces(
+    request: HttpRequest,
+    *,
+    limit: int = 10,
+    offset: int = 0,
+    ordering: str = "",
+) -> str:
+    """List workspaces by delegating to WorkspaceViewSet."""
+    query_params: dict[str, str] = {
+        "limit": str(limit),
+        "offset": str(offset),
+    }
+    if ordering:
+        query_params["ordering"] = ordering
+
+    path = reverse("v2_management:workspace-list")
+    return _call_view(request, _workspace_list_view, path, query_params)
+
+
+@register_tool(
+    description=(
+        "Get details of a specific workspace by UUID (V2 API). "
+        "Optionally includes workspace ancestry. "
+        "Calls: GET /api/v2/workspaces/{uuid}/"
+    ),
+    requires_auth=True,
+)
+def get_workspace(
+    request: HttpRequest,
+    *,
+    workspace_uuid: str,
+    include_ancestry: str = "false",
+) -> str:
+    """Get a single workspace by delegating to WorkspaceViewSet."""
+    query_params: dict[str, str] = {}
+    if include_ancestry and include_ancestry != "false":
+        query_params["include_ancestry"] = include_ancestry
+
+    path = reverse("v2_management:workspace-detail", kwargs={"pk": workspace_uuid})
+    return _call_detail_view(request, _workspace_detail_view, path, query_params, pk=workspace_uuid)
+
+
+@register_tool(
+    description=(
+        "List role bindings for the authenticated organization (V2 API). "
+        "Supports filtering by role_id, resource_type, resource_id, subject_type, subject_id. "
+        "Calls: GET /api/v2/role-bindings/"
+    ),
+    requires_auth=True,
+)
+def list_role_bindings(
+    request: HttpRequest,
+    *,
+    limit: int = 10,
+    offset: int = 0,
+    role_id: str = "",
+    resource_type: str = "",
+    resource_id: str = "",
+    subject_type: str = "",
+    subject_id: str = "",
+) -> str:
+    """List role bindings by delegating to RoleBindingViewSet."""
+    query_params: dict[str, str] = {
+        "limit": str(limit),
+        "offset": str(offset),
+    }
+    if role_id:
+        query_params["role_id"] = role_id
+    if resource_type:
+        query_params["resource_type"] = resource_type
+    if resource_id:
+        query_params["resource_id"] = resource_id
+    if subject_type:
+        query_params["subject_type"] = subject_type
+    if subject_id:
+        query_params["subject_id"] = subject_id
+
+    path = reverse("v2_management:role-bindings-list")
+    return _call_view(request, _role_binding_list_view, path, query_params)
+
+
+@register_tool(
+    description=(
+        "List role bindings grouped by subject (V2 API). Requires resource_id and resource_type. "
+        "Optionally filter by subject_type and subject_id. "
+        "Calls: GET /api/v2/role-bindings/by-subject/"
+    ),
+    requires_auth=True,
+)
+def list_role_bindings_by_subject(
+    request: HttpRequest,
+    *,
+    resource_id: str,
+    resource_type: str,
+    subject_type: str = "",
+    subject_id: str = "",
+    limit: int = 10,
+    offset: int = 0,
+) -> str:
+    """List role bindings by subject by delegating to RoleBindingViewSet.by_subject."""
+    query_params: dict[str, str] = {
+        "resource_id": resource_id,
+        "resource_type": resource_type,
+        "limit": str(limit),
+        "offset": str(offset),
+    }
+    if subject_type:
+        query_params["subject_type"] = subject_type
+    if subject_id:
+        query_params["subject_id"] = subject_id
+
+    path = reverse("v2_management:role-bindings-by-subject")
+    return _call_view(request, _role_binding_by_subject_view, path, query_params)
 
 
 # --- JSON-RPC parsing ---

--- a/rbac/management/mcp_views.py
+++ b/rbac/management/mcp_views.py
@@ -227,25 +227,17 @@ def list_principals(
     return response.content.decode()
 
 
-def _call_view(request: HttpRequest, view: Callable[..., Any], path: str, query_params: dict[str, str]) -> str:
-    """Call a Django view with cloned request and return the response as a JSON string."""
-    view_request = _clone_request(request, path, data=query_params)
-    response = view(view_request)
-    if hasattr(response, "data"):
-        return json.dumps(response.data, default=str)
-    return response.content.decode()
-
-
-def _call_detail_view(
+def _call_view(
     request: HttpRequest,
     view: Callable[..., Any],
     path: str,
     query_params: dict[str, str],
     **view_kwargs: str,
 ) -> str:
-    """Call a Django detail view with cloned request and return the response as a JSON string.
+    """Call a Django view with cloned request and return the response as a JSON string.
 
-    Pass the lookup kwarg as a keyword argument, e.g. ``pk=value`` or ``uuid=value``.
+    For detail views, pass the lookup kwarg as a keyword argument,
+    e.g. ``_call_view(request, view, path, {}, pk=value)``.
     """
     view_request = _clone_request(request, path, data=query_params)
     response = view(view_request, **view_kwargs)
@@ -387,7 +379,7 @@ def get_role_v2(
 ) -> str:
     """Get a single V2 role by delegating to RoleV2ViewSet."""
     path = reverse("v2_management:roles-detail", kwargs={"uuid": role_uuid})
-    return _call_detail_view(request, _role_v2_detail_view, path, {}, uuid=role_uuid)
+    return _call_view(request, _role_v2_detail_view, path, {}, uuid=role_uuid)
 
 
 @register_tool(
@@ -431,7 +423,7 @@ def get_group(
 ) -> str:
     """Get a single group by delegating to GroupViewSet."""
     path = reverse("v1_management:group-detail", kwargs={"uuid": group_uuid})
-    return _call_detail_view(request, _group_detail_view, path, {}, uuid=group_uuid)
+    return _call_view(request, _group_detail_view, path, {}, uuid=group_uuid)
 
 
 @register_tool(
@@ -455,7 +447,7 @@ def list_group_principals(
         query_params["principal_type"] = principal_type
 
     path = reverse("v1_management:group-principals", kwargs={"uuid": group_uuid})
-    return _call_detail_view(request, _group_principals_view, path, query_params, uuid=group_uuid)
+    return _call_view(request, _group_principals_view, path, query_params, uuid=group_uuid)
 
 
 @register_tool(
@@ -508,7 +500,7 @@ def get_cross_account_request(
 ) -> str:
     """Get a single cross-account request by delegating to CrossAccountRequestViewSet."""
     path = reverse("v1_api:cross-detail", kwargs={"pk": request_id})
-    return _call_detail_view(request, _cross_account_detail_view, path, {}, pk=request_id)
+    return _call_view(request, _cross_account_detail_view, path, {}, pk=request_id)
 
 
 @register_tool(
@@ -558,7 +550,7 @@ def get_workspace(
         query_params["include_ancestry"] = include_ancestry
 
     path = reverse("v2_management:workspace-detail", kwargs={"pk": workspace_uuid})
-    return _call_detail_view(request, _workspace_detail_view, path, query_params, pk=workspace_uuid)
+    return _call_view(request, _workspace_detail_view, path, query_params, pk=workspace_uuid)
 
 
 @register_tool(

--- a/rbac/management/mcp_views.py
+++ b/rbac/management/mcp_views.py
@@ -254,30 +254,26 @@ def _call_detail_view(
     return response.content.decode()
 
 
-# ┌──────────────────────────────────────────────────────────────────┐
-# │                   MCP Tool → API Endpoint Map                   │
-# ├──────────────────────────┬───────────────────────────────────────┤
-# │ MCP Tool                 │ API Endpoint(s)                      │
-# ├──────────────────────────┼───────────────────────────────────────┤
-# │ hello                    │ (none — in-process greeting)         │
-# │ list_principals          │ GET /api/v1/principals/              │
-# │ get_status               │ GET /api/v1/status/                  │
-# │ list_permissions         │ GET /api/v1/permissions/             │
-# │ list_audit_logs          │ GET /api/v1/auditlogs/               │
-# │ list_roles_v2            │ GET /api/v2/roles/                   │
-# │ get_role_v2              │ GET /api/v2/roles/{uuid}/            │
-# │ list_groups              │ GET /api/v1/groups/                  │
-# │ get_group                │ GET /api/v1/groups/{uuid}/           │
-# │ list_group_principals    │ GET /api/v1/groups/{uuid}/principals/│
-# │ list_cross_account_reqs  │ GET /api/v1/cross-account-requests/  │
-# │ get_cross_account_req    │ GET /api/v1/cross-account-requests/  │
-# │                          │     {uuid}/                          │
-# │ list_workspaces          │ GET /api/v2/workspaces/              │
-# │ get_workspace            │ GET /api/v2/workspaces/{uuid}/       │
-# │ list_role_bindings       │ GET /api/v2/role-bindings/           │
-# │ list_role_bindings_by_   │ GET /api/v2/role-bindings/by-subject/│
-# │   subject                │                                     │
-# └──────────────────────────┴───────────────────────────────────────┘
+# ┌─────────────────────────────────┬────────────────────────────────────────────┐
+# │ MCP Tool                        │ API Endpoint                               │
+# ├─────────────────────────────────┼────────────────────────────────────────────┤
+# │ hello                           │ (none — in-process greeting)               │
+# │ list_principals                 │ GET /api/v1/principals/                    │
+# │ get_status                      │ GET /api/v1/status/                        │
+# │ list_permissions                │ GET /api/v1/permissions/                   │
+# │ list_audit_logs                 │ GET /api/v1/auditlogs/                     │
+# │ list_roles_v2                   │ GET /api/v2/roles/                         │
+# │ get_role_v2                     │ GET /api/v2/roles/{uuid}/                  │
+# │ list_groups                     │ GET /api/v1/groups/                        │
+# │ get_group                       │ GET /api/v1/groups/{uuid}/                 │
+# │ list_group_principals           │ GET /api/v1/groups/{uuid}/principals/      │
+# │ list_cross_account_requests     │ GET /api/v1/cross-account-requests/        │
+# │ get_cross_account_request       │ GET /api/v1/cross-account-requests/{id}/   │
+# │ list_workspaces                 │ GET /api/v2/workspaces/                    │
+# │ get_workspace                   │ GET /api/v2/workspaces/{uuid}/             │
+# │ list_role_bindings              │ GET /api/v2/role-bindings/                 │
+# │ list_role_bindings_by_subject   │ GET /api/v2/role-bindings/by-subject/      │
+# └─────────────────────────────────┴────────────────────────────────────────────┘
 
 
 @register_tool(
@@ -290,11 +286,7 @@ def _call_detail_view(
 def get_status(request: HttpRequest) -> str:
     """Return server status by delegating to the status view."""
     path = reverse("v1_api:server-status")
-    view_request = _clone_request(request, path)
-    response = _status_view(view_request)
-    if hasattr(response, "data"):
-        return json.dumps(response.data, default=str)
-    return response.content.decode()
+    return _call_view(request, _status_view, path, {})
 
 
 @register_tool(
@@ -371,12 +363,15 @@ def list_roles_v2(
     *,
     limit: int = 10,
     offset: int = 0,
+    ordering: str = "",
 ) -> str:
     """List V2 roles by delegating to RoleV2ViewSet."""
     query_params: dict[str, str] = {
         "limit": str(limit),
         "offset": str(offset),
     }
+    if ordering:
+        query_params["ordering"] = ordering
     path = reverse("v2_management:roles-list")
     return _call_view(request, _role_v2_list_view, path, query_params)
 
@@ -460,11 +455,7 @@ def list_group_principals(
         query_params["principal_type"] = principal_type
 
     path = reverse("v1_management:group-principals", kwargs={"uuid": group_uuid})
-    view_request = _clone_request(request, path, data=query_params)
-    response = _group_principals_view(view_request, uuid=group_uuid)
-    if hasattr(response, "data"):
-        return json.dumps(response.data, default=str)
-    return response.content.decode()
+    return _call_detail_view(request, _group_principals_view, path, query_params, uuid=group_uuid)
 
 
 @register_tool(

--- a/rbac/management/mcp_views.py
+++ b/rbac/management/mcp_views.py
@@ -252,8 +252,8 @@ def _call_view(
 # │ get_status                      │ GET /api/v1/status/                        │
 # │ list_permissions                │ GET /api/v1/permissions/                   │
 # │ list_audit_logs                 │ GET /api/v1/auditlogs/                     │
-# │ list_roles_v2                   │ GET /api/v2/roles/                         │
-# │ get_role_v2                     │ GET /api/v2/roles/{uuid}/                  │
+# │ list_roles                   │ GET /api/v2/roles/                         │
+# │ get_role                     │ GET /api/v2/roles/{uuid}/                  │
 # │ list_groups                     │ GET /api/v1/groups/                        │
 # │ get_group                       │ GET /api/v1/groups/{uuid}/                 │
 # │ list_group_principals           │ GET /api/v1/groups/{uuid}/principals/      │
@@ -348,7 +348,7 @@ def list_audit_logs(
     ),
     requires_auth=True,
 )
-def list_roles_v2(
+def list_roles(
     request: HttpRequest,
     *,
     limit: int = 10,
@@ -370,7 +370,7 @@ def list_roles_v2(
     description="Get details of a specific role by UUID (V2 API). Calls: GET /api/v2/roles/{uuid}/",
     requires_auth=True,
 )
-def get_role_v2(
+def get_role(
     request: HttpRequest,
     *,
     role_uuid: str,

--- a/rbac/management/mcp_views.py
+++ b/rbac/management/mcp_views.py
@@ -219,12 +219,7 @@ def list_principals(
     }
 
     path = reverse("v1_management:principals")
-    view_request = _clone_request(request, path, data=query_params)
-    response = _principal_view(view_request)
-
-    if hasattr(response, "data"):
-        return json.dumps(response.data, default=str)
-    return response.content.decode()
+    return _call_view(request, _principal_view, path, query_params)
 
 
 def _call_view(
@@ -234,15 +229,18 @@ def _call_view(
     query_params: dict[str, str],
     **view_kwargs: str,
 ) -> str:
-    """Call a Django view with cloned request and return the response as a JSON string.
+    """Call a Django view with cloned request and return the response body.
 
     For detail views, pass the lookup kwarg as a keyword argument,
     e.g. ``_call_view(request, view, path, {}, pk=value)``.
+
+    DRF responses are rendered via their configured renderer so the
+    output matches exactly what the API would return.
     """
     view_request = _clone_request(request, path, data=query_params)
     response = view(view_request, **view_kwargs)
-    if hasattr(response, "data"):
-        return json.dumps(response.data, default=str)
+    if hasattr(response, "render"):
+        response = response.render()
     return response.content.decode()
 
 
@@ -542,12 +540,12 @@ def get_workspace(
     request: HttpRequest,
     *,
     workspace_uuid: str,
-    include_ancestry: str = "false",
+    include_ancestry: bool = False,
 ) -> str:
     """Get a single workspace by delegating to WorkspaceViewSet."""
     query_params: dict[str, str] = {}
-    if include_ancestry and include_ancestry != "false":
-        query_params["include_ancestry"] = include_ancestry
+    if include_ancestry:
+        query_params["include_ancestry"] = "true"
 
     path = reverse("v2_management:workspace-detail", kwargs={"pk": workspace_uuid})
     return _call_view(request, _workspace_detail_view, path, query_params, pk=workspace_uuid)

--- a/tests/management/test_mcp_views.py
+++ b/tests/management/test_mcp_views.py
@@ -639,8 +639,8 @@ class MCPViewTests(MCPToolTestMixin, IdentityRequest):
             "get_status",
             "list_permissions",
             "list_audit_logs",
-            "list_roles_v2",
-            "get_role_v2",
+            "list_roles",
+            "get_role",
             "list_groups",
             "get_group",
             "list_group_principals",
@@ -835,11 +835,11 @@ class MCPViewV2ToolsTests(MCPToolTestMixin, IdentityRequest):
         Principal.objects.all().delete()
         super().tearDown()
 
-    # --- list_roles_v2 / get_role_v2 ---
+    # --- list_roles / get_role ---
 
-    def test_list_roles_v2_success(self):
-        """Positive: list_roles_v2 returns role data."""
-        response = self._call_tool("list_roles_v2")
+    def test_list_roles_success(self):
+        """Positive: list_roles returns role data."""
+        response = self._call_tool("list_roles")
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         data = response.json()
@@ -848,9 +848,9 @@ class MCPViewV2ToolsTests(MCPToolTestMixin, IdentityRequest):
         self.assertIn("meta", tool_output)
         self.assertIn("data", tool_output)
 
-    def test_list_roles_v2_without_auth_returns_error(self):
-        """Permission: list_roles_v2 without auth returns auth error."""
-        response = self._call_tool("list_roles_v2", use_auth=False)
+    def test_list_roles_without_auth_returns_error(self):
+        """Permission: list_roles without auth returns auth error."""
+        response = self._call_tool("list_roles", use_auth=False)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         data = response.json()

--- a/tests/management/test_mcp_views.py
+++ b/tests/management/test_mcp_views.py
@@ -17,14 +17,16 @@
 """Test the MCP views via _private/_a2s/ path."""
 
 import json
+import uuid
 from unittest.mock import patch
 
+from django.test import override_settings
 from rest_framework import status
 from rest_framework.test import APIClient
 
 from api.models import Tenant
 from management.mcp_views import ToolConfig
-from management.models import Access, Group, Permission, Policy, Principal, Role
+from management.models import Access, AuditLog, Group, Permission, Policy, Principal, Role
 from tests.identity_request import IdentityRequest
 
 
@@ -602,6 +604,274 @@ class MCPViewTests(IdentityRequest):
             self.assertEqual(response.status_code, status.HTTP_200_OK)
             data = response.json()
             self.assertEqual(data["id"], "abc-123")
+
+    # --- New read-only tools tests ---
+
+    def _call_tool(self, tool_name, arguments=None, use_auth=True):
+        """Helper to call an MCP tool and return the parsed response."""
+        body = {
+            "jsonrpc": "2.0",
+            "method": "tools/call",
+            "id": 100,
+            "params": {"name": tool_name, "arguments": arguments or {}},
+        }
+        kwargs = {"data": json.dumps(body), "content_type": "application/json"}
+        if use_auth:
+            kwargs.update(self.headers)
+        return self.client.post(self.url, **kwargs)
+
+    def _get_tool_output(self, response):
+        """Extract tool output from MCP response."""
+        data = response.json()
+        return json.loads(data["result"]["content"][0]["text"])
+
+    def test_tools_list_includes_all_new_tools(self):
+        """Positive: tools/list includes all newly added read-only tools."""
+        body = {"jsonrpc": "2.0", "method": "tools/list", "id": 2, "params": {}}
+        response = self.client.post(self.url, data=json.dumps(body), content_type="application/json", **self.headers)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        tool_names = [t["name"] for t in response.json()["result"]["tools"]]
+        expected_tools = [
+            "get_status",
+            "list_permissions",
+            "list_audit_logs",
+            "list_roles_v2",
+            "get_role_v2",
+            "list_groups",
+            "get_group",
+            "list_group_principals",
+            "list_cross_account_requests",
+            "get_cross_account_request",
+            "list_workspaces",
+            "get_workspace",
+            "list_role_bindings",
+            "list_role_bindings_by_subject",
+        ]
+        for tool in expected_tools:
+            self.assertIn(tool, tool_names, f"Tool '{tool}' missing from tools/list")
+
+    # --- get_status ---
+
+    def test_get_status_returns_server_info(self):
+        """Positive: get_status returns server status with auth."""
+        response = self._call_tool("get_status")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertFalse(data["result"]["isError"])
+        tool_output = self._get_tool_output(response)
+        self.assertIn("api_version", tool_output)
+        self.assertIn("commit", tool_output)
+
+    # --- list_permissions ---
+
+    def test_list_permissions_success(self):
+        """Positive: list_permissions returns permission data."""
+        Permission.objects.create(
+            application="rbac",
+            resource_type="roles",
+            verb="read",
+            permission="rbac:roles:read",
+            tenant=self.tenant,
+        )
+        response = self._call_tool("list_permissions")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertFalse(data["result"]["isError"])
+        tool_output = self._get_tool_output(response)
+        self.assertIn("meta", tool_output)
+        self.assertIn("data", tool_output)
+
+    def test_list_permissions_without_auth_returns_error(self):
+        """Permission: list_permissions without auth returns auth error."""
+        response = self._call_tool("list_permissions", use_auth=False)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertIn("error", data)
+        self.assertEqual(data["error"]["code"], -32000)
+
+    # --- list_audit_logs ---
+
+    def test_list_audit_logs_success(self):
+        """Positive: list_audit_logs returns audit log data."""
+        response = self._call_tool("list_audit_logs")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertFalse(data["result"]["isError"])
+        tool_output = self._get_tool_output(response)
+        self.assertIn("meta", tool_output)
+        self.assertIn("data", tool_output)
+
+    def test_list_audit_logs_without_auth_returns_error(self):
+        """Permission: list_audit_logs without auth returns auth error."""
+        response = self._call_tool("list_audit_logs", use_auth=False)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertIn("error", data)
+        self.assertEqual(data["error"]["code"], -32000)
+
+    # --- list_groups / get_group / list_group_principals ---
+
+    def test_list_groups_success(self):
+        """Positive: list_groups returns group data."""
+        Group.objects.create(name="test_group", tenant=self.tenant)
+        response = self._call_tool("list_groups")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertFalse(data["result"]["isError"])
+        tool_output = self._get_tool_output(response)
+        self.assertIn("meta", tool_output)
+        self.assertIn("data", tool_output)
+
+    def test_list_groups_without_auth_returns_error(self):
+        """Permission: list_groups without auth returns auth error."""
+        response = self._call_tool("list_groups", use_auth=False)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertIn("error", data)
+        self.assertEqual(data["error"]["code"], -32000)
+
+    def test_get_group_success(self):
+        """Positive: get_group returns group detail."""
+        group = Group.objects.create(name="detail_group", tenant=self.tenant)
+        response = self._call_tool("get_group", {"group_uuid": str(group.uuid)})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertFalse(data["result"]["isError"])
+        tool_output = self._get_tool_output(response)
+        self.assertEqual(tool_output["name"], "detail_group")
+
+    @patch(
+        "management.principal.proxy.PrincipalProxy.request_filtered_principals",
+        return_value={
+            "status_code": 200,
+            "data": [{"username": "test_user"}],
+        },
+    )
+    def test_list_group_principals_success(self, mock_request):
+        """Positive: list_group_principals returns principals in group."""
+        group = Group.objects.create(name="principals_group", tenant=self.tenant)
+        group.principals.add(self.principal)
+        response = self._call_tool("list_group_principals", {"group_uuid": str(group.uuid)})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertFalse(data["result"]["isError"])
+        tool_output = self._get_tool_output(response)
+        self.assertIn("data", tool_output)
+
+    # --- list_cross_account_requests / get_cross_account_request ---
+
+    def test_list_cross_account_requests_success(self):
+        """Positive: list_cross_account_requests returns request data."""
+        response = self._call_tool("list_cross_account_requests")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertFalse(data["result"]["isError"])
+        tool_output = self._get_tool_output(response)
+        self.assertIn("meta", tool_output)
+        self.assertIn("data", tool_output)
+
+    def test_list_cross_account_requests_without_auth_returns_error(self):
+        """Permission: list_cross_account_requests without auth returns auth error."""
+        response = self._call_tool("list_cross_account_requests", use_auth=False)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertIn("error", data)
+        self.assertEqual(data["error"]["code"], -32000)
+
+
+@override_settings(V2_APIS_ENABLED=True)
+class MCPViewV2ToolsTests(IdentityRequest):
+    """Test the MCP V2 tools that require V2_APIS_ENABLED=True."""
+
+    def setUp(self):
+        """Set up the MCP V2 tool tests."""
+        super().setUp()
+        self.url = "/_private/_a2s/mcp/"
+        self.client = APIClient()
+        self.principal = Principal.objects.create(username="test_user", tenant=self.tenant)
+
+    def tearDown(self):
+        """Tear down MCP V2 tool tests."""
+        Principal.objects.all().delete()
+        super().tearDown()
+
+    def _call_tool(self, tool_name, arguments=None, use_auth=True):
+        """Helper to call an MCP tool and return the parsed response."""
+        body = {
+            "jsonrpc": "2.0",
+            "method": "tools/call",
+            "id": 100,
+            "params": {"name": tool_name, "arguments": arguments or {}},
+        }
+        kwargs = {"data": json.dumps(body), "content_type": "application/json"}
+        if use_auth:
+            kwargs.update(self.headers)
+        return self.client.post(self.url, **kwargs)
+
+    def _get_tool_output(self, response):
+        """Extract tool output from MCP response."""
+        data = response.json()
+        return json.loads(data["result"]["content"][0]["text"])
+
+    # --- list_roles_v2 / get_role_v2 ---
+
+    def test_list_roles_v2_without_auth_returns_error(self):
+        """Permission: list_roles_v2 without auth returns auth error."""
+        response = self._call_tool("list_roles_v2", use_auth=False)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertIn("error", data)
+        self.assertEqual(data["error"]["code"], -32000)
+
+    # --- list_workspaces / get_workspace ---
+
+    def test_list_workspaces_without_auth_returns_error(self):
+        """Permission: list_workspaces without auth returns auth error."""
+        response = self._call_tool("list_workspaces", use_auth=False)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertIn("error", data)
+        self.assertEqual(data["error"]["code"], -32000)
+
+    # --- list_role_bindings ---
+
+    def test_list_role_bindings_without_auth_returns_error(self):
+        """Permission: list_role_bindings without auth returns auth error."""
+        response = self._call_tool("list_role_bindings", use_auth=False)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertIn("error", data)
+        self.assertEqual(data["error"]["code"], -32000)
+
+    # --- list_role_bindings_by_subject ---
+
+    def test_list_role_bindings_by_subject_without_auth_returns_error(self):
+        """Permission: list_role_bindings_by_subject without auth returns auth error."""
+        response = self._call_tool(
+            "list_role_bindings_by_subject",
+            {"resource_id": "test-id", "resource_type": "workspace"},
+            use_auth=False,
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertIn("error", data)
+        self.assertEqual(data["error"]["code"], -32000)
 
 
 class MCPViewNonAdminTests(IdentityRequest):

--- a/tests/management/test_mcp_views.py
+++ b/tests/management/test_mcp_views.py
@@ -838,6 +838,17 @@ class MCPViewV2ToolsTests(MCPToolTestMixin, IdentityRequest):
 
     # --- list_roles_v2 / get_role_v2 ---
 
+    def test_list_roles_v2_success(self):
+        """Positive: list_roles_v2 returns role data."""
+        response = self._call_tool("list_roles_v2")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertFalse(data["result"]["isError"])
+        tool_output = self._get_tool_output(response)
+        self.assertIn("meta", tool_output)
+        self.assertIn("data", tool_output)
+
     def test_list_roles_v2_without_auth_returns_error(self):
         """Permission: list_roles_v2 without auth returns auth error."""
         response = self._call_tool("list_roles_v2", use_auth=False)
@@ -849,6 +860,17 @@ class MCPViewV2ToolsTests(MCPToolTestMixin, IdentityRequest):
 
     # --- list_workspaces / get_workspace ---
 
+    def test_list_workspaces_success(self):
+        """Positive: list_workspaces returns workspace data."""
+        response = self._call_tool("list_workspaces")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertFalse(data["result"]["isError"])
+        tool_output = self._get_tool_output(response)
+        self.assertIn("meta", tool_output)
+        self.assertIn("data", tool_output)
+
     def test_list_workspaces_without_auth_returns_error(self):
         """Permission: list_workspaces without auth returns auth error."""
         response = self._call_tool("list_workspaces", use_auth=False)
@@ -859,6 +881,17 @@ class MCPViewV2ToolsTests(MCPToolTestMixin, IdentityRequest):
         self.assertEqual(data["error"]["code"], -32000)
 
     # --- list_role_bindings ---
+
+    def test_list_role_bindings_success(self):
+        """Positive: list_role_bindings returns role binding data."""
+        response = self._call_tool("list_role_bindings")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertFalse(data["result"]["isError"])
+        tool_output = self._get_tool_output(response)
+        self.assertIn("meta", tool_output)
+        self.assertIn("data", tool_output)
 
     def test_list_role_bindings_without_auth_returns_error(self):
         """Permission: list_role_bindings without auth returns auth error."""

--- a/tests/management/test_mcp_views.py
+++ b/tests/management/test_mcp_views.py
@@ -30,7 +30,29 @@ from management.models import Access, AuditLog, Group, Permission, Policy, Princ
 from tests.identity_request import IdentityRequest
 
 
-class MCPViewTests(IdentityRequest):
+class MCPToolTestMixin:
+    """Shared helpers for calling MCP tools in tests."""
+
+    def _call_tool(self, tool_name, arguments=None, use_auth=True):
+        """Helper to call an MCP tool and return the parsed response."""
+        body = {
+            "jsonrpc": "2.0",
+            "method": "tools/call",
+            "id": 100,
+            "params": {"name": tool_name, "arguments": arguments or {}},
+        }
+        kwargs = {"data": json.dumps(body), "content_type": "application/json"}
+        if use_auth:
+            kwargs.update(self.headers)
+        return self.client.post(self.url, **kwargs)
+
+    def _get_tool_output(self, response):
+        """Extract tool output from MCP response."""
+        data = response.json()
+        return json.loads(data["result"]["content"][0]["text"])
+
+
+class MCPViewTests(MCPToolTestMixin, IdentityRequest):
     """Test the MCP endpoint at /_private/_a2s/mcp/ (agent-to-service with public auth)."""
 
     def setUp(self):
@@ -607,24 +629,6 @@ class MCPViewTests(IdentityRequest):
 
     # --- New read-only tools tests ---
 
-    def _call_tool(self, tool_name, arguments=None, use_auth=True):
-        """Helper to call an MCP tool and return the parsed response."""
-        body = {
-            "jsonrpc": "2.0",
-            "method": "tools/call",
-            "id": 100,
-            "params": {"name": tool_name, "arguments": arguments or {}},
-        }
-        kwargs = {"data": json.dumps(body), "content_type": "application/json"}
-        if use_auth:
-            kwargs.update(self.headers)
-        return self.client.post(self.url, **kwargs)
-
-    def _get_tool_output(self, response):
-        """Extract tool output from MCP response."""
-        data = response.json()
-        return json.loads(data["result"]["content"][0]["text"])
-
     def test_tools_list_includes_all_new_tools(self):
         """Positive: tools/list includes all newly added read-only tools."""
         body = {"jsonrpc": "2.0", "method": "tools/list", "id": 2, "params": {}}
@@ -817,7 +821,7 @@ class MCPViewTests(IdentityRequest):
 
 
 @override_settings(V2_APIS_ENABLED=True)
-class MCPViewV2ToolsTests(IdentityRequest):
+class MCPViewV2ToolsTests(MCPToolTestMixin, IdentityRequest):
     """Test the MCP V2 tools that require V2_APIS_ENABLED=True."""
 
     def setUp(self):
@@ -831,24 +835,6 @@ class MCPViewV2ToolsTests(IdentityRequest):
         """Tear down MCP V2 tool tests."""
         Principal.objects.all().delete()
         super().tearDown()
-
-    def _call_tool(self, tool_name, arguments=None, use_auth=True):
-        """Helper to call an MCP tool and return the parsed response."""
-        body = {
-            "jsonrpc": "2.0",
-            "method": "tools/call",
-            "id": 100,
-            "params": {"name": tool_name, "arguments": arguments or {}},
-        }
-        kwargs = {"data": json.dumps(body), "content_type": "application/json"}
-        if use_auth:
-            kwargs.update(self.headers)
-        return self.client.post(self.url, **kwargs)
-
-    def _get_tool_output(self, response):
-        """Extract tool output from MCP response."""
-        data = response.json()
-        return json.loads(data["result"]["content"][0]["text"])
 
     # --- list_roles_v2 / get_role_v2 ---
 

--- a/tests/management/test_mcp_views.py
+++ b/tests/management/test_mcp_views.py
@@ -17,7 +17,6 @@
 """Test the MCP views via _private/_a2s/ path."""
 
 import json
-import uuid
 from unittest.mock import patch
 
 from django.test import override_settings
@@ -26,7 +25,7 @@ from rest_framework.test import APIClient
 
 from api.models import Tenant
 from management.mcp_views import ToolConfig
-from management.models import Access, AuditLog, Group, Permission, Policy, Principal, Role
+from management.models import Access, Group, Permission, Policy, Principal, Role
 from tests.identity_request import IdentityRequest
 
 

--- a/tests/management/test_mcp_views.py
+++ b/tests/management/test_mcp_views.py
@@ -684,6 +684,31 @@ class MCPViewTests(IdentityRequest):
         self.assertIn("meta", tool_output)
         self.assertIn("data", tool_output)
 
+    def test_list_permissions_filters_by_application(self):
+        """Positive: list_permissions filters results by application argument."""
+        Permission.objects.create(
+            application="rbac",
+            resource_type="roles",
+            verb="read",
+            permission="rbac:roles:read",
+            tenant=self.tenant,
+        )
+        Permission.objects.create(
+            application="cost-management",
+            resource_type="reports",
+            verb="read",
+            permission="cost-management:reports:read",
+            tenant=self.tenant,
+        )
+        response = self._call_tool("list_permissions", {"application": "rbac"})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        tool_output = self._get_tool_output(response)
+        permissions = tool_output["data"]
+        self.assertTrue(len(permissions) >= 1)
+        for perm in permissions:
+            self.assertTrue(perm["permission"].startswith("rbac:"))
+
     def test_list_permissions_without_auth_returns_error(self):
         """Permission: list_permissions without auth returns auth error."""
         response = self._call_tool("list_permissions", use_auth=False)


### PR DESCRIPTION
## Summary

- Adds 14 new read-only MCP tools exposing GET endpoints for status, permissions, audit logs, roles (v2), groups, group principals, cross-account requests, workspaces, role-bindings, and role-bindings by subject
- Each tool delegates to the existing ViewSet/view via `_clone_request()`, preserving all permission checks, serialization, and pagination
- Adds shared `_call_view()` and `_call_detail_view()` helpers to eliminate boilerplate across tools
- Adds inline endpoint map documentation in the source showing which MCP tool maps to which API endpoint
- Includes comprehensive tests (50 total) covering tool registration, successful invocation, argument passthrough, and auth enforcement

### MCP Tool → API Endpoint Map

| MCP Tool | API Endpoint |
|----------|-------------|
| `get_status` | `GET /api/v1/status/` |
| `list_permissions` | `GET /api/v1/permissions/` |
| `list_audit_logs` | `GET /api/v1/auditlogs/` |
| `list_roles_v2` | `GET /api/v2/roles/` |
| `get_role_v2` | `GET /api/v2/roles/{uuid}/` |
| `list_groups` | `GET /api/v1/groups/` |
| `get_group` | `GET /api/v1/groups/{uuid}/` |
| `list_group_principals` | `GET /api/v1/groups/{uuid}/principals/` |
| `list_cross_account_requests` | `GET /api/v1/cross-account-requests/` |
| `get_cross_account_request` | `GET /api/v1/cross-account-requests/{id}/` |
| `list_workspaces` | `GET /api/v2/workspaces/` |
| `get_workspace` | `GET /api/v2/workspaces/{uuid}/` |
| `list_role_bindings` | `GET /api/v2/role-bindings/` |
| `list_role_bindings_by_subject` | `GET /api/v2/role-bindings/by-subject/` |

## Test plan

- [x] `tox -e lint` passes (flake8 + black)
- [x] All 2712 tests pass (full suite via `tox -e py312-fast`)
- [x] All 50 MCP tests pass
- [x] All new tools appear in `tools/list` response
- [x] Auth enforcement verified for all `requires_auth=True` tools
- [x] Argument passthrough verified (e.g. `list_permissions` with `application` filter)
- [x] Successful invocations verified for status, permissions, audit logs, groups, cross-account requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a suite of read-only MCP tools that proxy key RBAC GET endpoints for status, permissions, audit logs, roles, groups, cross-account requests, workspaces, and role bindings via shared view-calling helpers, along with tests verifying registration, behavior, and auth enforcement.

New Features:
- Expose RBAC status, permissions, audit logs, roles (v2), groups, group principals, cross-account requests, workspaces, and role bindings as read-only MCP tools backed by existing API views.

Enhancements:
- Introduce shared helpers for invoking Django/DRF views from MCP tools to reduce duplication and ensure consistent response rendering.
- Document the mapping between MCP tools and their corresponding API endpoints inline in the MCP views module.

Tests:
- Add comprehensive MCP tool tests covering tool registration, successful calls, parameter handling, and authentication requirements, including separate coverage for v2-only tools under appropriate feature flags.