### PR TITLE
[RHCLOUD-46801] Filter by resource_type and id when listing roles

### DIFF
--- a/rbac/management/role/v2_serializer.py
+++ b/rbac/management/role/v2_serializer.py
@@ -16,6 +16,8 @@
 #
 """Serializers for RoleV2 API."""
 
+import uuid
+
 from django.utils.translation import gettext as _
 from management.exceptions import RequiredFieldError
 from management.role.v2_exceptions import (
@@ -180,6 +182,15 @@ class RoleV2ListSerializer(serializers.Serializer):
     def validate_fields(self, value):
         """Parse, validate, and resolve fields parameter into a set of field names."""
         return validate_fields_parameter(value, RoleV2Service.DEFAULT_LIST_FIELDS)
+
+    def validate_resource_id(self, value):
+        """Return a UUID (or None if omitted/blank) for workspace resource filtering."""
+        if value in (None, ""):
+            return None
+        try:
+            return uuid.UUID(str(value).strip())
+        except ValueError as e:
+            raise serializers.ValidationError(_("Enter a valid UUID.")) from e
 
     def validate(self, data):
         """Cross-field validation: resource_id requires resource_type."""

--- a/rbac/management/role/v2_service.py
+++ b/rbac/management/role/v2_service.py
@@ -27,6 +27,7 @@ from django.db import IntegrityError
 from django.db.models import QuerySet
 from management.atomic_transactions import atomic
 from management.exceptions import NotFoundError, RequiredFieldError
+from management.models import Workspace
 from management.permission.exceptions import InvalidPermissionDataError
 from management.permission.model import PermissionValue
 from management.permission.scope_service import Scope, permission_scope_cache, scopes_for_resource_type
@@ -256,7 +257,7 @@ class RoleV2Service:
 
         resource_type = params.get("resource_type")
         if resource_type:
-            queryset = self._filter_by_resource_type(queryset, resource_type)
+            queryset = self._filter_by_resource_type(queryset, resource_type, resource_id=params.get("resource_id"))
 
         name = params.get("name")
         if name:
@@ -264,8 +265,15 @@ class RoleV2Service:
 
         return queryset
 
-    def _filter_by_resource_type(self, queryset: QuerySet, resource_type: str) -> QuerySet:
+    def _filter_by_resource_type(
+        self, queryset: QuerySet, resource_type: str, resource_id: Optional[uuid.UUID] = None
+    ) -> QuerySet:
         """Filter roles to those whose highest permission scope maps to resource_type.
+
+        For ``resource_type=workspace``:
+        - With no ``resource_id``: only DEFAULT-scoped roles (default workspace and custom workspaces).
+        - With ``resource_id`` the root workspace UUID: only ROOT-scoped roles.
+        - With any other workspace UUID: only DEFAULT-scoped roles.
 
         Uses DB-level filtering with cached Permission-ID-to-Scope mappings to
         avoid loading all roles and their permissions into Python memory.
@@ -273,6 +281,19 @@ class RoleV2Service:
         matching_scopes = scopes_for_resource_type(resource_type)
         if not matching_scopes:
             return queryset.none()
+
+        if resource_type == "workspace":
+            if resource_id is not None:
+                try:
+                    workspace = Workspace.objects.get(id=resource_id, tenant=self.tenant)
+                except Workspace.DoesNotExist:
+                    return queryset.none()
+                if workspace.type == Workspace.Types.ROOT:
+                    matching_scopes = {Scope.ROOT}
+                else:
+                    matching_scopes = {Scope.DEFAULT}
+            else:
+                matching_scopes = {Scope.DEFAULT}
 
         higher_non_matching = {s for s in (set(Scope) - matching_scopes) if s > max(matching_scopes)}
 

--- a/tests/management/role/test_v2_serializer.py
+++ b/tests/management/role/test_v2_serializer.py
@@ -371,6 +371,19 @@ class RoleV2ListSerializerTests(IdentityRequest):
         self.assertTrue(serializer.is_valid(), serializer.errors)
         self.assertEqual(serializer.validated_data["fields"], set(RoleV2ResponseSerializer.Meta.fields))
 
+    def test_valid_resource_id_as_uuid(self):
+        """resource_id is parsed to uuid.UUID when valid."""
+        uid = "550e8400-e29b-41d4-a716-446655440000"
+        serializer = RoleV2ListSerializer(data={"resource_type": "workspace", "resource_id": uid})
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        self.assertEqual(str(serializer.validated_data["resource_id"]), uid)
+
+    def test_invalid_resource_id_returns_error(self):
+        """Non-UUID resource_id is rejected."""
+        serializer = RoleV2ListSerializer(data={"resource_type": "workspace", "resource_id": "not-a-uuid"})
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("resource_id", serializer.errors)
+
 
 @override_settings(ATOMIC_RETRY_DISABLED=True)
 class RoleV2RequestSerializerTests(IdentityRequest):

--- a/tests/management/role/test_v2_service.py
+++ b/tests/management/role/test_v2_service.py
@@ -817,6 +817,24 @@ class RoleV2ServiceListResourceTypeTests(IdentityRequest):
         super().setUp()
         self.service = RoleV2Service(tenant=self.tenant)
 
+        self._root_ws, _ = Workspace.objects.get_or_create(
+            tenant=self.tenant,
+            type=Workspace.Types.ROOT,
+            defaults={
+                "name": Workspace.SpecialNames.ROOT,
+                "description": Workspace.SpecialDescriptions.ROOT,
+            },
+        )
+        self._default_ws, _ = Workspace.objects.get_or_create(
+            tenant=self.tenant,
+            type=Workspace.Types.DEFAULT,
+            defaults={
+                "name": Workspace.SpecialNames.DEFAULT,
+                "description": Workspace.SpecialDescriptions.DEFAULT,
+                "parent": self._root_ws,
+            },
+        )
+
         scope_service = ImplicitResourceService(
             tenant_scope_permissions=["tenant_app:*:*"],
             root_scope_permissions=["root_app:*:*"],
@@ -861,11 +879,11 @@ class RoleV2ServiceListResourceTypeTests(IdentityRequest):
         names = set(queryset.values_list("name", flat=True))
         self.assertEqual(names, {"tenant_role", "mixed_role"})
 
-    def test_list_resource_type_workspace_returns_workspace_scoped_roles(self):
-        """Roles whose highest scope is DEFAULT or ROOT should be returned for resource_type=workspace."""
+    def test_list_resource_type_workspace_returns_default_scoped_roles_only(self):
+        """resource_type=workspace without resource_id returns only DEFAULT-scoped roles."""
         queryset = self.service.list({"resource_type": "workspace"})
         names = set(queryset.values_list("name", flat=True))
-        self.assertEqual(names, {"default_role", "root_role"})
+        self.assertEqual(names, {"default_role"})
 
     def test_list_resource_type_workspace_excludes_mixed_role(self):
         """A role with both default and tenant permissions has highest scope TENANT and should not appear for workspace."""
@@ -894,3 +912,32 @@ class RoleV2ServiceListResourceTypeTests(IdentityRequest):
         """Combined filters that contradict each other return empty."""
         queryset = self.service.list({"resource_type": "workspace", "name": "tenant_role"})
         self.assertEqual(queryset.count(), 0)
+
+    def test_list_resource_type_workspace_with_root_resource_id_returns_root_scoped_only(self):
+        """resource_type=workspace with the root workspace id returns only ROOT-scoped roles."""
+        queryset = self.service.list({"resource_type": "workspace", "resource_id": self._root_ws.id})
+        names = set(queryset.values_list("name", flat=True))
+        self.assertEqual(names, {"root_role"})
+
+    def test_list_resource_type_workspace_with_default_resource_id_returns_default_scoped_only(self):
+        """resource_type=workspace with the default workspace id returns only DEFAULT-scoped roles."""
+        queryset = self.service.list({"resource_type": "workspace", "resource_id": self._default_ws.id})
+        names = set(queryset.values_list("name", flat=True))
+        self.assertEqual(names, {"default_role"})
+
+    def test_list_resource_type_workspace_with_nonexistent_resource_id_returns_empty(self):
+        """Unknown workspace id yields no roles for resource_type=workspace."""
+        queryset = self.service.list({"resource_type": "workspace", "resource_id": uuid.uuid4()})
+        self.assertEqual(queryset.count(), 0)
+
+    def test_list_resource_type_workspace_with_standard_resource_id_returns_default_scoped_only(self):
+        """A non-root (e.g. standard) workspace id lists the same as default: DEFAULT-scoped roles only."""
+        child = Workspace.objects.create(
+            name="Sub WS",
+            tenant=self.tenant,
+            type=Workspace.Types.STANDARD,
+            parent=self._default_ws,
+        )
+        queryset = self.service.list({"resource_type": "workspace", "resource_id": child.id})
+        names = set(queryset.values_list("name", flat=True))
+        self.assertEqual(names, {"default_role"})

--- a/tests/management/role/test_v2_view.py
+++ b/tests/management/role/test_v2_view.py
@@ -31,7 +31,7 @@ from rest_framework.test import APIClient
 from api.models import Tenant
 from management import v2_urls
 from management.audit_log.model import AuditLog
-from management.models import Permission
+from management.models import Permission, Workspace
 from management.permission.scope_service import ImplicitResourceService, PermissionScopeCache
 from management.relation_replicator.noop_replicator import NoopReplicator
 from management.relation_replicator.outbox_replicator import OutboxReplicator
@@ -44,16 +44,16 @@ from management.utils import PRINCIPAL_CACHE, as_uuid
 from rbac import urls
 from tests.identity_request import IdentityRequest
 from tests.v2_util import bootstrap_tenant_for_v2_test
-from unittest.mock import ANY, patch
 
 CACHE_PATCH_TARGET = "management.role.v2_service.permission_scope_cache"
 
 
-def _scope_cache(tenant_perms="", root_perms=""):
+def _scope_cache(tenant_perms="", root_perms="", default_perms=""):
     """Build a PermissionScopeCache backed by a test ImplicitResourceService."""
     scope_service = ImplicitResourceService(
         tenant_scope_permissions=[p.strip() for p in tenant_perms.split(",") if p.strip()],
         root_scope_permissions=[p.strip() for p in root_perms.split(",") if p.strip()],
+        default_scope_permissions=[p.strip() for p in default_perms.split(",") if p.strip()],
     )
     return PermissionScopeCache(scope_service)
 
@@ -922,7 +922,7 @@ class RoleV2ViewSetTests(IdentityRequest):
 
     @patch(CACHE_PATCH_TARGET, _scope_cache(tenant_perms="tenant_app:*:*", root_perms="root_app:*:*"))
     def test_list_roles_filter_by_resource_type_workspace(self):
-        """Test that resource_type=workspace returns only workspace-scoped roles."""
+        """Test that resource_type=workspace (no resource_id) returns only DEFAULT-scoped roles."""
         tenant_perm = Permission.objects.create(permission="tenant_app:res:read", tenant=self.tenant)
         tenant_role = RoleV2.objects.create(name="tenant_role", description="Tenant", tenant=self.tenant)
         tenant_role.permissions.add(tenant_perm)
@@ -949,6 +949,59 @@ class RoleV2ViewSetTests(IdentityRequest):
         self.assertNotIn("mixed_role", names)
 
     @patch(CACHE_PATCH_TARGET, _scope_cache(tenant_perms="tenant_app:*:*", root_perms="root_app:*:*"))
+    def test_list_roles_resource_type_workspace_root_resource_id_only_root_scoped(self):
+        """resource_id=root workspace UUID lists only roles whose highest scope is ROOT."""
+        root_perm = Permission.objects.create(permission="root_app:res:read", tenant=self.tenant)
+        def_perm = Permission.objects.create(permission="def_only:res:read", tenant=self.tenant)
+        root_only = RoleV2.objects.create(name="root_only", description="R", tenant=self.tenant)
+        root_only.permissions.add(root_perm)
+        def_only = RoleV2.objects.create(name="def_only", description="D", tenant=self.tenant)
+        def_only.permissions.add(def_perm)
+
+        root = Workspace.objects.root(tenant=self.tenant)
+        url = f"{self.url}?resource_type=workspace&resource_id={root.id}"
+        response = self.client.get(url, **self.headers)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        names = {r["name"] for r in response.data["data"]}
+        self.assertIn("root_only", names)
+        self.assertNotIn("def_only", names)
+        self.assertNotIn("test_role", names)
+
+    @patch(CACHE_PATCH_TARGET, _scope_cache(tenant_perms="tenant_app:*:*", root_perms="root_app:*:*"))
+    def test_list_roles_resource_type_workspace_default_resource_id_only_default_scoped(self):
+        """resource_id=default (or any non-root) workspace lists only DEFAULT-scoped roles."""
+        root_perm = Permission.objects.create(permission="root_app:res:read", tenant=self.tenant)
+        def_perm = Permission.objects.create(permission="def_for_cmp:res:read", tenant=self.tenant)
+        root_r = RoleV2.objects.create(name="root_scoped", description="R2", tenant=self.tenant)
+        root_r.permissions.add(root_perm)
+        def_r = RoleV2.objects.create(name="def_scoped", description="D2", tenant=self.tenant)
+        def_r.permissions.add(def_perm)
+
+        default_ws = Workspace.objects.default(tenant=self.tenant)
+        url = f"{self.url}?resource_type=workspace&resource_id={default_ws.id}"
+        response = self.client.get(url, **self.headers)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        names = {r["name"] for r in response.data["data"]}
+        self.assertIn("def_scoped", names)
+        self.assertIn("test_role", names)
+        self.assertNotIn("root_scoped", names)
+
+    def test_list_roles_resource_id_invalid_uuid_returns_400(self):
+        """Invalid resource_id is rejected before listing."""
+        url = f"{self.url}?resource_type=workspace&resource_id=not-a-uuid"
+        response = self.client.get(url, **self.headers)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    @patch(CACHE_PATCH_TARGET, _scope_cache())
+    def test_list_roles_resource_id_unknown_workspace_returns_empty(self):
+        """resource_id with no matching workspace for the tenant returns an empty list."""
+        unknown = uuid.uuid4()
+        url = f"{self.url}?resource_type=workspace&resource_id={unknown}"
+        response = self.client.get(url, **self.headers)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["data"], [])
+
+    @patch(CACHE_PATCH_TARGET, _scope_cache(tenant_perms="tenant_app:*:*", root_perms="root_app:*:*"))
     def test_list_roles_without_resource_type_returns_all_scopes(self):
         """Test that omitting resource_type returns roles from all scopes."""
         tenant_perm = Permission.objects.create(permission="tenant_app:res:read", tenant=self.tenant)
@@ -964,14 +1017,15 @@ class RoleV2ViewSetTests(IdentityRequest):
 
     def test_list_roles_resource_id_without_resource_type_returns_400(self):
         """Test that providing resource_id without resource_type returns 400."""
-        url = f"{self.url}?resource_id=some-id"
+        url = f"{self.url}?resource_id=00000000-0000-0000-0000-0000000000aa"
         response = self.client.get(url, **self.headers)
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_list_roles_resource_id_with_resource_type_accepted(self):
-        """Test that providing resource_id with resource_type is accepted."""
-        url = f"{self.url}?resource_type=workspace&resource_id=some-id"
+        """Test that providing a valid resource_id with resource_type is accepted."""
+        root = Workspace.objects.root(tenant=self.tenant)
+        url = f"{self.url}?resource_type=workspace&resource_id={root.id}"
         response = self.client.get(url, **self.headers)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)


### PR DESCRIPTION
## Link(s) to Jira
- https://redhat.atlassian.net/browse/RHCLOUD-46801

## Description of Intent of Change(s)
Filter by resource_type and id when listing roles

## Local Testing
Unit test

## Checklist
- [x] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Support filtering roles by workspace resource_type and resource_id, distinguishing root vs default workspaces and enforcing UUID validation for resource_id.

Bug Fixes:
- Ensure invalid or non-UUID resource_id values are rejected with validation errors and 400 responses instead of being silently accepted.

Enhancements:
- Refine workspace role listing so that workspace filters without resource_id return only default-scoped roles, root workspace IDs return only root-scoped roles, and non-root workspace IDs return only default-scoped roles.

Tests:
- Add and update service, view, and serializer tests to cover workspace resource_id handling, scope-specific role filtering, invalid UUIDs, and unknown workspace IDs.