### PR TITLE
RHCLOUD-44659: Use configured image and tag for orphan job

### DIFF
--- a/deploy/rbac-clowdapp.yml
+++ b/deploy/rbac-clowdapp.yml
@@ -1226,7 +1226,6 @@ objects:
       - name: fix-orphan-relations
         podSpec:
           image: ${IMAGE}:${IMAGE_TAG}
-          imagePullPolicy: Always
           command:
             - /opt/rbac/rbac/manage.py
             - fix_orphan_relations

--- a/deploy/rbac-clowdapp.yml
+++ b/deploy/rbac-clowdapp.yml
@@ -1225,7 +1225,7 @@ objects:
           env: *workspace_job_env_vars
       - name: fix-orphan-relations
         podSpec:
-          image: quay.io/cloudservices/rbac:latest
+          image: ${IMAGE}:${IMAGE_TAG}
           imagePullPolicy: Always
           command:
             - /opt/rbac/rbac/manage.py


### PR DESCRIPTION
## Link(s) to Jira
[RHCLOUD-44659](https://redhat.atlassian.net/browse/RHCLOUD-44659)

## Description of Intent of Change(s)
Use the configured image for the orphan removal job instead of `:latest` in order to ensure that the correct version of the job is run. (I've just had an instance in prod where it reused an old image because the implicit pull )

Also remove the `imagePullPolicy` field, which isn't actually defined by Clowder.

[RHCLOUD-44659]: https://redhat.atlassian.net/browse/RHCLOUD-44659?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Enhancements:
- Align the orphan-relations job image reference with the deployment configuration by using ${IMAGE}:${IMAGE_TAG} and removing the unused image pull policy.