### PR TITLE
feat(DB): Increase max-length for ExtTenant and ExtRoleRelation

### DIFF
--- a/rbac/management/migrations/0087_alter_extrolerelation_ext_id_alter_exttenant_name.py
+++ b/rbac/management/migrations/0087_alter_extrolerelation_ext_id_alter_exttenant_name.py
@@ -1,0 +1,21 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("management", "0086_alter_auditlog_resource_type_add_role_binding"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="extrolerelation",
+            name="ext_id",
+            field=models.CharField(max_length=64),
+        ),
+        migrations.AlterField(
+            model_name="exttenant",
+            name="name",
+            field=models.CharField(max_length=64, unique=True),
+        ),
+    ]

--- a/rbac/management/role/model.py
+++ b/rbac/management/role/model.py
@@ -131,14 +131,14 @@ class ResourceDefinition(TenantAwareModel):
 class ExtTenant(models.Model):
     """External tenant."""
 
-    name = models.CharField(max_length=20, null=False, unique=True)
+    name = models.CharField(max_length=64, null=False, unique=True)
 
 
 class ExtRoleRelation(models.Model):
     """External relation info of role."""
 
     ext_tenant = models.ForeignKey(ExtTenant, null=True, on_delete=models.CASCADE, related_name="ext_role_relation")
-    ext_id = models.CharField(max_length=20, null=False)
+    ext_id = models.CharField(max_length=64, null=False)
     role = models.OneToOneField(Role, on_delete=models.CASCADE, null=False, related_name="ext_relation")
 
     class Meta:


### PR DESCRIPTION
Role names 'OCM Cluster Autoscaler Editor' exceed the limit of 20 characters and causes data seeding to fail

## Link(s) to Jira
RHINENG-23964

## Description of Intent of Change(s)
Trying to deploy Kessel to Ephemeral on pr-check fails on seeding data due to exceeded limit of characters for Role name

## Local Testing
RHINENG-23964

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Increase maximum allowed length for external tenant and role relation identifiers.

New Features:
- Support longer external tenant names and external role IDs in the RBAC management models.

Enhancements:
- Add a Django migration to expand the ext_tenant.name and ext_role_relation.ext_id field sizes and enforce uniqueness on external role IDs.