### PR TITLE
[RHCLOUD-46801] Restrict editing v2 role with mixed scope

### DIFF
--- a/rbac/management/permission/scope_service.py
+++ b/rbac/management/permission/scope_service.py
@@ -320,6 +320,13 @@ SCOPE_RESOURCE_TYPE: dict[Scope, str] = {
 }
 """Maps each Scope to the resource_type string it binds to."""
 
+SCOPE_DISPLAY_NAME: dict[Scope, str] = {
+    Scope.DEFAULT: "Default Workspace",
+    Scope.ROOT: "Root Workspace",
+    Scope.TENANT: "Organization",
+}
+"""User-facing label for each Scope (avoids exposing internal 'tenant' terminology)."""
+
 
 def scopes_for_resource_type(resource_type: str) -> set[Scope]:
     """Return all Scope values that map to the given resource_type."""

--- a/rbac/management/role/v2_service.py
+++ b/rbac/management/role/v2_service.py
@@ -30,7 +30,9 @@ from management.exceptions import NotFoundError, RequiredFieldError
 from management.permission.exceptions import InvalidPermissionDataError
 from management.permission.model import PermissionValue
 from management.permission.scope_service import (
+    SCOPE_DISPLAY_NAME,
     Scope,
+    default_implicit_resource_service,
     permission_scope_cache,
     scope_for_resource,
     scopes_for_resource_type,
@@ -118,6 +120,19 @@ class RoleV2Service:
                     "Permissions from migration-excluded applications cannot be used in V2 custom roles: "
                     + ", ".join(bad_apps)
                 )
+
+        perms_by_scope: dict[Scope, list[str]] = {}
+        for p in permissions:
+            scope = default_implicit_resource_service.scope_for_permission(p.permission)
+            perms_by_scope.setdefault(scope, []).append(p.permission)
+        if len(perms_by_scope) > 1:
+            details = "; ".join(
+                f"{SCOPE_DISPLAY_NAME[scope]}: {', '.join(sorted(perms))}"
+                for scope, perms in sorted(perms_by_scope.items())
+            )
+            raise InvalidRolePermissionsError(
+                f"All permissions in a role must belong to the same scope. Found: {details}"
+            )
 
         return permissions
 

--- a/rbac/management/role_binding/service.py
+++ b/rbac/management/role_binding/service.py
@@ -28,7 +28,12 @@ from management.atomic_transactions import atomic
 from management.exceptions import InvalidFieldError, NotFoundError, RequiredFieldError
 from management.group.model import Group
 from management.group.platform import DefaultGroupNotAvailableError, GlobalPolicyIdService
-from management.permission.scope_service import Scope, default_implicit_resource_service, scope_for_resource
+from management.permission.scope_service import (
+    SCOPE_DISPLAY_NAME,
+    Scope,
+    default_implicit_resource_service,
+    scope_for_resource,
+)
 from management.principal.model import Principal
 from management.relation_replicator.noop_replicator import NoopReplicator
 from management.relation_replicator.outbox_replicator import OutboxReplicator
@@ -1133,7 +1138,7 @@ class RoleBindingService:
                 mismatched.append(f"{role.name} ({role.uuid})")
 
         if mismatched:
-            scope_label = expected.name.lower()
+            scope_label = SCOPE_DISPLAY_NAME[expected]
             raise InvalidFieldError(
                 "roles",
                 f"The following roles are not scoped for this resource ({scope_label}): {', '.join(mismatched)}",

--- a/tests/management/role/test_v2_service.py
+++ b/tests/management/role/test_v2_service.py
@@ -222,6 +222,57 @@ class RoleV2ServiceTests(IdentityRequest):
         self.assertIn("Duplicate Name", str(cm.exception))
         self.assertEqual(cm.exception.name, "Duplicate Name")
 
+    def test_create_role_with_mixed_scope_permissions_raises_error(self):
+        """Creating a role with permissions from different scopes is rejected."""
+        from management.permission.scope_service import ImplicitResourceService
+        from management.role.v2_exceptions import InvalidRolePermissionsError
+
+        scope_service = ImplicitResourceService(
+            tenant_scope_permissions=["tenant_app:*:*"],
+            root_scope_permissions=["root_app:*:*"],
+        )
+        Permission.objects.create(permission="tenant_app:res:read", tenant=self.tenant)
+        Permission.objects.create(permission="root_app:res:read", tenant=self.tenant)
+
+        with patch("management.role.v2_service.default_implicit_resource_service", scope_service):
+            with self.assertRaises(InvalidRolePermissionsError) as ctx:
+                self.service.create(
+                    name="Mixed Scope Role",
+                    description="Should fail",
+                    permission_data=[
+                        {"application": "tenant_app", "resource_type": "res", "operation": "read"},
+                        {"application": "root_app", "resource_type": "res", "operation": "read"},
+                    ],
+                    tenant=self.tenant,
+                )
+            msg = str(ctx.exception)
+            self.assertIn("same scope", msg)
+            self.assertIn("tenant_app:res:read", msg)
+            self.assertIn("root_app:res:read", msg)
+
+    def test_create_role_with_same_scope_permissions_succeeds(self):
+        """Creating a role where all permissions share the same scope succeeds."""
+        from management.permission.scope_service import ImplicitResourceService
+
+        scope_service = ImplicitResourceService(
+            tenant_scope_permissions=["tenant_app:*:*"],
+            root_scope_permissions=[],
+        )
+        Permission.objects.create(permission="tenant_app:res:read", tenant=self.tenant)
+        Permission.objects.create(permission="tenant_app:res:write", tenant=self.tenant)
+
+        with patch("management.role.v2_service.default_implicit_resource_service", scope_service):
+            role = self.service.create(
+                name="Same Scope Role",
+                description="Should pass",
+                permission_data=[
+                    {"application": "tenant_app", "resource_type": "res", "operation": "read"},
+                    {"application": "tenant_app", "resource_type": "res", "operation": "write"},
+                ],
+                tenant=self.tenant,
+            )
+        self.assertEqual(role.permissions.count(), 2)
+
     def test_create_role_generates_uuid(self):
         """Test that creating a role auto-generates a UUID."""
         permission_data = [


### PR DESCRIPTION
## Link(s) to Jira
- https://redhat.atlassian.net/browse/RHCLOUD-46801

## Description of Intent of Change(s)
Restricting roles to have permissions with different scope

## Local Testing
Unit test

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Enforce that v2 roles only contain permissions from a single scope and improve user-facing scope messaging.

Bug Fixes:
- Prevent creation of roles that mix permissions from different scopes by validating resolved permissions before saving.
- Use human-friendly scope labels instead of internal enum names when reporting role scope mismatches in role bindings.

Enhancements:
- Introduce a user-facing display name mapping for permission scopes to avoid exposing internal terminology in error messages.

Tests:
- Add unit tests verifying that creating a role with mixed-scope permissions fails with a clear error and same-scope permissions succeed.