### PR TITLE
[RHCLOUD-45423] Add api to run migration to replicate role to tenant relationship

### DIFF
--- a/rbac/internal/custom_v2_role_tenant_migration.py
+++ b/rbac/internal/custom_v2_role_tenant_migration.py
@@ -1,0 +1,133 @@
+#
+# Copyright 2026 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+"""Backfill rbac/role#owner@rbac/tenant for custom V2 roles from each role's tenant row.
+
+Scans the ``RoleV2`` table only (custom roles are on the order of thousands), not the tenant table
+(millions of rows). Uses keyset pagination on ``rolev2.pk``.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from django.conf import settings
+from management.atomic_transactions import atomic_block
+from management.relation_replicator.noop_replicator import NoopReplicator
+from management.relation_replicator.outbox_replicator import OutboxReplicator
+from management.relation_replicator.relation_replicator import (
+    PartitionKey,
+    RelationReplicator,
+    ReplicationEvent,
+    ReplicationEventType,
+)
+from management.role.relations import role_owner_relationship
+from management.role.v2_model import RoleV2
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_CHUNK_SIZE = 500
+
+
+class TenantResourceIdMissingError(ValueError):
+    """Raised when a custom role's tenant has no ``tenant_resource_id()`` (no ``org_id``)."""
+
+
+def _require_tenant_resource_id(role: RoleV2, resource_id: str | None) -> str:
+    if resource_id:
+        return resource_id
+    tenant = role.tenant
+    raise TenantResourceIdMissingError(
+        f"Tenant for custom role has no tenant_resource_id (org_id missing): "
+        f"role_uuid={role.uuid} role_name={role.name!r} tenant_id={tenant.pk}"
+    )
+
+
+def _base_queryset():
+    """Return all custom V2 roles (custom roles are only created for org tenants in practice)."""
+    return RoleV2.objects.filter(type=RoleV2.Types.CUSTOM).select_related("tenant").order_by("pk")
+
+
+def _process_chunk(
+    *,
+    chunk: list[RoleV2],
+    replicator: RelationReplicator,
+) -> None:
+    for role in chunk:
+        tenant = role.tenant
+        resource_id = _require_tenant_resource_id(role, tenant.tenant_resource_id())
+
+        replicator.replicate(
+            ReplicationEvent(
+                event_type=ReplicationEventType.UPDATE_CUSTOM_ROLE,
+                info={
+                    "role_uuid": str(role.uuid),
+                    "org_id": str(tenant.org_id) if tenant.org_id else "",
+                },
+                partition_key=PartitionKey.byEnvironment(),
+                add=[role_owner_relationship(role.uuid, resource_id)],
+                remove=[],
+            )
+        )
+        logger.info(
+            "Replicated owner tuple for custom V2 role uuid=%s name=%r tenant org_id=%s",
+            role.uuid,
+            role.name,
+            tenant.org_id,
+        )
+
+
+def replicate_custom_v2_role_owner_relationships(
+    *,
+    replicator: RelationReplicator | None = None,
+) -> dict[str, Any]:
+    """Emit owner tuples for every custom V2 role from ``role.tenant.tenant_resource_id()``.
+
+    Iterates **custom roles only** (typically thousands of rows), not tenants. Does not change PostgreSQL
+    role rows; only replicates ``rbac/role:<uuid>#owner@rbac/tenant:<id>``.
+
+    Raises ``TenantResourceIdMissingError`` if any custom role's tenant has no ``tenant_resource_id()``.
+
+    Fetches and processes in fixed-size chunks (``DEFAULT_CHUNK_SIZE``, keyset pagination on ``rolev2.pk``).
+    Each chunk is read and processed inside a separate SERIALIZABLE transaction (see ``atomic_block``).
+    """
+    if replicator is None:
+        if settings.REPLICATION_TO_RELATION_ENABLED:
+            replicator = OutboxReplicator()
+        else:
+            replicator = NoopReplicator()
+
+    base = _base_queryset()
+    replicated_count = 0
+
+    last_pk = 0
+    while True:
+        with atomic_block():
+            chunk = list(base.filter(pk__gt=last_pk)[:DEFAULT_CHUNK_SIZE])
+            if not chunk:
+                break
+            last_pk = chunk[-1].pk
+            _process_chunk(
+                chunk=chunk,
+                replicator=replicator,
+            )
+            replicated_count += len(chunk)
+
+    return {
+        "replicated_count": replicated_count,
+    }

--- a/rbac/internal/custom_v2_role_tenant_migration.py
+++ b/rbac/internal/custom_v2_role_tenant_migration.py
@@ -18,17 +18,18 @@
 """Backfill rbac/role#owner@rbac/tenant for custom V2 roles from each role's tenant row.
 
 Scans the ``RoleV2`` table only (custom roles are on the order of thousands), not the tenant table
-(millions of rows). Uses keyset pagination on ``rolev2.pk``.
+(millions of rows). Streams rows with ``QuerySet.iterator()`` and ``itertools.batched`` so Django
+handles fetch batching; each batch is still wrapped in ``atomic_block()`` (SERIALIZABLE) like before.
 """
 
 from __future__ import annotations
 
 import logging
+from itertools import batched
 from typing import Any
 
 from django.conf import settings
 from management.atomic_transactions import atomic_block
-from management.relation_replicator.noop_replicator import NoopReplicator
 from management.relation_replicator.outbox_replicator import OutboxReplicator
 from management.relation_replicator.relation_replicator import (
     PartitionKey,
@@ -48,7 +49,8 @@ class TenantResourceIdMissingError(ValueError):
     """Raised when a custom role's tenant has no ``tenant_resource_id()`` (no ``org_id``)."""
 
 
-def _require_tenant_resource_id(role: RoleV2, resource_id: str | None) -> str:
+def _require_tenant_resource_id(role: RoleV2) -> str:
+    resource_id = role.tenant.tenant_resource_id()
     if resource_id:
         return resource_id
     tenant = role.tenant
@@ -63,33 +65,28 @@ def _base_queryset():
     return RoleV2.objects.filter(type=RoleV2.Types.CUSTOM).select_related("tenant").order_by("pk")
 
 
-def _process_chunk(
-    *,
-    chunk: list[RoleV2],
-    replicator: RelationReplicator,
-) -> None:
-    for role in chunk:
-        tenant = role.tenant
-        resource_id = _require_tenant_resource_id(role, tenant.tenant_resource_id())
+def _replicate_role(role: RoleV2, replicator: RelationReplicator) -> None:
+    resource_id = _require_tenant_resource_id(role)
+    tenant = role.tenant
 
-        replicator.replicate(
-            ReplicationEvent(
-                event_type=ReplicationEventType.UPDATE_CUSTOM_ROLE,
-                info={
-                    "role_uuid": str(role.uuid),
-                    "org_id": str(tenant.org_id) if tenant.org_id else "",
-                },
-                partition_key=PartitionKey.byEnvironment(),
-                add=[role_owner_relationship(role.uuid, resource_id)],
-                remove=[],
-            )
+    replicator.replicate(
+        ReplicationEvent(
+            event_type=ReplicationEventType.UPDATE_CUSTOM_ROLE,
+            info={
+                "role_uuid": str(role.uuid),
+                "org_id": str(tenant.org_id) if tenant.org_id else "",
+            },
+            partition_key=PartitionKey.byEnvironment(),
+            add=[role_owner_relationship(role.uuid, resource_id)],
+            remove=[],
         )
-        logger.info(
-            "Replicated owner tuple for custom V2 role uuid=%s name=%r tenant org_id=%s",
-            role.uuid,
-            role.name,
-            tenant.org_id,
-        )
+    )
+    logger.info(
+        "Replicated owner tuple for custom V2 role uuid=%s name=%r tenant org_id=%s",
+        role.uuid,
+        role.name,
+        tenant.org_id,
+    )
 
 
 def replicate_custom_v2_role_owner_relationships(
@@ -103,30 +100,22 @@ def replicate_custom_v2_role_owner_relationships(
 
     Raises ``TenantResourceIdMissingError`` if any custom role's tenant has no ``tenant_resource_id()``.
 
-    Fetches and processes in fixed-size chunks (``DEFAULT_CHUNK_SIZE``, keyset pagination on ``rolev2.pk``).
-    Each chunk is read and processed inside a separate SERIALIZABLE transaction (see ``atomic_block``).
+    Streams rows with ``iterator()`` (see Django docs for fetch behavior with ``select_related``).
+    Each batch of up to ``DEFAULT_CHUNK_SIZE`` roles is processed inside a separate SERIALIZABLE
+    transaction (see ``atomic_block``).
     """
     if replicator is None:
         if settings.REPLICATION_TO_RELATION_ENABLED:
             replicator = OutboxReplicator()
-        else:
-            replicator = NoopReplicator()
+        raise ValueError("Replication to relations is disabled")
 
-    base = _base_queryset()
     replicated_count = 0
 
-    last_pk = 0
-    while True:
+    for chunk in batched(_base_queryset().iterator(), DEFAULT_CHUNK_SIZE):
         with atomic_block():
-            chunk = list(base.filter(pk__gt=last_pk)[:DEFAULT_CHUNK_SIZE])
-            if not chunk:
-                break
-            last_pk = chunk[-1].pk
-            _process_chunk(
-                chunk=chunk,
-                replicator=replicator,
-            )
-            replicated_count += len(chunk)
+            for role in chunk:
+                _replicate_role(role, replicator)
+                replicated_count += 1
 
     return {
         "replicated_count": replicated_count,

--- a/rbac/internal/custom_v2_role_tenant_migration.py
+++ b/rbac/internal/custom_v2_role_tenant_migration.py
@@ -18,14 +18,14 @@
 """Backfill rbac/role#owner@rbac/tenant for custom V2 roles from each role's tenant row.
 
 Scans the ``RoleV2`` table only (custom roles are on the order of thousands), not the tenant table
-(millions of rows). Streams rows with ``QuerySet.iterator()`` and ``itertools.batched`` so Django
-handles fetch batching; each batch is still wrapped in ``atomic_block()`` (SERIALIZABLE) like before.
+(millions of rows). Each batch is locked with ``select_for_update()`` inside an ``atomic_block()``
+to prevent concurrent V1 dual-write operations (which run at READ COMMITTED) from modifying roles
+mid-replication.
 """
 
 from __future__ import annotations
 
 import logging
-from itertools import batched
 from typing import Any
 
 from django.conf import settings
@@ -100,22 +100,27 @@ def replicate_custom_v2_role_owner_relationships(
 
     Raises ``TenantResourceIdMissingError`` if any custom role's tenant has no ``tenant_resource_id()``.
 
-    Streams rows with ``iterator()`` (see Django docs for fetch behavior with ``select_related``).
-    Each batch of up to ``DEFAULT_CHUNK_SIZE`` roles is processed inside a separate SERIALIZABLE
-    transaction (see ``atomic_block``).
+    Each batch of up to ``DEFAULT_CHUNK_SIZE`` roles is locked with ``select_for_update()`` inside
+    an ``atomic_block()`` (SERIALIZABLE) to guard against concurrent V1 dual-write operations that
+    run at READ COMMITTED. Keyset pagination (``pk__gt``) is used to advance between batches.
     """
     if replicator is None:
-        if settings.REPLICATION_TO_RELATION_ENABLED:
-            replicator = OutboxReplicator()
-        raise ValueError("Replication to relations is disabled")
+        if not settings.REPLICATION_TO_RELATION_ENABLED:
+            raise ValueError("Replication to relations is disabled")
+        replicator = OutboxReplicator()
 
     replicated_count = 0
+    last_pk = 0
 
-    for chunk in batched(_base_queryset().iterator(), DEFAULT_CHUNK_SIZE):
+    while True:
         with atomic_block():
+            chunk = list(_base_queryset().filter(pk__gt=last_pk).select_for_update()[:DEFAULT_CHUNK_SIZE])
+            if not chunk:
+                break
             for role in chunk:
                 _replicate_role(role, replicator)
                 replicated_count += 1
+            last_pk = chunk[-1].pk
 
     return {
         "replicated_count": replicated_count,

--- a/rbac/internal/specs/openapi.json
+++ b/rbac/internal/specs/openapi.json
@@ -3794,43 +3794,22 @@
           "Relations"
         ],
         "summary": "Read tuples from the relations api.",
-        "description": "Reads relation tuples from the relations api based on filter criteria. Custom roles include an `owner` edge from `rbac/role` to `rbac/tenant` (tenant resource id is `{PRINCIPAL_USER_DOMAIN}/{org_id}`); RBAC replicates this so `role#read` / `role#write` can derive from the tenant per the rbac schema.",
+        "description": "Reads relation tuples from the relations api based on filter criteria.",
         "requestBody": {
           "content": {
             "application/json": {
-              "examples": {
-                "GroupMember": {
-                  "summary": "Group membership",
-                  "value": {
-                    "filter": {
-                      "resource_namespace": "rbac",
-                      "resource_type": "group",
-                      "resource_id": "bob_club",
-                      "relation": "member",
-                      "subject_filter": {
-                        "subject_namespace": "rbac",
-                        "subject_type": "principal",
-                        "subject_id": "bob",
-                        "relation": null
-                      }
-                    }
-                  }
-                },
-                "CustomRoleOwner": {
-                  "summary": "Custom role owner to tenant",
-                  "description": "Query the owner link for a V2 custom role UUID.",
-                  "value": {
-                    "filter": {
-                      "resource_namespace": "rbac",
-                      "resource_type": "role",
-                      "resource_id": "019d8dab-4282-7141-b898-94f02d1986a4",
-                      "relation": "owner",
-                      "subject_filter": {
-                        "subject_namespace": "rbac",
-                        "subject_type": "tenant",
-                        "subject_id": "localhost/1234567",
-                        "relation": null
-                      }
+              "example": {
+                "value": {
+                  "filter": {
+                    "resource_namespace": "rbac",
+                    "resource_type": "group",
+                    "resource_id": "bob_club",
+                    "relation": "member",
+                    "subject_filter": {
+                      "subject_namespace": "rbac",
+                      "subject_type": "principal",
+                      "subject_id": "bob",
+                      "relation": null
                     }
                   }
                 }
@@ -3857,7 +3836,6 @@
                 },
                 "examples": {
                   "Success": {
-                    "summary": "Group member tuple",
                     "value": {
                       "tuples": [
                         {
@@ -3877,34 +3855,6 @@
                                   "name": "principal"
                                 },
                                 "id": "bob"
-                              }
-                            }
-                          }
-                        }
-                      ]
-                    }
-                  },
-                  "RoleOwner": {
-                    "summary": "Custom role owner tuple",
-                    "value": {
-                      "tuples": [
-                        {
-                          "tuple": {
-                            "resource": {
-                              "type": {
-                                "namespace": "rbac",
-                                "name": "role"
-                              },
-                              "id": "019d8dab-4282-7141-b898-94f02d1986a4"
-                            },
-                            "relation": "owner",
-                            "subject": {
-                              "subject": {
-                                "type": {
-                                  "namespace": "rbac",
-                                  "name": "tenant"
-                                },
-                                "id": "localhost/1234567"
                               }
                             }
                           }

--- a/rbac/internal/specs/openapi.json
+++ b/rbac/internal/specs/openapi.json
@@ -3799,18 +3799,16 @@
           "content": {
             "application/json": {
               "example": {
-                "value": {
-                  "filter": {
-                    "resource_namespace": "rbac",
-                    "resource_type": "group",
-                    "resource_id": "bob_club",
-                    "relation": "member",
-                    "subject_filter": {
-                      "subject_namespace": "rbac",
-                      "subject_type": "principal",
-                      "subject_id": "bob",
-                      "relation": null
-                    }
+                "filter": {
+                  "resource_namespace": "rbac",
+                  "resource_type": "group",
+                  "resource_id": "bob_club",
+                  "relation": "member",
+                  "subject_filter": {
+                    "subject_namespace": "rbac",
+                    "subject_type": "principal",
+                    "subject_id": "bob",
+                    "relation": null
                   }
                 }
               }

--- a/rbac/internal/specs/openapi.json
+++ b/rbac/internal/specs/openapi.json
@@ -3794,21 +3794,44 @@
           "Relations"
         ],
         "summary": "Read tuples from the relations api.",
-        "description": "Reads relation tuples from the relations api based on filter criteria.",
+        "description": "Reads relation tuples from the relations api based on filter criteria. Custom roles include an `owner` edge from `rbac/role` to `rbac/tenant` (tenant resource id is `{PRINCIPAL_USER_DOMAIN}/{org_id}`); RBAC replicates this so `role#read` / `role#write` can derive from the tenant per the rbac schema.",
         "requestBody": {
           "content": {
             "application/json": {
-              "example": {
-                "filter": {
-                  "resource_namespace": "rbac",
-                  "resource_type": "group",
-                  "resource_id": "bob_club",
-                  "relation": "member",
-                  "subject_filter": {
-                    "subject_namespace": "rbac",
-                    "subject_type": "principal",
-                    "subject_id": "bob",
-                    "relation": null
+              "examples": {
+                "GroupMember": {
+                  "summary": "Group membership",
+                  "value": {
+                    "filter": {
+                      "resource_namespace": "rbac",
+                      "resource_type": "group",
+                      "resource_id": "bob_club",
+                      "relation": "member",
+                      "subject_filter": {
+                        "subject_namespace": "rbac",
+                        "subject_type": "principal",
+                        "subject_id": "bob",
+                        "relation": null
+                      }
+                    }
+                  }
+                },
+                "CustomRoleOwner": {
+                  "summary": "Custom role owner to tenant",
+                  "description": "Query the owner link for a V2 custom role UUID.",
+                  "value": {
+                    "filter": {
+                      "resource_namespace": "rbac",
+                      "resource_type": "role",
+                      "resource_id": "019d8dab-4282-7141-b898-94f02d1986a4",
+                      "relation": "owner",
+                      "subject_filter": {
+                        "subject_namespace": "rbac",
+                        "subject_type": "tenant",
+                        "subject_id": "localhost/1234567",
+                        "relation": null
+                      }
+                    }
                   }
                 }
               }
@@ -3834,6 +3857,7 @@
                 },
                 "examples": {
                   "Success": {
+                    "summary": "Group member tuple",
                     "value": {
                       "tuples": [
                         {
@@ -3853,6 +3877,34 @@
                                   "name": "principal"
                                 },
                                 "id": "bob"
+                              }
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  "RoleOwner": {
+                    "summary": "Custom role owner tuple",
+                    "value": {
+                      "tuples": [
+                        {
+                          "tuple": {
+                            "resource": {
+                              "type": {
+                                "namespace": "rbac",
+                                "name": "role"
+                              },
+                              "id": "019d8dab-4282-7141-b898-94f02d1986a4"
+                            },
+                            "relation": "owner",
+                            "subject": {
+                              "subject": {
+                                "type": {
+                                  "namespace": "rbac",
+                                  "name": "tenant"
+                                },
+                                "id": "localhost/1234567"
                               }
                             }
                           }

--- a/rbac/internal/urls.py
+++ b/rbac/internal/urls.py
@@ -120,6 +120,10 @@ urlpatterns = [
     path("api/utils/remove_unassigned_system_binding_mappings/", views.remove_unassigned_system_binding_mappings),
     path("api/utils/expire_orphaned_cross_account_requests/", views.expire_orphaned_cross_account_requests),
     path("api/utils/remove_deleted_workspace_bindings/", views.remove_deleted_workspace_bindings),
+    path(
+        "api/utils/migrate_custom_v2_roles_to_tenant/",
+        views.migrate_custom_v2_roles_to_tenant,
+    ),
 ]
 
 urlpatterns.extend(integration_urlpatterns)

--- a/rbac/internal/views.py
+++ b/rbac/internal/views.py
@@ -35,6 +35,7 @@ from django.views.decorators.http import require_http_methods
 from feature_flags import FEATURE_FLAGS
 from google.protobuf import json_format
 from grpc import RpcError
+from internal.custom_v2_role_tenant_migration import replicate_custom_v2_role_owner_relationships
 from internal.errors import SentryDiagnosticError, UserNotFoundError
 from internal.jwt_utils import JWTManager, JWTProvider
 from internal.utils import (
@@ -2578,3 +2579,26 @@ def remove_deleted_workspace_bindings(request):
     except Exception as e:
         logger.exception("Error removing bindings for deleted workspaces", exc_info=True)
         return JsonResponse({"detail": f"Error removing bindings for deleted workspaces: {str(e)}"}, status=500)
+
+
+@require_http_methods(["POST"])
+def migrate_custom_v2_roles_to_tenant(request):
+    """Replicate owner tuples for custom V2 roles from each role's tenant resource id.
+
+    POST /_private/api/utils/migrate_custom_v2_roles_to_tenant/
+
+    Iterates ``RoleV2`` with ``type=custom`` (scans custom roles only, not every tenant row). With
+    ``tenant`` loaded, emits ``rbac/role#owner@rbac/tenant`` for ``tenant.tenant_resource_id()``.
+    Fails with 500 if any custom role's tenant has no resource id. Does not update role rows.
+
+    Returns:
+        JSON with ``replicated``, ``skipped``, and counts.
+    """
+    logger.info("migrate_custom_v2_roles_to_tenant")
+
+    try:
+        result = replicate_custom_v2_role_owner_relationships()
+        return JsonResponse(result, status=200)
+    except Exception as e:
+        logger.exception("migrate_custom_v2_roles_to_tenant failed", exc_info=True)
+        return JsonResponse({"detail": str(e)}, status=500)

--- a/tests/internal/test_custom_v2_role_tenant_migration.py
+++ b/tests/internal/test_custom_v2_role_tenant_migration.py
@@ -17,17 +17,22 @@
 
 """Tests for replicating custom V2 role owner tuples."""
 
-from unittest.mock import MagicMock
-
 from django.test import TestCase, override_settings
 from internal.custom_v2_role_tenant_migration import (
     TenantResourceIdMissingError,
     replicate_custom_v2_role_owner_relationships,
 )
 from management.models import Permission
-from management.relation_replicator.relation_replicator import ReplicationEventType
 from management.role.relations import role_owner_relationship
 from management.role.v2_model import CustomRoleV2
+from migration_tool.in_memory_tuples import (
+    InMemoryRelationReplicator,
+    InMemoryTuples,
+    all_of,
+    relation,
+    resource,
+    subject,
+)
 from tests.v2_util import bootstrap_tenant_for_v2_test
 
 from api.models import Tenant
@@ -61,17 +66,27 @@ class ReplicateCustomV2RoleOwnerTests(TestCase):
         role = CustomRoleV2.objects.create(name="custom_a", tenant=self.org_tenant)
         role.permissions.add(self.perm)
 
-        replicator = MagicMock()
+        tuples = InMemoryTuples()
+        replicator = InMemoryRelationReplicator(tuples)
         result = replicate_custom_v2_role_owner_relationships(replicator=replicator)
 
         self.assertEqual(result["replicated_count"], 1)
-        replicator.replicate.assert_called_once()
-        event = replicator.replicate.call_args[0][0]
-        self.assertEqual(event.event_type, ReplicationEventType.UPDATE_CUSTOM_ROLE)
-        self.assertEqual(len(event.add), 1)
-        self.assertEqual(event.remove, [])
-        expected = role_owner_relationship(role.uuid, self.org_tenant.tenant_resource_id())
-        self.assertEqual(event.add[0], expected)
+        self.assertEqual(len(tuples), 1)
+
+        role_uuid = str(role.uuid)
+        tenant_rid = self.org_tenant.tenant_resource_id()
+        self.assertIsNotNone(tenant_rid)
+        expected = role_owner_relationship(role_uuid, tenant_rid)
+        self.assertIn(expected, tuples)
+
+        owner_matches = tuples.find_tuples(
+            all_of(
+                resource("rbac", "role", role_uuid),
+                relation("owner"),
+                subject("rbac", "tenant", tenant_rid),
+            )
+        )
+        self.assertEqual(len(owner_matches), 1)
 
     def test_raises_when_tenant_has_no_resource_id(self):
         """Non-public tenant without org_id has no tenant_resource_id; migration fails."""
@@ -83,21 +98,23 @@ class ReplicateCustomV2RoleOwnerTests(TestCase):
         )
         CustomRoleV2.objects.create(name="no_res_id", tenant=no_org).permissions.add(self.perm)
 
-        replicator = MagicMock()
+        tuples = InMemoryTuples()
+        replicator = InMemoryRelationReplicator(tuples)
         with self.assertRaises(TenantResourceIdMissingError):
             replicate_custom_v2_role_owner_relationships(replicator=replicator)
 
-        replicator.replicate.assert_not_called()
+        self.assertEqual(len(tuples), 0)
 
     def test_raises_for_custom_role_on_public_tenant(self):
         """Public tenant has no tenant_resource_id; migration fails."""
         CustomRoleV2.objects.create(name="on_public", tenant=self.public_tenant).permissions.add(self.perm)
 
-        replicator = MagicMock()
+        tuples = InMemoryTuples()
+        replicator = InMemoryRelationReplicator(tuples)
         with self.assertRaises(TenantResourceIdMissingError):
             replicate_custom_v2_role_owner_relationships(replicator=replicator)
 
-        replicator.replicate.assert_not_called()
+        self.assertEqual(len(tuples), 0)
 
     def test_processes_all_non_public_org_tenants(self):
         """All custom roles on distinct non-public tenants are replicated."""
@@ -109,11 +126,30 @@ class ReplicateCustomV2RoleOwnerTests(TestCase):
         )
         bootstrap_tenant_for_v2_test(other)
 
-        CustomRoleV2.objects.create(name="r1", tenant=self.org_tenant).permissions.add(self.perm)
-        CustomRoleV2.objects.create(name="r2", tenant=other).permissions.add(self.perm)
+        r1 = CustomRoleV2.objects.create(name="r1", tenant=self.org_tenant)
+        r1.permissions.add(self.perm)
+        r2 = CustomRoleV2.objects.create(name="r2", tenant=other)
+        r2.permissions.add(self.perm)
 
-        replicator = MagicMock()
+        tuples = InMemoryTuples()
+        replicator = InMemoryRelationReplicator(tuples)
         result = replicate_custom_v2_role_owner_relationships(replicator=replicator)
 
         self.assertEqual(result["replicated_count"], 2)
-        self.assertEqual(replicator.replicate.call_count, 2)
+        self.assertEqual(len(tuples), 2)
+
+        exp1 = role_owner_relationship(r1.uuid, self.org_tenant.tenant_resource_id())
+        exp2 = role_owner_relationship(r2.uuid, other.tenant_resource_id())
+        self.assertIn(exp1, tuples)
+        self.assertIn(exp2, tuples)
+
+        for role, tenant in ((r1, self.org_tenant), (r2, other)):
+            rid = tenant.tenant_resource_id()
+            found = tuples.find_tuples(
+                all_of(
+                    resource("rbac", "role", str(role.uuid)),
+                    relation("owner"),
+                    subject("rbac", "tenant", rid),
+                )
+            )
+            self.assertEqual(len(found), 1, f"Expected owner tuple for role {role.uuid}")

--- a/tests/internal/test_custom_v2_role_tenant_migration.py
+++ b/tests/internal/test_custom_v2_role_tenant_migration.py
@@ -1,0 +1,119 @@
+#
+# Copyright 2026 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+"""Tests for replicating custom V2 role owner tuples."""
+
+from unittest.mock import MagicMock
+
+from django.test import TestCase, override_settings
+from internal.custom_v2_role_tenant_migration import (
+    TenantResourceIdMissingError,
+    replicate_custom_v2_role_owner_relationships,
+)
+from management.models import Permission
+from management.relation_replicator.relation_replicator import ReplicationEventType
+from management.role.relations import role_owner_relationship
+from management.role.v2_model import CustomRoleV2
+from tests.v2_util import bootstrap_tenant_for_v2_test
+
+from api.models import Tenant
+
+
+@override_settings(ATOMIC_RETRY_DISABLED=True)
+class ReplicateCustomV2RoleOwnerTests(TestCase):
+    """Tests for replicate_custom_v2_role_owner_relationships."""
+
+    def setUp(self):
+        """Set up tenants."""
+        self.public_tenant = Tenant.objects.get(tenant_name=Tenant.PUBLIC_TENANT_NAME)
+        self.org_tenant = Tenant.objects.create(
+            tenant_name="owner_tuple_tenant",
+            account_id="acc-ot",
+            org_id="org-owner-001",
+            ready=True,
+        )
+        bootstrap_tenant_for_v2_test(self.org_tenant)
+
+        self.perm = Permission.objects.create(
+            tenant=self.public_tenant,
+            application="inventory",
+            resource_type="hosts",
+            verb="read",
+            permission="inventory:hosts:read",
+        )
+
+    def test_replicates_owner_tuple_using_tenant_resource_id(self):
+        """Each custom role with an org tenant gets one owner tuple replicated."""
+        role = CustomRoleV2.objects.create(name="custom_a", tenant=self.org_tenant)
+        role.permissions.add(self.perm)
+
+        replicator = MagicMock()
+        result = replicate_custom_v2_role_owner_relationships(replicator=replicator)
+
+        self.assertEqual(result["replicated_count"], 1)
+        replicator.replicate.assert_called_once()
+        event = replicator.replicate.call_args[0][0]
+        self.assertEqual(event.event_type, ReplicationEventType.UPDATE_CUSTOM_ROLE)
+        self.assertEqual(len(event.add), 1)
+        self.assertEqual(event.remove, [])
+        expected = role_owner_relationship(role.uuid, self.org_tenant.tenant_resource_id())
+        self.assertEqual(event.add[0], expected)
+
+    def test_raises_when_tenant_has_no_resource_id(self):
+        """Non-public tenant without org_id has no tenant_resource_id; migration fails."""
+        no_org = Tenant.objects.create(
+            tenant_name="no_org_id_tenant",
+            account_id="acc-none",
+            org_id=None,
+            ready=True,
+        )
+        CustomRoleV2.objects.create(name="no_res_id", tenant=no_org).permissions.add(self.perm)
+
+        replicator = MagicMock()
+        with self.assertRaises(TenantResourceIdMissingError):
+            replicate_custom_v2_role_owner_relationships(replicator=replicator)
+
+        replicator.replicate.assert_not_called()
+
+    def test_raises_for_custom_role_on_public_tenant(self):
+        """Public tenant has no tenant_resource_id; migration fails."""
+        CustomRoleV2.objects.create(name="on_public", tenant=self.public_tenant).permissions.add(self.perm)
+
+        replicator = MagicMock()
+        with self.assertRaises(TenantResourceIdMissingError):
+            replicate_custom_v2_role_owner_relationships(replicator=replicator)
+
+        replicator.replicate.assert_not_called()
+
+    def test_processes_all_non_public_org_tenants(self):
+        """All custom roles on distinct non-public tenants are replicated."""
+        other = Tenant.objects.create(
+            tenant_name="owner_tuple_other",
+            account_id="acc-ot2",
+            org_id="org-owner-002",
+            ready=True,
+        )
+        bootstrap_tenant_for_v2_test(other)
+
+        CustomRoleV2.objects.create(name="r1", tenant=self.org_tenant).permissions.add(self.perm)
+        CustomRoleV2.objects.create(name="r2", tenant=other).permissions.add(self.perm)
+
+        replicator = MagicMock()
+        result = replicate_custom_v2_role_owner_relationships(replicator=replicator)
+
+        self.assertEqual(result["replicated_count"], 2)
+        self.assertEqual(replicator.replicate.call_count, 2)


### PR DESCRIPTION
## Link(s) to Jira
- https://redhat.atlassian.net/browse/RHCLOUD-45423

## Description of Intent of Change(s)
For existing roles, replicate their relationships to tenants

## Local Testing
Unit test

## Checklist
- [x] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Add an internal utility endpoint and migration routine to backfill owner relationships between custom V2 roles and their tenants using relation replication.

New Features:
- Introduce a POST-only internal API endpoint to trigger migration of custom V2 role owner relationships to tenants.

Enhancements:
- Add a migration helper that scans custom V2 roles and emits owner relationship replication events in paginated chunks, with support for real or no-op replicators.

Tests:
- Add unit tests covering successful replication of owner tuples, error handling when tenants lack resource IDs, and processing of multiple tenants.