### PR TITLE
[RHCLOUD-46801] Restrict the roles binding to resources not the same scope

### DIFF
--- a/rbac/api/cross_access/relation_api_dual_write_cross_access_handler.py
+++ b/rbac/api/cross_access/relation_api_dual_write_cross_access_handler.py
@@ -154,6 +154,7 @@ class RelationApiDualWriteCrossAccessHandler(RelationApiDualWriteSubjectHandler)
             replicator=_LocalReplicator(self),
             principal_source=str(self._source_key()),
             allow_external_subjects=True,
+            skip_scope_validation=True,
         )
 
     def _add_car_roles_v1(self, roles: set[Role]):

--- a/rbac/management/permission/scope_service.py
+++ b/rbac/management/permission/scope_service.py
@@ -326,6 +326,27 @@ def scopes_for_resource_type(resource_type: str) -> set[Scope]:
     return {scope for scope, rt in SCOPE_RESOURCE_TYPE.items() if rt == resource_type}
 
 
+def scope_for_resource(resource_type: str, resource_id: str, tenant: Tenant) -> Scope | None:
+    """Return the single expected Scope for a (resource_type, resource_id) pair, or None if unknown.
+
+    * ``tenant`` -> ``Scope.TENANT``
+    * ``workspace`` with the root workspace -> ``Scope.ROOT``
+    * ``workspace`` with any other workspace -> ``Scope.DEFAULT``
+    * anything else -> ``None``
+    """
+    if resource_type == "tenant":
+        return Scope.TENANT
+    if resource_type == "workspace":
+        try:
+            workspace = Workspace.objects.get(id=resource_id, tenant=tenant)
+        except Workspace.DoesNotExist:
+            return None
+        if workspace.type == Workspace.Types.ROOT:
+            return Scope.ROOT
+        return Scope.DEFAULT
+    return None
+
+
 """
 A global ImplicitResourceService configured using Django Settings.
 

--- a/rbac/management/role/v2_service.py
+++ b/rbac/management/role/v2_service.py
@@ -27,10 +27,14 @@ from django.db import IntegrityError
 from django.db.models import QuerySet
 from management.atomic_transactions import atomic
 from management.exceptions import NotFoundError, RequiredFieldError
-from management.models import Workspace
 from management.permission.exceptions import InvalidPermissionDataError
 from management.permission.model import PermissionValue
-from management.permission.scope_service import Scope, permission_scope_cache, scopes_for_resource_type
+from management.permission.scope_service import (
+    Scope,
+    permission_scope_cache,
+    scope_for_resource,
+    scopes_for_resource_type,
+)
 from management.permission.service import PermissionService
 from management.relation_replicator.noop_replicator import NoopReplicator
 from management.relation_replicator.outbox_replicator import OutboxReplicator
@@ -284,14 +288,11 @@ class RoleV2Service:
 
         if resource_type == "workspace":
             if resource_id is not None:
-                try:
-                    workspace = Workspace.objects.get(id=resource_id, tenant=self.tenant)
-                except Workspace.DoesNotExist:
+                assert self.tenant is not None
+                resolved = scope_for_resource(resource_type, str(resource_id), self.tenant)
+                if resolved is None:
                     return queryset.none()
-                if workspace.type == Workspace.Types.ROOT:
-                    matching_scopes = {Scope.ROOT}
-                else:
-                    matching_scopes = {Scope.DEFAULT}
+                matching_scopes = {resolved}
             else:
                 matching_scopes = {Scope.DEFAULT}
 

--- a/rbac/management/role_binding/service.py
+++ b/rbac/management/role_binding/service.py
@@ -28,7 +28,7 @@ from management.atomic_transactions import atomic
 from management.exceptions import InvalidFieldError, NotFoundError, RequiredFieldError
 from management.group.model import Group
 from management.group.platform import DefaultGroupNotAvailableError, GlobalPolicyIdService
-from management.permission.scope_service import Scope
+from management.permission.scope_service import Scope, default_implicit_resource_service, scope_for_resource
 from management.principal.model import Principal
 from management.relation_replicator.noop_replicator import NoopReplicator
 from management.relation_replicator.outbox_replicator import OutboxReplicator
@@ -97,11 +97,13 @@ class RoleBindingService:
         replicator: RelationReplicator | None = None,
         principal_source: str = API_PRINCIPAL_SOURCE,
         allow_external_subjects: bool = False,
+        skip_scope_validation: bool = False,
     ):
         """Initialize the service with a tenant and optional replicator."""
         self.tenant = tenant
         self._principal_source = principal_source
         self._allow_external_subjects = allow_external_subjects
+        self._skip_scope_validation = skip_scope_validation
 
         if settings.REPLICATION_TO_RELATION_ENABLED:
             self._replicator = replicator if replicator is not None else OutboxReplicator()
@@ -296,6 +298,9 @@ class RoleBindingService:
 
         for resource_type, resource_id in {(r.resource_type, r.resource_id) for r in requests}:
             self._validate_resource(resource_type, resource_id)
+
+        for req in requests:
+            self._validate_role_scopes([roles_by_uuid[req.role_id]], req.resource_type, req.resource_id)
 
         access_groups = self._group_by_subject_resource(requests, roles_by_uuid)
         all_tuples_to_add: list[RelationTuple] = []
@@ -1005,6 +1010,7 @@ class RoleBindingService:
         ensure_v2_write_activated(self.tenant)
 
         roles = self._get_roles(role_ids)
+        self._validate_role_scopes(roles, resource_type, resource_id)
 
         subject = Subject.objects.by_type(type=subject_type, id=subject_id)
 
@@ -1095,6 +1101,43 @@ class RoleBindingService:
             raise InvalidFieldError("roles", f"The following roles do not exist: {', '.join(missing)}")
 
         return roles
+
+    def _validate_role_scopes(self, roles: list[RoleV2], resource_type: str, resource_id: str) -> None:
+        """Validate that each role's highest scope matches the target resource.
+
+        Uses ``ImplicitResourceService.highest_scope_for_permissions`` to compute
+        the scope from each role's permission strings.
+
+        Must be called after ``_validate_resource`` which ensures the resource
+        exists. Empty *roles* is valid (means "unbind all") and skips the check.
+
+        Raises:
+            InvalidFieldError: If any role's scope does not match the resource.
+            NotFoundError: If the resource cannot be resolved to a scope (should
+                not happen when ``_validate_resource`` ran first).
+        """
+        if self._skip_scope_validation or not roles:
+            return
+
+        expected = scope_for_resource(resource_type, resource_id, self.tenant)
+        if expected is None:
+            if resource_type in ("workspace", "tenant"):
+                raise NotFoundError(resource_type, resource_id)
+            return
+
+        mismatched: list[str] = []
+        for role in roles:
+            perm_strings = list(role.permissions.values_list("permission", flat=True))
+            role_scope = default_implicit_resource_service.highest_scope_for_permissions(perm_strings)
+            if role_scope != expected:
+                mismatched.append(f"{role.name} ({role.uuid})")
+
+        if mismatched:
+            scope_label = expected.name.lower()
+            raise InvalidFieldError(
+                "roles",
+                f"The following roles are not scoped for this resource ({scope_label}): {', '.join(mismatched)}",
+            )
 
     def _replace_role_bindings(
         self,

--- a/tests/management/role_binding/test_service.py
+++ b/tests/management/role_binding/test_service.py
@@ -2626,6 +2626,93 @@ class UpdateRoleBindingsForSubjectTests(_ReplicationAssertionsMixin, IdentityReq
         self.assertIn("admin default group", str(context.exception))
         admin_group.delete()
 
+    def test_update_rejects_tenant_scoped_role_on_workspace(self):
+        """Binding a tenant-scoped role to a workspace should fail."""
+        from management.permission.scope_service import ImplicitResourceService
+
+        scope_service = ImplicitResourceService(
+            tenant_scope_permissions=["tenant_app:*:*"],
+            root_scope_permissions=[],
+        )
+
+        tenant_perm = Permission.objects.create(permission="tenant_app:res:read", tenant=self.tenant)
+        tenant_role = RoleV2.objects.create(name="tenant_role", description="Tenant", tenant=self.tenant)
+        tenant_role.permissions.add(tenant_perm)
+
+        with patch("management.role_binding.service.default_implicit_resource_service", scope_service):
+            with self.assertRaises(InvalidFieldError) as ctx:
+                self.service.update_role_bindings_for_subject(
+                    resource_type="workspace",
+                    resource_id=str(self.workspace.id),
+                    subject_type="group",
+                    subject_id=str(self.group.uuid),
+                    role_ids=[str(tenant_role.uuid)],
+                )
+            self.assertIn("not scoped", str(ctx.exception))
+
+    def test_update_rejects_default_scoped_role_on_root_workspace(self):
+        """Binding a default-scoped role to the root workspace should fail."""
+        from management.permission.scope_service import ImplicitResourceService
+
+        scope_service = ImplicitResourceService(
+            tenant_scope_permissions=[],
+            root_scope_permissions=["root_app:*:*"],
+        )
+
+        with patch("management.role_binding.service.default_implicit_resource_service", scope_service):
+            with self.assertRaises(InvalidFieldError) as ctx:
+                self.service.update_role_bindings_for_subject(
+                    resource_type="workspace",
+                    resource_id=str(self.root_workspace.id),
+                    subject_type="group",
+                    subject_id=str(self.group.uuid),
+                    role_ids=[str(self.role1.uuid)],
+                )
+            self.assertIn("not scoped", str(ctx.exception))
+
+    def test_update_rejects_default_scoped_role_on_tenant(self):
+        """Binding a default-scoped role to a tenant resource should fail."""
+        from management.permission.scope_service import ImplicitResourceService
+
+        scope_service = ImplicitResourceService(
+            tenant_scope_permissions=["tenant_app:*:*"],
+            root_scope_permissions=[],
+        )
+
+        with patch("management.role_binding.service.default_implicit_resource_service", scope_service):
+            with self.assertRaises(InvalidFieldError) as ctx:
+                self.service.update_role_bindings_for_subject(
+                    resource_type="tenant",
+                    resource_id=self.tenant.tenant_resource_id(),
+                    subject_type="group",
+                    subject_id=str(self.group.uuid),
+                    role_ids=[str(self.role1.uuid)],
+                )
+            self.assertIn("not scoped", str(ctx.exception))
+
+    def test_update_allows_correctly_scoped_role_on_root_workspace(self):
+        """A root-scoped role should be accepted on the root workspace."""
+        from management.permission.scope_service import ImplicitResourceService
+
+        scope_service = ImplicitResourceService(
+            tenant_scope_permissions=[],
+            root_scope_permissions=["root_app:*:*"],
+        )
+
+        root_perm = Permission.objects.create(permission="root_app:res:read", tenant=self.tenant)
+        root_role = RoleV2.objects.create(name="root_role", description="Root", tenant=self.tenant)
+        root_role.permissions.add(root_perm)
+
+        with patch("management.role_binding.service.default_implicit_resource_service", scope_service):
+            result = self.service.update_role_bindings_for_subject(
+                resource_type="workspace",
+                resource_id=str(self.root_workspace.id),
+                subject_type="group",
+                subject_id=str(self.group.uuid),
+                role_ids=[str(root_role.uuid)],
+            )
+        self.assertEqual({r.uuid for r in result.roles}, {root_role.uuid})
+
 
 @override_settings(ATOMIC_RETRY_DISABLED=True)
 class ReplaceRoleBindingsTests(_ReplicationAssertionsMixin, IdentityRequest):


### PR DESCRIPTION
## Link(s) to Jira
- https://redhat.atlassian.net/browse/RHCLOUD-46801

## Description of Intent of Change(s)
Do not allow the roles in different scope to be bound to the wrong resource.

## Local Testing
Unit tests

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Enforce that roles can only be bound to resources matching their scope and reuse a shared helper to resolve resource scopes.

New Features:
- Add validation that role scopes match the target resource when creating or updating role bindings.

Bug Fixes:
- Prevent tenant-scoped and default-scoped roles from being bound to incompatible resources such as root workspaces, non-root workspaces, or tenant resources.

Enhancements:
- Introduce a shared scope_for_resource helper to resolve the expected scope for tenant and workspace resources and reuse it in role and role-binding services.
- Align role filtering by workspace resource to use the shared scope resolution logic instead of duplicating workspace-type checks.

Tests:
- Add unit tests covering acceptance and rejection of role bindings based on correct or incorrect scope for tenant, workspace, and root workspace resources.