### PR TITLE
fix(roles): block system role name reuse

### DIFF
--- a/rbac/management/role/serializer.py
+++ b/rbac/management/role/serializer.py
@@ -259,6 +259,7 @@ class RoleSerializer(serializers.ModelSerializer):
             message = "System roles may not be updated."
             error = {key: [_(message)]}
             raise serializers.ValidationError(error)
+        _validate_name_not_system_role(data.get("name"), data.get("display_name"), self.instance)
         return super().validate(data)
 
 
@@ -418,6 +419,7 @@ class RolePatchSerializer(RoleSerializer):
             message = "System roles may not be updated."
             error = {key: [_(message)]}
             raise serializers.ValidationError(error)
+        _validate_name_not_system_role(data.get("name"), data.get("display_name"), self.instance)
         return super().validate(data)
 
 
@@ -429,6 +431,23 @@ class BindingMappingSerializer(serializers.ModelSerializer):
 
         model = BindingMapping
         fields = "__all__"
+
+
+def _validate_name_not_system_role(name, display_name, instance=None):
+    """Validate that name/display_name do not conflict with system role names (case-insensitive)."""
+    public_tenant = Tenant.objects.get(tenant_name="public")
+
+    if name and (not instance or instance.name != name):
+        if Role.objects.filter(system=True, tenant=public_tenant, name__iexact=name).exists():
+            raise serializers.ValidationError(
+                {"name": [_(f"Role name '{name}' conflicts with an existing system role.")]}
+            )
+
+    if display_name and (not instance or instance.display_name != display_name):
+        if Role.objects.filter(system=True, tenant=public_tenant, display_name__iexact=display_name).exists():
+            raise serializers.ValidationError(
+                {"display_name": [_(f"Display name '{display_name}' conflicts with an existing system role.")]}
+            )
 
 
 def obtain_applications(obj):

--- a/rbac/management/role/serializer.py
+++ b/rbac/management/role/serializer.py
@@ -440,11 +440,7 @@ def _validate_name_not_system_role(name, display_name, instance=None):
     if name and (not instance or instance.name != name):
         if Role.objects.filter(system=True, tenant=public_tenant, name__iexact=name).exists():
             raise serializers.ValidationError(
-                {
-                    "name": [
-                        _("Role name '%(name)s' conflicts with an existing system role.") % {"name": name}
-                    ]
-                }
+                {"name": [_("Role name '%(name)s' conflicts with an existing system role.") % {"name": name}]}
             )
 
     if display_name and (not instance or instance.display_name != display_name):

--- a/rbac/management/role/serializer.py
+++ b/rbac/management/role/serializer.py
@@ -440,13 +440,21 @@ def _validate_name_not_system_role(name, display_name, instance=None):
     if name and (not instance or instance.name != name):
         if Role.objects.filter(system=True, tenant=public_tenant, name__iexact=name).exists():
             raise serializers.ValidationError(
-                {"name": [_("Role name '%(name)s' conflicts with an existing system role.") % {"name": name}]}
+                {
+                    "name": [
+                        _("Role name '%(name)s' conflicts with an existing system role.") % {"name": name}
+                    ]
+                }
             )
 
     if display_name and (not instance or instance.display_name != display_name):
         if Role.objects.filter(system=True, tenant=public_tenant, display_name__iexact=display_name).exists():
             raise serializers.ValidationError(
-                {"display_name": [_("Display name '%(name)s' conflicts with an existing system role.") % {"name": display_name}]}
+                {
+                    "display_name": [
+                        _("Display name '%(name)s' conflicts with an existing system role.") % {"name": display_name}
+                    ]
+                }
             )
 
 

--- a/rbac/management/role/serializer.py
+++ b/rbac/management/role/serializer.py
@@ -440,13 +440,13 @@ def _validate_name_not_system_role(name, display_name, instance=None):
     if name and (not instance or instance.name != name):
         if Role.objects.filter(system=True, tenant=public_tenant, name__iexact=name).exists():
             raise serializers.ValidationError(
-                {"name": [_(f"Role name '{name}' conflicts with an existing system role.")]}
+                {"name": [_("Role name '%(name)s' conflicts with an existing system role.") % {"name": name}]}
             )
 
     if display_name and (not instance or instance.display_name != display_name):
         if Role.objects.filter(system=True, tenant=public_tenant, display_name__iexact=display_name).exists():
             raise serializers.ValidationError(
-                {"display_name": [_(f"Display name '{display_name}' conflicts with an existing system role.")]}
+                {"display_name": [_("Display name '%(name)s' conflicts with an existing system role.") % {"name": display_name}]}
             )
 
 

--- a/rbac/management/role/serializer.py
+++ b/rbac/management/role/serializer.py
@@ -412,16 +412,6 @@ class RolePatchSerializer(RoleSerializer):
         instance = update_role(instance, validated_data, clear_access=False)
         return instance
 
-    def validate(self, data):
-        """Validate the input data of patching role."""
-        if self.instance.system:
-            key = "role.update"
-            message = "System roles may not be updated."
-            error = {key: [_(message)]}
-            raise serializers.ValidationError(error)
-        _validate_name_not_system_role(data.get("name"), data.get("display_name"), self.instance)
-        return super().validate(data)
-
 
 class BindingMappingSerializer(serializers.ModelSerializer):
     """Serializer for the binding mapping."""

--- a/rbac/management/role/v2_serializer.py
+++ b/rbac/management/role/v2_serializer.py
@@ -231,7 +231,9 @@ class RoleV2RequestSerializer(serializers.ModelSerializer):
             type__in=[RoleV2.Types.SEEDED, RoleV2.Types.PLATFORM],
             name__iexact=value,
         ).exists():
-            raise serializers.ValidationError(_("Role name '%(name)s' conflicts with an existing system role.") % {"name": value})
+            raise serializers.ValidationError(
+                _("Role name '%(name)s' conflicts with an existing system role.") % {"name": value}
+            )
 
         return value
 

--- a/rbac/management/role/v2_serializer.py
+++ b/rbac/management/role/v2_serializer.py
@@ -16,6 +16,7 @@
 #
 """Serializers for RoleV2 API."""
 
+from django.utils.translation import gettext as _
 from management.exceptions import RequiredFieldError
 from management.role.v2_exceptions import (
     InvalidRolePermissionsError,
@@ -230,7 +231,7 @@ class RoleV2RequestSerializer(serializers.ModelSerializer):
             type__in=[RoleV2.Types.SEEDED, RoleV2.Types.PLATFORM],
             name__iexact=value,
         ).exists():
-            raise serializers.ValidationError(f"Role name '{value}' conflicts with an existing system role.")
+            raise serializers.ValidationError(_("Role name '%(name)s' conflicts with an existing system role.") % {"name": value})
 
         return value
 

--- a/rbac/management/role/v2_serializer.py
+++ b/rbac/management/role/v2_serializer.py
@@ -214,9 +214,24 @@ class RoleV2RequestSerializer(serializers.ModelSerializer):
         fields = ("id", "name", "description", "permissions")
 
     def validate_name(self, value):
-        """Reject names containing '*' which conflicts with glob/wildcard search syntax."""
+        """Reject names containing '*' or matching system/seeded role names (case-insensitive)."""
         if isinstance(value, str) and "*" in value:
             raise serializers.ValidationError("Role name must not contain asterisks (*).")
+
+        # Skip check if name hasn't changed on update
+        if self.instance and self.instance.name == value:
+            return value
+
+        from api.models import Tenant
+
+        public_tenant = Tenant.objects.get(tenant_name="public")
+        if RoleV2.objects.filter(
+            tenant=public_tenant,
+            type__in=[RoleV2.Types.SEEDED, RoleV2.Types.PLATFORM],
+            name__iexact=value,
+        ).exists():
+            raise serializers.ValidationError(f"Role name '{value}' conflicts with an existing system role.")
+
         return value
 
     @property

--- a/tests/management/role/test_v2_view.py
+++ b/tests/management/role/test_v2_view.py
@@ -1216,6 +1216,40 @@ class RoleV2ViewSetTests(IdentityRequest):
         self.assertEqual(response.data["status"], 400)
         self.assertIn("already exists", response.data["detail"])
 
+    def test_create_role_with_seeded_role_name_returns_400(self):
+        """Test that creating a custom role with the same name as a seeded role is rejected."""
+        public_tenant, _ = Tenant.objects.get_or_create(tenant_name="public")
+        SeededRoleV2.objects.create(name="Vulnerability viewer", description="Seeded", tenant=public_tenant)
+
+        data = {
+            "name": "vulnerability viewer",
+            "description": "Custom role with seeded name",
+            "permissions": [{"application": "inventory", "resource_type": "hosts", "operation": "read"}],
+        }
+
+        response = self.client.post(self.url, data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("conflicts with an existing system role", str(response.data))
+
+    def test_update_role_to_seeded_role_name_returns_400(self):
+        """Test that updating a custom role to a seeded role name is rejected."""
+        public_tenant, _ = Tenant.objects.get_or_create(tenant_name="public")
+        SeededRoleV2.objects.create(name="Patch viewer", description="Seeded", tenant=public_tenant)
+
+        role = CustomRoleV2.objects.create(name="My Custom Role", description="Custom", tenant=self.tenant)
+        role.permissions.add(self.permission2)
+
+        update_url = reverse("v2_management:roles-detail", kwargs={"uuid": str(role.uuid)})
+        data = {
+            "name": "PATCH VIEWER",
+            "description": "Trying to rename to seeded name",
+            "permissions": [{"application": "inventory", "resource_type": "hosts", "operation": "read"}],
+        }
+
+        response = self.client.put(update_url, data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("conflicts with an existing system role", str(response.data))
+
     def test_create_role_missing_permissions_returns_problem_details(self):
         """Test that missing permissions returns ProblemDetails format."""
         data = {

--- a/tests/management/role/test_view.py
+++ b/tests/management/role/test_view.py
@@ -2322,6 +2322,58 @@ class RoleViewsetTests(IdentityRequest):
             f"Role '{name}' already exists for a tenant.",
         )
 
+    def test_create_role_with_system_role_name_fail(self):
+        """Test that creating a custom role with the same name as a system role is rejected."""
+        client = APIClient()
+        # Use the system role name from setUp (case-insensitive match)
+        test_data = {"name": "SYSTEM_ROLE", "access": []}
+
+        response = client.post(URL, test_data, format="json", **self.headers)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("conflicts with an existing system role", str(response.data))
+
+    def test_create_role_with_system_role_display_name_fail(self):
+        """Test that creating a custom role with the same display_name as a system role is rejected."""
+        client = APIClient()
+        # Use the system role display_name from setUp (case-insensitive match)
+        test_data = {"name": "unique_custom_name", "display_name": "System_Display", "access": []}
+
+        response = client.post(URL, test_data, format="json", **self.headers)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("conflicts with an existing system role", str(response.data))
+
+    def test_update_role_to_system_role_name_fail(self):
+        """Test that updating a custom role to have the same name as a system role is rejected."""
+        client = APIClient()
+        # Create a custom role first
+        test_data = {"name": "my_custom_role", "access": []}
+        response = client.post(URL, test_data, format="json", **self.headers)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        role_uuid = response.data.get("uuid")
+
+        # Try to update name to match system role (case-insensitive)
+        url = reverse("v1_management:role-detail", kwargs={"uuid": role_uuid})
+        update_data = {"name": "System_Role", "display_name": "my_custom_role", "access": []}
+        response = client.put(url, update_data, format="json", **self.headers)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("conflicts with an existing system role", str(response.data))
+
+    def test_patch_role_to_system_role_name_fail(self):
+        """Test that patching a custom role to have the same name as a system role is rejected."""
+        client = APIClient()
+        # Create a custom role first
+        test_data = {"name": "my_patchable_role", "access": []}
+        response = client.post(URL, test_data, format="json", **self.headers)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        role_uuid = response.data.get("uuid")
+
+        # Try to patch name to match system role (case-insensitive)
+        url = reverse("v1_management:role-detail", kwargs={"uuid": role_uuid})
+        patch_data = {"name": "SYSTEM_ROLE"}
+        response = client.patch(url, patch_data, format="json", **self.headers)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("conflicts with an existing system role", str(response.data))
+
     @override_settings(ROLE_CREATE_ALLOW_LIST="someApp")
     def test_create_role_with_invalid_equals_operation(self):
         """Test that we cannot create a role when a List value is paired with the 'equal' operation."""


### PR DESCRIPTION
RHCLOUD-37254

Prevents creating or updating custom roles with names (or display names) that match existing system/seeded roles, using case-insensitive comparison.

**Problem:** The API allowed users to create custom roles with names identical to system roles (e.g. "Vulnerability viewer"), causing ambiguity and potential security risks. The UI already blocked this, but the API did not.

**Changes:**

- **V1 serializer** (`serializer.py`): Added `_validate_name_not_system_role()` helper that checks both `name` and `display_name` against system roles (where `system=True` in the public tenant). Called from `RoleSerializer.validate()` and `RolePatchSerializer.validate()`.
- **V2 serializer** (`v2_serializer.py`): Extended `validate_name()` in `RoleV2RequestSerializer` to check against seeded/platform role names in the public tenant.
- Both validations skip the check when the name hasn't changed on update.
- Returns 400 with a clear error message: `"Role name '<name>' conflicts with an existing system role."`

**Tests added (6):**
- V1: create with system name, create with system display_name, update to system name, patch to system name
- V2: create with seeded name, update to seeded name

Related: [RHCLOUD-36017](https://redhat.atlassian.net/browse/RHCLOUD-36017)

[RHCLOUD-36017]: https://redhat.atlassian.net/browse/RHCLOUD-36017?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Disallow creating or updating custom roles whose names or display names conflict with existing system/seeded roles using case-insensitive comparison.

Bug Fixes:
- Prevent custom roles in both v1 and v2 APIs from reusing names or display names of existing system/seeded roles, eliminating ambiguity and potential security issues.

Tests:
- Add v1 tests covering create, update, and patch operations failing when role name or display_name matches a system role.
- Add v2 tests verifying create and update operations fail when the role name matches a seeded role name in the public tenant.