### PR TITLE
RHCLOUD-46122: Remove bindings when deleting workspaces

### DIFF
--- a/rbac/management/role/view.py
+++ b/rbac/management/role/view.py
@@ -31,7 +31,7 @@ from django.db.models.aggregates import Count
 from django.http import Http404
 from django.utils.translation import gettext as _
 from django_filters import rest_framework as filters
-from internal.utils import get_workspace_ids_from_resource_definition, is_resource_a_workspace
+from internal.utils import get_workspace_ids_from_resource_definition
 from management.filters import CommonFilters
 from management.models import AuditLog, Permission
 from management.notifications.notification_handlers import role_obj_change_notification_handler
@@ -46,6 +46,7 @@ from management.role.serializer import AccessSerializer, RoleDynamicSerializer, 
 from management.tenant_mapping.v2_activation import V1WriteBlockedError, assert_v1_write_allowed
 from management.utils import validate_uuid
 from management.workspace.model import Workspace
+from migration_tool.sharedSystemRolesReplicatedRoleBindings import attribute_key_to_v2_related_resource_type
 from rest_framework import mixins, serializers, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.filters import OrderingFilter
@@ -674,7 +675,12 @@ class RoleViewSet(
                 resourceDefinitions = perm.get("resourceDefinitions", [])
                 for resourceDefinition in resourceDefinitions:
                     attributeFilter = resourceDefinition.get("attributeFilter")
-                    if is_resource_a_workspace(app, resource_type, attributeFilter):
+                    filter_key = attributeFilter.get("key")
+
+                    if filter_key is not None and attribute_key_to_v2_related_resource_type(filter_key) == (
+                        "rbac",
+                        "workspace",
+                    ):
                         workspace_ids = get_workspace_ids_from_resource_definition(attributeFilter)
                         if len(workspace_ids) >= 1:
                             unique_workspace_ids = set(workspace_ids)

--- a/rbac/management/workspace/service.py
+++ b/rbac/management/workspace/service.py
@@ -154,7 +154,22 @@ def _update_custom_roles_for_removed_workspace(workspace_id: uuid.UUID, replicat
             tenant_version = lock_tenant_version(role.tenant)
 
             if tenant_version != TenantVersion.VERSION_1:
-                logger.info(f"Not processing role (pk={role.pk!r}) that is not in a V1 tenant.")
+                logger.info(
+                    f"Not updating role (pk={role.pk!r}) that is not in a V1 tenant; "
+                    f"only removing orphan BindingMappings."
+                )
+
+                # BindingMappings are no longer authoritative in a non-V1 tenant, so we don't need to handle any
+                # relations updates. We delete them here only to ensure that we have a clean slate later (since we
+                # want to make strong assertions about what BindingMappings exist in
+                # _remove_workspace_direct_role_bindings).
+                BindingMapping.objects.filter(
+                    resource_type_namespace="rbac",
+                    resource_type_name="workspace",
+                    resource_id=workspace_id_str,
+                    role=role,
+                ).delete()
+
                 continue
 
             dual_write = RelationApiDualWriteHandler(
@@ -254,9 +269,9 @@ def _update_custom_roles_for_removed_workspace(workspace_id: uuid.UUID, replicat
 
 # This must be SERIALIZABLE because we are potentially interacting with RoleBindings in V2 tenants.
 @atomic
-def _remove_workspace_system_role_bindings(workspace: Workspace, replicator: RelationReplicator) -> int:
+def _remove_workspace_direct_role_bindings(workspace: Workspace, replicator: RelationReplicator) -> int:
     """
-    Delete role bindings bound to system roles for a workspace about to be deleted.
+    Delete role bindings bound a workspace about to be deleted.
 
     It is assumed that all role bindings bound to custom roles have already been removed.
     """
@@ -264,6 +279,30 @@ def _remove_workspace_system_role_bindings(workspace: Workspace, replicator: Rel
 
     if tenant_version not in (TenantVersion.VERSION_1, TenantVersion.VERSION_2):
         raise RuntimeError(f"Unexpected tenant version: {tenant_version!r}")
+
+    binding_mappings = list(
+        BindingMapping.objects.filter(
+            resource_type_namespace="rbac",
+            resource_type_name="workspace",
+            resource_id=str(workspace.id),
+        )
+    )
+
+    # There shouldn't have been any BindingMappings bound to a system role and a standard workspace created while the
+    # tenant was V1. (System roles won't have any relevant resource definitions naming the workspace, and their scope
+    # will always put them in the default workspace, root workspace, or the tenant in V1.)
+    #
+    # If the tenant has been converted to V2, no additional BindingMappings will have been created since that time.
+    #
+    # Since we have already removed all BindingMappings that came from custom roles in
+    # _update_custom_roles_for_removed_workspace (including any from V1 custom roles left over in a V2 tenant!),
+    # there shouldn't be any remaining here.
+    if len(binding_mappings) > 0:
+        raise AssertionError(
+            f"A standard workspace should not have any remaining BindingMappings "
+            f"(after removing any from custom roles), but found "
+            f"BindingMappings with pks={[bm.pk for bm in binding_mappings]}"
+        )
 
     role_bindings = list(
         RoleBinding.objects.filter(
@@ -274,23 +313,19 @@ def _remove_workspace_system_role_bindings(workspace: Workspace, replicator: Rel
         .select_for_update(of=["self"])
     )
 
-    binding_mappings = list(
-        BindingMapping.objects.filter(
-            resource_type_namespace="rbac",
-            resource_type_name="workspace",
-            resource_id=str(workspace.id),
-        ).select_for_update()
-    )
+    # In a V1 tenant, there shouldn't be any RoleBindings remaining for a standard workspace for the same reasons
+    # as BindingMappings above. (BindingMappings and RoleBindings should always be in sync in a V1 tenant.)
+    #
+    # In a V2 tenant, we can have RoleBindings that were either directly created in the workspace or that were
+    # created for a V1 custom role and not torn down in _update_custom_roles_for_removed_workspace (since that just
+    # removes to-be-orphaned BindingMappings in V2 tenants, which aren't authoritative anyway). In either case,
+    # we need to actually handle those RoleBindings (including by updating relations).
 
     if tenant_version == TenantVersion.VERSION_1:
-        # We should have already removed all bindings from resource definitions in custom roles; there should be no
-        # role bindings for system roles in a standard workspace in a V1 tenant (since they should all be bound to
-        # the default workspace, root workspace, or tenant as appropriate).
-
-        if (len(role_bindings) > 0) or (len(binding_mappings) > 0):
+        if len(role_bindings) > 0:
             raise AssertionError(
-                f"A standard workspace in a V1 tenant should exist, but found "
-                f"BindingMappings with pks={[bm.pk for bm in binding_mappings]} and"
+                f"A standard workspace should not have any remaining RoleBindings "
+                f"(after removing any from custom roles), but found "
                 f"RoleBindings with pks={[rb.pk for rb in role_bindings]}"
             )
 
@@ -308,11 +343,6 @@ def _remove_workspace_system_role_bindings(workspace: Workspace, replicator: Rel
 
     if len(role_bindings) > 0:
         RoleBinding.objects.filter(pk__in=(rb.pk for rb in role_bindings)).delete()
-
-    # The BindingMappings are irrelevant in a V2 tenant, but delete them anyway to avoid having to deal with any
-    # orphans later.
-    if len(binding_mappings) > 0:
-        BindingMapping.objects.filter(pk__in=(bm.pk for bm in role_bindings)).delete()
 
     return len(role_bindings)
 
@@ -419,7 +449,7 @@ class WorkspaceService:
         roles_updated_count = _update_custom_roles_for_removed_workspace(instance.id, replicator=self._replicator)
         logger.info(f"Updated {roles_updated_count} custom roles for workspace {instance.id} removal")
 
-        system_bindings_removed_count = _remove_workspace_system_role_bindings(instance, replicator=self._replicator)
+        system_bindings_removed_count = _remove_workspace_direct_role_bindings(instance, replicator=self._replicator)
         logger.info(f"Removed {system_bindings_removed_count} system roles for workspace {instance.id} removal")
 
         dual_write_handler = self._dual_write_handler(instance, ReplicationEventType.DELETE_WORKSPACE)

--- a/rbac/management/workspace/service.py
+++ b/rbac/management/workspace/service.py
@@ -16,24 +16,37 @@
 #
 """Service for workspace management."""
 
+import itertools
 import logging
 import select
 import time
 import uuid
 from collections import deque
 from itertools import groupby
+from typing import Optional
 
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.db import connection, transaction
 from django.db.models import Q
 from feature_flags import FEATURE_FLAGS
-from internal.utils import get_workspace_ids_from_resource_definition, is_resource_a_workspace
+from internal.utils import get_workspace_ids_from_resource_definition
 from management.atomic_transactions import atomic
 from management.models import ResourceDefinition, Role, Workspace
-from management.relation_replicator.relation_replicator import ReplicationEventType
+from management.relation_replicator.outbox_replicator import OutboxReplicator
+from management.relation_replicator.relation_replicator import (
+    PartitionKey,
+    RelationReplicator,
+    ReplicationEvent,
+    ReplicationEventType,
+)
+from management.role.model import BindingMapping
 from management.role.relation_api_dual_write_handler import RelationApiDualWriteHandler
+from management.role.v2_model import RoleV2
+from management.role_binding.model import RoleBinding
+from management.tenant_mapping.v2_activation import TenantVersion, lock_tenant_version
 from management.workspace.relation_api_dual_write_workspace_handler import RelationApiDualWriteWorkspaceHandler
+from migration_tool.sharedSystemRolesReplicatedRoleBindings import attribute_key_to_v2_related_resource_type
 from prometheus_client import Counter, Histogram
 from psycopg2 import sql
 from rest_framework import serializers
@@ -83,7 +96,7 @@ LISTEN_SQL = sql.SQL("LISTEN {};").format(sql.Identifier(READ_YOUR_WRITES_CHANNE
 UNLISTEN_SQL = sql.SQL("UNLISTEN {};").format(sql.Identifier(READ_YOUR_WRITES_CHANNEL))
 
 
-def update_roles_for_removed_workspace(workspace_id: uuid.UUID) -> int:
+def _update_custom_roles_for_removed_workspace(workspace_id: uuid.UUID, replicator: RelationReplicator) -> int:
     """
     Update roles that reference a removed workspace and replicate the changes.
 
@@ -118,13 +131,7 @@ def update_roles_for_removed_workspace(workspace_id: uuid.UUID) -> int:
             ),
             attributeFilter__key=workspace_filter_key,
         )
-        .values(
-            "id",
-            "access__role_id",
-            "access__permission__permission",
-            "access__permission__application",
-            "access__permission__resource_type",
-        )
+        .values("id", "access__role_id")
         .order_by("access__role_id")
     )
 
@@ -145,7 +152,16 @@ def update_roles_for_removed_workspace(workspace_id: uuid.UUID) -> int:
                 logger.warning(f"Role vanished before it could be updated: pk={role_id!r}")
                 continue
 
-            dual_write = RelationApiDualWriteHandler(role, ReplicationEventType.FIX_RESOURCE_DEFINITIONS)
+            tenant_version = lock_tenant_version(role.tenant)
+
+            if tenant_version != TenantVersion.VERSION_1:
+                logger.info(f"Not processing role (pk={role.pk!r}) that is not in a V1 tenant.")
+                continue
+
+            dual_write = RelationApiDualWriteHandler(
+                role, ReplicationEventType.FIX_RESOURCE_DEFINITIONS, replicator=replicator
+            )
+
             dual_write.prepare_for_update()  # Capture current bindings
 
             # Lock the ResourceDefinitions to prevent concurrent modifications
@@ -156,13 +172,8 @@ def update_roles_for_removed_workspace(workspace_id: uuid.UUID) -> int:
             rds_to_update = []
 
             for rd in locked_rds:
-                # Use metadata from initial query to avoid traversing FKs (access.permission)
-                meta = rds_metadata[rd.id]
-                app_name = meta["access__permission__application"]
-                res_type = meta["access__permission__resource_type"]
-
-                # Double-check is_resource_a_workspace
-                if not is_resource_a_workspace(app_name, res_type, rd.attributeFilter):
+                # Double-check that this resource definition is for workspaces.
+                if attribute_key_to_v2_related_resource_type(rd.attributeFilter["key"]) != ("rbac", "workspace"):
                     continue
 
                 # Get workspace IDs from resource definition
@@ -242,8 +253,94 @@ def update_roles_for_removed_workspace(workspace_id: uuid.UUID) -> int:
     return roles_updated
 
 
+# This must be SERIALIZABLE because we are potentially interacting with RoleBindings in V2 tenants.
+@atomic
+def _remove_workspace_system_role_bindings(workspace: Workspace, replicator: RelationReplicator) -> int:
+    """
+    Delete role bindings bound to system roles for a workspace about to be deleted.
+
+    It is assumed that all role bindings bound to custom roles have already been removed.
+    """
+    tenant_version = lock_tenant_version(workspace.tenant)
+
+    if tenant_version not in (TenantVersion.VERSION_1, TenantVersion.VERSION_2):
+        raise RuntimeError(f"Unexpected tenant version: {tenant_version!r}")
+
+    role_bindings = list(
+        RoleBinding.objects.filter(
+            resource_type="workspace",
+            resource_id=str(workspace.id),
+        )
+        .select_related("role")
+        .select_for_update(of=["self"])
+    )
+
+    if tenant_version == TenantVersion.VERSION_1:
+        # We need to lock the relevant BindingMappings so that they can't be changed concurrently from V1 code.
+        binding_mappings = list(
+            BindingMapping.objects.filter(
+                resource_type_namespace="rbac",
+                resource_type_name="workspace",
+                resource_id=str(workspace.id),
+            )
+            .select_related("role")
+            .prefetch_related("group_entries", "principal_entries")
+            .select_for_update(of=["self"])
+        )
+
+        # Any bindings from resource definitions should have been removed, since we have previously removed the
+        # workspace from all custom roles. Since this is a standard workspace, there should be no bindings from any
+        # role's implicit scope. So, none of this workspace's role bindings should reference a custom role.
+
+        if any(not bm.role.system for bm in binding_mappings):
+            raise RuntimeError("All BindingMappings for custom roles to this workspace should have been removed")
+
+        if any(rb.role.type == RoleV2.Types.CUSTOM for rb in role_bindings):
+            raise RuntimeError("All RoleBindings for custom roles to this workspace should have been removed")
+
+        binding_mapping_ids = set(bm.mappings["id"] for bm in binding_mappings)
+        role_binding_ids = set(str(rb.uuid) for rb in role_bindings)
+
+        if binding_mapping_ids != role_binding_ids:
+            raise AssertionError(
+                f"Found mismatched BindingMapping IDs and RoleBinding IDs during workspace deletion: "
+                f"BindingMapping IDs={binding_mapping_ids}, "
+                f"RoleBinding IDs={role_binding_ids}"
+            )
+
+    for batch in itertools.batched(itertools.chain.from_iterable(rb.all_tuples() for rb in role_bindings), 1000):
+        replicator.replicate(
+            ReplicationEvent(
+                event_type=ReplicationEventType.DELETE_WORKSPACE,
+                partition_key=PartitionKey.byEnvironment(),
+                remove=list(batch),
+                info={"org_id": workspace.tenant.org_id, "workspace_id": str(workspace.id)},
+            )
+        )
+
+    RoleBinding.objects.filter(pk__in=(rb.pk for rb in role_bindings)).delete()
+
+    return len(role_bindings)
+
+
 class WorkspaceService:
     """Workspace service."""
+
+    _replicator: RelationReplicator
+
+    def __init__(self, replicator: Optional[RelationReplicator] = None):
+        """Create a WorkspaceService that uses the provided replicator (defaulting to OutboxReplicator)."""
+        if replicator is None:
+            replicator = OutboxReplicator()
+
+        self._replicator = replicator
+
+    def _dual_write_handler(
+        self, workspace: Workspace, event_type: ReplicationEventType
+    ) -> RelationApiDualWriteWorkspaceHandler:
+        return RelationApiDualWriteWorkspaceHandler(
+            workspace=workspace, event_type=event_type, replicator=self._replicator
+        )
 
     @atomic
     def create(self, validated_data: dict, request_tenant: Tenant) -> Workspace:
@@ -265,7 +362,7 @@ class WorkspaceService:
                 )
 
             workspace = Workspace.objects.create(**validated_data, tenant=parent.tenant)
-            dual_write_handler = RelationApiDualWriteWorkspaceHandler(workspace, ReplicationEventType.CREATE_WORKSPACE)
+            dual_write_handler = self._dual_write_handler(workspace, ReplicationEventType.CREATE_WORKSPACE)
             dual_write_handler.replicate_new_workspace()
 
             # After the outbox message is created & committed, LISTEN for a NOTIFY
@@ -298,7 +395,7 @@ class WorkspaceService:
 
         try:
             instance.save()
-            dual_write_handler = RelationApiDualWriteWorkspaceHandler(instance, ReplicationEventType.UPDATE_WORKSPACE)
+            dual_write_handler = self._dual_write_handler(instance, ReplicationEventType.UPDATE_WORKSPACE)
             dual_write_handler.replicate_updated_workspace(instance.parent, skip_ws_events)
         except ValidationError as e:
             message = e.message_dict
@@ -312,25 +409,28 @@ class WorkspaceService:
             raise serializers.ValidationError(message)
         return instance
 
+    @atomic
     def destroy(self, instance: Workspace) -> None:
         """Destroy workspace."""
+        # Lock the workspace to prevent concurrent modifications or referencing
+        # by new/updated roles during deletion
+        instance = Workspace.objects.select_for_update().get(pk=instance.pk)
+
         if instance.type != Workspace.Types.STANDARD:
             raise serializers.ValidationError(f"Unable to delete {instance.type} workspace")
         if Workspace.objects.filter(parent=instance, tenant=instance.tenant).exists():
             raise serializers.ValidationError("Unable to delete due to workspace dependencies")
 
-        with transaction.atomic():
-            # Lock the workspace to prevent concurrent modifications or referencing
-            # by new/updated roles during deletion
-            Workspace.objects.select_for_update().get(pk=instance.pk)
+        # Update roles that reference this workspace before deleting it
+        roles_updated_count = _update_custom_roles_for_removed_workspace(instance.id, replicator=self._replicator)
+        logger.info(f"Updated {roles_updated_count} custom roles for workspace {instance.id} removal")
 
-            # Update roles that reference this workspace before deleting it
-            role_update_results = update_roles_for_removed_workspace(instance.id)
-            logger.info(f"Updated {role_update_results} roles for workspace {instance.id} removal")
+        system_bindings_removed_count = _remove_workspace_system_role_bindings(instance, replicator=self._replicator)
+        logger.info(f"Removed {system_bindings_removed_count} system roles for workspace {instance.id} removal")
 
-            dual_write_handler = RelationApiDualWriteWorkspaceHandler(instance, ReplicationEventType.DELETE_WORKSPACE)
-            dual_write_handler.replicate_deleted_workspace()
-            instance.delete()
+        dual_write_handler = self._dual_write_handler(instance, ReplicationEventType.DELETE_WORKSPACE)
+        dual_write_handler.replicate_deleted_workspace()
+        instance.delete()
 
     def move(self, instance: Workspace, target_workspace_id: uuid.UUID) -> Workspace:
         """Move a workspace under new parent."""
@@ -343,7 +443,7 @@ class WorkspaceService:
         previous_parent_workspace = instance.parent
         instance.parent = target_workspace
         instance.save(update_fields=["parent"])
-        dual_write_handler = RelationApiDualWriteWorkspaceHandler(instance, ReplicationEventType.MOVE_WORKSPACE)
+        dual_write_handler = self._dual_write_handler(instance, ReplicationEventType.MOVE_WORKSPACE)
         dual_write_handler.replicate_updated_workspace(previous_parent_workspace, skip_ws_events=True)
         return instance
 

--- a/rbac/management/workspace/service.py
+++ b/rbac/management/workspace/service.py
@@ -310,6 +310,7 @@ def _remove_workspace_direct_role_bindings(workspace: Workspace, replicator: Rel
             resource_id=str(workspace.id),
         )
         .select_related("role")
+        .prefetch_related("group_entries", "principal_entries")
         .select_for_update(of=["self"])
     )
 

--- a/rbac/management/workspace/service.py
+++ b/rbac/management/workspace/service.py
@@ -42,7 +42,6 @@ from management.relation_replicator.relation_replicator import (
 )
 from management.role.model import BindingMapping
 from management.role.relation_api_dual_write_handler import RelationApiDualWriteHandler
-from management.role.v2_model import RoleV2
 from management.role_binding.model import RoleBinding
 from management.tenant_mapping.v2_activation import TenantVersion, lock_tenant_version
 from management.workspace.relation_api_dual_write_workspace_handler import RelationApiDualWriteWorkspaceHandler
@@ -275,38 +274,27 @@ def _remove_workspace_system_role_bindings(workspace: Workspace, replicator: Rel
         .select_for_update(of=["self"])
     )
 
+    binding_mappings = list(
+        BindingMapping.objects.filter(
+            resource_type_namespace="rbac",
+            resource_type_name="workspace",
+            resource_id=str(workspace.id),
+        ).select_for_update()
+    )
+
     if tenant_version == TenantVersion.VERSION_1:
-        # We need to lock the relevant BindingMappings so that they can't be changed concurrently from V1 code.
-        binding_mappings = list(
-            BindingMapping.objects.filter(
-                resource_type_namespace="rbac",
-                resource_type_name="workspace",
-                resource_id=str(workspace.id),
-            )
-            .select_related("role")
-            .prefetch_related("group_entries", "principal_entries")
-            .select_for_update(of=["self"])
-        )
+        # We should have already removed all bindings from resource definitions in custom roles; there should be no
+        # role bindings for system roles in a standard workspace in a V1 tenant (since they should all be bound to
+        # the default workspace, root workspace, or tenant as appropriate).
 
-        # Any bindings from resource definitions should have been removed, since we have previously removed the
-        # workspace from all custom roles. Since this is a standard workspace, there should be no bindings from any
-        # role's implicit scope. So, none of this workspace's role bindings should reference a custom role.
-
-        if any(not bm.role.system for bm in binding_mappings):
-            raise RuntimeError("All BindingMappings for custom roles to this workspace should have been removed")
-
-        if any(rb.role.type == RoleV2.Types.CUSTOM for rb in role_bindings):
-            raise RuntimeError("All RoleBindings for custom roles to this workspace should have been removed")
-
-        binding_mapping_ids = set(bm.mappings["id"] for bm in binding_mappings)
-        role_binding_ids = set(str(rb.uuid) for rb in role_bindings)
-
-        if binding_mapping_ids != role_binding_ids:
+        if (len(role_bindings) > 0) or (len(binding_mappings) > 0):
             raise AssertionError(
-                f"Found mismatched BindingMapping IDs and RoleBinding IDs during workspace deletion: "
-                f"BindingMapping IDs={binding_mapping_ids}, "
-                f"RoleBinding IDs={role_binding_ids}"
+                f"A standard workspace in a V1 tenant should exist, but found "
+                f"BindingMappings with pks={[bm.pk for bm in binding_mappings]} and"
+                f"RoleBindings with pks={[rb.pk for rb in role_bindings]}"
             )
+
+        return 0
 
     for batch in itertools.batched(itertools.chain.from_iterable(rb.all_tuples() for rb in role_bindings), 1000):
         replicator.replicate(
@@ -318,7 +306,13 @@ def _remove_workspace_system_role_bindings(workspace: Workspace, replicator: Rel
             )
         )
 
-    RoleBinding.objects.filter(pk__in=(rb.pk for rb in role_bindings)).delete()
+    if len(role_bindings) > 0:
+        RoleBinding.objects.filter(pk__in=(rb.pk for rb in role_bindings)).delete()
+
+    # The BindingMappings are irrelevant in a V2 tenant, but delete them anyway to avoid having to deal with any
+    # orphans later.
+    if len(binding_mappings) > 0:
+        BindingMapping.objects.filter(pk__in=(bm.pk for bm in role_bindings)).delete()
 
     return len(role_bindings)
 

--- a/rbac/management/workspace/view.py
+++ b/rbac/management/workspace/view.py
@@ -23,6 +23,7 @@ import pgtransaction
 from django.core.exceptions import ValidationError
 from django.db import OperationalError, transaction
 from django_filters import rest_framework as filters
+from management.atomic_transactions import atomic_with_retry
 from management.audit_log.model import AuditLog
 from management.base_viewsets import BaseV2ViewSet
 from management.permissions.workspace_access import WorkspaceAccessPermission
@@ -220,7 +221,7 @@ class WorkspaceViewSet(WorkspaceObjectAccessMixin, BaseV2ViewSet):
         serializer = self.get_serializer(page, many=True)
         return self.get_paginated_response(serializer.data)
 
-    @transaction.atomic()
+    @atomic_with_retry(retries=3)
     def destroy(self, request, *args, **kwargs):
         """
         Destroy the instance.

--- a/rbac/migration_tool/sharedSystemRolesReplicatedRoleBindings.py
+++ b/rbac/migration_tool/sharedSystemRolesReplicatedRoleBindings.py
@@ -118,7 +118,6 @@ def v1_role_to_v2_bindings(
     from internal.utils import (
         get_or_create_ungrouped_workspace,
         get_workspace_ids_from_resource_definition,
-        is_resource_a_workspace,
     )
 
     perm_groupings: _PermissionGroupings = {}
@@ -141,20 +140,30 @@ def v1_role_to_v2_bindings(
                     # Skip empty values
                     continue
 
-            # validate permission was not added to workspace out of users org for v1 (RHCLOUD-35481)
-            if is_resource_a_workspace(permission.application, permission.resource_type, attri_filter):
-                workspace_ids = get_workspace_ids_from_resource_definition(attri_filter)
-                if len(workspace_ids) >= 1:
-                    is_same_tenant = Workspace.objects.filter(id__in=workspace_ids, tenant=v1_role.tenant).exists()
-                    if not is_same_tenant:
-                        logger.info(f"""skipping migrating permission '{permission}' from v1 role '{v1_role.name}'
-                            -- it was added to workspace outside of users org""")
-                        continue
-
             resource_type = attribute_key_to_v2_related_resource_type(attri_filter["key"])
+
             if resource_type is None:
                 # Resource type not mapped to v2
                 continue
+
+            # validate permission was not added to workspace out of users org for v1 (RHCLOUD-35481)
+            if resource_type == ("rbac", "workspace"):
+                requested_workspace_ids = set(get_workspace_ids_from_resource_definition(attri_filter))
+
+                if len(requested_workspace_ids) > 0:
+                    actual_workspace_ids = set(
+                        w.id for w in Workspace.objects.filter(tenant=v1_role.tenant, id__in=requested_workspace_ids)
+                    )
+
+                    if requested_workspace_ids != actual_workspace_ids:
+                        logger.info(
+                            f"Skipping migrating permission '{permission}' from v1 role '{v1_role.name}'; "
+                            f"it was added to workspaces outside of users org: "
+                            f"{requested_workspace_ids - actual_workspace_ids}"
+                        )
+
+                        continue
+
             for resource_id in values_from_attribute_filter(attri_filter):
                 if resource_id is None:
                     if resource_type != ("rbac", "workspace"):
@@ -288,6 +297,25 @@ def permission_groupings_to_v2_role_bindings(
 
     if not all(r.type == RoleV2.Types.CUSTOM for r in existing_v2_roles):
         raise ValueError(f"All provided V2 roles ({existing_v2_roles}) must be CUSTOM roles.")
+
+    requested_workspace_ids = set(
+        r.resource_id for r in perm_groupings.keys() if r.resource_type == ("rbac", "workspace")
+    )
+
+    if len(requested_workspace_ids) > 0:
+        # Ensure the workspaces we want exist and lock them to prevent them from being concurrently deleted.
+        locked_workspace_ids = set(
+            str(id)
+            for id in Workspace.objects.select_for_update()
+            .filter(tenant=v1_role.tenant, id__in=requested_workspace_ids)
+            .values_list("id", flat=True)
+        )
+
+        if requested_workspace_ids != locked_workspace_ids:
+            raise ValueError(
+                f"Could not migrate role referencing nonexistent workspaces: "
+                f"{requested_workspace_ids - locked_workspace_ids}"
+            )
 
     existing_mappings_by_resource = {mapping.get_role_binding().resource: mapping for mapping in existing_mappings}
 

--- a/tests/identity_request.py
+++ b/tests/identity_request.py
@@ -170,4 +170,7 @@ class IdentityRequest(BaseIdentityRequest, TestCase):
 
 @override_settings(REPLICATION_TO_RELATION_ENABLED=True, PRINCIPAL_USER_DOMAIN="redhat")
 class TransactionalIdentityRequest(BaseIdentityRequest, TransactionTestCase):
-    pass
+    def setUp(self):
+        super().setUp()
+
+        Tenant.objects.get_or_create(tenant_name="public")

--- a/tests/internal/test_cleanup_orphan_bindings.py
+++ b/tests/internal/test_cleanup_orphan_bindings.py
@@ -893,8 +893,13 @@ class RebuildTenantWorkspaceRelationsTest(DualWriteTestCase):
     def setUp(self):
         """Set up test data."""
         super().setUp()
-        # DualWriteTestCase creates self.tuples, self.fixture, and self.tenant
-        # But we do NOT set up workspace hierarchy - we want to test rebuilding it
+
+        # Switch to a new tenant because we care about the exact number of workspaces in the tenant (and
+        # DualWriteTestCase creates some extra ones for its own purposes).
+        self.switch_to_new_tenant(name="another tenant", org_id="7654321")
+
+        # Clear tuples, since we want to test rebuilding it
+        self.tuples.clear()
 
     def _create_kessel_read_tuples_mock(self):
         """Create a mock function that reads tuples from our InMemoryTuples store."""

--- a/tests/internal/test_views.py
+++ b/tests/internal/test_views.py
@@ -829,12 +829,16 @@ class InternalViewsetTests(BaseInternalViewsetTests):
         dual_write_handler = SeedingRelationApiDualWriteHandler(role_system, replicator=replicator)
         dual_write_handler.replicate_new_system_role()
 
+        ws_2 = Workspace.objects.create(
+            tenant=self.tenant, parent=Workspace.objects.default(tenant=self.tenant), name="ws_2"
+        )
+
         role_custom = fixture.new_custom_role(
             name="custom_role",
             tenant=self.tenant,
             resource_access=fixture.workspace_access(
                 permissions,
-                ws_2=["app1:hosts:read", "inventory:hosts:write"],
+                **{str(ws_2.id): ["app1:hosts:read", "inventory:hosts:write"]},
             ),
         )
         dual_write = RelationApiDualWriteHandler(

--- a/tests/internal/test_views.py
+++ b/tests/internal/test_views.py
@@ -3752,24 +3752,19 @@ def invalid_destructive_time():
     return datetime.now(timezone.utc).replace(tzinfo=pytz.UTC) - timedelta(hours=1)
 
 
+@override_settings(ATOMIC_RETRY_DISABLED=True)
 class WorkspaceViewsetTests(BaseInternalViewsetTests):
     """Test the /api/utils/workspace/ endpoint from internal viewset"""
 
     def setUp(self):
         """Set up the Workspace view tests."""
         super().setUp()
-        self.root_workspace = Workspace.objects.create(
-            name="Root Workspace",
-            tenant=self.tenant,
-            type=Workspace.Types.ROOT,
-        )
-        self.default_workspace = Workspace.objects.create(
-            tenant=self.tenant,
-            type=Workspace.Types.DEFAULT,
-            name="Default Workspace",
-            description="Default Description",
-            parent_id=self.root_workspace.id,
-        )
+
+        bootstrap_result = bootstrap_tenant_for_v2_test(self.tenant)
+
+        self.default_workspace = bootstrap_result.default_workspace
+        self.root_workspace = bootstrap_result.root_workspace
+
         self.standard_workspace = Workspace.objects.create(
             name="Standard Workspace",
             description="Standard Workspace - description",
@@ -3777,6 +3772,7 @@ class WorkspaceViewsetTests(BaseInternalViewsetTests):
             parent=self.default_workspace,
             type=Workspace.Types.STANDARD,
         )
+
         self.ungrouped_workspace = Workspace.objects.create(
             name="Ungrouped Hosts Workspace",
             description="Ungrouped Hosts Workspace - description",

--- a/tests/management/role/test_dual_write.py
+++ b/tests/management/role/test_dual_write.py
@@ -101,8 +101,26 @@ class DualWriteTestCase(TestCase):
         super().setUp()
         self.tuples = InMemoryTuples()
         self.fixture = RbacFixture()
-        self.tenant = self.fixture.new_tenant(org_id="1234567").tenant
+
+        bootstrapped_tenant = self.fixture.new_tenant(org_id="1234567")
+        self.tenant = bootstrapped_tenant.tenant
         self.test_tenant = self.tenant
+
+        ws_1 = Workspace.objects.create(
+            tenant=self.tenant, parent=bootstrapped_tenant.default_workspace, name="DualWriteTestCase Workspace 1"
+        )
+
+        ws_2 = Workspace.objects.create(
+            tenant=self.tenant, parent=bootstrapped_tenant.default_workspace, name="DualWriteTestCase Workspace 2"
+        )
+
+        ws_3 = Workspace.objects.create(
+            tenant=self.tenant, parent=bootstrapped_tenant.default_workspace, name="DualWriteTestCase Workspace 3"
+        )
+
+        self.ws_1_id = str(ws_1.id)
+        self.ws_2_id = str(ws_2.id)
+        self.ws_3_id = str(ws_3.id)
 
     def switch_to_new_tenant(self, name: str, org_id: str) -> Tenant:
         """Switch to a new tenant with the given name and org_id."""
@@ -180,6 +198,29 @@ class DualWriteTestCase(TestCase):
         dual_write.replicate_new_or_updated_role(role)
         return role
 
+    def _test_workspace_perms(self, ws_1: Optional[list[str]], ws_2: Optional[list[str]], ws_3: Optional[list[str]]):
+        workspace_perms = {}
+
+        for ws_id, requested_perms in [(self.ws_1_id, ws_1), (self.ws_2_id, ws_2), (self.ws_3_id, ws_3)]:
+            if requested_perms is not None:
+                workspace_perms[ws_id] = requested_perms
+
+        return workspace_perms
+
+    def given_v1_role_on_test_workspaces(
+        self,
+        name: str,
+        default: list[str] = [],
+        ws_1: Optional[list[str]] = None,
+        ws_2: Optional[list[str]] = None,
+        ws_3: Optional[list[str]] = None,
+    ) -> Role:
+        """Create a new custom role with the given ID and permissions for the pre-created test workspaces."""
+
+        return self.given_v1_role(
+            name=name, default=default, **self._test_workspace_perms(ws_1=ws_1, ws_2=ws_2, ws_3=ws_3)
+        )
+
     def given_update_to_v1_role(
         self, role: Role, default: list[str] = [], replicator: Optional[RelationReplicator] = None, **kwargs: list[str]
     ):
@@ -192,6 +233,19 @@ class DualWriteTestCase(TestCase):
         )
         dual_write.replicate_new_or_updated_role(role)
         return role
+
+    def given_update_to_v1_role_on_test_workspaces(
+        self,
+        role: Role,
+        default: list[str] = [],
+        ws_1: Optional[list[str]] = None,
+        ws_2: Optional[list[str]] = None,
+        ws_3: Optional[list[str]] = None,
+    ) -> Role:
+        """Create a new custom role with the given ID and permissions for the pre-created test workspaces."""
+        return self.given_update_to_v1_role(
+            role=role, default=default, **self._test_workspace_perms(ws_1=ws_1, ws_2=ws_2, ws_3=ws_3)
+        )
 
     def given_v1_role_removed(self, role: Role, replicator: Optional[RelationReplicator] = None):
         """Remove the given custom role."""
@@ -593,13 +647,13 @@ class DualWriteGroupTestCase(DualWriteTestCase):
         )
 
     def test_custom_roles_group_assignments_tuples(self):
-        role_1 = self.given_v1_role(
+        role_1 = self.given_v1_role_on_test_workspaces(
             "r1",
             default=["app1:hosts:read", "inventory:hosts:write"],
             ws_2=["app1:hosts:read", "inventory:hosts:write"],
         )
 
-        role_2 = self.given_v1_role(
+        role_2 = self.given_v1_role_on_test_workspaces(
             "r2",
             default=["app2:hosts:read", "inventory:systems:write"],
             ws_2=["app2:hosts:read", "inventory:systems:write"],
@@ -662,7 +716,7 @@ class DualWriteGroupTestCase(DualWriteTestCase):
         self.assertEqual(mappings["groups"], [str(group.uuid)])
 
     def test_adding_same_role_again_and_unassign_it_once(self):
-        role_test = self.given_v1_role(
+        role_test = self.given_v1_role_on_test_workspaces(
             "rtest",
             default=["app1:hosts:read", "inventory:hosts:write"],
             ws_2=["app1:hosts:read", "inventory:hosts:write"],
@@ -819,13 +873,13 @@ class DualWriteGroupTestCase(DualWriteTestCase):
 
     def test_delete_group_removes_group_from_role_bindings(self):
         # Add two groups to two roles
-        role_1 = self.given_v1_role(
+        role_1 = self.given_v1_role_on_test_workspaces(
             "r1",
             default=["app1:hosts:read", "inventory:hosts:write"],
             ws_2=["app1:hosts:read", "inventory:hosts:write"],
         )
 
-        role_2 = self.given_v1_role(
+        role_2 = self.given_v1_role_on_test_workspaces(
             "r2",
             default=["app2:hosts:read", "inventory:systems:write"],
             ws_2=["app2:hosts:read", "inventory:systems:write"],
@@ -977,7 +1031,7 @@ class DualWriteGroupTestCase(DualWriteTestCase):
         )
 
     def test_delete_group_removes_role_binding_for_system_roles_if_last_group(self):
-        role_1 = self.given_v1_role(
+        role_1 = self.given_v1_role_on_test_workspaces(
             "r1",
             default=["app1:hosts:read", "inventory:hosts:write"],
             ws_2=["app1:hosts:read", "inventory:hosts:write"],
@@ -1017,7 +1071,7 @@ class DualWriteGroupTestCase(DualWriteTestCase):
 
     def test_delete_group_keeps_role_binding_for_system_roles_if_not_last_group(self):
         """Keep the role binding if it still has other groups assigned to it."""
-        role_1 = self.given_v1_role(
+        role_1 = self.given_v1_role_on_test_workspaces(
             "r1",
             default=["app1:hosts:read", "inventory:hosts:write"],
             ws_2=["app1:hosts:read", "inventory:hosts:write"],
@@ -2148,7 +2202,7 @@ class DualWriteCustomRolesTestCase(DualWriteTestCase):
 
     def test_non_default_resource_only(self):
         """Test a role with access to a specific resource only."""
-        for workspaces in [["ws_1"], ["ws_1", "ws_2", "ws_3", "ws_4"]]:
+        for workspaces in [[self.ws_1_id], [self.ws_1_id, self.ws_2_id, self.ws_3_id]]:
             for permissions in [
                 ["inventory:hosts:read"],
                 ["inventory:hosts:read", "inventory:hosts:write", "inventory:hosts:delete"],
@@ -2158,7 +2212,7 @@ class DualWriteCustomRolesTestCase(DualWriteTestCase):
 
     def test_many_different_permissions(self):
         """Test creating a role with many different sets of permissions."""
-        role = self.given_v1_role(
+        role = self.given_v1_role_on_test_workspaces(
             "r1", default=["inventory:hosts:read"], ws_1=["inventory:hosts:write"], ws_2=["inventory:hosts:delete"]
         )
 
@@ -2167,15 +2221,15 @@ class DualWriteCustomRolesTestCase(DualWriteTestCase):
 
         for workspace, permissions in [
             (self.default_workspace(), ["inventory:hosts:read"]),
-            ("ws_1", ["inventory:hosts:write"]),
-            ("ws_2", ["inventory:hosts:delete"]),
+            (self.ws_1_id, ["inventory:hosts:write"]),
+            (self.ws_2_id, ["inventory:hosts:delete"]),
         ]:
             role = self.expect_1_v2_role_with_permissions(permissions)
             self.expect_1_role_binding_to_workspace(workspace, for_v2_roles=[role], for_groups=[str(group.uuid)])
 
     def test_partial_overlap(self):
         """Test creating a role where some, but not all, workspaces share the same permissions."""
-        role = self.given_v1_role(
+        role = self.given_v1_role_on_test_workspaces(
             "r1",
             default=["inventory:hosts:read"],
             ws_1=["inventory:hosts:read"],
@@ -2193,14 +2247,14 @@ class DualWriteCustomRolesTestCase(DualWriteTestCase):
             self.default_workspace(), for_v2_roles=[read_role], for_groups=[str(group.uuid)]
         )
 
-        self.expect_1_role_binding_to_workspace("ws_1", for_v2_roles=[read_role], for_groups=[str(group.uuid)])
+        self.expect_1_role_binding_to_workspace(self.ws_1_id, for_v2_roles=[read_role], for_groups=[str(group.uuid)])
 
-        self.expect_1_role_binding_to_workspace("ws_2", for_v2_roles=[write_role], for_groups=[str(group.uuid)])
-        self.expect_1_role_binding_to_workspace("ws_3", for_v2_roles=[write_role], for_groups=[str(group.uuid)])
+        self.expect_1_role_binding_to_workspace(self.ws_2_id, for_v2_roles=[write_role], for_groups=[str(group.uuid)])
+        self.expect_1_role_binding_to_workspace(self.ws_3_id, for_v2_roles=[write_role], for_groups=[str(group.uuid)])
 
     def test_role_with_same_default_and_resource_permission_reuses_same_v2_role(self):
         """With same resource permissions (when one of those is the default workspace), reuse the same v2 role."""
-        role = self.given_v1_role(
+        role = self.given_v1_role_on_test_workspaces(
             "r1",
             default=["app1:hosts:read", "inventory:hosts:write"],
             ws_2=["app1:hosts:read", "inventory:hosts:write"],
@@ -2213,17 +2267,17 @@ class DualWriteCustomRolesTestCase(DualWriteTestCase):
         self.expect_1_role_binding_to_workspace(
             self.default_workspace(), for_v2_roles=[id], for_groups=[str(group.uuid)]
         )
-        self.expect_1_role_binding_to_workspace("ws_2", for_v2_roles=[id], for_groups=[str(group.uuid)])
+        self.expect_1_role_binding_to_workspace(self.ws_2_id, for_v2_roles=[id], for_groups=[str(group.uuid)])
 
     def test_add_permissions_to_role(self):
         """Modify the role in place when adding permissions."""
-        role = self.given_v1_role(
+        role = self.given_v1_role_on_test_workspaces(
             "r1",
             default=["app1:hosts:read", "inventory:hosts:write"],
             ws_2=["app1:hosts:read", "inventory:hosts:write"],
         )
 
-        self.given_update_to_v1_role(
+        self.given_update_to_v1_role_on_test_workspaces(
             role,
             default=["app1:hosts:read", "inventory:hosts:write"],
             ws_2=["app1:hosts:read", "inventory:hosts:write", "app2:hosts:read"],
@@ -2242,17 +2296,19 @@ class DualWriteCustomRolesTestCase(DualWriteTestCase):
             for_v2_roles=[role_for_default],
             for_groups=[str(group.uuid)],
         )
-        self.expect_1_role_binding_to_workspace("ws_2", for_v2_roles=[role_for_ws_2], for_groups=[str(group.uuid)])
+        self.expect_1_role_binding_to_workspace(
+            self.ws_2_id, for_v2_roles=[role_for_ws_2], for_groups=[str(group.uuid)]
+        )
 
     def test_remove_permissions_from_role(self):
         """Modify the role in place when removing permissions."""
-        role = self.given_v1_role(
+        role = self.given_v1_role_on_test_workspaces(
             "r1",
             default=["app1:hosts:read", "inventory:hosts:write"],
             ws_2=["app1:hosts:read", "inventory:hosts:write"],
         )
 
-        self.given_update_to_v1_role(
+        self.given_update_to_v1_role_on_test_workspaces(
             role,
             default=["app1:hosts:read", "inventory:hosts:write"],
             ws_2=["app1:hosts:read"],
@@ -2269,24 +2325,26 @@ class DualWriteCustomRolesTestCase(DualWriteTestCase):
             for_v2_roles=[role_for_default],
             for_groups=[str(group.uuid)],
         )
-        self.expect_1_role_binding_to_workspace("ws_2", for_v2_roles=[role_for_ws_2], for_groups=[str(group.uuid)])
+        self.expect_1_role_binding_to_workspace(
+            self.ws_2_id, for_v2_roles=[role_for_ws_2], for_groups=[str(group.uuid)]
+        )
 
     def test_remove_permissions_from_role_back_to_original(self):
         """Modify the role in place when removing permissions, consolidating roles."""
         """Modify the role in place when adding permissions."""
-        role = self.given_v1_role(
+        role = self.given_v1_role_on_test_workspaces(
             "r1",
             default=["app1:hosts:read", "inventory:hosts:write"],
             ws_2=["app1:hosts:read", "inventory:hosts:write"],
         )
 
-        self.given_update_to_v1_role(
+        self.given_update_to_v1_role_on_test_workspaces(
             role,
             default=["app1:hosts:read", "inventory:hosts:write"],
             ws_2=["app1:hosts:read", "inventory:hosts:write", "app2:hosts:read"],
         )
 
-        self.given_update_to_v1_role(
+        self.given_update_to_v1_role_on_test_workspaces(
             role,
             default=["app1:hosts:read", "inventory:hosts:write"],
             ws_2=["app1:hosts:read", "inventory:hosts:write"],
@@ -2294,11 +2352,11 @@ class DualWriteCustomRolesTestCase(DualWriteTestCase):
 
         id = self.expect_1_v2_role_with_permissions(["app1:hosts:read", "inventory:hosts:write"])
         self.expect_1_role_binding_to_workspace(self.default_workspace(), for_v2_roles=[id], for_groups=[])
-        self.expect_1_role_binding_to_workspace("ws_2", for_v2_roles=[id], for_groups=[])
+        self.expect_1_role_binding_to_workspace(self.ws_2_id, for_v2_roles=[id], for_groups=[])
 
     def test_add_resource_uses_existing_groups(self):
         """New bindings get existing groups."""
-        role = self.given_v1_role(
+        role = self.given_v1_role_on_test_workspaces(
             "r1",
             default=["app1:hosts:read", "inventory:hosts:write"],
             ws_2=["app1:hosts:read", "inventory:hosts:write"],
@@ -2309,7 +2367,7 @@ class DualWriteCustomRolesTestCase(DualWriteTestCase):
         self.given_roles_assigned_to_group(g1, roles=[role])
         self.given_roles_assigned_to_group(g2, roles=[role])
 
-        self.given_update_to_v1_role(
+        self.given_update_to_v1_role_on_test_workspaces(
             role,
             default=["app1:hosts:read", "inventory:hosts:write"],
             ws_2=["app1:hosts:read", "inventory:hosts:write"],
@@ -2318,11 +2376,13 @@ class DualWriteCustomRolesTestCase(DualWriteTestCase):
 
         role = self.expect_1_v2_role_with_permissions(["app1:hosts:read", "inventory:hosts:write"])
 
-        self.expect_1_role_binding_to_workspace("ws_3", for_v2_roles=[role], for_groups=[str(g1.uuid), str(g2.uuid)])
+        self.expect_1_role_binding_to_workspace(
+            self.ws_3_id, for_v2_roles=[role], for_groups=[str(g1.uuid), str(g2.uuid)]
+        )
 
     def test_delete_role(self):
         """Delete the role and its bindings when deleting a custom role."""
-        role = self.given_v1_role(
+        role = self.given_v1_role_on_test_workspaces(
             "r1",
             default=["app1:hosts:read", "inventory:hosts:write"],
             ws_2=["app1:hosts:read", "inventory:hosts:write"],
@@ -2362,13 +2422,13 @@ class DualWriteCustomRolesTestCase(DualWriteTestCase):
 
     def test_remove_resource_removes_role_binding(self):
         """Remove the role binding when removing the resource from attribute filter."""
-        role = self.given_v1_role(
+        role = self.given_v1_role_on_test_workspaces(
             "r1",
             default=["app1:hosts:read", "inventory:hosts:write"],
             ws_2=["app1:hosts:read", "inventory:hosts:write"],
         )
 
-        self.given_update_to_v1_role(
+        self.given_update_to_v1_role_on_test_workspaces(
             role,
             ws_2=["app1:hosts:read", "inventory:hosts:write"],
         )
@@ -2376,17 +2436,17 @@ class DualWriteCustomRolesTestCase(DualWriteTestCase):
         role = self.expect_1_v2_role_with_permissions(["app1:hosts:read", "inventory:hosts:write"])
 
         self.expect_num_role_bindings(1)
-        self.expect_1_role_binding_to_workspace("ws_2", for_v2_roles=[role], for_groups=[])
+        self.expect_1_role_binding_to_workspace(self.ws_2_id, for_v2_roles=[role], for_groups=[])
 
     def test_two_roles_with_same_resource_permissions_create_two_v2_roles(self):
         """Create two v2 roles when two roles have the same resource permissions across different resources."""
-        self.given_v1_role(
+        self.given_v1_role_on_test_workspaces(
             "r1",
             default=["app1:hosts:read", "inventory:hosts:write"],
             ws_2=["app1:hosts:read", "inventory:hosts:write"],
         )
 
-        self.given_v1_role(
+        self.given_v1_role_on_test_workspaces(
             "r2",
             default=["app1:hosts:read", "inventory:hosts:write"],
             ws_2=["app1:hosts:read", "inventory:hosts:write"],
@@ -2396,12 +2456,12 @@ class DualWriteCustomRolesTestCase(DualWriteTestCase):
 
         self.expect_1_role_binding_to_workspace(self.default_workspace(), for_v2_roles=[roles[0]], for_groups=[])
         self.expect_1_role_binding_to_workspace(self.default_workspace(), for_v2_roles=[roles[1]], for_groups=[])
-        self.expect_1_role_binding_to_workspace("ws_2", for_v2_roles=[roles[0]], for_groups=[])
-        self.expect_1_role_binding_to_workspace("ws_2", for_v2_roles=[roles[1]], for_groups=[])
+        self.expect_1_role_binding_to_workspace(self.ws_2_id, for_v2_roles=[roles[0]], for_groups=[])
+        self.expect_1_role_binding_to_workspace(self.ws_2_id, for_v2_roles=[roles[1]], for_groups=[])
 
     def test_unassigned_role_keeps_role_binding(self):
         """Unassigning a role from a group does not remove the role binding."""
-        role = self.given_v1_role(
+        role = self.given_v1_role_on_test_workspaces(
             "r1",
             default=["app1:hosts:read", "inventory:hosts:write"],
             ws_2=["app1:hosts:read", "inventory:hosts:write"],
@@ -2422,7 +2482,7 @@ class DualWriteCustomRolesTestCase(DualWriteTestCase):
 
     def test_assign_group_no_rolebindngs(self):
         """Test assigning a group to a custom role before RoleBindings have been created for it."""
-        role = self.given_v1_role(
+        role = self.given_v1_role_on_test_workspaces(
             "r1",
             default=["app1:hosts:read", "inventory:hosts:write"],
         )
@@ -2576,6 +2636,17 @@ class DualWriteCustomRolesTestCase(DualWriteTestCase):
 
         with self.assertRaises(DualWriteException):
             self.given_update_to_v1_role(role, default=["inventory:*:*"])
+
+    def test_ignore_out_of_tenant_workspace(self):
+        another_tenant = Tenant.objects.create(tenant_name="another tenant", org_id="23456")
+        bootstrap_result = bootstrap_tenant_for_v2_test(another_tenant)
+
+        role = self.given_v1_role("a role", default=[], **{str(bootstrap_result.root_workspace.id): ["inventory:*:*"]})
+
+        # There should be no binding in the default workspace because there are no permissions there.
+        # There should be no binding in the other tenant's workspace because it should be ignored.
+        self.assertFalse(BindingMapping.objects.filter(role=role).exists())
+        self.assertFalse(RoleBinding.objects.filter(role__v1_source=role).exists())
 
 
 @override_settings(ATOMIC_RETRY_DISABLED=True)

--- a/tests/management/role/test_view.py
+++ b/tests/management/role/test_view.py
@@ -3291,7 +3291,7 @@ class RoleWorkspaceValidationTests(IdentityRequest):
         except Exception as e:
             self.fail(f"validate_role raised an unexpected exception: {e}")
 
-    def test_workspace_validation_non_inventory_app_skipped(self):
+    def test_workspace_validation_non_inventory_app_fails(self):
         """Test that non-inventory applications skip workspace validation."""
         # Create permission for different app
         Permission.objects.create(
@@ -3318,15 +3318,22 @@ class RoleWorkspaceValidationTests(IdentityRequest):
 
         self.request_mock.data = request_data
 
+        from rest_framework import serializers
         from management.role.view import RoleViewSet
 
         viewset = RoleViewSet()
 
-        # Should not raise exception since app is not inventory
-        try:
+        with self.assertRaises(serializers.ValidationError) as context:
             viewset.validate_role(self.request_mock)
-        except Exception as e:
-            self.fail(f"validate_role raised an unexpected exception: {e}")
+
+        error_dict = context.exception.detail
+        self.assertIn("role", error_dict)
+        error_msg = str(error_dict["role"][0])
+        self.assertIn(
+            "user from org 'tenant1_org_id' cannot add permission 'app:groups:read' to workspace outside their org",
+            error_msg,
+        )
+        self.assertIn(f"Invalid workspace IDs: {self.tenant2_workspace.id}", error_msg)
 
     def test_workspace_validation_multiple_resource_definitions(self):
         """Test validation with multiple resourceDefinitions, some valid, some invalid."""
@@ -3420,43 +3427,6 @@ class RoleWorkspaceValidationTests(IdentityRequest):
         self.assertIn("resourceDefinitions", error_dict)
         self.assertIn("attributeFilter", error_dict["resourceDefinitions"][0])
         self.assertIn("This field is required.", error_dict["resourceDefinitions"][0]["attributeFilter"][0])
-
-    @patch("management.role.view.is_resource_a_workspace")
-    def test_workspace_validation_is_resource_workspace_called(self, mock_is_resource_workspace):
-        """Test that is_resource_a_workspace is called with correct parameters."""
-        mock_is_resource_workspace.return_value = False  # Make it return False to skip validation
-
-        request_data = {
-            "name": "test_role",
-            "access": [
-                {
-                    "permission": "inventory:groups:read",
-                    "resourceDefinitions": [
-                        {
-                            "attributeFilter": {
-                                "key": "group.id",
-                                "operation": "equal",
-                                "value": str(self.tenant1_workspace.id),
-                            }
-                        }
-                    ],
-                }
-            ],
-        }
-
-        self.request_mock.data = request_data
-
-        from management.role.view import RoleViewSet
-
-        viewset = RoleViewSet()
-        viewset.validate_role(self.request_mock)
-
-        # Verify is_resource_a_workspace was called with correct parameters
-        mock_is_resource_workspace.assert_called_once_with(
-            "inventory",
-            "groups",
-            {"key": "group.id", "operation": "equal", "value": str(self.tenant1_workspace.id)},
-        )
 
     @patch("management.role.view.get_workspace_ids_from_resource_definition")
     def test_workspace_validation_get_workspace_id_called(self, mock_get_workspace_ids):

--- a/tests/management/workspace/test_service.py
+++ b/tests/management/workspace/test_service.py
@@ -22,8 +22,11 @@ from unittest.mock import Mock, call, patch
 
 from django.test import TestCase
 
-from management.workspace.service import WorkspaceService
-from tests.v2_util import bootstrap_tenant_for_v2_test
+from management.role.v2_model import RoleV2, CustomRoleV2, PlatformRoleV2
+from management.role_binding.model import RoleBinding
+from management.role_binding.service import RoleBindingService
+from tests.util import assert_v2_tuples_consistent
+from tests.v2_util import bootstrap_tenant_for_v2_test, seed_v2_role_from_v1
 
 
 @dataclass
@@ -158,7 +161,14 @@ from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.test.utils import override_settings
 
-from migration_tool.in_memory_tuples import InMemoryTuples, InMemoryRelationReplicator
+from migration_tool.in_memory_tuples import (
+    InMemoryTuples,
+    InMemoryRelationReplicator,
+    all_of,
+    relation,
+    subject_type,
+    resource,
+)
 
 
 @override_settings(ATOMIC_RETRY_DISABLED=True)
@@ -187,6 +197,12 @@ class WorkspaceServiceTestBase(TestCase):
 
         cls.tuples = InMemoryTuples()
         cls.in_memory_replicator = InMemoryRelationReplicator(cls.tuples)
+
+    def tearDown(self):
+        with self.subTest(msg="tuple consistency"):
+            assert_v2_tuples_consistent(test=self, tuples=self.tuples)
+
+        super().tearDown()
 
 
 class WorkspaceServiceCreateTests(WorkspaceServiceTestBase):
@@ -334,6 +350,12 @@ class WorkspaceServiceUpdateTests(WorkspaceServiceTestBase):
         )
 
 
+@override_settings(
+    ATOMIC_RETRY_DISABLED=True,
+    REPLICATION_TO_RELATION_ENABLED=True,
+    ROOT_SCOPE_PERMISSIONS="",
+    TENANT_SCOPE_PERMISSIONS="",
+)
 class WorkspaceServiceDestroyTests(WorkspaceServiceTestBase):
     """Tests for the destroy method"""
 
@@ -356,9 +378,6 @@ class WorkspaceServiceDestroyTests(WorkspaceServiceTestBase):
         self.assertFalse(Workspace.objects.filter(id=self.standard_child_workspace.id).exists())
 
     @override_settings(
-        REPLICATION_TO_RELATION_ENABLED=True,
-        ROOT_SCOPE_PERMISSIONS="",
-        TENANT_SCOPE_PERMISSIONS="",
         REMOVE_NULL_VALUE=False,
     )
     @patch("management.relation_replicator.outbox_replicator.OutboxReplicator.replicate")
@@ -469,6 +488,69 @@ class WorkspaceServiceDestroyTests(WorkspaceServiceTestBase):
             str(workspace_to_keep.id),
             "Remaining binding should be for the kept workspace",
         )
+
+    def _do_test_destroy_with_bindings_v2(self, role: RoleV2):
+        replicator = InMemoryRelationReplicator(self.tuples)
+        binding_service = RoleBindingService(tenant=self.tenant, replicator=replicator)
+        workspace_service = WorkspaceService(replicator=replicator)
+
+        group = Group.objects.create(tenant=self.tenant, name="a group")
+
+        parent_uuid = str(self.standard_workspace.id)
+        child_uuid = str(self.standard_child_workspace.id)
+
+        def assert_workspace_binding_count(workspace_id: str, count: int):
+            self.assertEqual(
+                count, RoleBinding.objects.filter(resource_type="workspace", resource_id=workspace_id).count()
+            )
+
+            self.assertEqual(
+                count,
+                self.tuples.count_tuples(
+                    all_of(
+                        resource("rbac", "workspace", workspace_id),
+                        relation("binding"),
+                        subject_type("rbac", "role_binding"),
+                    )
+                ),
+            )
+
+        def assert_bindings(parent_count: int, child_count: int):
+            # Check both parent and child workspaces to ensure that we don't accidentally delete anything from the
+            # parent.
+            assert_workspace_binding_count(parent_uuid, parent_count)
+            assert_workspace_binding_count(child_uuid, child_count)
+
+        binding_service.update_role_bindings_for_subject(
+            resource_type="workspace",
+            resource_id=str(self.standard_workspace.id),
+            subject_type="group",
+            subject_id=str(group.uuid),
+            role_ids=[str(role.uuid)],
+        )
+
+        binding_service.update_role_bindings_for_subject(
+            resource_type="workspace",
+            resource_id=str(self.standard_child_workspace.id),
+            subject_type="group",
+            subject_id=str(group.uuid),
+            role_ids=[str(role.uuid)],
+        )
+
+        assert_bindings(parent_count=1, child_count=1)
+
+        workspace_service.destroy(self.standard_child_workspace)
+        assert_bindings(1, 0)
+
+    def test_destroy_with_seeded_bindings_v2(self):
+        public_tenant = Tenant.objects.get(tenant_name="public")
+        v1_role = Role.objects.create(tenant=public_tenant, name="system role", system=True)
+
+        self._do_test_destroy_with_bindings_v2(seed_v2_role_from_v1(v1_role))
+
+    def test_destroy_with_custom_bindings_v2(self):
+        role = CustomRoleV2.objects.create(tenant=self.tenant, name="a role")
+        self._do_test_destroy_with_bindings_v2(role)
 
 
 class WorkspaceHierarchyTests(WorkspaceServiceTestBase):

--- a/tests/management/workspace/test_service.py
+++ b/tests/management/workspace/test_service.py
@@ -22,9 +22,12 @@ from unittest.mock import Mock, call, patch
 
 from django.test import TestCase
 
+from management.group.relation_api_dual_write_group_handler import RelationApiDualWriteGroupHandler
 from management.role.v2_model import RoleV2, CustomRoleV2, PlatformRoleV2
 from management.role_binding.model import RoleBinding
 from management.role_binding.service import RoleBindingService
+from management.tenant_mapping.v2_activation import ensure_v2_write_activated
+from tests.management.role.test_dual_write import RbacFixture
 from tests.util import assert_v2_tuples_consistent
 from tests.v2_util import bootstrap_tenant_for_v2_test, seed_v2_role_from_v1
 
@@ -488,6 +491,66 @@ class WorkspaceServiceDestroyTests(WorkspaceServiceTestBase):
             str(workspace_to_keep.id),
             "Remaining binding should be for the kept workspace",
         )
+
+    @patch("management.relation_replicator.outbox_replicator.OutboxReplicator.replicate")
+    def test_destroy_custom_role_v2(self, replicate):
+        """Test that bindings from a V1 custom role are properly deleted in a tenant migrated to V2."""
+        replicate.side_effect = self.in_memory_replicator.replicate
+
+        workspace = Workspace.objects.create(name="a workspace", tenant=self.tenant)
+
+        def assert_binding_exists(value: bool):
+            self.assertEqual(
+                int(value),
+                self.tuples.count_tuples(
+                    all_of(resource("rbac", "workspace", str(workspace.id)), relation("binding"))
+                ),
+            )
+
+            self.assertEqual(
+                value,
+                BindingMapping.objects.filter(
+                    resource_type_namespace="rbac",
+                    resource_type_name="workspace",
+                    resource_id=str(workspace.id),
+                    role=custom_role,
+                ).exists(),
+            )
+
+            self.assertEqual(
+                value,
+                RoleBinding.objects.filter(
+                    resource_type="workspace",
+                    resource_id=str(workspace.id),
+                    role__v1_source=custom_role,
+                ).exists(),
+            )
+
+        assert_binding_exists(False)
+
+        fixture = RbacFixture()
+        custom_role = fixture.new_custom_role(
+            "custom role", fixture.workspace_access(default=[], **{str(workspace.id): ["rbac:*:*"]}), self.tenant
+        )
+        group, _ = fixture.new_group("a group", self.tenant, ["p1"])
+
+        RelationApiDualWriteHandler(
+            role=custom_role, event_type=ReplicationEventType.CREATE_CUSTOM_ROLE
+        ).replicate_new_or_updated_role(custom_role)
+
+        group_handler = RelationApiDualWriteGroupHandler(group=group, event_type=ReplicationEventType.ASSIGN_ROLE)
+        group_handler.generate_relations_reset_roles([custom_role])
+        group_handler.replicate()
+
+        ensure_v2_write_activated(self.tenant)
+
+        assert_binding_exists(True)
+
+        # This should remove the binding (including both the BindingMapping and RoleBinding models), despite the tenant
+        # having been migrated to V2.
+        self.service.destroy(workspace)
+
+        assert_binding_exists(False)
 
     def _do_test_destroy_with_bindings_v2(self, role: RoleV2):
         replicator = InMemoryRelationReplicator(self.tuples)

--- a/tests/management/workspace/test_service.py
+++ b/tests/management/workspace/test_service.py
@@ -499,6 +499,22 @@ class WorkspaceServiceDestroyTests(WorkspaceServiceTestBase):
 
         workspace = Workspace.objects.create(name="a workspace", tenant=self.tenant)
 
+        fixture = RbacFixture()
+        custom_role = fixture.new_custom_role(
+            "custom role", fixture.workspace_access(default=[], **{str(workspace.id): ["rbac:*:*"]}), self.tenant
+        )
+        group, _ = fixture.new_group("a group", self.tenant, ["p1"])
+
+        RelationApiDualWriteHandler(
+            role=custom_role, event_type=ReplicationEventType.CREATE_CUSTOM_ROLE
+        ).replicate_new_or_updated_role(custom_role)
+
+        group_handler = RelationApiDualWriteGroupHandler(group=group, event_type=ReplicationEventType.ASSIGN_ROLE)
+        group_handler.generate_relations_reset_roles([custom_role])
+        group_handler.replicate()
+
+        ensure_v2_write_activated(self.tenant)
+
         def assert_binding_exists(value: bool):
             self.assertEqual(
                 int(value),
@@ -525,24 +541,6 @@ class WorkspaceServiceDestroyTests(WorkspaceServiceTestBase):
                     role__v1_source=custom_role,
                 ).exists(),
             )
-
-        assert_binding_exists(False)
-
-        fixture = RbacFixture()
-        custom_role = fixture.new_custom_role(
-            "custom role", fixture.workspace_access(default=[], **{str(workspace.id): ["rbac:*:*"]}), self.tenant
-        )
-        group, _ = fixture.new_group("a group", self.tenant, ["p1"])
-
-        RelationApiDualWriteHandler(
-            role=custom_role, event_type=ReplicationEventType.CREATE_CUSTOM_ROLE
-        ).replicate_new_or_updated_role(custom_role)
-
-        group_handler = RelationApiDualWriteGroupHandler(group=group, event_type=ReplicationEventType.ASSIGN_ROLE)
-        group_handler.generate_relations_reset_roles([custom_role])
-        group_handler.replicate()
-
-        ensure_v2_write_activated(self.tenant)
 
         assert_binding_exists(True)
 

--- a/tests/management/workspace/test_view.py
+++ b/tests/management/workspace/test_view.py
@@ -24,7 +24,7 @@ from uuid import uuid4
 
 from django.conf import settings
 from django.core.exceptions import ValidationError
-from django.db import OperationalError
+from django.db import OperationalError, transaction
 from django.test.utils import override_settings
 from django.urls import clear_url_caches
 from importlib import reload
@@ -51,6 +51,7 @@ from migration_tool.utils import create_relationship
 from api.models import Tenant
 from rbac import urls
 from tests.identity_request import IdentityRequest, TransactionalIdentityRequest
+from tests.v2_util import bootstrap_tenant_for_v2_test
 
 
 class BasicWorkspaceViewTests:
@@ -103,18 +104,11 @@ class WorkspaceViewTests(IdentityRequest, BasicWorkspaceViewTests):
         self.tenant.save()
 
         self.service = WorkspaceService()
-        self.root_workspace = Workspace.objects.create(
-            name="Root Workspace",
-            tenant=self.tenant,
-            type=Workspace.Types.ROOT,
-        )
-        self.default_workspace = Workspace.objects.create(
-            tenant=self.tenant,
-            type=Workspace.Types.DEFAULT,
-            name="Default Workspace",
-            description="Default Description",
-            parent_id=self.root_workspace.id,
-        )
+
+        bootstrap_result = bootstrap_tenant_for_v2_test(self.tenant)
+        self.default_workspace = bootstrap_result.default_workspace
+        self.root_workspace = bootstrap_result.root_workspace
+
         self.ungrouped_workspace = Workspace.objects.create(
             name="Ungrouped Hosts Workspace",
             description="Ungrouped Hosts Workspace - description",
@@ -145,6 +139,7 @@ class WorkspaceViewTests(IdentityRequest, BasicWorkspaceViewTests):
         PRINCIPAL_CACHE.delete_all_principals_for_tenant(self.tenant.org_id)
 
 
+@override_settings(ATOMIC_RETRY_DISABLED=True)
 class TransactionalWorkspaceViewTests(TransactionalIdentityRequest, BasicWorkspaceViewTests):
     @override_settings(WORKSPACE_HIERARCHY_DEPTH_LIMIT=10)
     def setUp(self):
@@ -155,18 +150,12 @@ class TransactionalWorkspaceViewTests(TransactionalIdentityRequest, BasicWorkspa
         self.tenant.save()
 
         self.service = WorkspaceService()
-        self.root_workspace = Workspace.objects.create(
-            name="Root Workspace",
-            tenant=self.tenant,
-            type=Workspace.Types.ROOT,
-        )
-        self.default_workspace = Workspace.objects.create(
-            tenant=self.tenant,
-            type=Workspace.Types.DEFAULT,
-            name="Default Workspace",
-            description="Default Description",
-            parent_id=self.root_workspace.id,
-        )
+
+        with transaction.atomic():
+            bootstrap_result = bootstrap_tenant_for_v2_test(self.tenant)
+            self.default_workspace = bootstrap_result.default_workspace
+            self.root_workspace = bootstrap_result.root_workspace
+
         self.ungrouped_workspace = Workspace.objects.create(
             name="Ungrouped Hosts Workspace",
             description="Ungrouped Hosts Workspace - description",
@@ -197,7 +186,12 @@ class TransactionalWorkspaceViewTests(TransactionalIdentityRequest, BasicWorkspa
         PRINCIPAL_CACHE.delete_all_principals_for_tenant(self.tenant.org_id)
 
 
-@override_settings(V2_APIS_ENABLED=True, WORKSPACE_HIERARCHY_DEPTH_LIMIT=100, WORKSPACE_RESTRICT_DEFAULT_PEERS=False)
+@override_settings(
+    ATOMIC_RETRY_DISABLED=True,
+    V2_APIS_ENABLED=True,
+    WORKSPACE_HIERARCHY_DEPTH_LIMIT=100,
+    WORKSPACE_RESTRICT_DEFAULT_PEERS=False,
+)
 class WorkspaceTestsCreateUpdateDelete(TransactionalWorkspaceViewTests):
     """Tests for create/update/delete workspaces."""
 
@@ -1802,7 +1796,7 @@ class WorkspaceTestsCreateUpdateDelete(TransactionalWorkspaceViewTests):
             client.post(url, data, format="json", **self.headers)
 
 
-@override_settings(V2_APIS_ENABLED=True, WORKSPACE_HIERARCHY_DEPTH_LIMIT=5)
+@override_settings(ATOMIC_RETRY_DISABLED=True, V2_APIS_ENABLED=True, WORKSPACE_HIERARCHY_DEPTH_LIMIT=5)
 class WorkspaceMove(TransactionalWorkspaceViewTests):
     """Tests for move workspace."""
 
@@ -2678,7 +2672,7 @@ class WorkspaceMove(TransactionalWorkspaceViewTests):
         self.assertEqual(response["Retry-After"], "1")
 
 
-@override_settings(V2_APIS_ENABLED=True)
+@override_settings(ATOMIC_RETRY_DISABLED=True, V2_APIS_ENABLED=True)
 class WorkspaceTestsList(WorkspaceViewTests):
     """Tests for listing workspaces."""
 
@@ -3258,7 +3252,7 @@ class WorkspaceTestsList(WorkspaceViewTests):
         self.assertNotIn(str(self.default_workspace.id), returned_ids)
 
 
-@override_settings(V2_APIS_ENABLED=True)
+@override_settings(ATOMIC_RETRY_DISABLED=True, V2_APIS_ENABLED=True)
 class WorkspaceTestsDetail(WorkspaceViewTests):
     """Tests for get workspace detail."""
 
@@ -3432,7 +3426,7 @@ class WorkspaceTestsDetail(WorkspaceViewTests):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
 
-@override_settings(V2_APIS_ENABLED=False)
+@override_settings(ATOMIC_RETRY_DISABLED=True, V2_APIS_ENABLED=False)
 class WorkspaceViewTestsV2Disabled(WorkspaceViewTests):
     def test_get_workspace_list(self):
         """Test for accessing v2 APIs which should be disabled by default."""
@@ -3443,7 +3437,7 @@ class WorkspaceViewTestsV2Disabled(WorkspaceViewTests):
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
 
-@override_settings(WORKSPACE_HIERARCHY_DEPTH_LIMIT=2, V2_APIS_ENABLED=True)
+@override_settings(ATOMIC_RETRY_DISABLED=True, WORKSPACE_HIERARCHY_DEPTH_LIMIT=2, V2_APIS_ENABLED=True)
 class WorkspaceViewTestsWithHierarchyLimit(TransactionalWorkspaceViewTests):
     """Test workspace hierarchy limits."""
 
@@ -3471,7 +3465,7 @@ class WorkspaceViewTestsWithHierarchyLimit(TransactionalWorkspaceViewTests):
         self.assertEqual(response.get("content-type"), "application/problem+json")
 
 
-@override_settings(WORKSPACE_RESTRICT_DEFAULT_PEERS=True, V2_APIS_ENABLED=True)
+@override_settings(ATOMIC_RETRY_DISABLED=True, WORKSPACE_RESTRICT_DEFAULT_PEERS=True, V2_APIS_ENABLED=True)
 class WorkspaceViewTestsWithPeerRestrictions(TransactionalWorkspaceViewTests):
     """Test workspace peer restrictions."""
 

--- a/tests/management/workspace/test_workspace_inventory_access.py
+++ b/tests/management/workspace/test_workspace_inventory_access.py
@@ -23,6 +23,7 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, Mock, patch
 from uuid import uuid4
 
+from django.db import transaction
 from django.test import TransactionTestCase
 from django.test.utils import override_settings
 from django.urls import clear_url_caches, reverse
@@ -53,6 +54,7 @@ from tests.identity_request import BaseIdentityRequest
 
 from api.models import Tenant
 from rbac import urls
+from tests.v2_util import bootstrap_tenant_for_v2_test
 
 
 class TransactionIdentityRequest(BaseIdentityRequest, TransactionTestCase):
@@ -65,6 +67,7 @@ class TransactionIdentityRequest(BaseIdentityRequest, TransactionTestCase):
     pass
 
 
+@override_settings(ATOMIC_RETRY_DISABLED=True)
 @override_settings(V2_APIS_ENABLED=True, WORKSPACE_HIERARCHY_DEPTH_LIMIT=10)
 @override_settings(WORKSPACE_ACCESS_CHECK_V2_ENABLED=True)
 class WorkspaceInventoryAccessV2Tests(TransactionIdentityRequest):
@@ -78,18 +81,12 @@ class WorkspaceInventoryAccessV2Tests(TransactionIdentityRequest):
         self.tenant.save()
 
         self.service = WorkspaceService()
-        self.root_workspace = Workspace.objects.create(
-            name="Root Workspace",
-            tenant=self.tenant,
-            type=Workspace.Types.ROOT,
-        )
-        self.default_workspace = Workspace.objects.create(
-            tenant=self.tenant,
-            type=Workspace.Types.DEFAULT,
-            name="Default Workspace",
-            description="Default Description",
-            parent_id=self.root_workspace.id,
-        )
+
+        with transaction.atomic():
+            bootstrap_result = bootstrap_tenant_for_v2_test(self.tenant)
+            self.default_workspace = bootstrap_result.default_workspace
+            self.root_workspace = bootstrap_result.root_workspace
+
         self.ungrouped_workspace = Workspace.objects.create(
             name="Ungrouped Hosts Workspace",
             description="Ungrouped Hosts Workspace - description",

--- a/tests/migration_tool/tests_migrate.py
+++ b/tests/migration_tool/tests_migrate.py
@@ -401,18 +401,31 @@ class MigrateTestTupleStore(TestCase):
         self.o1 = self.fixture.new_tenant("o1")
         self.o2 = self.fixture.new_tenant("o2")
 
+        o1_w1 = Workspace.objects.create(
+            tenant=self.o1.tenant, parent=Workspace.objects.default(tenant=self.o1.tenant), name="o1_w1"
+        )
+
+        o1_w2 = Workspace.objects.create(
+            tenant=self.o1.tenant, parent=Workspace.objects.default(tenant=self.o1.tenant), name="o1_w2"
+        )
+
+        self.o1_w1_id = str(o1_w1.id)
+        self.o1_w2_id = str(o1_w2.id)
+
         # Tenanted objects for o1
         self.o1_r1 = self.fixture.new_custom_role(
             "o1_r1", self.fixture.workspace_access(default=["app5:res5:verb5"]), self.o1.tenant
         )
         self.o1_r2 = self.fixture.new_custom_role(
-            "o1_r2", self.fixture.workspace_access(o1_w1=["app1:res1:verb1"]), self.o1.tenant
+            "o1_r2", self.fixture.workspace_access(**{self.o1_w1_id: ["app1:res1:verb1"]}), self.o1.tenant
         )
         self.o1_r3 = self.fixture.new_custom_role(
             "o1_r3",
             self.fixture.workspace_access(
-                o1_w1=["app2:res2:verb2"],
-                o1_w2=["app2:res2:verb2", "app3:res3:verb3"],
+                **{
+                    self.o1_w1_id: ["app2:res2:verb2"],
+                    self.o1_w2_id: ["app2:res2:verb2", "app3:res3:verb3"],
+                }
             ),
             self.o1.tenant,
         )
@@ -533,7 +546,7 @@ class MigrateTestTupleStore(TestCase):
         # 4
         self.assertTrue(
             self.relations.find_tuples(
-                all_of(resource("rbac", "workspace", "o1_w1"), relation("binding"))
+                all_of(resource("rbac", "workspace", self.o1_w1_id), relation("binding"))
             ).traverse_subject(
                 [
                     all_of(
@@ -549,7 +562,7 @@ class MigrateTestTupleStore(TestCase):
         # 3
         self.assertTrue(
             self.relations.find_tuples(
-                all_of(resource("rbac", "workspace", "o1_w1"), relation("binding"))
+                all_of(resource("rbac", "workspace", self.o1_w1_id), relation("binding"))
             ).traverse_subject(
                 [
                     all_of(
@@ -564,7 +577,7 @@ class MigrateTestTupleStore(TestCase):
         # 4
         self.assertTrue(
             self.relations.find_tuples(
-                all_of(resource("rbac", "workspace", "o1_w2"), relation("binding"))
+                all_of(resource("rbac", "workspace", self.o1_w2_id), relation("binding"))
             ).traverse_subject(
                 [
                     all_of(


### PR DESCRIPTION
## Link(s) to Jira
[RHCLOUD-46122](https://redhat.atlassian.net/browse/RHCLOUD-46122)

## Description of Intent of Change(s)
We need to delete role bindings that belong to a workspace when deleting the workspace.

To make sure there's no race conditions, during custom role creation, we also need to (1) check that _all_ workspaces we're binding to exist and (2) lock all of those workspaces.

Part (1) means that we end up having to update a bunch of tests to actually create workspaces before trying to put role bindings in them. It also means that we have to check for workspace existence for _all_ resource definitions, not just those for `inventory` permissions.

[RHCLOUD-46122]: https://redhat.atlassian.net/browse/RHCLOUD-46122?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ