### PR TITLE
RHCLOUD-45800: Send notifications for V2 role operations

### DIFF
--- a/rbac/management/notifications/notification_handlers.py
+++ b/rbac/management/notifications/notification_handlers.py
@@ -26,6 +26,7 @@ from uuid import uuid4
 
 from core.kafka import RBACProducer
 from django.conf import settings
+from management.role.v2_model import RoleV2
 
 from api.models import Tenant
 
@@ -113,6 +114,29 @@ def role_obj_change_notification_handler(role_obj, operation, user=None):
     # Role updated (including access/resourceDefinition update)
     elif operation == "updated":
         event_type = "custom-role-updated"
+
+    notify(event_type, payload, org_id)
+
+
+def custom_v2_role_obj_change_notification_handler(role_obj: RoleV2, operation: str, user):
+    """Signal handler for setting notification message when RoleV2 object changes."""
+    if not settings.NOTIFICATIONS_ENABLED:
+        return
+
+    if role_obj.type != RoleV2.Types.CUSTOM:
+        raise ValueError("Notifications are supported only for custom V2 roles")
+
+    org_id = user.org_id
+    payload = payload_builder(user.username, role_obj)
+
+    event_type = {
+        "created": "custom-v2-role-created",
+        "deleted": "custom-v2-role-deleted",
+        "updated": "custom-v2-role-updated",
+    }.get(operation)
+
+    if event_type is None:
+        raise ValueError(f"Invalid operation: {operation!r}")
 
     notify(event_type, payload, org_id)
 

--- a/rbac/management/role/v2_view.py
+++ b/rbac/management/role/v2_view.py
@@ -16,9 +16,12 @@
 #
 """View for RoleV2 management."""
 
+import logging
+
 from management.atomic_transactions import atomic_block
 from management.audit_log.model import AuditLog
 from management.base_viewsets import BaseV2ViewSet
+from management.notifications.notification_handlers import custom_v2_role_obj_change_notification_handler
 from management.permissions.role_v2_access import RoleV2KesselAccessPermission
 from management.permissions.v2_edit_api_access import V2WriteRequiresWorkspacesEnabled
 from management.role.v2_exceptions import CustomRoleRequiredError, RolesNotFoundError
@@ -131,6 +134,8 @@ class RoleV2ViewSet(AtomicOperationsMixin, BaseV2ViewSet):
             audit_log = AuditLog()
             audit_log.log_create(request=request, resource=AuditLog.ROLE_V2)
 
+        custom_v2_role_obj_change_notification_handler(role, "created", request.user)
+
         # Build response with field selection (from context) and permission ordering
         input_permissions = request.data.get("permissions", [])
         context = self.get_serializer_context()
@@ -149,6 +154,8 @@ class RoleV2ViewSet(AtomicOperationsMixin, BaseV2ViewSet):
             serializer = self.get_serializer(instance, data=request.data)
             serializer.is_valid(raise_exception=True)
             role = serializer.save()
+
+        custom_v2_role_obj_change_notification_handler(role, "updated", request.user)
 
         # Build response with field selection (from context) and permission ordering
         input_permissions = request.data.get("permissions", [])
@@ -191,5 +198,16 @@ class RoleV2ViewSet(AtomicOperationsMixin, BaseV2ViewSet):
                 {"title": "An internal error occurred.", "detail": str(e)},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
+
+        # We don't allow a revert here because sending a notification in the middle could fail. This would make it
+        # unclear what to do with all of the earlier notifications that have already been sent.
+        for role in removed_roles:
+            try:
+                custom_v2_role_obj_change_notification_handler(role, "deleted", request.user)
+            except Exception:
+                logging.error(
+                    f"Failed to send notification for deleted role: role pk={role.pk!r}, name={role.name!r}",
+                    exc_info=True,
+                )
 
         return Response(status=status.HTTP_204_NO_CONTENT)

--- a/tests/management/role/test_v2_view.py
+++ b/tests/management/role/test_v2_view.py
@@ -21,6 +21,7 @@ from collections.abc import Iterable
 from importlib import reload
 from unittest.mock import ANY, patch
 
+from django.conf import settings
 from django.test import override_settings
 from django.urls import clear_url_caches, reverse
 from django.utils.dateparse import parse_datetime
@@ -43,6 +44,7 @@ from management.utils import PRINCIPAL_CACHE, as_uuid
 from rbac import urls
 from tests.identity_request import IdentityRequest
 from tests.v2_util import bootstrap_tenant_for_v2_test
+from unittest.mock import ANY, patch
 
 CACHE_PATCH_TARGET = "management.role.v2_service.permission_scope_cache"
 
@@ -1063,7 +1065,9 @@ class RoleV2ViewSetTests(IdentityRequest):
         self.assertIn("workspaces", str(response.data).lower())
         mock_is_v2_edit_enabled.assert_called_once_with(self.customer_data["org_id"])
 
-    def test_create_role_success(self):
+    @override_settings(NOTIFICATIONS_ENABLED=True)
+    @patch("core.kafka.RBACProducer.send_kafka_message")
+    def test_create_role_success(self, send_kafka_message):
         """Test creating a role via API returns 201"""
         data = {
             "name": "API Test Role",
@@ -1084,6 +1088,28 @@ class RoleV2ViewSetTests(IdentityRequest):
         )
 
         self._assert_audit_log(action=AuditLog.CREATE, description=f"Created V2 role: {data['name']}")
+
+        send_kafka_message.assert_called_with(
+            settings.NOTIFICATIONS_TOPIC,
+            {
+                "bundle": "console",
+                "application": "rbac",
+                "event_type": "custom-v2-role-created",
+                "timestamp": ANY,
+                "events": [
+                    {
+                        "metadata": {},
+                        "payload": {
+                            "name": data["name"],
+                            "username": self.user_data["username"],
+                            "uuid": response.data["id"],
+                        },
+                    }
+                ],
+                "org_id": self.tenant.org_id,
+            },
+            ANY,
+        )
 
     def test_create_role_multiple_permissions(self):
         """Test creating a role with multiple permissions returns all permissions."""
@@ -1406,7 +1432,9 @@ class RoleV2ViewSetTests(IdentityRequest):
     # Tests for PUT /api/v2/roles/{uuid}/ (update)
     # ==========================================================================
 
-    def test_update_role_success(self):
+    @override_settings(NOTIFICATIONS_ENABLED=True)
+    @patch("core.kafka.RBACProducer.send_kafka_message")
+    def test_update_role_success(self, send_kafka_message):
         """Test updating a role via API returns 200."""
         role = CustomRoleV2.objects.create(
             name="Original Role",
@@ -1438,6 +1466,28 @@ class RoleV2ViewSetTests(IdentityRequest):
         self._assert_audit_log(
             action=AuditLog.EDIT,
             description=f"V2 role {role.name}:\nEdited name\nEdited description\nEdited permissions",
+        )
+
+        send_kafka_message.assert_called_with(
+            settings.NOTIFICATIONS_TOPIC,
+            {
+                "bundle": "console",
+                "application": "rbac",
+                "event_type": "custom-v2-role-updated",
+                "timestamp": ANY,
+                "events": [
+                    {
+                        "metadata": {},
+                        "payload": {
+                            "name": data["name"],
+                            "username": self.user_data["username"],
+                            "uuid": response.data["id"],
+                        },
+                    }
+                ],
+                "org_id": self.tenant.org_id,
+            },
+            ANY,
         )
 
     def test_update_role_changes_permissions(self):
@@ -1854,7 +1904,9 @@ class RoleV2ViewSetTests(IdentityRequest):
         self.assertIn("errors", data)
         self.assertEqual(data["errors"], [{"message": data["detail"], "field": "ids"}])
 
-    def test_delete(self):
+    @override_settings(NOTIFICATIONS_ENABLED=True)
+    @patch("core.kafka.RBACProducer.send_kafka_message")
+    def test_delete(self, send_kafka_message):
         create_response = self._create_role()
         response = self._request_delete({"ids": [create_response["id"]]})
 
@@ -1862,6 +1914,28 @@ class RoleV2ViewSetTests(IdentityRequest):
         self.assertFalse(RoleV2.objects.filter(uuid=create_response["id"]).exists())
 
         self._assert_audit_log(action=AuditLog.DELETE, description=f"Deleted V2 role: {create_response['name']}")
+
+        send_kafka_message.assert_called_with(
+            settings.NOTIFICATIONS_TOPIC,
+            {
+                "bundle": "console",
+                "application": "rbac",
+                "event_type": "custom-v2-role-deleted",
+                "timestamp": ANY,
+                "events": [
+                    {
+                        "metadata": {},
+                        "payload": {
+                            "name": create_response["name"],
+                            "username": self.user_data["username"],
+                            "uuid": create_response["id"],
+                        },
+                    }
+                ],
+                "org_id": self.tenant.org_id,
+            },
+            ANY,
+        )
 
     def test_delete_empty(self):
         """Test that deleting 0 roles is successful."""


### PR DESCRIPTION
## Link(s) to Jira
[RHCLOUD-45800](https://redhat.atlassian.net/browse/RHCLOUD-45800)

## Description of Intent of Change(s)
Send notifications for V2 role changes.

## Summary by Sourcery

Send notifications when custom V2 roles are created, updated, or deleted and verify this behavior in API tests.

New Features:
- Trigger notification events for custom V2 role create, update, and delete operations via the V2 role API.

Enhancements:
- Add a dedicated notification handler for custom V2 role changes with validation of supported operations and role types.

Tests:
- Extend V2 role API tests to assert that the correct notification messages are sent for create, update, and delete operations when notifications are enabled.

[RHCLOUD-45800]: https://redhat.atlassian.net/browse/RHCLOUD-45800?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ