### PR TITLE
[RHCLOUD-47210] Add log for v2 orgs calling access endpoint

### DIFF
--- a/rbac/management/access/view.py
+++ b/rbac/management/access/view.py
@@ -17,6 +17,8 @@
 
 """View for principal access."""
 
+import logging
+
 from django.db.models import Prefetch
 from management.cache import AccessCache
 from management.models import Access, ResourceDefinition
@@ -34,6 +36,8 @@ from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.settings import api_settings
 from rest_framework.views import APIView
+
+logger = logging.getLogger(__name__)
 
 ORDER_FIELD = "order_by"
 VALID_ORDER_VALUES = ["application", "resource_type", "verb", "-application", "-resource_type", "-verb"]
@@ -164,6 +168,12 @@ class AccessView(APIView):
 
         v2_error = validate_v2_application_param(request)
         if v2_error is not None:
+            # Only v2-enabled orgs can receive a validation error from validate_v2_application_param.
+            logger.info(
+                "V2 org called v1 /access/ endpoint: org_id=%s application=%s result=rejected",
+                getattr(request.user, "org_id", None),
+                request.query_params.get(APPLICATION_KEY, ""),
+            )
             return v2_error
 
         principal = get_principal_from_request(request)

--- a/tests/management/access/test_view.py
+++ b/tests/management/access/test_view.py
@@ -1307,14 +1307,22 @@ class AccessViewTests(IdentityRequest):
         self.assertIn("legacy_app:*:*", permissions)
 
     @override_settings(V2_MIGRATION_APP_EXCLUDE_LIST=["legacy_app"])
+    @patch("management.access.view.logger")
     @patch("management.access.view.is_v2_edit_enabled_for_request", return_value=True)
-    def test_access_v2_tenant_disallowed_app_rejected(self, _mock_v2):
+    def test_access_v2_tenant_disallowed_app_rejected(self, _mock_v2, mock_log):
         """V2 orgs are rejected when querying an app not in V2_MIGRATION_APP_EXCLUDE_LIST."""
         client = APIClient()
         url = f"{reverse('v1_management:access')}?application=other_app"
         response = client.get(url, **self.headers)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn("Disallowed", response.data.get("detail", ""))
+        mock_log.info.assert_called_once()
+        msg, arg_org, arg_app = mock_log.info.call_args[0]
+        self.assertIn("result=rejected", msg)
+        self.assertIn("org_id=%s", msg)
+        self.assertIn("application=%s", msg)
+        self.assertEqual(str(self.tenant.org_id), str(arg_org))
+        self.assertEqual("other_app", arg_app)
 
     @override_settings(V2_MIGRATION_APP_EXCLUDE_LIST=["legacy_app"])
     @patch("management.access.view.is_v2_edit_enabled_for_request", return_value=True)


### PR DESCRIPTION
## Link(s) to Jira
- https://redhat.atlassian.net/browse/RHCLOUD-47210

## Description of Intent of Change(s)
The what, why and how.

## Local Testing
How can the feature be exercised?
How can the bug be exploited and fix confirmed?
Is any special local setup required?

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Log v2 organisation calls to the v1 access endpoint when the requested application is disallowed and ensure this behaviour is covered by tests.

New Features:
- Add structured info-level logging when a v2-enabled org calls the v1 /access endpoint with a disallowed application.

Tests:
- Extend access endpoint tests to assert the new v2 org rejection log message and parameters.