### PR TITLE
Properly set isolation level in atomic_with_retry

### DIFF
--- a/rbac/management/atomic_transactions.py
+++ b/rbac/management/atomic_transactions.py
@@ -55,7 +55,7 @@ def atomic_with_retry(retries: int):
             if is_atomic_disabled():
                 return transaction.atomic()(func)(*args, **kwargs)
             else:
-                return pgtransaction.atomic(retry=retries)(func)(*args, **kwargs)
+                return pgtransaction.atomic(isolation_level=ISOLATION_LEVEL, retry=retries)(func)(*args, **kwargs)
 
         return wrapper
 


### PR DESCRIPTION
## Link(s) to Jira
N/A

## Description of Intent of Change(s)
This breaks (a) nested calls to functions for `SERIALIZABLE` transactions and (b) guarantees that we were relying on in multiple places. Oops.

## Summary by Sourcery

Bug Fixes:
- Fix missing isolation level configuration in atomic_with_retry PostgreSQL transactions, restoring expected transactional guarantees.