### PR TITLE
[RHCLOUD-47210] Add prometheus metrics for v1 `/access` rejections from v2-enabled orgs

### DIFF
--- a/rbac/management/access/view.py
+++ b/rbac/management/access/view.py
@@ -32,6 +32,7 @@ from management.utils import (
     validate_and_get_key,
     validate_key,
 )
+from prometheus_client import Counter
 from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.settings import api_settings
@@ -39,10 +40,39 @@ from rest_framework.views import APIView
 
 logger = logging.getLogger(__name__)
 
+v1_access_by_v2_org_total = Counter(
+    "rbac_v1_access_v2_org_total",
+    "Tracks v1 /access calls made by orgs that have been v2-enabled.",
+    ["org_id", "application", "caller_type"],
+)
+
 ORDER_FIELD = "order_by"
 VALID_ORDER_VALUES = ["application", "resource_type", "verb", "-application", "-resource_type", "-verb"]
 STATUS_KEY = "status"
 VALID_STATUS_VALUE = ["enabled", "disabled", "all"]
+
+
+def _record_v2_org_v1_access_rejected(request):
+    """Increment Prometheus counter and log context when a v2-enabled org's v1 /access call is rejected."""
+    app_param = request.query_params.get(APPLICATION_KEY, "")
+    caller_type = "service_account" if request.user.is_service_account else "user"
+    v1_access_by_v2_org_total.labels(
+        org_id=request.user.org_id,
+        application=app_param,
+        caller_type=caller_type,
+    ).inc()
+    logger.info(
+        "V2 org called v1 /access/ endpoint: org_id=%s application=%s caller_type=%s "
+        "user_id=%s client_id=%s is_org_admin=%s request_id=%s user_agent=%s result=rejected",
+        request.user.org_id,
+        app_param,
+        caller_type,
+        request.user.user_id,
+        request.user.client_id if request.user.is_service_account else None,
+        request.user.admin,
+        getattr(request, "req_id", None),
+        request.headers.get("user-agent"),
+    )
 
 
 def validate_v2_application_param(request):
@@ -168,12 +198,7 @@ class AccessView(APIView):
 
         v2_error = validate_v2_application_param(request)
         if v2_error is not None:
-            # Only v2-enabled orgs can receive a validation error from validate_v2_application_param.
-            logger.info(
-                "V2 org called v1 /access/ endpoint: org_id=%s application=%s result=rejected",
-                getattr(request.user, "org_id", None),
-                request.query_params.get(APPLICATION_KEY, ""),
-            )
+            _record_v2_org_v1_access_rejected(request)
             return v2_error
 
         principal = get_principal_from_request(request)

--- a/tests/management/access/test_view.py
+++ b/tests/management/access/test_view.py
@@ -1317,12 +1317,10 @@ class AccessViewTests(IdentityRequest):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn("Disallowed", response.data.get("detail", ""))
         mock_log.info.assert_called_once()
-        msg, arg_org, arg_app = mock_log.info.call_args[0]
-        self.assertIn("result=rejected", msg)
-        self.assertIn("org_id=%s", msg)
-        self.assertIn("application=%s", msg)
-        self.assertEqual(str(self.tenant.org_id), str(arg_org))
-        self.assertEqual("other_app", arg_app)
+        log_msg = mock_log.info.call_args[0][0] % mock_log.info.call_args[0][1:]
+        self.assertIn("result=rejected", log_msg)
+        self.assertIn(str(self.tenant.org_id), log_msg)
+        self.assertIn("other_app", log_msg)
 
     @override_settings(V2_MIGRATION_APP_EXCLUDE_LIST=["legacy_app"])
     @patch("management.access.view.is_v2_edit_enabled_for_request", return_value=True)
@@ -1343,3 +1341,120 @@ class AccessViewTests(IdentityRequest):
         response = client.get(url, **self.headers)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn("other_app", response.data.get("detail", ""))
+
+    @override_settings(V2_MIGRATION_APP_EXCLUDE_LIST=["legacy_app"])
+    @patch("management.access.view.is_v2_edit_enabled_for_request", return_value=True)
+    def test_access_v2_org_metric_disallowed_app(self, _mock_v2):
+        """Test that the counter is incremented when a v2 org requests a disallowed application."""
+        from management.access.view import v1_access_by_v2_org_total
+
+        client = APIClient()
+        url = f"{reverse('v1_management:access')}?application=other_app"
+        before = v1_access_by_v2_org_total.labels(
+            org_id=self.customer_data["org_id"], application="other_app", caller_type="user"
+        )._value.get()
+        response = client.get(url, **self.headers)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        after = v1_access_by_v2_org_total.labels(
+            org_id=self.customer_data["org_id"], application="other_app", caller_type="user"
+        )._value.get()
+        self.assertEqual(after, before + 1)
+
+    @override_settings(V2_MIGRATION_APP_EXCLUDE_LIST=["legacy_app"])
+    @patch("management.access.view.is_v2_edit_enabled_for_request", return_value=True)
+    def test_access_v2_org_metric_empty_app(self, _mock_v2):
+        """Test that the counter is incremented when a v2 org requests with empty application."""
+        from management.access.view import v1_access_by_v2_org_total
+
+        client = APIClient()
+        url = f"{reverse('v1_management:access')}?application="
+        before = v1_access_by_v2_org_total.labels(
+            org_id=self.customer_data["org_id"], application="", caller_type="user"
+        )._value.get()
+        response = client.get(url, **self.headers)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        after = v1_access_by_v2_org_total.labels(
+            org_id=self.customer_data["org_id"], application="", caller_type="user"
+        )._value.get()
+        self.assertEqual(after, before + 1)
+
+    @override_settings(V2_MIGRATION_APP_EXCLUDE_LIST=["legacy_app"])
+    @patch("management.access.view.logger")
+    @patch("management.access.view.is_v2_edit_enabled_for_request", return_value=True)
+    def test_access_v2_org_metric_logs_context(self, _mock_v2, mock_logger):
+        """Test that a structured log line is emitted when a v2 org is rejected from v1 /access."""
+        client = APIClient()
+        url = f"{reverse('v1_management:access')}?application=other_app"
+        response = client.get(url, **self.headers, HTTP_USER_AGENT="insights-chrome/1.0")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        mock_logger.info.assert_called_once()
+        log_msg = mock_logger.info.call_args[0][0] % mock_logger.info.call_args[0][1:]
+        self.assertIn("result=rejected", log_msg)
+        self.assertIn(self.customer_data["org_id"], log_msg)
+        self.assertIn("other_app", log_msg)
+        self.assertIn("caller_type=user", log_msg)
+        self.assertIn("user_id=", log_msg)
+        self.assertIn("request_id=", log_msg)
+        self.assertIn("user_agent=insights-chrome/1.0", log_msg)
+
+    @override_settings(V2_MIGRATION_APP_EXCLUDE_LIST=["legacy_app"])
+    @patch("management.access.view.is_v2_edit_enabled_for_request", return_value=True)
+    def test_access_v2_org_metric_service_account_caller_type(self, _mock_v2):
+        """Test that the metric labels caller_type as service_account for service account requests."""
+        from management.access.view import v1_access_by_v2_org_total
+
+        client = APIClient()
+        url = f"{reverse('v1_management:access')}?application=other_app"
+        before = v1_access_by_v2_org_total.labels(
+            org_id=self.customer_data["org_id"], application="other_app", caller_type="service_account"
+        )._value.get()
+        response = client.get(url, **self.headers_service_account)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        after = v1_access_by_v2_org_total.labels(
+            org_id=self.customer_data["org_id"], application="other_app", caller_type="service_account"
+        )._value.get()
+        self.assertEqual(after, before + 1)
+
+    @override_settings(ROLE_CREATE_ALLOW_LIST="legacy_app")
+    @override_settings(V2_MIGRATION_APP_EXCLUDE_LIST=["legacy_app"])
+    @patch("management.access.view.is_v2_edit_enabled_for_request", return_value=True)
+    def test_access_v2_org_allowed_app_no_metric(self, _mock_v2):
+        """Test that the counter is NOT incremented when a v2 org requests an allowed application."""
+        from management.access.view import v1_access_by_v2_org_total
+
+        perm = Permission.objects.create(permission="legacy_app:*:*", tenant=self.tenant)
+        role = Role.objects.create(name="allowed_metric_role", tenant=self.tenant)
+        Access.objects.create(role=role, permission=perm, tenant=self.tenant)
+        policy = Policy.objects.create(name="allowed_metric_policy", tenant=self.tenant)
+        policy.roles.add(role)
+        policy.group = self.group
+        policy.save()
+
+        client = APIClient()
+        url = f"{reverse('v1_management:access')}?application=legacy_app"
+        before = v1_access_by_v2_org_total.labels(
+            org_id=self.customer_data["org_id"], application="legacy_app", caller_type="user"
+        )._value.get()
+        response = client.get(url, **self.headers)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        after = v1_access_by_v2_org_total.labels(
+            org_id=self.customer_data["org_id"], application="legacy_app", caller_type="user"
+        )._value.get()
+        self.assertEqual(after, before)
+
+    @patch("management.access.view.is_v2_edit_enabled_for_request", return_value=False)
+    def test_access_v1_org_no_metric(self, _mock_v2):
+        """Test that the counter is NOT incremented for non-v2 orgs."""
+        from management.access.view import v1_access_by_v2_org_total
+
+        client = APIClient()
+        url = f"{reverse('v1_management:access')}?application=app"
+        before = v1_access_by_v2_org_total.labels(
+            org_id=self.customer_data["org_id"], application="app", caller_type="user"
+        )._value.get()
+        response = client.get(url, **self.headers)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        after = v1_access_by_v2_org_total.labels(
+            org_id=self.customer_data["org_id"], application="app", caller_type="user"
+        )._value.get()
+        self.assertEqual(after, before)

--- a/tests/management/access/test_view.py
+++ b/tests/management/access/test_view.py
@@ -188,8 +188,11 @@ class AccessViewTests(IdentityRequest):
         return role
 
     @override_settings(ROLE_CREATE_ALLOW_LIST="app")
-    def test_get_access_success(self):
+    @patch("management.access.view.is_v2_edit_enabled_for_request", return_value=False)
+    def test_get_access_success(self, _mock_v2):
         """Test that we can obtain the expected access without pagination."""
+        from management.access.view import v1_access_by_v2_org_total
+
         role_name = "roleA"
         response = self.create_role(role_name, headers=self.headers)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
@@ -204,6 +207,9 @@ class AccessViewTests(IdentityRequest):
         # Test that we can retrieve the principal access
         url = "{}?application={}".format(reverse("v1_management:access"), "app")
         client = APIClient()
+        before = v1_access_by_v2_org_total.labels(
+            org_id=self.customer_data["org_id"], application="app", caller_type="user"
+        )._value.get()
         response = client.get(url, **self.headers)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIsNotNone(response.data.get("data"))
@@ -211,6 +217,10 @@ class AccessViewTests(IdentityRequest):
         self.assertEqual(len(response.data.get("data")), 2)
         self.assertEqual(response.data.get("meta").get("limit"), 2)
         self.assertEqual(self.access_data, response.data.get("data")[0])
+        after = v1_access_by_v2_org_total.labels(
+            org_id=self.customer_data["org_id"], application="app", caller_type="user"
+        )._value.get()
+        self.assertEqual(after, before)
 
         # the platform default permission could also be retrieved
         url = "{}?application={}".format(reverse("v1_management:access"), "default")
@@ -1299,20 +1309,34 @@ class AccessViewTests(IdentityRequest):
         policy.group = self.group
         policy.save()
 
+        from management.access.view import v1_access_by_v2_org_total
+
         client = APIClient()
         url = f"{reverse('v1_management:access')}?application=legacy_app"
+        before = v1_access_by_v2_org_total.labels(
+            org_id=self.customer_data["org_id"], application="legacy_app", caller_type="user"
+        )._value.get()
         response = client.get(url, **self.headers)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         permissions = [row["permission"] for row in response.data.get("data", [])]
         self.assertIn("legacy_app:*:*", permissions)
+        after = v1_access_by_v2_org_total.labels(
+            org_id=self.customer_data["org_id"], application="legacy_app", caller_type="user"
+        )._value.get()
+        self.assertEqual(after, before)
 
     @override_settings(V2_MIGRATION_APP_EXCLUDE_LIST=["legacy_app"])
     @patch("management.access.view.logger")
     @patch("management.access.view.is_v2_edit_enabled_for_request", return_value=True)
     def test_access_v2_tenant_disallowed_app_rejected(self, _mock_v2, mock_log):
         """V2 orgs are rejected when querying an app not in V2_MIGRATION_APP_EXCLUDE_LIST."""
+        from management.access.view import v1_access_by_v2_org_total
+
         client = APIClient()
         url = f"{reverse('v1_management:access')}?application=other_app"
+        before = v1_access_by_v2_org_total.labels(
+            org_id=self.customer_data["org_id"], application="other_app", caller_type="user"
+        )._value.get()
         response = client.get(url, **self.headers)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn("Disallowed", response.data.get("detail", ""))
@@ -1321,16 +1345,29 @@ class AccessViewTests(IdentityRequest):
         self.assertIn("result=rejected", log_msg)
         self.assertIn(str(self.tenant.org_id), log_msg)
         self.assertIn("other_app", log_msg)
+        after = v1_access_by_v2_org_total.labels(
+            org_id=self.customer_data["org_id"], application="other_app", caller_type="user"
+        )._value.get()
+        self.assertEqual(after, before + 1)
 
     @override_settings(V2_MIGRATION_APP_EXCLUDE_LIST=["legacy_app"])
     @patch("management.access.view.is_v2_edit_enabled_for_request", return_value=True)
     def test_access_v2_tenant_empty_application_rejected(self, _mock_v2):
         """V2 orgs are rejected when application= is empty."""
+        from management.access.view import v1_access_by_v2_org_total
+
         client = APIClient()
         url = f"{reverse('v1_management:access')}?application="
+        before = v1_access_by_v2_org_total.labels(
+            org_id=self.customer_data["org_id"], application="", caller_type="user"
+        )._value.get()
         response = client.get(url, **self.headers)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn("must specify", response.data.get("detail", ""))
+        after = v1_access_by_v2_org_total.labels(
+            org_id=self.customer_data["org_id"], application="", caller_type="user"
+        )._value.get()
+        self.assertEqual(after, before + 1)
 
     @override_settings(V2_MIGRATION_APP_EXCLUDE_LIST=["legacy_app"])
     @patch("management.access.view.is_v2_edit_enabled_for_request", return_value=True)
@@ -1341,42 +1378,6 @@ class AccessViewTests(IdentityRequest):
         response = client.get(url, **self.headers)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn("other_app", response.data.get("detail", ""))
-
-    @override_settings(V2_MIGRATION_APP_EXCLUDE_LIST=["legacy_app"])
-    @patch("management.access.view.is_v2_edit_enabled_for_request", return_value=True)
-    def test_access_v2_org_metric_disallowed_app(self, _mock_v2):
-        """Test that the counter is incremented when a v2 org requests a disallowed application."""
-        from management.access.view import v1_access_by_v2_org_total
-
-        client = APIClient()
-        url = f"{reverse('v1_management:access')}?application=other_app"
-        before = v1_access_by_v2_org_total.labels(
-            org_id=self.customer_data["org_id"], application="other_app", caller_type="user"
-        )._value.get()
-        response = client.get(url, **self.headers)
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        after = v1_access_by_v2_org_total.labels(
-            org_id=self.customer_data["org_id"], application="other_app", caller_type="user"
-        )._value.get()
-        self.assertEqual(after, before + 1)
-
-    @override_settings(V2_MIGRATION_APP_EXCLUDE_LIST=["legacy_app"])
-    @patch("management.access.view.is_v2_edit_enabled_for_request", return_value=True)
-    def test_access_v2_org_metric_empty_app(self, _mock_v2):
-        """Test that the counter is incremented when a v2 org requests with empty application."""
-        from management.access.view import v1_access_by_v2_org_total
-
-        client = APIClient()
-        url = f"{reverse('v1_management:access')}?application="
-        before = v1_access_by_v2_org_total.labels(
-            org_id=self.customer_data["org_id"], application="", caller_type="user"
-        )._value.get()
-        response = client.get(url, **self.headers)
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        after = v1_access_by_v2_org_total.labels(
-            org_id=self.customer_data["org_id"], application="", caller_type="user"
-        )._value.get()
-        self.assertEqual(after, before + 1)
 
     @override_settings(V2_MIGRATION_APP_EXCLUDE_LIST=["legacy_app"])
     @patch("management.access.view.logger")
@@ -1414,47 +1415,3 @@ class AccessViewTests(IdentityRequest):
             org_id=self.customer_data["org_id"], application="other_app", caller_type="service_account"
         )._value.get()
         self.assertEqual(after, before + 1)
-
-    @override_settings(ROLE_CREATE_ALLOW_LIST="legacy_app")
-    @override_settings(V2_MIGRATION_APP_EXCLUDE_LIST=["legacy_app"])
-    @patch("management.access.view.is_v2_edit_enabled_for_request", return_value=True)
-    def test_access_v2_org_allowed_app_no_metric(self, _mock_v2):
-        """Test that the counter is NOT incremented when a v2 org requests an allowed application."""
-        from management.access.view import v1_access_by_v2_org_total
-
-        perm = Permission.objects.create(permission="legacy_app:*:*", tenant=self.tenant)
-        role = Role.objects.create(name="allowed_metric_role", tenant=self.tenant)
-        Access.objects.create(role=role, permission=perm, tenant=self.tenant)
-        policy = Policy.objects.create(name="allowed_metric_policy", tenant=self.tenant)
-        policy.roles.add(role)
-        policy.group = self.group
-        policy.save()
-
-        client = APIClient()
-        url = f"{reverse('v1_management:access')}?application=legacy_app"
-        before = v1_access_by_v2_org_total.labels(
-            org_id=self.customer_data["org_id"], application="legacy_app", caller_type="user"
-        )._value.get()
-        response = client.get(url, **self.headers)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        after = v1_access_by_v2_org_total.labels(
-            org_id=self.customer_data["org_id"], application="legacy_app", caller_type="user"
-        )._value.get()
-        self.assertEqual(after, before)
-
-    @patch("management.access.view.is_v2_edit_enabled_for_request", return_value=False)
-    def test_access_v1_org_no_metric(self, _mock_v2):
-        """Test that the counter is NOT incremented for non-v2 orgs."""
-        from management.access.view import v1_access_by_v2_org_total
-
-        client = APIClient()
-        url = f"{reverse('v1_management:access')}?application=app"
-        before = v1_access_by_v2_org_total.labels(
-            org_id=self.customer_data["org_id"], application="app", caller_type="user"
-        )._value.get()
-        response = client.get(url, **self.headers)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        after = v1_access_by_v2_org_total.labels(
-            org_id=self.customer_data["org_id"], application="app", caller_type="user"
-        )._value.get()
-        self.assertEqual(after, before)


### PR DESCRIPTION
## Link(s) to Jira
- [RHCLOUD-47210](https://redhat.atlassian.net/browse/RHCLOUD-47210)

## Description of Intent of Change(s)
This enhances #2782 by:

- Adding metrics when v2-enabled orgs get rejected requests from `/access` requests
- Adding additional fields to logging for debugging:
    - caller_type (user vs service_account)
    - client_id (for service accounts)
    - is_org_admin
    - request_id (from x-rh-insights-request-id)
    - user_agent
    - user_id

## Local Testing
- Add at least one service to `V2_MIGRATION_APP_EXCLUDE_LIST`
- Request access for a migrated service as a v1 and v2 org: `curl -s http://localhost:8000/api/rbac/v1/access/?application=inventory`
- Check the log and `/metrics` endpoint
- Request access for a non-migrated service as a v1 and v2 org: `curl -s http://localhost:8000/api/rbac/v1/access/?application=inventory`

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices


[RHCLOUD-47210]: https://redhat.atlassian.net/browse/RHCLOUD-47210?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Track and log v1 /access rejections for v2-enabled organizations with Prometheus metrics and enriched context logging.

New Features:
- Expose a Prometheus counter tracking v1 /access calls made by v2-enabled orgs, labeled by org, application, and caller type.

Enhancements:
- Add a helper to centralize recording of v2-org rejections from the v1 /access endpoint and emit structured logs with extended context including caller type, client ID, org admin status, request ID, user agent, and user ID.

Tests:
- Add and update tests to verify metric increments for rejected v2-org /access calls, correct caller_type labeling, absence of metrics for allowed apps and non-v2 orgs, and presence of the new log fields.