### PR TITLE
[RHCLOUD-47081] feat(mcp): unify V1/V2 tools with auto-detection and deployment gating

### DIFF
--- a/rbac/management/mcp_views.py
+++ b/rbac/management/mcp_views.py
@@ -28,6 +28,7 @@ from datetime import datetime, timezone
 from functools import lru_cache, wraps
 from typing import Any, Callable
 
+from django.conf import settings
 from django.http import HttpRequest, HttpResponse, JsonResponse
 from django.test import RequestFactory
 from django.urls import reverse
@@ -61,6 +62,7 @@ _permission_options_view = PermissionViewSet.as_view({"get": "options"})
 _auditlog_list_view = AuditLogViewSet.as_view({"get": "list"})
 _role_access_view = RoleViewSet.as_view({"get": "access"})
 _role_v1_list_view = RoleViewSet.as_view({"get": "list"})
+_role_v1_detail_view = RoleViewSet.as_view({"get": "retrieve"})
 _role_v2_list_view = RoleV2ViewSet.as_view({"get": "list"})
 _role_v2_detail_view = RoleV2ViewSet.as_view({"get": "retrieve"})
 _group_list_view = GroupViewSet.as_view({"get": "list"})
@@ -110,6 +112,16 @@ mcp = FastMCP("RBAC")
 # stub functions and a manual config dict.
 
 
+class ApiVersion:
+    """API version classification for MCP tools."""
+
+    UNIFIED = "unified"
+    COMMON = "common"
+    V1 = "v1"
+    V2 = "v2"
+    UNVERSIONED = "unversioned"
+
+
 @dataclass(frozen=True)
 class ToolConfig:
     """Configuration for an MCP tool."""
@@ -117,6 +129,7 @@ class ToolConfig:
     fn: Callable[..., str]
     requires_auth: bool = False
     passes_request: bool = False
+    api_version: str = ApiVersion.COMMON
 
 
 _TOOL_CONFIG: dict[str, ToolConfig] = {}
@@ -126,6 +139,7 @@ def register_tool(
     *,
     description: str,
     requires_auth: bool = False,
+    api_version: str = ApiVersion.COMMON,
 ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
     """Register a tool with both FastMCP and _TOOL_CONFIG.
 
@@ -146,6 +160,7 @@ def register_tool(
             fn=fn,
             requires_auth=requires_auth,
             passes_request=passes_request,
+            api_version=api_version,
         )
 
         if passes_request:
@@ -201,6 +216,7 @@ def _clone_request(source: HttpRequest, path: str, **kwargs: Any) -> HttpRequest
         "the current server date in UTC. No authentication required. "
         "Use this to verify MCP connectivity."
     ),
+    api_version=ApiVersion.UNVERSIONED,
 )
 def hello(message: str = "Hello, World!") -> str:
     """Respond to a greeting — no authentication required."""
@@ -272,33 +288,34 @@ def _call_view(
     return response.content.decode()
 
 
-# ┌─────────────────────────────────┬────────────────────────────────────────────┐
-# │ MCP Tool                        │ API Endpoint                               │
-# ├─────────────────────────────────┼────────────────────────────────────────────┤
-# │ hello                           │ (none — in-process greeting)               │
-# │ list_principals                 │ GET /api/v1/principals/                    │
-# │ get_status                      │ GET /api/v1/status/                        │
-# │ list_permissions                │ GET /api/v1/permissions/                   │
-# │ list_permission_options         │ GET /api/v1/permissions/options/            │
-# │ list_audit_logs                 │ GET /api/v1/auditlogs/                     │
-# │ list_access                     │ GET /api/v1/access/                        │
-# │ search_roles                    │ GET /api/v1/roles/                         │
-# │ list_roles                      │ GET /api/v2/roles/                         │
-# │ get_role                        │ GET /api/v2/roles/{uuid}/                  │
-# │ list_role_access                │ GET /api/v1/roles/{uuid}/access/           │
-# │ list_groups                     │ GET /api/v1/groups/                        │
-# │ get_group                       │ GET /api/v1/groups/{uuid}/                 │
-# │ list_group_principals           │ GET /api/v1/groups/{uuid}/principals/      │
-# │ list_group_roles                │ GET /api/v1/groups/{uuid}/roles/           │
-# │ list_cross_account_requests     │ GET /api/v1/cross-account-requests/        │
-# │ get_cross_account_request       │ GET /api/v1/cross-account-requests/{id}/   │
-# │ list_workspaces                 │ GET /api/v2/workspaces/                    │
-# │ get_workspace                   │ GET /api/v2/workspaces/{uuid}/             │
-# │ list_role_bindings              │ GET /api/v2/role-bindings/                 │
-# │ list_role_bindings_by_subject   │ GET /api/v2/role-bindings/by-subject/      │
-# │ check_user_permission           │ V1: GET /api/v1/access/                    │
-# │                                 │ V2: role-bindings → roles (view-delegated) │
-# └─────────────────────────────────┴────────────────────────────────────────────┘
+# ┌──────────────────────────────────┬───────────┬────────────────────────────────────────────┐
+# │ MCP Tool                         │ Version   │ API Endpoint                               │
+# ├──────────────────────────────────┼───────────┼────────────────────────────────────────────┤
+# │ hello                            │ unver.    │ (none — in-process greeting)               │
+# │ get_status                       │ unver.    │ GET /api/v1/status/                        │
+# │ list_principals                  │ common    │ GET /api/v1/principals/                    │
+# │ list_permissions                 │ common    │ GET /api/v1/permissions/                   │
+# │ list_permission_options          │ common    │ GET /api/v1/permissions/options/            │
+# │ list_audit_logs                  │ common    │ GET /api/v1/auditlogs/                     │
+# │ list_groups                      │ common    │ GET /api/v1/groups/                        │
+# │ get_group                        │ common    │ GET /api/v1/groups/{uuid}/                 │
+# │ list_group_principals            │ common    │ GET /api/v1/groups/{uuid}/principals/      │
+# │ list_cross_account_requests      │ common    │ GET /api/v1/cross-account-requests/        │
+# │ get_cross_account_request        │ common    │ GET /api/v1/cross-account-requests/{id}/   │
+# │ list_workspaces                  │ common    │ GET /api/v2/workspaces/                    │
+# │ get_workspace                    │ common    │ GET /api/v2/workspaces/{uuid}/             │
+# │ search_roles                     │ unified   │ V1: GET /api/v1/roles/                     │
+# │                                  │           │ V2: GET /api/v2/roles/                     │
+# │ get_role                         │ unified   │ V1: GET /api/v1/roles/{uuid}/ + /access/   │
+# │                                  │           │ V2: GET /api/v2/roles/{uuid}/              │
+# │ check_user_permission            │ unified   │ V1: GET /api/v1/access/                    │
+# │                                  │           │ V2: role-bindings → roles                  │
+# │ list_access                      │ v1        │ GET /api/v1/access/                        │
+# │ list_group_roles                 │ v1        │ GET /api/v1/groups/{uuid}/roles/           │
+# │ list_role_access                 │ v1        │ GET /api/v1/roles/{uuid}/access/           │
+# │ list_role_bindings               │ v2        │ GET /api/v2/role-bindings/                 │
+# │ list_role_bindings_by_subject    │ v2        │ GET /api/v2/role-bindings/by-subject/      │
+# └──────────────────────────────────┴───────────┴────────────────────────────────────────────┘
 
 
 @register_tool(
@@ -307,6 +324,7 @@ def _call_view(
         "platform info, Python version and loaded modules. No authentication required. "
         "Calls: GET /api/v1/status/"
     ),
+    api_version=ApiVersion.UNVERSIONED,
 )
 def get_status(request: HttpRequest) -> str:
     """Return server status by delegating to the status view."""
@@ -407,6 +425,7 @@ def list_audit_logs(
         "Calls: GET /api/v1/access/"
     ),
     requires_auth=True,
+    api_version=ApiVersion.V1,
 )
 def list_access(
     request: HttpRequest,
@@ -482,6 +501,7 @@ def list_permission_options(
         "Calls: GET /api/v1/groups/{uuid}/roles/"
     ),
     requires_auth=True,
+    api_version=ApiVersion.V1,
 )
 def list_group_roles(
     request: HttpRequest,
@@ -526,6 +546,7 @@ def list_group_roles(
         "Calls: GET /api/v1/roles/{uuid}/access/"
     ),
     requires_auth=True,
+    api_version=ApiVersion.V1,
 )
 def list_role_access(
     request: HttpRequest,
@@ -545,17 +566,19 @@ def list_role_access(
 
 @register_tool(
     description=(
-        "Search and filter roles by name, display_name, permission, application, or system flag. "
+        "Search and filter roles by name, permission, application, or other criteria. "
+        "Automatically detects whether the organization uses V1 or V2 and routes accordingly. "
         "Best tool for answering 'which role grants permission X?' or 'find role named Y'. "
         "TROUBLESHOOTING: To find a role by name, call search_roles(name='<role_name>'). "
         "To find which roles grant a specific permission, call "
         "search_roles(permission='<app>:<resource>:<verb>'). Accepts comma-separated permissions. "
         "To see all roles for an application, call search_roles(application='<app>'). "
-        "Order by: 'name', 'display_name', 'modified', 'policyCount' (prefix with '-' to reverse). "
-        "Returns: {meta: {count}, links, data: [{uuid, name, display_name, description, system, ...}]}. "
-        "Calls: GET /api/v1/roles/"
+        "V2 orgs support name with '*' wildcards (e.g., name='Cost*') and resource_type filter. "
+        "V1 orgs additionally support display_name, system flag filters. "
+        "Returns: {meta: {count}, links, data: [{uuid, name, description, ...}], org_version: 'v1'|'v2'}."
     ),
     requires_auth=True,
+    api_version=ApiVersion.UNIFIED,
 )
 def search_roles(
     request: HttpRequest,
@@ -567,9 +590,28 @@ def search_roles(
     permission: str = "",
     application: str = "",
     system: str = "",
+    resource_type: str = "",
     order_by: str = "",
 ) -> str:
-    """Search roles by delegating to RoleViewSet."""
+    """Search roles, auto-detecting V1/V2 and delegating to the appropriate view."""
+    tenant = getattr(request, "tenant", None)
+    if tenant and is_v2_write_activated(tenant):
+        return _search_roles_v2(request, limit, offset, name, resource_type, order_by)
+    return _search_roles_v1(request, limit, offset, name, display_name, permission, application, system, order_by)
+
+
+def _search_roles_v1(
+    request: HttpRequest,
+    limit: int,
+    offset: int,
+    name: str,
+    display_name: str,
+    permission: str,
+    application: str,
+    system: str,
+    order_by: str,
+) -> str:
+    """Search roles using V1 API."""
     query_params: dict[str, str] = {
         "limit": str(limit),
         "offset": str(offset),
@@ -588,53 +630,82 @@ def search_roles(
         query_params["order_by"] = order_by
 
     path = reverse("v1_management:role-list")
-    return _call_view(request, _role_v1_list_view, path, query_params)
+    raw = _call_view(request, _role_v1_list_view, path, query_params)
+    result = json.loads(raw)
+    result["org_version"] = "v1"
+    return json.dumps(result)
 
 
-@register_tool(
-    description=(
-        "List roles using the V2 API. Roles define sets of permissions that can be bound to "
-        "subjects via role bindings. Order by: 'name', '-name', 'last_modified', '-last_modified'. "
-        "Returns: {meta: {count}, links, data: [{uuid, name, description, permissions, ...}]}. "
-        "Calls: GET /api/v2/roles/"
-    ),
-    requires_auth=True,
-)
-def list_roles(
+def _search_roles_v2(
     request: HttpRequest,
-    *,
-    limit: int = 10,
-    offset: int = 0,
-    order_by: str = "",
+    limit: int,
+    offset: int,
+    name: str,
+    resource_type: str,
+    order_by: str,
 ) -> str:
-    """List V2 roles by delegating to RoleV2ViewSet."""
+    """Search roles using V2 API."""
     query_params: dict[str, str] = {
         "limit": str(limit),
         "offset": str(offset),
     }
+    if name:
+        query_params["name"] = name
+    if resource_type:
+        query_params["resource_type"] = resource_type
     if order_by:
         query_params["order_by"] = order_by
+
     path = reverse("v2_management:roles-list")
-    return _call_view(request, _role_v2_list_view, path, query_params)
+    raw = _call_view(request, _role_v2_list_view, path, query_params)
+    result = json.loads(raw)
+    result["org_version"] = "v2"
+    return json.dumps(result)
 
 
 @register_tool(
     description=(
-        "Get details of a specific role by UUID using the V2 API. Returns the role's name, "
-        "description, and the list of permissions it grants. "
-        "Returns: {uuid, name, description, permissions: [{application, resource_type, verb}]}. "
-        "Calls: GET /api/v2/roles/{uuid}/"
+        "Get details of a specific role by UUID, including its permissions. "
+        "Automatically detects whether the organization uses V1 or V2 and routes accordingly. "
+        "Returns: {uuid, name, description, permissions: [...], org_version: 'v1'|'v2'}."
     ),
     requires_auth=True,
+    api_version=ApiVersion.UNIFIED,
 )
 def get_role(
     request: HttpRequest,
     *,
     role_uuid: str,
 ) -> str:
-    """Get a single V2 role by delegating to RoleV2ViewSet."""
+    """Get a single role, auto-detecting V1/V2 and delegating to the appropriate view."""
+    tenant = getattr(request, "tenant", None)
+    if tenant and is_v2_write_activated(tenant):
+        return _get_role_v2(request, role_uuid)
+    return _get_role_v1(request, role_uuid)
+
+
+def _get_role_v1(request: HttpRequest, role_uuid: str) -> str:
+    """Get role details using V1 API (retrieve + access)."""
+    detail_path = reverse("v1_management:role-detail", kwargs={"uuid": role_uuid})
+    detail_raw = _call_view(request, _role_v1_detail_view, detail_path, {}, uuid=role_uuid)
+    result = json.loads(detail_raw)
+
+    access_path = reverse("v1_management:role-access", kwargs={"uuid": role_uuid})
+    access_raw = _call_view(request, _role_access_view, access_path, {"limit": "1000"}, uuid=role_uuid)
+    access_data = json.loads(access_raw)
+
+    result["permissions"] = access_data.get("data", [])
+    result["org_version"] = "v1"
+    return json.dumps(result)
+
+
+def _get_role_v2(request: HttpRequest, role_uuid: str) -> str:
+    """Get role details using V2 API."""
     path = reverse("v2_management:roles-detail", kwargs={"uuid": role_uuid})
-    return _call_view(request, _role_v2_detail_view, path, {}, uuid=role_uuid)
+    raw = _call_view(request, _role_v2_detail_view, path, {}, uuid=role_uuid)
+    result = json.loads(raw)
+    result["org_version"] = "v2"
+    return json.dumps(result)
 
 
 @register_tool(
@@ -866,6 +937,7 @@ def get_workspace(
         "Calls: GET /api/v2/role-bindings/"
     ),
     requires_auth=True,
+    api_version=ApiVersion.V2,
 )
 def list_role_bindings(
     request: HttpRequest,
@@ -916,6 +988,7 @@ def list_role_bindings(
         "Calls: GET /api/v2/role-bindings/by-subject/"
     ),
     requires_auth=True,
+    api_version=ApiVersion.V2,
 )
 def list_role_bindings_by_subject(
     request: HttpRequest,
@@ -975,6 +1048,7 @@ def _permission_matches(granted_permission: str, requested_permission: str) -> b
         "V2 resolves: role bindings → roles → permissions (internally)."
     ),
     requires_auth=True,
+    api_version=ApiVersion.UNIFIED,
 )
 def check_user_permission(
     request: HttpRequest,
@@ -1070,7 +1144,7 @@ def check_user_permission(
             "hint": f"User '{username}' does not have permission '{permission}' in this V2 organization. "
             f"Use list_role_bindings(granted_subject_type='user', "
             f"granted_subject_id='{principal.uuid}') to see all role bindings, "
-            f"or search_roles(permission='{permission}') to find which roles grant this permission.",
+            f"or search_roles(name='*') to browse available roles.",
         }
     )
 
@@ -1285,8 +1359,14 @@ def _get_tools() -> list[Any]:
     return asyncio.run(mcp.list_tools())
 
 
+def _is_v2_available() -> bool:
+    """Check whether V2 API routes are mounted."""
+    return getattr(settings, "V2_APIS_ENABLED", False)
+
+
 def _handle_tools_list(request: HttpRequest, request_id: Any, params: dict[str, Any]) -> JsonResponse:
     """Handle MCP tools/list request using FastMCP's registered tools."""
+    v2_available = _is_v2_available()
     tools_data = [
         {
             "name": tool.name,
@@ -1294,6 +1374,7 @@ def _handle_tools_list(request: HttpRequest, request_id: Any, params: dict[str, 
             "inputSchema": tool.inputSchema,
         }
         for tool in _get_tools()
+        if v2_available or _TOOL_CONFIG.get(tool.name, ToolConfig(fn=lambda: "")).api_version != ApiVersion.V2
     ]
     return _success_response(request_id, {"tools": tools_data})
 
@@ -1326,6 +1407,14 @@ def _handle_tools_call(request: HttpRequest, request_id: Any, params: dict[str, 
     if config is None:
         logger.warning("mcp: tools/call unknown tool='%s'", tool_name)
         return _error_response(request_id, -32602, f"Unknown tool: {tool_name}")
+
+    if config.api_version == ApiVersion.V2 and not _is_v2_available():
+        logger.warning("mcp: tools/call tool='%s' rejected, V2 APIs not enabled", tool_name)
+        return _error_response(
+            request_id,
+            -32602,
+            f"Tool '{tool_name}' requires V2 APIs, which are not enabled in this deployment.",
+        )
 
     org_id = getattr(getattr(request, "user", None), "org_id", None)
     logger.info(

--- a/tests/management/test_mcp_views.py
+++ b/tests/management/test_mcp_views.py
@@ -24,7 +24,7 @@ from importlib import reload
 from django.test import override_settings
 from django.urls import clear_url_caches
 from django.utils import timezone
-from management.mcp_views import ToolConfig, _permission_matches
+from management.mcp_views import ApiVersion, ToolConfig, _TOOL_CONFIG, _permission_matches
 from management.models import Access, Group, Permission, Policy, Principal, Role
 from management.role.v2_model import RoleV2
 from management.role_binding.model import RoleBinding, RoleBindingGroup, RoleBindingPrincipal
@@ -636,8 +636,8 @@ class MCPViewTests(MCPToolTestMixin, IdentityRequest):
 
     # --- New read-only tools tests ---
 
-    def test_tools_list_includes_all_new_tools(self):
-        """Positive: tools/list includes all newly added read-only tools."""
+    def test_tools_list_includes_non_v2_tools(self):
+        """Positive: tools/list includes all non-V2-only tools when V2 is disabled."""
         body = {"jsonrpc": "2.0", "method": "tools/list", "id": 2, "params": {}}
         response = self.client.post(self.url, data=json.dumps(body), content_type="application/json", **self.headers)
 
@@ -650,7 +650,6 @@ class MCPViewTests(MCPToolTestMixin, IdentityRequest):
             "list_permission_options",
             "list_audit_logs",
             "search_roles",
-            "list_roles",
             "get_role",
             "list_role_access",
             "list_groups",
@@ -661,12 +660,21 @@ class MCPViewTests(MCPToolTestMixin, IdentityRequest):
             "get_cross_account_request",
             "list_workspaces",
             "get_workspace",
-            "list_role_bindings",
-            "list_role_bindings_by_subject",
             "check_user_permission",
         ]
         for tool in expected_tools:
             self.assertIn(tool, tool_names, f"Tool '{tool}' missing from tools/list")
+
+    def test_tools_list_excludes_v2_only_tools_when_v2_disabled(self):
+        """Negative: V2-only tools are hidden when V2_APIS_ENABLED=False."""
+        body = {"jsonrpc": "2.0", "method": "tools/list", "id": 2, "params": {}}
+        response = self.client.post(self.url, data=json.dumps(body), content_type="application/json", **self.headers)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        tool_names = [t["name"] for t in response.json()["result"]["tools"]]
+        v2_only_tools = [name for name, cfg in _TOOL_CONFIG.items() if cfg.api_version == ApiVersion.V2]
+        for tool in v2_only_tools:
+            self.assertNotIn(tool, tool_names, f"V2-only tool '{tool}' should be hidden")
 
     # --- get_status ---
 
@@ -976,6 +984,8 @@ class MCPViewV2ToolsTests(MCPToolTestMixin, IdentityRequest):
 
     def setUp(self):
         """Set up the MCP V2 tool tests."""
+        reload(urls)
+        clear_url_caches()
         super().setUp()
         self.url = "/_private/_a2s/mcp/"
         self.client = APIClient()
@@ -998,27 +1008,17 @@ class MCPViewV2ToolsTests(MCPToolTestMixin, IdentityRequest):
         Principal.objects.all().delete()
         super().tearDown()
 
-    # --- list_roles / get_role ---
+    # --- V2 gating: tools/list includes V2-only tools ---
 
-    def test_list_roles_success(self):
-        """Positive: list_roles returns role data."""
-        response = self._call_tool("list_roles")
-
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        data = response.json()
-        self.assertFalse(data["result"]["isError"])
-        tool_output = self._get_tool_output(response)
-        self.assertIn("meta", tool_output)
-        self.assertIn("data", tool_output)
-
-    def test_list_roles_without_auth_returns_error(self):
-        """Permission: list_roles without auth returns auth error."""
-        response = self._call_tool("list_roles", use_auth=False)
+    def test_tools_list_includes_v2_only_tools_when_v2_enabled(self):
+        """Positive: V2-only tools are visible when V2_APIS_ENABLED=True."""
+        body = {"jsonrpc": "2.0", "method": "tools/list", "id": 2, "params": {}}
+        response = self.client.post(self.url, data=json.dumps(body), content_type="application/json", **self.headers)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        data = response.json()
-        self.assertIn("error", data)
-        self.assertEqual(data["error"]["code"], -32000)
+        tool_names = [t["name"] for t in response.json()["result"]["tools"]]
+        self.assertIn("list_role_bindings", tool_names)
+        self.assertIn("list_role_bindings_by_subject", tool_names)
 
     # --- list_workspaces / get_workspace ---
 
@@ -1195,7 +1195,7 @@ class MCPCheckUserPermissionTests(MCPToolTestMixin, IdentityRequest):
 
 
 class MCPSearchRolesTests(MCPToolTestMixin, IdentityRequest):
-    """Tests for the search_roles MCP tool."""
+    """Tests for the unified search_roles MCP tool (V1 path)."""
 
     def setUp(self):
         """Set up search_roles tests."""
@@ -1208,8 +1208,8 @@ class MCPSearchRolesTests(MCPToolTestMixin, IdentityRequest):
         Role.objects.all().delete()
         super().tearDown()
 
-    def test_search_roles_success(self):
-        """Positive: search_roles returns role data."""
+    def test_search_roles_v1_success(self):
+        """Positive: search_roles on V1 org returns role data with org_version=v1."""
         Role.objects.create(name="test_v1_role", tenant=self.tenant)
         response = self._call_tool("search_roles")
 
@@ -1219,9 +1219,10 @@ class MCPSearchRolesTests(MCPToolTestMixin, IdentityRequest):
         tool_output = self._get_tool_output(response)
         self.assertIn("meta", tool_output)
         self.assertIn("data", tool_output)
+        self.assertEqual(tool_output["org_version"], "v1")
 
-    def test_search_roles_filter_by_name(self):
-        """Positive: search_roles filters by name."""
+    def test_search_roles_v1_filter_by_name(self):
+        """Positive: search_roles on V1 org filters by name."""
         Role.objects.create(name="Patch Reviewer", tenant=self.tenant)
         Role.objects.create(name="Other Role", tenant=self.tenant)
         response = self._call_tool("search_roles", {"name": "Patch Reviewer"})
@@ -1231,6 +1232,7 @@ class MCPSearchRolesTests(MCPToolTestMixin, IdentityRequest):
         self.assertTrue(tool_output["meta"]["count"] >= 1)
         for role in tool_output["data"]:
             self.assertIn("Patch Reviewer", role["name"])
+        self.assertEqual(tool_output["org_version"], "v1")
 
     def test_search_roles_without_auth_returns_error(self):
         """Permission: search_roles without auth returns auth error."""
@@ -1512,3 +1514,175 @@ class MCPCheckUserPermissionV2Tests(MCPToolTestMixin, IdentityRequest):
         self.assertTrue(tool_output["allowed"])
         self.assertEqual(tool_output["matched_permission"], "vulnerability:vulnerability:*")
         self.assertEqual(tool_output["org_version"], "v2")
+
+
+@override_settings(BYPASS_BOP_VERIFICATION=True, V2_APIS_ENABLED=True)
+class MCPUnifiedSearchRolesV2Tests(MCPToolTestMixin, IdentityRequest):
+    """Tests for the unified search_roles MCP tool routing to V2."""
+
+    def setUp(self):
+        """Set up V2 search_roles tests."""
+        reload(urls)
+        clear_url_caches()
+        super().setUp()
+        self.url = "/_private/_a2s/mcp/"
+        self.client = APIClient()
+        self.enterContext(
+            patch(
+                "management.permissions.role_v2_access.get_kessel_principal_id",
+                return_value="localhost/test-user-id",
+            )
+        )
+        self.enterContext(
+            patch(
+                "management.permissions.role_v2_access.WorkspaceInventoryAccessChecker.check_resource_access",
+                return_value=True,
+            )
+        )
+        TenantMapping.objects.create(tenant=self.tenant, v2_write_activated_at=timezone.now())
+
+    def tearDown(self):
+        """Tear down V2 search_roles tests."""
+        RoleV2.objects.all().delete()
+        TenantMapping.objects.all().delete()
+        super().tearDown()
+
+    def test_search_roles_v2_success(self):
+        """Positive: search_roles on V2 org returns role data with org_version=v2."""
+        RoleV2.objects.create(name="V2 Custom Role", tenant=self.tenant, type=RoleV2.Types.CUSTOM)
+        response = self._call_tool("search_roles")
+
+        self.assertEqual(response.status_code, 200)
+        tool_output = self._get_tool_output(response)
+        self.assertIn("meta", tool_output)
+        self.assertIn("data", tool_output)
+        self.assertEqual(tool_output["org_version"], "v2")
+
+    def test_search_roles_v2_filter_by_name(self):
+        """Positive: search_roles on V2 org filters by name."""
+        RoleV2.objects.create(name="Cost Reader", tenant=self.tenant, type=RoleV2.Types.CUSTOM)
+        RoleV2.objects.create(name="Other V2 Role", tenant=self.tenant, type=RoleV2.Types.CUSTOM)
+        response = self._call_tool("search_roles", {"name": "Cost Reader"})
+
+        self.assertEqual(response.status_code, 200)
+        tool_output = self._get_tool_output(response)
+        self.assertEqual(tool_output["org_version"], "v2")
+        role_names = [r["name"] for r in tool_output["data"]]
+        self.assertIn("Cost Reader", role_names)
+
+
+@override_settings(BYPASS_BOP_VERIFICATION=True, V2_APIS_ENABLED=True)
+class MCPUnifiedGetRoleTests(MCPToolTestMixin, IdentityRequest):
+    """Tests for the unified get_role MCP tool routing to V1 and V2."""
+
+    def setUp(self):
+        """Set up get_role tests."""
+        reload(urls)
+        clear_url_caches()
+        super().setUp()
+        self.url = "/_private/_a2s/mcp/"
+        self.client = APIClient()
+        self.enterContext(
+            patch(
+                "management.permissions.role_v2_access.get_kessel_principal_id",
+                return_value="localhost/test-user-id",
+            )
+        )
+        self.enterContext(
+            patch(
+                "management.permissions.role_v2_access.WorkspaceInventoryAccessChecker.check_resource_access",
+                return_value=True,
+            )
+        )
+
+    def tearDown(self):
+        """Tear down get_role tests."""
+        RoleV2.objects.all().delete()
+        Permission.objects.all().delete()
+        TenantMapping.objects.all().delete()
+        Role.objects.all().delete()
+        super().tearDown()
+
+    def test_get_role_v1_returns_role_with_permissions(self):
+        """Positive: get_role on V1 org returns role details with permissions and org_version=v1."""
+        perm = Permission.objects.create(
+            application="cost-management",
+            resource_type="cost_model",
+            verb="read",
+            permission="cost-management:cost_model:read",
+            tenant=self.tenant,
+        )
+        role = Role.objects.create(name="Cost Reader V1", tenant=self.tenant)
+        access = Access.objects.create(role=role, permission=perm, tenant=self.tenant)
+        Policy.objects.create(name="auto_policy", group=None, tenant=self.tenant).roles.add(role)
+
+        response = self._call_tool("get_role", {"role_uuid": str(role.uuid)})
+
+        self.assertEqual(response.status_code, 200)
+        tool_output = self._get_tool_output(response)
+        self.assertEqual(tool_output["uuid"], str(role.uuid))
+        self.assertEqual(tool_output["org_version"], "v1")
+        self.assertIn("permissions", tool_output)
+
+        access.delete()
+        perm.delete()
+
+    def test_get_role_v2_returns_role_with_permissions(self):
+        """Positive: get_role on V2 org returns role details with permissions and org_version=v2."""
+        TenantMapping.objects.create(tenant=self.tenant, v2_write_activated_at=timezone.now())
+
+        perm = Permission.objects.create(
+            application="vulnerability",
+            resource_type="vulnerability",
+            verb="read",
+            permission="vulnerability:vulnerability:read",
+            tenant=self.tenant,
+        )
+        role = RoleV2.objects.create(name="Vuln Reader V2", tenant=self.tenant)
+        role.permissions.add(perm)
+
+        response = self._call_tool("get_role", {"role_uuid": str(role.uuid)})
+
+        self.assertEqual(response.status_code, 200)
+        tool_output = self._get_tool_output(response)
+        self.assertEqual(tool_output["id"], str(role.uuid))
+        self.assertEqual(tool_output["org_version"], "v2")
+        self.assertIn("permissions", tool_output)
+
+
+class MCPDeploymentGatingTests(MCPToolTestMixin, IdentityRequest):
+    """Tests for deployment-level V2 tool gating."""
+
+    def setUp(self):
+        """Set up gating tests."""
+        super().setUp()
+        self.url = "/_private/_a2s/mcp/"
+        self.client = APIClient()
+
+    def test_calling_v2_tool_when_v2_disabled_returns_error(self):
+        """Negative: calling a V2-only tool when V2 is disabled returns a clear error."""
+        response = self._call_tool("list_role_bindings")
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertIn("error", data)
+        self.assertIn("V2 APIs", data["error"]["message"])
+
+    def test_api_version_classification(self):
+        """Verify all tools have an api_version set."""
+        for tool_name, config in _TOOL_CONFIG.items():
+            self.assertIn(
+                config.api_version,
+                (ApiVersion.UNIFIED, ApiVersion.COMMON, ApiVersion.V1, ApiVersion.V2, ApiVersion.UNVERSIONED),
+                f"Tool '{tool_name}' has unexpected api_version: {config.api_version}",
+            )
+
+    def test_unified_tools_are_always_listed(self):
+        """Positive: unified tools appear in tools/list regardless of V2 setting."""
+        body = {"jsonrpc": "2.0", "method": "tools/list", "id": 2, "params": {}}
+        response = self.client.post(self.url, data=json.dumps(body), content_type="application/json", **self.headers)
+
+        tool_names = [t["name"] for t in response.json()["result"]["tools"]]
+        self.assertIn("search_roles", tool_names)
+        self.assertIn("get_role", tool_names)
+        self.assertIn("check_user_permission", tool_names)


### PR DESCRIPTION
## Summary
- **Unify `search_roles`**: merges `search_roles` (V1) + `list_roles` (V2) into a single tool that auto-detects org version via `is_v2_write_activated()` — V2 path now exposes `name` (with glob wildcards) and `resource_type` filters
- **Unify `get_role`**: auto-detects V1/V2 — V1 path returns role detail + access permissions, V2 path returns role with inline permissions
- **Add `ApiVersion` classification** to `ToolConfig` (`unified`/`common`/`v1`/`v2`/`unversioned`) and classify all 21 MCP tools
- **Deployment-level gating**: V2-only tools (`list_role_bindings`, `list_role_bindings_by_subject`) are hidden from `tools/list` and rejected in `tools/call` with a clear error when `V2_APIS_ENABLED=False`
- **Fix V2 hint** in `check_user_permission` to reference unified tool names

### Tool Classification

| Category | Tools |
|----------|-------|
| **Unified** (auto-detect V1/V2) | `search_roles`, `get_role`, `check_user_permission` |
| **Common** (same for both) | `list_principals`, `list_permissions`, `list_permission_options`, `list_audit_logs`, `list_groups`, `get_group`, `list_group_principals`, `list_cross_account_requests`, `get_cross_account_request`, `list_workspaces`, `get_workspace` |
| **V1-only** | `list_access`, `list_group_roles`, `list_role_access` |
| **V2-only** (gated) | `list_role_bindings`, `list_role_bindings_by_subject` |
| **Unversioned** | `hello`, `get_status` |

## Test plan
- [x] `search_roles` routes to V1 backend for V1 orgs (returns `org_version: "v1"`)
- [x] `search_roles` routes to V2 backend for V2 orgs (returns `org_version: "v2"`)
- [x] `search_roles` V2 path supports name filtering
- [x] `get_role` routes to V1 backend (role + permissions) for V1 orgs
- [x] `get_role` routes to V2 backend for V2 orgs
- [x] V2-only tools hidden from `tools/list` when `V2_APIS_ENABLED=False`
- [x] V2-only tools visible in `tools/list` when `V2_APIS_ENABLED=True`
- [x] Calling V2 tool when disabled returns clear error (not `NoReverseMatch`)
- [x] Unified tools always appear in `tools/list` regardless of V2 setting
- [x] All tools have valid `api_version` classification
- [x] All 87 MCP tests pass, linting clean

Implements: [RHCLOUD-47081](https://redhat.atlassian.net/browse/RHCLOUD-47081)

[RHCLOUD-47081]: https://redhat.atlassian.net/browse/RHCLOUD-47081?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Unify MCP role tools across V1/V2 APIs with deployment-aware gating of V2-only tools and richer version-aware responses.

New Features:
- Introduce unified search_roles tool that auto-detects org API version and routes to V1 or V2 backends while exposing version-specific filters and org_version metadata.
- Introduce unified get_role tool that auto-detects org API version and returns role details with inline permissions and org_version metadata.
- Add ApiVersion classification to MCP tool configuration and surface it through tool registration for all tools.

Bug Fixes:
- Prevent V2-only MCP tools from appearing in tools/list or being callable when V2 APIs are disabled, returning a clear error instead of routing failures.
- Correct check_user_permission V2 hint text to reference the unified search_roles tool usage.

Enhancements:
- Refine tools/list handling to always include unified tools while conditionally hiding V2-only tools based on deployment settings.
- Extend search_roles V2 behavior to support name wildcard and resource_type filters while keeping V1-specific filters on the V1 path.
- Add org_version markers to MCP role search and detail responses to distinguish V1 vs V2 behavior in clients.

Tests:
- Expand and reorganize MCP tests to cover unified search_roles and get_role behavior across V1/V2 orgs, V2-only tool visibility, deployment-level V2 gating, and api_version classification for all tools.