### PR TITLE
Get the specs in sync

### DIFF
--- a/docs/source/specs/v2/openapi.json
+++ b/docs/source/specs/v2/openapi.json
@@ -675,7 +675,7 @@
                   "$ref": "#/components/schemas/FieldMask"
                 }
               ],
-              "default": "resource(id),subject(id),roles(id)"
+              "default": "resource(id),subject(id,type),roles(id)"
             },
             "explode": false
           }

--- a/docs/source/specs/v2/openapi.yaml
+++ b/docs/source/specs/v2/openapi.yaml
@@ -434,7 +434,7 @@ paths:
           schema:
             allOf:
               - $ref: '#/components/schemas/FieldMask'
-            default: resource(id),subject(id),roles(id)
+            default: resource(id),subject(id,type),roles(id)
           explode: false
       responses:
         '200':


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Update the documented default field mask to include the subject type field in the v2 OpenAPI spec.