### PR TITLE
RHCLOUD-46814: Deleted workspace binding migration

### DIFF
--- a/rbac/internal/migrations/remove_deleted_workspace_bindings.py
+++ b/rbac/internal/migrations/remove_deleted_workspace_bindings.py
@@ -34,6 +34,7 @@ def _handle_role_binding_batch(tenant: Tenant, raw_bindings: list[RoleBinding], 
         .filter(resource_type="workspace")
         .filter(~Exists(Workspace.objects.filter(id=Cast(OuterRef("resource_id"), UUIDField()))))
         .exclude(uuid__in=bootstrap_lock.tenant_mapping.role_binding_ids())
+        .prefetch_related("group_entries", "principal_entries")
         .select_for_update()
     )
 

--- a/rbac/internal/migrations/remove_deleted_workspace_bindings.py
+++ b/rbac/internal/migrations/remove_deleted_workspace_bindings.py
@@ -1,0 +1,74 @@
+import itertools
+from typing import Optional
+
+from django.conf import settings
+from django.db.models import Exists, OuterRef, UUIDField
+from django.db.models.functions import Cast
+
+from api.models import Tenant
+from management.atomic_transactions import atomic, atomic_with_retry
+from management.relation_replicator.outbox_replicator import OutboxReplicator
+from management.relation_replicator.relation_replicator import (
+    RelationReplicator,
+    ReplicationEvent,
+    ReplicationEventType,
+    PartitionKey,
+)
+from management.role_binding.model import RoleBinding
+from management.tenant_service.v2 import lock_tenant_for_bootstrap
+from management.workspace.model import Workspace
+
+
+@atomic_with_retry(retries=3)
+def _handle_role_binding_batch(tenant: Tenant, raw_bindings: list[RoleBinding], replicator: RelationReplicator):
+    bootstrap_lock = lock_tenant_for_bootstrap(tenant)
+
+    # Exclude any default access bindings here due to paranoia, even though they should never end up referencing a
+    # deleted workspace.
+    #
+    # The workspaces subquery here synchronizes with workspaces being created in a SERIALIZABLE transaction in
+    # WorkspaceService.
+    role_bindings = list(
+        RoleBinding.objects.filter(pk__in=(b.pk for b in raw_bindings))
+        .filter(tenant=tenant)
+        .filter(resource_type="workspace")
+        .filter(~Exists(Workspace.objects.filter(id=Cast(OuterRef("resource_id"), UUIDField()))))
+        .exclude(uuid__in=bootstrap_lock.tenant_mapping.role_binding_ids())
+        .select_for_update()
+    )
+
+    for tuples_batch in itertools.batched(
+        itertools.chain.from_iterable(rb.all_tuples() for rb in role_bindings), 1000
+    ):
+        replicator.replicate(
+            ReplicationEvent(
+                event_type=ReplicationEventType.REMOVE_DELETED_WORKSPACE_BINDINGS,
+                partition_key=PartitionKey.byEnvironment(),
+                remove=list(tuples_batch),
+                info={"org_id": tenant.org_id},
+            )
+        )
+
+    RoleBinding.objects.filter(pk__in=(rb.pk for rb in role_bindings)).delete()
+
+
+def remove_deleted_workspace_bindings(replicator: Optional[RelationReplicator] = None):
+    """Remove RoleBindings that are bound to a workspace that no longer exists."""
+    if replicator is None:
+        replicator = OutboxReplicator()
+
+    if not settings.REPLICATION_TO_RELATION_ENABLED:
+        raise RuntimeError("Cannot remove bindings without replicating.")
+
+    missing_workspace_bindings = (
+        RoleBinding.objects.filter(resource_type="workspace")
+        .filter(~Exists(Workspace.objects.filter(id=Cast(OuterRef("resource_id"), UUIDField()))))
+        .order_by("tenant")
+    )
+
+    for binding_batch in itertools.batched(missing_workspace_bindings.iterator(), 1000):
+        for tenant, tenant_bindings in itertools.groupby(binding_batch, lambda w: w.tenant):
+            _handle_role_binding_batch(tenant=tenant, raw_bindings=list(tenant_bindings), replicator=replicator)
+
+    # There are not currently any BindingMappings that reference deleted workspaces, so we don't have to handle them
+    # here.

--- a/rbac/internal/migrations/remove_orphan_relations.py
+++ b/rbac/internal/migrations/remove_orphan_relations.py
@@ -20,9 +20,6 @@ import logging
 from collections.abc import Callable, Iterable
 from typing import Protocol
 
-import pgtransaction
-from django.db.models import QuerySet
-
 from api.models import Tenant
 from django.db import transaction, OperationalError
 from internal.utils import (
@@ -30,13 +27,12 @@ from internal.utils import (
     iterate_tuples_from_kessel,
     lock_binding_mappings_with_roles_by_uuid,
 )
-from management.atomic_transactions import atomic_block
-from management.role.model import BindingMapping
+from management.atomic_transactions import atomic, atomic_block
 from management.models import Role, Workspace
 from management.relation_replicator.logging_replicator import stringify_spicedb_relationship
 from management.relation_replicator.outbox_replicator import OutboxReplicator
 from management.relation_replicator.relation_replicator import ReplicationEvent, ReplicationEventType, PartitionKey
-from management.role.v2_model import RoleV2, SeededRoleV2
+from management.role.v2_model import RoleV2
 from management.role_binding.model import RoleBinding
 from management.tenant_mapping.model import DefaultAccessType
 from management.tenant_mapping.v2_activation import (
@@ -558,18 +554,14 @@ def _local_workspace_ids_for(tenant: Tenant) -> set[str]:
     return set(str(u) for u in Workspace.objects.filter(tenant=tenant).values_list("id", flat=True))
 
 
+# This synchronizes with workspace creation in WorkspaceService being SERIALIZABLE (ensuring that a workspace we're
+# interested in isn't created after we check).
+@atomic
 def _remove_orphaned_workspace_parent_relations(
     tenant: Tenant, workspace_data: _RemoteWorkspaceData, commit_removal: _CommitRemoval
 ) -> int:
     """Removes any parent relations for workspaces that no longer exist locally, then returns the number removed."""
     remote_ids = workspace_data.workspace_ids()
-
-    # We do not need to lock workspaces locally while doing this. Workspace IDs are always random UUIDs, so there being
-    # a *new* workspace with an ID we are interested in created between the time we check and the time we commit the
-    # removals is virtually impossible.
-    #
-    # There is also no issue if a workspace has been locally deleted but the deletion has not yet been replicated.
-    # It can't be recreated (for the reasons above), and redundantly deleting the relation will have no effect.
 
     existing_local_ids = _local_workspace_ids_for(tenant)
     orphaned_ids = remote_ids - existing_local_ids

--- a/rbac/internal/urls.py
+++ b/rbac/internal/urls.py
@@ -119,6 +119,7 @@ urlpatterns = [
     path("api/utils/rebuild_tenant_workspace_relations/<str:org_id>/", views.rebuild_tenant_workspace_relations),
     path("api/utils/remove_unassigned_system_binding_mappings/", views.remove_unassigned_system_binding_mappings),
     path("api/utils/expire_orphaned_cross_account_requests/", views.expire_orphaned_cross_account_requests),
+    path("api/utils/remove_deleted_workspace_bindings/", views.remove_deleted_workspace_bindings),
 ]
 
 urlpatterns.extend(integration_urlpatterns)

--- a/rbac/internal/views.py
+++ b/rbac/internal/views.py
@@ -92,6 +92,7 @@ from management.tasks import (
     fix_missing_binding_base_tuples_in_worker,
     migrate_binding_scope_in_worker,
     migrate_data_in_worker,
+    remove_deleted_workspace_bindings_in_worker,
     remove_unassigned_system_binding_mappings_in_worker,
     run_migrations_in_worker,
     run_ocm_performance_in_worker,
@@ -2559,3 +2560,21 @@ def expire_orphaned_cross_account_requests(request):
     except Exception as e:
         logger.exception("Error removing orphaned CARs", exc_info=True)
         return JsonResponse({"detail": f"Error removing orphaned CARs: {str(e)}"}, status=500)
+
+
+@require_http_methods(["POST"])
+def remove_deleted_workspace_bindings(request):
+    """
+    Remove RoleBindings that reference workspaces that no longer exist.
+
+        POST /_private/api/utils/remove_deleted_workspace_bindings/
+
+    Returns:
+        JSON response indicating the task has been queued
+    """
+    try:
+        remove_deleted_workspace_bindings_in_worker.delay()
+        return JsonResponse({"message": "Cleanup enqueued in background worker."}, status=202)
+    except Exception as e:
+        logger.exception("Error removing bindings for deleted workspaces", exc_info=True)
+        return JsonResponse({"detail": f"Error removing bindings for deleted workspaces: {str(e)}"}, status=500)

--- a/rbac/management/relation_replicator/relation_replicator.py
+++ b/rbac/management/relation_replicator/relation_replicator.py
@@ -83,6 +83,7 @@ class ReplicationEventType(str, Enum):
     REMOVE_UNASSIGNED_BINDING_MAPPINGS = "remove_unassigned_binding_mappings"
     BATCH_CREATE_ROLE_BINDING = "batch_create_role_binding"
     UPDATE_ROLE_BINDINGS_FOR_SUBJECT = "update_role_bindings_for_subject"
+    REMOVE_DELETED_WORKSPACE_BINDINGS = "remove_deleted_workspace_bindings"
 
 
 class ReplicationEvent:

--- a/rbac/management/tasks.py
+++ b/rbac/management/tasks.py
@@ -161,5 +161,5 @@ def expire_orphaned_cross_account_requests_in_worker():
 
 @shared_task
 def remove_deleted_workspace_bindings_in_worker():
-    """Celery task to expire orphaned cross-account requests."""
+    """Celery task to remove role bindings that reference deleted workspaces."""
     return remove_deleted_workspace_bindings()

--- a/rbac/management/tasks.py
+++ b/rbac/management/tasks.py
@@ -22,6 +22,7 @@ from typing import Optional
 
 from celery import shared_task
 from django.core.management import call_command
+from internal.migrations.remove_deleted_workspace_bindings import remove_deleted_workspace_bindings
 from internal.migrations.remove_orphan_relations import cleanup_tenant_orphan_bindings
 from internal.utils import (
     clean_invalid_workspace_resource_definitions,
@@ -156,3 +157,9 @@ def remove_unassigned_system_binding_mappings_in_worker():
 def expire_orphaned_cross_account_requests_in_worker():
     """Celery task to expire orphaned cross-account requests."""
     return expire_orphaned_cross_account_requests()
+
+
+@shared_task
+def remove_deleted_workspace_bindings_in_worker():
+    """Celery task to expire orphaned cross-account requests."""
+    return remove_deleted_workspace_bindings()

--- a/rbac/management/workspace/service.py
+++ b/rbac/management/workspace/service.py
@@ -29,6 +29,7 @@ from django.db import connection, transaction
 from django.db.models import Q
 from feature_flags import FEATURE_FLAGS
 from internal.utils import get_workspace_ids_from_resource_definition, is_resource_a_workspace
+from management.atomic_transactions import atomic
 from management.models import ResourceDefinition, Role, Workspace
 from management.relation_replicator.relation_replicator import ReplicationEventType
 from management.role.relation_api_dual_write_handler import RelationApiDualWriteHandler
@@ -244,46 +245,44 @@ def update_roles_for_removed_workspace(workspace_id: uuid.UUID) -> int:
 class WorkspaceService:
     """Workspace service."""
 
+    @atomic
     def create(self, validated_data: dict, request_tenant: Tenant) -> Workspace:
         """Create workspace."""
-        with transaction.atomic():
-            try:
-                parent_id = validated_data.get("parent_id")
-                if parent_id is None:
-                    default = Workspace.objects.default(tenant=request_tenant)
-                    parent_id = default.id
-                parent = Workspace.objects.get(id=parent_id)
-                self._enforce_hierarchy_depth(parent_id, request_tenant)
-                if self._check_total_workspace_count_exceeded(request_tenant):
-                    # If two transactions to create workspaces happen at the same time
-                    # both will get the okay to add the workspace
-                    # which could lead to the case where there is an extra workspace over the allowed limit
-                    # locking will have a scalability impact so better not to catch this condition
-                    raise serializers.ValidationError(
-                        "The total number of workspaces allowed for this organization has been exceeded."
-                    )
-
-                workspace = Workspace.objects.create(**validated_data, tenant=parent.tenant)
-                dual_write_handler = RelationApiDualWriteWorkspaceHandler(
-                    workspace, ReplicationEventType.CREATE_WORKSPACE
+        try:
+            parent_id = validated_data.get("parent_id")
+            if parent_id is None:
+                default = Workspace.objects.default(tenant=request_tenant)
+                parent_id = default.id
+            parent = Workspace.objects.get(id=parent_id)
+            self._enforce_hierarchy_depth(parent_id, request_tenant)
+            if self._check_total_workspace_count_exceeded(request_tenant):
+                # If two transactions to create workspaces happen at the same time
+                # both will get the okay to add the workspace
+                # which could lead to the case where there is an extra workspace over the allowed limit
+                # locking will have a scalability impact so better not to catch this condition
+                raise serializers.ValidationError(
+                    "The total number of workspaces allowed for this organization has been exceeded."
                 )
-                dual_write_handler.replicate_new_workspace()
 
-                # After the outbox message is created & committed, LISTEN for a NOTIFY
+            workspace = Workspace.objects.create(**validated_data, tenant=parent.tenant)
+            dual_write_handler = RelationApiDualWriteWorkspaceHandler(workspace, ReplicationEventType.CREATE_WORKSPACE)
+            dual_write_handler.replicate_new_workspace()
 
-                if FEATURE_FLAGS.is_read_your_writes_workspace_enabled() and settings.REPLICATION_TO_RELATION_ENABLED:
-                    transaction.on_commit(lambda: self._wait_for_notify_post_commit(workspace.id))
+            # After the outbox message is created & committed, LISTEN for a NOTIFY
 
-                return workspace
-            except ValidationError as e:
-                message = e.message_dict
-                if hasattr(e, "error_dict") and "__all__" in e.error_dict:
-                    for error in e.error_dict["__all__"]:
-                        for msg in error.messages:
-                            if "unique_workspace_name_per_parent" in msg:
-                                message = "Can't create workspace with same name within same parent workspace"
-                                break
-                raise serializers.ValidationError(message)
+            if FEATURE_FLAGS.is_read_your_writes_workspace_enabled() and settings.REPLICATION_TO_RELATION_ENABLED:
+                transaction.on_commit(lambda: self._wait_for_notify_post_commit(workspace.id))
+
+            return workspace
+        except ValidationError as e:
+            message = e.message_dict
+            if hasattr(e, "error_dict") and "__all__" in e.error_dict:
+                for error in e.error_dict["__all__"]:
+                    for msg in error.messages:
+                        if "unique_workspace_name_per_parent" in msg:
+                            message = "Can't create workspace with same name within same parent workspace"
+                            break
+            raise serializers.ValidationError(message)
 
     def update(self, instance: Workspace, validated_data: dict) -> Workspace:
         """Update workspace."""

--- a/tests/internal/migrations/test_remove_deleted_workspace_bindings.py
+++ b/tests/internal/migrations/test_remove_deleted_workspace_bindings.py
@@ -1,0 +1,81 @@
+from unittest.mock import patch
+
+from django.test import override_settings
+
+from internal.migrations.remove_deleted_workspace_bindings import remove_deleted_workspace_bindings
+from management.role_binding.model import RoleBinding
+from management.role_binding.service import RoleBindingService, CreateBindingRequest
+from management.workspace.model import Workspace
+from management.workspace.service import WorkspaceService
+from migration_tool.in_memory_tuples import InMemoryRelationReplicator, all_of, resource, relation
+from tests.management.role.test_dual_write import DualWriteTestCase
+
+
+@override_settings(ATOMIC_RETRY_DISABLED=True)
+class RemoveDeletedWorkspaceBindingsTest(DualWriteTestCase):
+    @patch("management.relation_replicator.outbox_replicator.OutboxReplicator.replicate")
+    def test_v2_removal(self, replicate):
+        replicator = InMemoryRelationReplicator(self.tuples)
+        replicate.side_effect = replicator.replicate
+
+        workspace_service = WorkspaceService()
+        binding_service = RoleBindingService(tenant=self.tenant)
+
+        workspace_a = workspace_service.create({"name": "Workspace A"}, request_tenant=self.tenant)
+        workspace_b = workspace_service.create({"name": "Workspace B"}, request_tenant=self.tenant)
+
+        system_role = self.given_v1_system_role("system role", ["rbac:*:*"])
+        group, _ = self.given_group("a group", ["p1"])
+
+        def expect_ws_binding_count(workspace_id: str, count: int):
+            self.assertEqual(
+                count,
+                self.tuples.count_tuples(
+                    all_of(
+                        resource("rbac", "workspace", workspace_id),
+                        relation("binding"),
+                    )
+                ),
+            )
+
+            self.expect_role_bindings_to_workspace(
+                count,
+                workspace_id,
+                for_v2_roles=[str(system_role.uuid)],
+                for_groups=[str(group.uuid)],
+            )
+
+            self.assertEqual(
+                count,
+                RoleBinding.objects.filter(resource_type="workspace", resource_id=workspace_id).count(),
+            )
+
+        def expect_binding_counts(a_count: int, b_count: int):
+            expect_ws_binding_count(str(workspace_a.id), a_count)
+            expect_ws_binding_count(str(workspace_b.id), b_count)
+
+        binding_service.batch_create(
+            [
+                CreateBindingRequest(
+                    role_id=str(system_role.uuid),
+                    resource_type="workspace",
+                    resource_id=str(ws.id),
+                    subject_type="group",
+                    subject_id=str(group.uuid),
+                )
+                for ws in [workspace_a, workspace_b]
+            ]
+        )
+
+        expect_binding_counts(1, 1)
+
+        # Simulate workspace A being deleted before RoleBindings were removed for it.
+        Workspace.objects.filter(pk=workspace_a.pk).delete()
+
+        expect_binding_counts(1, 1)
+
+        remove_deleted_workspace_bindings(replicator=replicator)
+
+        # The binding for the deleted workspace A should have been removed, but the binding for the extant
+        # workspace B should still exist.
+        expect_binding_counts(0, 1)

--- a/tests/management/workspace/test_service.py
+++ b/tests/management/workspace/test_service.py
@@ -161,6 +161,7 @@ from django.test.utils import override_settings
 from migration_tool.in_memory_tuples import InMemoryTuples, InMemoryRelationReplicator
 
 
+@override_settings(ATOMIC_RETRY_DISABLED=True)
 class WorkspaceServiceTestBase(TestCase):
     """Base test class"""
 

--- a/tests/management/workspace/test_view.py
+++ b/tests/management/workspace/test_view.py
@@ -90,6 +90,7 @@ class BasicWorkspaceViewTests:
             group.principals.add(principal)
 
 
+@override_settings(ATOMIC_RETRY_DISABLED=True)
 class WorkspaceViewTests(IdentityRequest, BasicWorkspaceViewTests):
     """Test the Workspace view."""
 


### PR DESCRIPTION
## Link(s) to Jira
[RHCLOUD-46814](https://redhat.atlassian.net/browse/RHCLOUD-46814)

## Description of Intent of Change(s)
Add a migration to remove role bindings that reference deleted workspaces.

[RHCLOUD-46814]: https://redhat.atlassian.net/browse/RHCLOUD-46814?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Introduce a migration and supporting infrastructure to clean up role bindings that reference deleted workspaces, ensuring consistency between workspaces, role bindings, and relation tuples.

Bug Fixes:
- Remove role bindings that reference workspaces which no longer exist, preventing stale access references.

Enhancements:
- Add an internal API endpoint and background worker task to enqueue cleanup of bindings for deleted workspaces.
- Extend relation replication with a new event type for removing tuples associated with deleted workspace bindings.
- Make workspace creation and orphaned workspace parent relation cleanup run in atomic transactions aligned with replication behavior.
- Add tests covering the removal of bindings for deleted workspaces and adjust workspace-related tests for atomic retry settings.