### PR TITLE
Remove unused TENANT_TRANSLATOR_* deploy parameters

### DIFF
--- a/deploy/rbac-clowdapp.yml
+++ b/deploy/rbac-clowdapp.yml
@@ -1551,10 +1551,6 @@ parameters:
 - description: Enable sending out notification events (typo variant used by service deployer)
   name: NOTIFICATONS_ENABLED
   value: 'False'
-- name: TENANT_TRANSLATOR_HOST
-  required: true
-- name: TENANT_TRANSLATOR_PORT
-  value: '8892'
 - name: GUNICORN_WORKER_MULTIPLIER
   value: '2'
 - name: GUNICORN_THREAD_LIMIT


### PR DESCRIPTION
## Link(s) to Jira
[RHCLOUD-46930](https://redhat.atlassian.net/browse/RHCLOUD-46930)

## Description of Intent of Change(s)
These parameters are unused, and they're causing an error in RBAC multicluster deployment (which uses the new `hcc` app-interface environment, which doesn't provide values for these parameters).

[RHCLOUD-46930]: https://redhat.atlassian.net/browse/RHCLOUD-46930?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Deployment:
- Drop TENANT_TRANSLATOR_HOST and TENANT_TRANSLATOR_PORT parameters from the RBAC ClowdApp deployment configuration as they are no longer used.