### PR TITLE
feat(mcp): auto-detect V2 orgs in check_user_permission

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,6 +141,9 @@ rbac/management/principal/umb_certs/
 # ai
 .claude
 
+# git worktrees
+.worktrees/
+
 # direnv
 .envrc
 

--- a/rbac/management/mcp_views.py
+++ b/rbac/management/mcp_views.py
@@ -39,9 +39,12 @@ from management.audit_log.view import AuditLogViewSet
 from management.group.view import GroupViewSet
 from management.permission.view import PermissionViewSet
 from management.principal.view import PrincipalView
+from management.role.v2_model import RoleV2
 from management.role.v2_view import RoleV2ViewSet
 from management.role.view import RoleViewSet
+from management.role_binding.model import RoleBinding
 from management.role_binding.view import RoleBindingViewSet
+from management.tenant_mapping.v2_activation import is_v2_write_activated
 from management.workspace.view import WorkspaceViewSet
 from mcp.server.fastmcp import FastMCP
 from prometheus_client import Counter, Histogram
@@ -392,13 +395,14 @@ def list_audit_logs(
 
 @register_tool(
     description=(
-        "List access permissions for a principal. By default shows access for the currently "
-        "authenticated user. Set 'username' to query another user's access (requires org admin "
-        "or rbac:principal:read permission). Each entry is a permission string "
+        "List access permissions for a principal (V1 API only). By default shows access for the "
+        "currently authenticated user. Set 'username' to query another user's access (requires "
+        "org admin or rbac:principal:read permission). Each entry is a permission string "
         "with optional resource definitions that further constrain it. "
-        "TROUBLESHOOTING: To check what user X can do, call "
-        "list_access(username='X', application='<app>'). This resolves all groups, "
-        "roles, and policies for that user and returns their effective permissions. "
+        "IMPORTANT: This is a V1-only endpoint. For V2 organizations, this returns only legacy "
+        "V1 access and does NOT include V2 role binding permissions. For V2 orgs, use "
+        "check_user_permission (which auto-detects V1/V2) or list_role_bindings with "
+        "granted_subject_type='principal' and granted_subject_principal_user_id='<username>'. "
         "Order by: 'application', 'resource_type', 'verb' (prefix with '-' to reverse). "
         "Returns: {meta: {count}, links, data: [{permission, resourceDefinitions: [...]}]}. "
         "Calls: GET /api/v1/access/"
@@ -849,13 +853,16 @@ def get_workspace(
         "a role to a subject (user/group) within a resource scope (e.g. workspace). "
         "Filter by role_id, resource_type, resource_id, subject_type, or subject_id. "
         "ACCESS RESOLUTION: To find what permissions a user has (or which are missing) in V2, "
-        "(1) call list_role_bindings(granted_subject_type='user', granted_subject_id='<user_id>') "
-        "to find all effective bindings including those inherited through group membership "
+        "(1) call list_role_bindings(granted_subject_type='principal', "
+        "granted_subject_principal_user_id='<username>') to find all effective bindings "
+        "including those inherited through group membership "
         "(this is the V2 equivalent of list_access(username=X) for V1), "
         "(2) for each binding extract the role UUID, "
         "(3) call get_role(role_uuid=...) or list_role_access(role_uuid=...) to inspect "
         "the role's permissions, (4) compare against the required permissions to identify "
         "what is granted and what is missing. "
+        "TIP: For a quick yes/no check, use check_user_permission instead — it auto-detects "
+        "V1/V2 and does the full resolution automatically. "
         "Returns: {meta: {count}, links, data: [{uuid, role, resource, subject, ...}]}. "
         "Calls: GET /api/v2/role-bindings/"
     ),
@@ -873,6 +880,7 @@ def list_role_bindings(
     subject_id: str = "",
     granted_subject_type: str = "",
     granted_subject_id: str = "",
+    granted_subject_principal_user_id: str = "",
 ) -> str:
     """List role bindings by delegating to RoleBindingViewSet."""
     query_params: dict[str, str] = {
@@ -893,6 +901,8 @@ def list_role_bindings(
         query_params["granted_subject_type"] = granted_subject_type
     if granted_subject_id:
         query_params["granted_subject_id"] = granted_subject_id
+    if granted_subject_principal_user_id:
+        query_params["granted_subject.principal.user_id"] = granted_subject_principal_user_id
 
     path = reverse("v2_management:role-bindings-list")
     return _call_view(request, _role_binding_list_view, path, query_params)
@@ -951,17 +961,19 @@ def _permission_matches(granted_permission: str, requested_permission: str) -> b
 
 @register_tool(
     description=(
-        "Check whether a specific user has a specific permission (V1 only). Returns true/false "
-        "with the matched permission and resource definitions if granted. "
+        "Check whether a specific user has a specific permission. Returns true/false "
+        "with the matched permission details. Automatically detects whether the organization "
+        "is V1 or V2 and uses the appropriate access resolution method: "
+        "V1 uses the access endpoint; V2 resolves role bindings and inspects role permissions. "
         "The permission format is 'application:resource_type:verb' (e.g., "
         "'cost-management:cost_model:write'). Supports wildcard matching. "
         "Requires org admin or rbac:principal:read permission to check another user. "
-        "ACCESS RESOLUTION: This is the fastest way to answer 'Can user X do Y?' in V1. "
-        "For V2 applications, use list_role_bindings — see its ACCESS RESOLUTION section "
-        "for the step-by-step workflow to find what permissions a user has or is missing. "
-        "Returns: {allowed: bool, username, permission, matched_permission, resource_definitions} "
+        "ACCESS RESOLUTION: This is the fastest way to answer 'Can user X do Y?' — "
+        "it works for both V1 and V2 organizations automatically. "
+        "Returns: {allowed: bool, username, permission, matched_permission, ...} "
         "or {allowed: false, hint: str}. "
-        "Calls: GET /api/v1/access/?username=X&application=Y (internally)"
+        "V1 calls: GET /api/v1/access/?username=X&application=Y (internally). "
+        "V2 resolves: role bindings → roles → permissions (internally)."
     ),
     requires_auth=True,
 )
@@ -971,7 +983,7 @@ def check_user_permission(
     username: str,
     permission: str,
 ) -> str:
-    """Check if a user has a specific permission by delegating to AccessView."""
+    """Check if a user has a specific permission by delegating to AccessView (V1) or role bindings (V2)."""
     parts = permission.split(":")
     if len(parts) != 3:
         return json.dumps(
@@ -981,7 +993,16 @@ def check_user_permission(
             }
         )
 
-    application = parts[0]
+    tenant = getattr(request, "tenant", None)
+    if tenant and is_v2_write_activated(tenant):
+        return _check_user_permission_v2(request, username, permission)
+
+    return _check_user_permission_v1(request, username, permission)
+
+
+def _check_user_permission_v1(request: HttpRequest, username: str, permission: str) -> str:
+    """Check user permission using V1 access endpoint."""
+    application = permission.split(":")[0]
     query_params: dict[str, str] = {
         "application": application,
         "username": username,
@@ -1025,6 +1046,7 @@ def check_user_permission(
                 }
             )
 
+    application = permission.split(":")[0]
     return json.dumps(
         {
             "allowed": False,
@@ -1034,6 +1056,90 @@ def check_user_permission(
             "hint": f"User '{username}' does not have permission '{permission}'. "
             f"Use list_access(username='{username}', application='{application}') to see all "
             f"permissions, or list_groups(username='{username}') to trace the group/role chain.",
+        }
+    )
+
+
+def _check_user_permission_v2(request: HttpRequest, username: str, permission: str) -> str:
+    """Check user permission using V2 role bindings."""
+    from management.principal.model import Principal
+
+    tenant = request.tenant
+
+    principal = Principal.objects.filter(username=username, tenant=tenant).first()
+    if not principal:
+        return json.dumps(
+            {
+                "allowed": False,
+                "username": username,
+                "permission": permission,
+                "org_version": "v2",
+                "hint": f"User '{username}' not found in this organization.",
+            }
+        )
+
+    bindings = list(
+        RoleBinding.objects.for_tenant(tenant)
+        .for_granted_subject("user", granted_subject_id=str(principal.uuid))
+        .prefetch_related("role__permissions", "role__children__permissions")
+    )
+
+    if not bindings:
+        return json.dumps(
+            {
+                "allowed": False,
+                "username": username,
+                "permission": permission,
+                "org_version": "v2",
+                "total_bindings_checked": 0,
+                "hint": f"User '{username}' has no role bindings in this V2 organization. "
+                f"Use list_role_bindings(granted_subject_type='user', "
+                f"granted_subject_id='{principal.uuid}') to see all role bindings.",
+            }
+        )
+
+    roles_checked: set[str] = set()
+    for binding in bindings:
+        role = binding.role
+        if not role:
+            continue
+
+        if role.type == RoleV2.Types.PLATFORM:
+            roles_to_check = list(role.children.all())
+        else:
+            roles_to_check = [role]
+
+        for r in roles_to_check:
+            role_uuid_str = str(r.uuid)
+            if role_uuid_str in roles_checked:
+                continue
+            roles_checked.add(role_uuid_str)
+
+            for perm in r.permissions.all():
+                if _permission_matches(perm.permission, permission):
+                    return json.dumps(
+                        {
+                            "allowed": True,
+                            "username": username,
+                            "permission": permission,
+                            "matched_permission": perm.permission,
+                            "role_name": r.name,
+                            "role_uuid": role_uuid_str,
+                            "org_version": "v2",
+                        }
+                    )
+
+    return json.dumps(
+        {
+            "allowed": False,
+            "username": username,
+            "permission": permission,
+            "org_version": "v2",
+            "total_roles_checked": len(roles_checked),
+            "hint": f"User '{username}' does not have permission '{permission}' in this V2 organization. "
+            f"Use list_role_bindings(granted_subject_type='user', "
+            f"granted_subject_id='{principal.uuid}') to see all role bindings, "
+            f"or search_roles(permission='{permission}') to find which roles grant this permission.",
         }
     )
 

--- a/tests/management/test_mcp_views.py
+++ b/tests/management/test_mcp_views.py
@@ -19,14 +19,22 @@
 import json
 from unittest.mock import patch
 
+from importlib import reload
+
 from django.test import override_settings
+from django.urls import clear_url_caches
+from django.utils import timezone
 from management.mcp_views import ToolConfig, _permission_matches
 from management.models import Access, Group, Permission, Policy, Principal, Role
+from management.role.v2_model import RoleV2
+from management.role_binding.model import RoleBinding, RoleBindingGroup, RoleBindingPrincipal
+from management.tenant_mapping.model import TenantMapping
 from rest_framework import status
 from rest_framework.test import APIClient
 from tests.identity_request import IdentityRequest
 
 from api.models import Tenant
+from rbac import urls
 
 
 class MCPToolTestMixin:
@@ -1336,3 +1344,158 @@ class MCPViewNonAdminTests(IdentityRequest):
         self.assertIsInstance(tool_output["errors"], list)
         self.assertGreater(len(tool_output["errors"]), 0)
         self.assertEqual(tool_output["errors"][0]["status"], "403")
+
+
+@override_settings(BYPASS_BOP_VERIFICATION=True, V2_APIS_ENABLED=True)
+class MCPCheckUserPermissionV2Tests(MCPToolTestMixin, IdentityRequest):
+    """Tests for check_user_permission auto-detecting V2 orgs and using role bindings."""
+
+    def setUp(self):
+        """Set up V2 check_user_permission tests with tenant mapping and role bindings."""
+        reload(urls)
+        clear_url_caches()
+        super().setUp()
+        self.url = "/_private/_a2s/mcp/"
+        self.client = APIClient()
+        self.test_username = self.user_data["username"]
+        self.principal = Principal.objects.create(username=self.test_username, tenant=self.tenant)
+
+        # Activate V2 for this tenant
+        TenantMapping.objects.create(tenant=self.tenant, v2_write_activated_at=timezone.now())
+
+        # Create V2 role with a permission
+        self.v2_perm = Permission.objects.create(
+            application="vulnerability",
+            resource_type="vulnerability",
+            verb="read",
+            permission="vulnerability:vulnerability:read",
+            tenant=self.tenant,
+        )
+        self.v2_role = RoleV2.objects.create(name="Vuln Reader", tenant=self.tenant)
+        self.v2_role.permissions.add(self.v2_perm)
+
+        # Create role binding assigning the role directly to the principal
+        self.binding = RoleBinding.objects.create(
+            tenant=self.tenant,
+            role=self.v2_role,
+            resource_type="workspace",
+            resource_id="root-workspace-id",
+        )
+        RoleBindingPrincipal.objects.create(binding=self.binding, principal=self.principal, source="direct")
+
+    def tearDown(self):
+        """Tear down V2 check_user_permission tests."""
+        RoleBindingPrincipal.objects.all().delete()
+        RoleBindingGroup.objects.all().delete()
+        RoleBinding.objects.all().delete()
+        RoleV2.objects.all().delete()
+        Permission.objects.all().delete()
+        TenantMapping.objects.all().delete()
+        Principal.objects.all().delete()
+        super().tearDown()
+
+    def test_v2_permission_allowed(self):
+        """Positive: V2 org auto-detects and returns allowed=True via role bindings."""
+        response = self._call_tool(
+            "check_user_permission",
+            {"username": self.test_username, "permission": "vulnerability:vulnerability:read"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        tool_output = self._get_tool_output(response)
+        self.assertTrue(tool_output["allowed"])
+        self.assertEqual(tool_output["username"], self.test_username)
+        self.assertEqual(tool_output["matched_permission"], "vulnerability:vulnerability:read")
+        self.assertEqual(tool_output["role_name"], "Vuln Reader")
+        self.assertEqual(tool_output["org_version"], "v2")
+
+    def test_v2_permission_denied(self):
+        """Negative: V2 org returns allowed=False when user lacks the permission."""
+        response = self._call_tool(
+            "check_user_permission",
+            {"username": self.test_username, "permission": "vulnerability:vulnerability:write"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        tool_output = self._get_tool_output(response)
+        self.assertFalse(tool_output["allowed"])
+        self.assertEqual(tool_output["org_version"], "v2")
+        self.assertIn("hint", tool_output)
+
+    def test_v2_user_not_found(self):
+        """Negative: V2 org returns hint when user doesn't exist."""
+        response = self._call_tool(
+            "check_user_permission",
+            {"username": "nonexistent_user", "permission": "vulnerability:vulnerability:read"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        tool_output = self._get_tool_output(response)
+        self.assertFalse(tool_output["allowed"])
+        self.assertEqual(tool_output["org_version"], "v2")
+        self.assertIn("not found", tool_output["hint"])
+
+    def test_v2_permission_via_group(self):
+        """Positive: V2 org resolves permissions inherited through group membership."""
+        # Create a group and add the principal to it
+        group = Group.objects.create(name="vuln_readers_group", tenant=self.tenant)
+        group.principals.add(self.principal)
+
+        # Create a separate role binding assigned to the group
+        write_perm = Permission.objects.create(
+            application="vulnerability",
+            resource_type="vulnerability",
+            verb="write",
+            permission="vulnerability:vulnerability:write",
+            tenant=self.tenant,
+        )
+        write_role = RoleV2.objects.create(name="Vuln Writer", tenant=self.tenant)
+        write_role.permissions.add(write_perm)
+        group_binding = RoleBinding.objects.create(
+            tenant=self.tenant,
+            role=write_role,
+            resource_type="workspace",
+            resource_id="root-workspace-id",
+        )
+        RoleBindingGroup.objects.create(binding=group_binding, group=group)
+
+        response = self._call_tool(
+            "check_user_permission",
+            {"username": self.test_username, "permission": "vulnerability:vulnerability:write"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        tool_output = self._get_tool_output(response)
+        self.assertTrue(tool_output["allowed"])
+        self.assertEqual(tool_output["role_name"], "Vuln Writer")
+        self.assertEqual(tool_output["org_version"], "v2")
+
+    def test_v2_wildcard_match(self):
+        """Positive: V2 wildcard permission matching works."""
+        wildcard_perm = Permission.objects.create(
+            application="vulnerability",
+            resource_type="vulnerability",
+            verb="*",
+            permission="vulnerability:vulnerability:*",
+            tenant=self.tenant,
+        )
+        wildcard_role = RoleV2.objects.create(name="Vuln Wildcard", tenant=self.tenant)
+        wildcard_role.permissions.add(wildcard_perm)
+        wildcard_binding = RoleBinding.objects.create(
+            tenant=self.tenant,
+            role=wildcard_role,
+            resource_type="workspace",
+            resource_id="root-workspace-id",
+        )
+        RoleBindingPrincipal.objects.create(binding=wildcard_binding, principal=self.principal, source="direct")
+
+        response = self._call_tool(
+            "check_user_permission",
+            {"username": self.test_username, "permission": "vulnerability:vulnerability:write"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        tool_output = self._get_tool_output(response)
+        self.assertTrue(tool_output["allowed"])
+        self.assertEqual(tool_output["matched_permission"], "vulnerability:vulnerability:*")
+        self.assertEqual(tool_output["org_version"], "v2")


### PR DESCRIPTION
## Summary
- `check_user_permission` now auto-detects V1/V2 orgs via `is_v2_write_activated(tenant)` and resolves permissions through role bindings for V2 orgs (ORM-based, handles platform role expansion and group-inherited bindings)
- `list_role_bindings` gains `granted_subject_principal_user_id` parameter so AI clients can query bindings by username directly
- Tool descriptions updated: `list_access` marked V1-only with V2 guidance, `check_user_permission` describes auto-detection, `list_role_bindings` ACCESS RESOLUTION updated with username-based example

## Test plan
- [x] V2 permission allowed (direct principal binding)
- [x] V2 permission denied (user lacks permission)
- [x] V2 user not found (nonexistent username)
- [x] V2 permission via group (inherited through group membership)
- [x] V2 wildcard match (e.g. `vulnerability:vulnerability:*` matches `:write`)
- [x] All existing V1 `check_user_permission` tests still pass
- [x] All existing MCP tests pass (73 tests total, pre-existing V2 URL failure excluded)
- [x] Linter passes (`flake8` + `black --check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Auto-detect organization version in the MCP check_user_permission tool and route permission checks through either V1 access APIs or V2 role bindings, updating related tooling and tests accordingly.

New Features:
- Add V2-aware permission resolution to check_user_permission using role bindings and role permissions, including platform role expansion and wildcard support.
- Extend list_role_bindings to support querying bindings by principal username via granted_subject_principal_user_id.

Enhancements:
- Clarify MCP tool descriptions to distinguish V1-only list_access behavior and document V1/V2 auto-detection and V2 access resolution flows for check_user_permission and list_role_bindings.

Tests:
- Add V2-specific MCP check_user_permission test suite covering direct bindings, missing permissions, nonexistent users, group-inherited permissions, and wildcard permission matching.