### PR TITLE
feat(mcp): add Redis-backed tool description overrides with internal endpoint

### DIFF
--- a/rbac/internal/urls.py
+++ b/rbac/internal/urls.py
@@ -124,6 +124,12 @@ urlpatterns = [
         "api/utils/migrate_custom_v2_roles_to_tenant/",
         views.migrate_custom_v2_roles_to_tenant,
     ),
+    path("api/utils/mcp_tool_descriptions/", views.mcp_tool_descriptions, name="mcp-tool-descriptions-list"),
+    path(
+        "api/utils/mcp_tool_descriptions/<str:tool_name>/",
+        views.mcp_tool_descriptions,
+        name="mcp-tool-descriptions-detail",
+    ),
 ]
 
 urlpatterns.extend(integration_urlpatterns)

--- a/rbac/internal/views.py
+++ b/rbac/internal/views.py
@@ -2602,3 +2602,74 @@ def migrate_custom_v2_roles_to_tenant(request):
     except Exception as e:
         logger.exception("migrate_custom_v2_roles_to_tenant failed", exc_info=True)
         return JsonResponse({"detail": str(e)}, status=500)
+
+
+@require_http_methods(["GET", "PUT", "DELETE"])
+def mcp_tool_descriptions(request, tool_name=None):
+    """Manage MCP tool description overrides stored in Redis.
+
+    GET  /_private/api/utils/mcp_tool_descriptions/           → list all overrides
+    GET  /_private/api/utils/mcp_tool_descriptions/<name>/    → get override for one tool
+    PUT  /_private/api/utils/mcp_tool_descriptions/<name>/    → set override
+    DELETE /_private/api/utils/mcp_tool_descriptions/<name>/  → remove override (revert to default)
+    """
+    from management.mcp_views import (
+        _TOOL_CONFIG,
+        _delete_description_override,
+        _get_all_description_overrides,
+        _get_description_override,
+        _get_tools,
+        _set_description_override,
+    )
+
+    if request.method == "GET" and tool_name is None:
+        overrides = _get_all_description_overrides()
+        defaults = {tool.name: tool.description or "" for tool in _get_tools()}
+        tools = []
+        for name, default_desc in sorted(defaults.items()):
+            override = overrides.get(name)
+            tools.append(
+                {
+                    "tool_name": name,
+                    "default_description": default_desc,
+                    "override_description": override,
+                    "active_description": override if override is not None else default_desc,
+                }
+            )
+        return JsonResponse({"tools": tools}, status=200)
+
+    if tool_name is None:
+        return JsonResponse({"detail": "tool_name is required for PUT/DELETE"}, status=400)
+
+    if tool_name not in _TOOL_CONFIG:
+        return JsonResponse({"detail": f"Unknown tool: {tool_name}"}, status=404)
+
+    if request.method == "GET":
+        override = _get_description_override(tool_name)
+        default_desc = next((t.description or "" for t in _get_tools() if t.name == tool_name), "")
+        return JsonResponse(
+            {
+                "tool_name": tool_name,
+                "default_description": default_desc,
+                "override_description": override,
+                "active_description": override if override is not None else default_desc,
+            },
+            status=200,
+        )
+
+    if request.method == "PUT":
+        body = load_request_body(request)
+        description = body.get("description")
+        if not description:
+            return JsonResponse({"detail": "Missing required field: description"}, status=400)
+        _set_description_override(tool_name, description)
+        logger.info("mcp: description override set for tool=%s", tool_name)
+        return JsonResponse({"tool_name": tool_name, "override_description": description}, status=200)
+
+    if request.method == "DELETE":
+        _delete_description_override(tool_name)
+        logger.info("mcp: description override removed for tool=%s", tool_name)
+        default_desc = next((t.description or "" for t in _get_tools() if t.name == tool_name), "")
+        return JsonResponse(
+            {"tool_name": tool_name, "override_description": None, "active_description": default_desc}, status=200
+        )

--- a/rbac/management/mcp_views.py
+++ b/rbac/management/mcp_views.py
@@ -28,12 +28,14 @@ from datetime import datetime, timezone
 from functools import lru_cache, wraps
 from typing import Any, Callable
 
+from django.conf import settings
 from django.http import HttpRequest, HttpResponse, JsonResponse
 from django.test import RequestFactory
 from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.views import View
 from django.views.decorators.csrf import csrf_exempt
+from redis import exceptions as redis_exceptions
 from management.access.view import AccessView
 from management.audit_log.view import AuditLogViewSet
 from management.group.view import GroupViewSet
@@ -97,6 +99,51 @@ _request_factory = RequestFactory()
 # Headers forwarded from the original request to internal view requests,
 # beyond the identity header (which is always forwarded).
 _FORWARDED_HEADERS = ("HTTP_X_REQUEST_ID", "HTTP_X_RH_INSIGHTS_REQUEST_ID")
+
+# --- Tool description overrides (Redis-backed, no restart needed) ---
+
+_REDIS_DESC_PREFIX = "mcp:desc:"
+
+
+def _get_redis():
+    """Get a Redis connection using the shared connection pool from management.cache."""
+    from management.cache import _connection_pool
+
+    from redis import Redis
+
+    return Redis(connection_pool=_connection_pool, ssl=settings.REDIS_SSL)
+
+
+def _get_description_override(tool_name: str) -> str | None:
+    try:
+        value = _get_redis().get(f"{_REDIS_DESC_PREFIX}{tool_name}")
+        return value.decode() if value else None
+    except redis_exceptions.RedisError:
+        logger.debug("mcp: redis unavailable for description override, tool=%s", tool_name)
+        return None
+
+
+def _set_description_override(tool_name: str, description: str) -> None:
+    _get_redis().set(f"{_REDIS_DESC_PREFIX}{tool_name}", description)
+
+
+def _delete_description_override(tool_name: str) -> None:
+    _get_redis().delete(f"{_REDIS_DESC_PREFIX}{tool_name}")
+
+
+def _get_all_description_overrides() -> dict[str, str]:
+    try:
+        r = _get_redis()
+        keys = r.keys(f"{_REDIS_DESC_PREFIX}*")
+        if not keys:
+            return {}
+        values = r.mget(keys)
+        prefix_len = len(_REDIS_DESC_PREFIX)
+        return {k.decode()[prefix_len:]: v.decode() for k, v in zip(keys, values) if v is not None}
+    except redis_exceptions.RedisError:
+        logger.debug("mcp: redis unavailable for description overrides")
+        return {}
+
 
 # --- MCP Server setup using the Anthropic MCP Python SDK ---
 
@@ -1287,10 +1334,11 @@ def _get_tools() -> list[Any]:
 
 def _handle_tools_list(request: HttpRequest, request_id: Any, params: dict[str, Any]) -> JsonResponse:
     """Handle MCP tools/list request using FastMCP's registered tools."""
+    overrides = _get_all_description_overrides()
     tools_data = [
         {
             "name": tool.name,
-            "description": tool.description or "",
+            "description": overrides.get(tool.name, tool.description or ""),
             "inputSchema": tool.inputSchema,
         }
         for tool in _get_tools()

--- a/rbac/management/mcp_views.py
+++ b/rbac/management/mcp_views.py
@@ -35,7 +35,6 @@ from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.views import View
 from django.views.decorators.csrf import csrf_exempt
-from redis import exceptions as redis_exceptions
 from management.access.view import AccessView
 from management.audit_log.view import AuditLogViewSet
 from management.group.view import GroupViewSet
@@ -48,6 +47,7 @@ from management.tenant_mapping.v2_activation import is_v2_write_activated
 from management.workspace.view import WorkspaceViewSet
 from mcp.server.fastmcp import FastMCP
 from prometheus_client import Counter, Histogram
+from redis import exceptions as redis_exceptions
 
 from api.common import RH_IDENTITY_HEADER
 from api.cross_access.view import CrossAccountRequestViewSet

--- a/tests/management/test_mcp_views.py
+++ b/tests/management/test_mcp_views.py
@@ -1564,13 +1564,31 @@ class MCPToolDescriptionEndpointTests(MCPToolTestMixin, IdentityRequest):
         internal_context = self._create_request_context(self.customer_data, self.user_data, is_internal=True)
         self.internal_headers = internal_context["request"].META
 
-    def tearDown(self):
-        """Clean up any Redis overrides."""
-        from management.mcp_views import _delete_description_override, _get_all_description_overrides
-
-        for tool_name in _get_all_description_overrides():
-            _delete_description_override(tool_name)
-        super().tearDown()
+        self._override_store = {}
+        patcher_get_all = patch(
+            "management.mcp_views._get_all_description_overrides",
+            side_effect=lambda: dict(self._override_store),
+        )
+        patcher_get = patch(
+            "management.mcp_views._get_description_override",
+            side_effect=lambda name: self._override_store.get(name),
+        )
+        patcher_set = patch(
+            "management.mcp_views._set_description_override",
+            side_effect=lambda name, desc: self._override_store.__setitem__(name, desc),
+        )
+        patcher_delete = patch(
+            "management.mcp_views._delete_description_override",
+            side_effect=lambda name: self._override_store.pop(name, None),
+        )
+        patcher_get_all.start()
+        patcher_get.start()
+        patcher_set.start()
+        patcher_delete.start()
+        self.addCleanup(patcher_get_all.stop)
+        self.addCleanup(patcher_get.stop)
+        self.addCleanup(patcher_set.stop)
+        self.addCleanup(patcher_delete.stop)
 
     def test_list_descriptions_returns_all_tools(self):
         """GET list returns all registered tools with default descriptions."""
@@ -1610,9 +1628,7 @@ class MCPToolDescriptionEndpointTests(MCPToolTestMixin, IdentityRequest):
 
     def test_delete_override_reverts_to_default(self):
         """DELETE removes override and reverts to default description."""
-        from management.mcp_views import _set_description_override
-
-        _set_description_override("hello", "temporary override")
+        self._override_store["hello"] = "temporary override"
 
         response = self.client.delete(f"{self.base_url}hello/", **self.internal_headers)
         self.assertEqual(response.status_code, 200)

--- a/tests/management/test_mcp_views.py
+++ b/tests/management/test_mcp_views.py
@@ -1512,3 +1512,136 @@ class MCPCheckUserPermissionV2Tests(MCPToolTestMixin, IdentityRequest):
         self.assertTrue(tool_output["allowed"])
         self.assertEqual(tool_output["matched_permission"], "vulnerability:vulnerability:*")
         self.assertEqual(tool_output["org_version"], "v2")
+
+
+class MCPToolDescriptionOverrideTests(MCPToolTestMixin, IdentityRequest):
+    """Test that Redis-backed description overrides are applied in tools/list."""
+
+    def setUp(self):
+        """Set up."""
+        super().setUp()
+        self.mcp_url = "/_private/_a2s/mcp/"
+        self.client = APIClient()
+
+    @patch(
+        "management.mcp_views._get_all_description_overrides",
+        return_value={"hello": "Overridden description for MCP"},
+    )
+    def test_override_appears_in_tools_list(self, mock_overrides):
+        """After setting an override, tools/list returns the overridden description."""
+        body = {"jsonrpc": "2.0", "method": "tools/list", "id": 2, "params": {}}
+        response = self.client.post(
+            self.mcp_url, data=json.dumps(body), content_type="application/json", **self.headers
+        )
+        self.assertEqual(response.status_code, 200)
+        tools = response.json()["result"]["tools"]
+        hello_tool = next(t for t in tools if t["name"] == "hello")
+        self.assertEqual(hello_tool["description"], "Overridden description for MCP")
+
+    @patch(
+        "management.mcp_views._get_all_description_overrides",
+        return_value={"hello": "custom hello"},
+    )
+    def test_non_overridden_tools_keep_defaults(self, mock_overrides):
+        """Overriding one tool does not affect other tools."""
+        body = {"jsonrpc": "2.0", "method": "tools/list", "id": 2, "params": {}}
+        response = self.client.post(
+            self.mcp_url, data=json.dumps(body), content_type="application/json", **self.headers
+        )
+        tools = response.json()["result"]["tools"]
+        principals_tool = next(t for t in tools if t["name"] == "list_principals")
+        self.assertIn("List principals", principals_tool["description"])
+
+
+class MCPToolDescriptionEndpointTests(MCPToolTestMixin, IdentityRequest):
+    """Test the internal endpoint for managing MCP tool description overrides."""
+
+    def setUp(self):
+        """Set up."""
+        super().setUp()
+        self.base_url = "/_private/api/utils/mcp_tool_descriptions/"
+        self.client = APIClient()
+        internal_context = self._create_request_context(self.customer_data, self.user_data, is_internal=True)
+        self.internal_headers = internal_context["request"].META
+
+    def tearDown(self):
+        """Clean up any Redis overrides."""
+        from management.mcp_views import _delete_description_override, _get_all_description_overrides
+
+        for tool_name in _get_all_description_overrides():
+            _delete_description_override(tool_name)
+        super().tearDown()
+
+    def test_list_descriptions_returns_all_tools(self):
+        """GET list returns all registered tools with default descriptions."""
+        response = self.client.get(self.base_url, **self.internal_headers)
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        tool_names = [t["tool_name"] for t in data["tools"]]
+        self.assertIn("hello", tool_names)
+        self.assertIn("list_principals", tool_names)
+        hello_tool = next(t for t in data["tools"] if t["tool_name"] == "hello")
+        self.assertIsNotNone(hello_tool["default_description"])
+        self.assertIsNone(hello_tool["override_description"])
+        self.assertEqual(hello_tool["active_description"], hello_tool["default_description"])
+
+    def test_get_single_tool_description(self):
+        """GET single tool returns its default description."""
+        response = self.client.get(f"{self.base_url}hello/", **self.internal_headers)
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data["tool_name"], "hello")
+        self.assertIsNone(data["override_description"])
+        self.assertIn("RBAC service", data["default_description"])
+
+    def test_set_description_override(self):
+        """PUT sets description override for a tool."""
+        new_desc = "Custom hello description for testing"
+        response = self.client.put(
+            f"{self.base_url}hello/",
+            data=json.dumps({"description": new_desc}),
+            content_type="application/json",
+            **self.internal_headers,
+        )
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data["tool_name"], "hello")
+        self.assertEqual(data["override_description"], new_desc)
+
+    def test_delete_override_reverts_to_default(self):
+        """DELETE removes override and reverts to default description."""
+        from management.mcp_views import _set_description_override
+
+        _set_description_override("hello", "temporary override")
+
+        response = self.client.delete(f"{self.base_url}hello/", **self.internal_headers)
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertIsNone(data["override_description"])
+
+        response = self.client.get(f"{self.base_url}hello/", **self.internal_headers)
+        data = response.json()
+        self.assertIsNone(data["override_description"])
+
+    def test_unknown_tool_returns_404(self):
+        """PUT/DELETE/GET for unknown tool returns 404."""
+        response = self.client.get(f"{self.base_url}nonexistent_tool/", **self.internal_headers)
+        self.assertEqual(response.status_code, 404)
+
+        response = self.client.put(
+            f"{self.base_url}nonexistent_tool/",
+            data=json.dumps({"description": "test"}),
+            content_type="application/json",
+            **self.internal_headers,
+        )
+        self.assertEqual(response.status_code, 404)
+
+    def test_put_without_description_returns_400(self):
+        """PUT without description field returns 400."""
+        response = self.client.put(
+            f"{self.base_url}hello/",
+            data=json.dumps({}),
+            content_type="application/json",
+            **self.internal_headers,
+        )
+        self.assertEqual(response.status_code, 400)


### PR DESCRIPTION
## Summary
- Adds Redis override layer to MCP `tools/list` so tool descriptions can be changed at runtime without restart
- Adds internal endpoint at `/_private/api/utils/mcp_tool_descriptions/` for managing overrides
- Hardcoded descriptions remain as defaults; Redis overrides take precedence and fall back gracefully if Redis is unavailable
- Supersedes #2786 and #2787

## Endpoints

| Method | Path | Action |
|--------|------|--------|
| `GET` | `/_private/api/utils/mcp_tool_descriptions/` | List all tools with default + override descriptions |
| `GET` | `/_private/api/utils/mcp_tool_descriptions/<tool_name>/` | Get one tool's descriptions |
| `PUT` | `/_private/api/utils/mcp_tool_descriptions/<tool_name>/` | Set override (`{"description": "..."}`) |
| `DELETE` | `/_private/api/utils/mcp_tool_descriptions/<tool_name>/` | Remove override, revert to default |

## Example usage
```bash
# See current description
curl /_private/api/utils/mcp_tool_descriptions/list_roles/

# Override it
curl -X PUT /_private/api/utils/mcp_tool_descriptions/list_roles/ \
  -H 'Content-Type: application/json' \
  -d '{"description": "new prompt text..."}'

# Revert to default
curl -X DELETE /_private/api/utils/mcp_tool_descriptions/list_roles/
```

## Test plan
- [x] Override appears in MCP `tools/list` response
- [x] Non-overridden tools keep default descriptions
- [x] List all tools with descriptions (GET /)
- [x] Get single tool description (GET /<name>/)
- [x] Set description override (PUT /<name>/)
- [x] Delete override reverts to default (DELETE /<name>/)
- [x] Unknown tool returns 404
- [x] Missing description field returns 400
- [x] All 60 existing MCP tests still pass

## Summary by Sourcery

Add Redis-backed MCP tool description overrides and an internal API for managing them.

New Features:
- Allow MCP tools/list responses to use Redis-backed description overrides instead of static descriptions.
- Expose internal HTTP endpoints to list, retrieve, set, and delete MCP tool description overrides.

Tests:
- Add tests verifying MCP tools/list respects overrides and non-overridden tools keep defaults.
- Add tests covering the internal MCP tool description management endpoints, including happy paths and error conditions.