### PR TITLE
RHCLOUD-46670 - Add sources as allowed field for role-binding/by-subject/

### DIFF
--- a/rbac/management/role_binding/serializer.py
+++ b/rbac/management/role_binding/serializer.py
@@ -58,6 +58,7 @@ class RoleBindingBySubjectFieldSelection(FieldSelection):
         "subject": {"id", "type", "group.name", "group.description", "group.user_count", "user.username"},
         "roles": {"id", "name"},
         "resource": {"id", "name", "type"},
+        "sources": {"id", "name", "type"},
     }
 
 

--- a/tests/management/role_binding/test_view.py
+++ b/tests/management/role_binding/test_view.py
@@ -4145,6 +4145,7 @@ class UpdateRoleBindingsBySubjectAPITests(IdentityRequest):
                     "Invalid field(s): Unknown field: 'bogus_field'."
                     " Valid resource fields: ['id', 'name', 'type']."
                     " Valid roles fields: ['id', 'name']."
+                    " Valid sources fields: ['id', 'name', 'type']."
                     " Valid subject fields: ['group.description', 'group.name',"
                     " 'group.user_count', 'id', 'type', 'user.username']."
                     " Valid root fields: ['last_modified'].",


### PR DESCRIPTION
## Link(s) to Jira
https://redhat.atlassian.net/browse/RHCLOUD-46670

## Description of Intent of Change(s)

Sources is missing from valid fields for the role-bindings/by-subject/ endpoint, readd this since this is a valid field now.


## Local Testing
How can the feature be exercised?
How can the bug be exploited and fix confirmed?
Is any special local setup required?

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Allow selecting sources fields in role bindings returned by the by-subject endpoint.

New Features:
- Support sources field selection for role_binding/by-subject responses.

Tests:
- Extend role binding view tests to cover validation messaging for sources field selection.