### PR TITLE
[RHCLOUD-46830] Deduplicate AGENTS.md and CLAUDE.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,13 +20,83 @@ insights-rbac is a Django REST Framework microservice providing Role-Based Acces
 
 | File | Purpose |
 |------|---------|
-| `CLAUDE.md` | Claude Code-specific commands and behavioral preferences |
+| `CLAUDE.md` | Claude Code-specific behavioral preferences (imports this file via `@AGENTS.md`) |
 | `CONTRIBUTING.md` | Contribution workflow, code style, PR format |
 | `docs/source/specs/v2/openapi.yaml` | V2 API specification (generated) |
 | `docs/source/specs/typespec/main.tsp` | TypeSpec source -- the contract for v2 API changes |
 | `Makefile` | Build, test, migration, and Docker commands |
 | `tox.ini` | Test environments, linting config, env vars for tests |
 | `.pre-commit-config.yaml` | Pre-commit hooks: flake8, black, trailing whitespace, django-upgrade, openapi-spec-validator |
+
+## Common Commands
+
+### Testing
+
+Django's test runner requires **dotted module paths**, not file paths. If `tox` is not on PATH, use `pipenv run tox`.
+
+```bash
+# Run all tests (with coverage)
+pipenv run tox -e py312
+
+# Run all tests without coverage (faster)
+pipenv run tox -e py312-fast
+
+# Run a specific test module
+pipenv run tox -e py312-fast -- tests.management.workspace.test_view
+
+# Run a specific test class
+pipenv run tox -e py312-fast -- tests.management.workspace.test_view.WorkspaceTestsList
+
+# Run a single test method
+pipenv run tox -e py312-fast -- tests.management.workspace.test_view.WorkspaceTestsList.test_workspace_list_unfiltered
+```
+
+### Linting and Formatting
+
+```bash
+pipenv run tox -e lint                             # flake8 + black --check
+pipenv run black -t py312 -l 119 rbac tests        # auto-format
+```
+
+### Local Development
+
+```bash
+# Docker (starts app on port 9080 + postgres + redis + celery)
+make docker-up
+make docker-logs
+make docker-down
+
+# Local Python (app on port 8000, needs Docker for DB)
+make start-db           # Postgres container on port 15432
+make run-migrations
+make serve
+```
+
+### Database
+
+```bash
+make make-migrations     # Generate new migration files
+make run-migrations      # Apply migrations
+make reinitdb            # Drop + recreate + migrate
+psql postgres -U postgres -h localhost -p 15432  # Direct DB access
+```
+
+### OpenAPI Spec
+
+```bash
+make generate_v2_spec    # Regenerate v2 spec from TypeSpec (requires TypeSpec installed in docs/source/specs/typespec/)
+```
+
+### Pre-commit Hooks
+
+The `.pre-commit-config.yaml` enforces:
+- flake8 (line length 120)
+- black (line length 119, target py312, check mode)
+- trailing-whitespace, end-of-file-fixer, debug-statements
+- django-upgrade (target 5.2)
+- openapi-spec-validator
+
+Run manually: `pipenv run pre-commit run --all-files`
 
 ## Key Conventions
 
@@ -41,17 +111,15 @@ insights-rbac is a Django REST Framework microservice providing Role-Based Acces
 
 ### Testing
 
-- **Test runner**: Django requires dotted module paths, not file paths. `pipenv run tox -e py312-fast` for fast iteration (no coverage). `pipenv run tox -e py312` for full coverage.
 - **Base classes**: Use `IdentityRequest` from `tests/identity_request.py` (provides tenant, identity headers, request context). Use `TransactionalIdentityRequest` for tests involving `pgtransaction.atomic(retry=...)` or `select_for_update`.
 - **V2 test setup**: Apply `@override_settings(V2_APIS_ENABLED=True)`, reload URLs with `reload(urls)` + `clear_url_caches()` in setUp, bootstrap tenant with `bootstrap_tenant_for_v2_test()`, mock Kessel permission checks.
 - **Parallel execution**: Tests run with `--parallel` and `--failfast`. Clean up created objects in `tearDown` since tests share the database.
 - **Mocking**: Always mock Kafka (`MOCK_KAFKA=True` is set in tox.ini), Kessel Inventory, and outbox replicator. Never mock Django ORM queries, serializer validation, or URL routing.
 
-### Code Style and Formatting
+### Code Style
 
-- **Black**: line length 119, target py312. Run `pipenv run black -t py312 -l 119 rbac tests`.
+- **Black**: line length 119, target py312.
 - **Flake8**: max line length 120, ignores D106/W503/C901, excludes migrations.
-- **Pre-commit hooks**: flake8, black (check mode), trailing-whitespace, end-of-file-fixer, debug-statements, django-upgrade (target 5.2), openapi-spec-validator.
 - **Import order**: PyCharm style (`flake8-import-order`), application imports are `rbac` and `api`.
 
 ### Commit Messages
@@ -72,21 +140,6 @@ Conventional commits format: `type(scope): short description in lowercase`. Type
 
 ### Database Migrations
 
-- Generate: `make make-migrations`
-- Apply: `make run-migrations`
-- Reset: `make reinitdb` (drops and recreates)
 - Migrations are excluded from linting and coverage.
 - Always test migrations against real PostgreSQL -- SQLite is not used.
 - New models should use UUID v7 as primary key (`uuid_utils.compat.uuid7`).
-
-### Local Development
-
-```bash
-# Docker full stack (port 9080 + postgres + redis + celery)
-make docker-up
-
-# Local python (port 8000, needs Docker DB on port 15432)
-make start-db
-make run-migrations
-make serve
-```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,75 +2,9 @@
 
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository. Architecture, patterns, and domain guidelines are in AGENTS.md and the docs/*-guidelines.md files -- this file contains only Claude Code-specific commands and behaviors.
+Claude Code-specific behavioral preferences. Architecture, commands, and conventions are in AGENTS.md.
 
-## Common Commands
-
-### Testing
-
-Django's test runner requires **dotted module paths**, not file paths. If `tox` is not on PATH, use `pipenv run tox`.
-
-```bash
-# Run all tests (with coverage)
-pipenv run tox -e py312
-
-# Run all tests without coverage (faster)
-pipenv run tox -e py312-fast
-
-# Run a specific test module
-pipenv run tox -e py312-fast -- tests.management.workspace.test_view
-
-# Run a specific test class
-pipenv run tox -e py312-fast -- tests.management.workspace.test_view.WorkspaceTestsList
-
-# Run a single test method
-pipenv run tox -e py312-fast -- tests.management.workspace.test_view.WorkspaceTestsList.test_workspace_list_unfiltered
-```
-
-### Linting and Formatting
-```bash
-pipenv run tox -e lint                             # flake8 + black --check
-pipenv run black -t py312 -l 119 rbac tests        # auto-format
-```
-
-### Local Development
-```bash
-# Docker (starts app on port 9080 + postgres + redis + celery)
-make docker-up
-make docker-logs
-make docker-down
-
-# Local python (app on port 8000, needs Docker for DB)
-make start-db           # Postgres container on port 15432
-make run-migrations
-make serve
-```
-
-### Database
-```bash
-make make-migrations     # Generate new migration files
-make run-migrations      # Apply migrations
-make reinitdb            # Drop + recreate + migrate
-psql postgres -U postgres -h localhost -p 15432  # Direct DB access
-```
-
-### OpenAPI Spec
-```bash
-make generate_v2_spec    # Regenerate v2 spec from TypeSpec (requires TypeSpec installed in docs/source/specs/typespec/)
-```
-
-## Pre-commit Hooks
-
-The `.pre-commit-config.yaml` enforces:
-- flake8 (line length 120)
-- black (line length 119, target py312, check mode)
-- trailing-whitespace, end-of-file-fixer, debug-statements
-- django-upgrade (target 5.2)
-- openapi-spec-validator
-
-Run manually: `pipenv run pre-commit run --all-files`
-
-## Claude Code Behavioral Preferences
+## Behavioral Preferences
 
 - Do NOT include `Co-Authored-By` lines in commits
 - Before running tests or linters, verify the database is running with `pg_isready -h localhost -p 15432`


### PR DESCRIPTION
## Link(s) to Jira
- https://redhat.atlassian.net/browse/RHCLOUD-46830

## Description of Intent of Change(s)

Follow-up to #2745, addressing Libor's review feedback about unifying AGENTS.md and CLAUDE.md.

The two files had significant content overlap -- command references for testing, linting, local dev, database, and OpenAPI appeared in both. This duplication would drift over time and contradicts the DRY principle Libor raised.

This PR moves all command references and duplicated content from CLAUDE.md into AGENTS.md, making it the single source of truth for all AI agents (Claude Code, Cursor, CodeRabbit, etc.). CLAUDE.md is slimmed to a thin wrapper that imports AGENTS.md via `@AGENTS.md` and adds only the 4 Claude Code-specific behavioral preferences.

Changes to AGENTS.md:
- Added "Common Commands" section with detailed examples (testing, linting, local dev, database, OpenAPI, pre-commit hooks)
- Removed duplicated command info from convention subsections (test runner command, Black run command, pre-commit hooks list, migration commands, local dev block)
- Updated Context Index description for CLAUDE.md
- Renamed "Code Style and Formatting" to "Code Style" (commands moved out)

Changes to CLAUDE.md:
- Reduced from 79 lines to 11 lines
- Removed all command sections (testing, linting, local dev, database, OpenAPI, pre-commit hooks)
- Kept only `@AGENTS.md` import + 4 behavioral preference bullets

Before: both files contained overlapping command sections (79 + 92 lines).
After: AGENTS.md has everything (145 lines), CLAUDE.md is minimal (11 lines).

## Local Testing
- Verify AGENTS.md contains all command references previously in CLAUDE.md
- Confirm CLAUDE.md only has behavioral preferences
- Check that no command or convention info was lost in the deduplication

## Checklist
- [x] if API spec changes are required, is the spec updated?
- [x] are there any pre/post merge actions required? if so, document here.
- [x] are theses changes covered by unit tests?
- [x] if warranted, are documentation changes accounted for?
- [x] does this require migration changes?
- [x] is there known, direct impact to dependent teams/components?

N/A -- documentation-only changes, no code changes.

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices

N/A -- documentation-only changes.

## Summary by Sourcery

Deduplicate AI agent documentation by consolidating shared commands and conventions into AGENTS.md and reducing CLAUDE.md to Claude-specific behavioral guidance.

Documentation:
- Centralize testing, linting, local development, database, OpenAPI, and pre-commit command references in AGENTS.md for all AI agents.
- Simplify CLAUDE.md to reference AGENTS.md and retain only Claude Code-specific behavioral preferences.