### PR TITLE
Return subject type by default

### DIFF
--- a/docs/source/specs/typespec/main.tsp
+++ b/docs/source/specs/typespec/main.tsp
@@ -713,7 +713,7 @@ namespace Workspaces {
 @tag("Role Bindings")
 @doc("Operations about role bindings")
 namespace RoleBindings {
-    const DefaultRoleBindingBySubjectFieldMask: FieldMask = "resource(id),subject(id),roles(id)";
+    const DefaultRoleBindingBySubjectFieldMask: FieldMask = "resource(id),subject(id,type),roles(id)";
 
     @doc("Subject kind for create/batch, by-subject, and list filters on the binding's subject (group UUID or user/principal UUID). Does not include principal as a separate type string; for external user ID use GET /role-bindings/ with granted_subject_type=principal and granted_subject.principal.user_id.")
     enum BindingSubjectType {

--- a/rbac/management/role_binding/serializer.py
+++ b/rbac/management/role_binding/serializer.py
@@ -833,7 +833,9 @@ class RoleBindingFieldMaskingMixin:
     * Default (no ``field_selection``): subject returns ``id`` + ``type``;
       roles returns ``id`` only; resource returns ``id`` only.
     * With ``field_selection``: only explicitly requested fields appear
-      and unrequested top-level sections are stripped entirely.
+      and unrequested top-level sections are stripped entirely. Subject
+      objects always include ``type`` (OpenAPI discriminator for
+      UserSubject | GroupSubject) even when not listed in ``fields``.
     """
 
     def __init__(self, *args, **kwargs):
@@ -870,8 +872,8 @@ class RoleBindingFieldMaskingMixin:
         subject = {}
         subject_fields = field_selection.get_nested("subject")
 
-        if "type" in subject_fields:
-            subject["type"] = subject_type
+        # UserSubject / GroupSubject require ``type`` for valid JSON and generated clients.
+        subject["type"] = subject_type
         if "id" in subject_fields:
             subject["id"] = subject_obj.uuid
 
@@ -968,7 +970,7 @@ class UpdateRoleBindingRequestSerializer(RoleBindingInputSerializerMixin, serial
     sanitization (``to_internal_value``) and ``validate_fields``.
     """
 
-    DEFAULT_FIELDS = "resource(id),subject(id),roles(id)"
+    DEFAULT_FIELDS = "resource(id),subject(id,type),roles(id)"
 
     # Query parameters
     resource_id = serializers.CharField(required=True, help_text="Resource ID to update bindings for")

--- a/tests/management/role_binding/test_serializer.py
+++ b/tests/management/role_binding/test_serializer.py
@@ -1989,22 +1989,22 @@ class UpdateRoleBindingResponseSerializerTests(IdentityRequest):
         self.assertEqual(data, {"resource": {"name": "My Workspace", "type": "workspace"}})
 
     def test_field_selection_subject_id(self):
-        """Requesting subject(id) returns only id."""
+        """Requesting subject(id) returns id and always-included type discriminator."""
         result = self._make_group_result()
         field_selection = RoleBindingBySubjectFieldSelection(nested_fields={"subject": {"id"}})
         serializer = UpdateRoleBindingResponseSerializer(result, context={"field_selection": field_selection})
         data = serializer.data
 
-        self.assertEqual(data, {"subject": {"id": self.group.uuid}})
+        self.assertEqual(data, {"subject": {"id": self.group.uuid, "type": "group"}})
 
     def test_field_selection_subject_without_id(self):
-        """When only subject(group.name) is requested, only group details appear."""
+        """When only subject(group.name) is requested, type plus group details appear."""
         result = self._make_group_result()
         field_selection = RoleBindingBySubjectFieldSelection(nested_fields={"subject": {"group.name"}})
         serializer = UpdateRoleBindingResponseSerializer(result, context={"field_selection": field_selection})
         data = serializer.data
 
-        self.assertEqual(data, {"subject": {"group": {"name": "test_group"}}})
+        self.assertEqual(data, {"subject": {"type": "group", "group": {"name": "test_group"}}})
 
     def test_field_selection_group_details(self):
         """Requesting subject(group.name,group.description,group.user_count) returns only those."""
@@ -2018,7 +2018,12 @@ class UpdateRoleBindingResponseSerializerTests(IdentityRequest):
 
         self.assertEqual(
             data,
-            {"subject": {"group": {"name": "test_group", "description": "A test group", "user_count": 3}}},
+            {
+                "subject": {
+                    "type": "group",
+                    "group": {"name": "test_group", "description": "A test group", "user_count": 3},
+                }
+            },
         )
 
     def test_field_selection_user_details(self):
@@ -2030,7 +2035,7 @@ class UpdateRoleBindingResponseSerializerTests(IdentityRequest):
 
         self.assertEqual(
             data,
-            {"subject": {"id": self.principal.uuid, "user": {"username": "testuser"}}},
+            {"subject": {"id": self.principal.uuid, "type": "user", "user": {"username": "testuser"}}},
         )
 
     def test_field_selection_resource_id_only(self):

--- a/tests/management/role_binding/test_view.py
+++ b/tests/management/role_binding/test_view.py
@@ -3846,7 +3846,7 @@ class UpdateRoleBindingsBySubjectAPITests(IdentityRequest):
         actual["roles"] = sorted(actual["roles"], key=lambda r: str(r["id"]))
         expected_roles = sorted([{"id": self.role1.uuid}, {"id": self.role2.uuid}], key=lambda r: str(r["id"]))
         expected = {
-            "subject": {"id": self.group.uuid},
+            "subject": {"id": self.group.uuid, "type": "group"},
             "roles": expected_roles,
             "resource": {"id": str(self.workspace.id)},
         }
@@ -3896,7 +3896,7 @@ class UpdateRoleBindingsBySubjectAPITests(IdentityRequest):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         expected = {
-            "subject": {"id": self.principal.uuid},
+            "subject": {"id": self.principal.uuid, "type": "user"},
             "roles": [{"id": self.role1.uuid}],
             "resource": {"id": str(self.workspace.id)},
         }
@@ -3932,7 +3932,7 @@ class UpdateRoleBindingsBySubjectAPITests(IdentityRequest):
 
         # Should only have role2 (role1 was replaced)
         expected = {
-            "subject": {"id": self.group.uuid},
+            "subject": {"id": self.group.uuid, "type": "group"},
             "roles": [{"id": self.role2.uuid}],
             "resource": {"id": str(self.workspace.id)},
         }
@@ -4211,7 +4211,7 @@ class UpdateRoleBindingsBySubjectAPITests(IdentityRequest):
 
         # Only one binding should be created despite the duplicate
         expected = {
-            "subject": {"id": self.group.uuid},
+            "subject": {"id": self.group.uuid, "type": "group"},
             "roles": [{"id": self.role1.uuid}],
             "resource": {"id": str(self.workspace.id)},
         }


### PR DESCRIPTION
## Link(s) to Jira
- 

## Description of Intent of Change(s)
Type is not included in the response

## Local Testing
Unit test

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Ensure role binding responses always include the subject type discriminator and align API defaults and documentation with this behavior.

Enhancements:
- Always include the subject type discriminator in serialized role binding subject data, even when not explicitly requested in field selection.
- Update default role binding by-subject field mask to include subject type in both serializer configuration and shared TypeSpec.
- Clarify serializer documentation around field selection behavior and subject type inclusion as an OpenAPI discriminator.

Documentation:
- Align role binding TypeSpec documentation to reflect the default inclusion of subject type in the subject field mask.

Tests:
- Update role binding serializer and view tests to expect subject type in responses and verify its presence across field selection scenarios.