### PR TITLE
 RHCLOUD-47270 - Add group_name filter to MCP audit tools

### DIFF
--- a/rbac/management/mcp_views.py
+++ b/rbac/management/mcp_views.py
@@ -730,10 +730,12 @@ def list_permission_options(
 
 @register_tool(
     description=(
-        "List roles assigned to a specific group. Provide either group_uuid OR group_name. "
+        "List roles assigned to a specific group. Provide either group_uuid OR group_name "
+        "(if both are provided, group_uuid takes precedence). "
         "Use group_name for convenience (case-insensitive lookup). "
         "Example: list_group_roles(group_name='<group-name>') to see roles assigned to that group. "
         "Filter results by role_name, role_description, role_display_name, or role_system. "
+        "Set exclude='true' to list roles NOT in the group. "
         "Order by: 'name', 'display_name', 'modified', 'policyCount' (prefix with '-' to reverse). "
         "Returns: {meta: {count}, links, data: [{uuid, name, description, system, ...}]}."
     ),

--- a/rbac/management/mcp_views.py
+++ b/rbac/management/mcp_views.py
@@ -421,17 +421,17 @@ def list_permissions(
 
 @register_tool(
     description=(
-        "List audit log entries showing who made changes to RBAC resources. "
-        "Use this to answer: 'Who added a role to group X?' or 'Who modified group Y?' "
-        "Filter by: principal_username (who made the change), resource_type "
+        "List audit log entries recording RBAC changes for the authenticated organization. "
+        "Each entry records who changed what (principal, resource_type, action). "
+        "Filter by principal_username (who made the change), resource_type "
         "(group/role/role_v2/user/permission/workspace/role_binding), action (add/edit/delete/create/remove), "
-        "or group_name (searches description for a specific group - USE THIS to narrow results). "
-        "IMPORTANT: Always set group_name when investigating a specific group to avoid scanning all 100+ entries. "
-        "Example: list_audit_logs(resource_type='group', action='add', group_name='<group-name>') "
-        "Set include_authorization=true to enrich each entry with the role and permission that authorized "
-        "the action (e.g., 'User Access administrator' role via 'Access Governance' group grants 'rbac:group:write'). "
-        "NOTE: Authorization shows actor's CURRENT role/permission — may differ from time of change. "
-        "Order by: 'created', 'principal_username', 'resource_type', 'action' (prefix with '-' to reverse)."
+        "group_name (filter by group), or role_name (filter by role). "
+        "IMPORTANT: Always set group_name and/or role_name to narrow results (avoids scanning 100+ entries). "
+        "Example: list_audit_logs(resource_type='group', action='add', group_name='Contractors', "
+        "role_name='Vulnerability administrator') "
+        "Set include_authorization=true to see the role/permission that authorized the action. "
+        "Order by: 'created', 'principal_username', 'resource_type', 'action' (prefix with '-' to reverse). "
+        "NOTE: Authorization shows actor's CURRENT role/permission — may differ from time of change."
     ),
     requires_auth=True,
 )
@@ -445,6 +445,7 @@ def list_audit_logs(
     resource_type: str = "",
     action: str = "",
     group_name: str = "",
+    role_name: str = "",
     include_authorization: bool = False,
 ) -> str:
     """List audit logs with optional authorization context."""
@@ -469,6 +470,8 @@ def list_audit_logs(
         queryset = queryset.filter(action=action)
     if group_name:
         queryset = queryset.filter(description__icontains=group_name)
+    if role_name:
+        queryset = queryset.filter(description__icontains=role_name)
 
     total_count = queryset.count()
     entries = list(queryset[offset : offset + limit])  # noqa: E203
@@ -758,7 +761,7 @@ def list_group_roles(
 
     resolved_uuid = group_uuid
     if not resolved_uuid and group_name:
-        group = Group.objects.filter(name__iexact=group_name, tenant=tenant).first()
+        group = Group.objects.filter(name__iexact=group_name, tenant=tenant).only("uuid").first()
         if not group:
             return json.dumps({"error": f"Group '{group_name}' not found"})
         resolved_uuid = str(group.uuid)

--- a/rbac/management/mcp_views.py
+++ b/rbac/management/mcp_views.py
@@ -428,7 +428,9 @@ def list_permissions(
         "or group_name (searches description for a specific group - USE THIS to narrow results). "
         "IMPORTANT: Always set group_name when investigating a specific group to avoid scanning all 100+ entries. "
         "Example: list_audit_logs(resource_type='group', action='add', group_name='<group-name>') "
-        "Set include_authorization=true to also see which role/permission authorized each action. "
+        "Set include_authorization=true to enrich each entry with the role and permission that authorized "
+        "the action (e.g., 'User Access administrator' role via 'Access Governance' group grants 'rbac:group:write'). "
+        "NOTE: Authorization shows actor's CURRENT role/permission — may differ from time of change. "
         "Order by: 'created', 'principal_username', 'resource_type', 'action' (prefix with '-' to reverse)."
     ),
     requires_auth=True,

--- a/rbac/management/mcp_views.py
+++ b/rbac/management/mcp_views.py
@@ -38,7 +38,7 @@ from django.views.decorators.csrf import csrf_exempt
 from management.access.view import AccessView
 from management.audit_log.view import AuditLogViewSet
 from management.group.view import GroupViewSet
-from management.models import Access, AuditLog
+from management.models import Access, AuditLog, Group
 from management.permission.view import PermissionViewSet
 from management.principal.model import Principal
 from management.principal.proxy import PrincipalProxy
@@ -421,17 +421,15 @@ def list_permissions(
 
 @register_tool(
     description=(
-        "List audit log entries recording RBAC changes for the authenticated organization. "
-        "Each entry records who changed what (principal, resource_type, action). "
-        "Filter by principal_username (who made the change), resource_type "
-        "(group/role/role_v2/user/permission/workspace/role_binding), or action (add/edit/delete/create/remove). "
-        "TROUBLESHOOTING: To investigate who made a specific RBAC change, filter by resource_type and action. "
-        "To see all changes by a specific user, set principal_username. "
-        "Set include_authorization=true to enrich each entry with the role and permission "
-        "that authorized the action (e.g., 'User Access administrator' role via 'Access Governance' "
-        "group grants 'rbac:group:write'). "
-        "Order by: 'created', 'principal_username', 'resource_type', 'action' (prefix with '-' to reverse). "
-        "NOTE: Authorization shows actor's CURRENT role/permission — may differ from time of change."
+        "List audit log entries showing who made changes to RBAC resources. "
+        "Use this to answer: 'Who added a role to group X?' or 'Who modified group Y?' "
+        "Filter by: principal_username (who made the change), resource_type "
+        "(group/role/role_v2/user/permission/workspace/role_binding), action (add/edit/delete/create/remove), "
+        "or group_name (searches description for a specific group - USE THIS to narrow results). "
+        "IMPORTANT: Always set group_name when investigating a specific group to avoid scanning all 100+ entries. "
+        "Example: list_audit_logs(resource_type='group', action='add', group_name='<group-name>') "
+        "Set include_authorization=true to also see which role/permission authorized each action. "
+        "Order by: 'created', 'principal_username', 'resource_type', 'action' (prefix with '-' to reverse)."
     ),
     requires_auth=True,
 )
@@ -444,6 +442,7 @@ def list_audit_logs(
     principal_username: str = "",
     resource_type: str = "",
     action: str = "",
+    group_name: str = "",
     include_authorization: bool = False,
 ) -> str:
     """List audit logs with optional authorization context."""
@@ -466,6 +465,8 @@ def list_audit_logs(
         queryset = queryset.filter(resource_type=resource_type)
     if action:
         queryset = queryset.filter(action=action)
+    if group_name:
+        queryset = queryset.filter(description__icontains=group_name)
 
     total_count = queryset.count()
     entries = list(queryset[offset : offset + limit])  # noqa: E203
@@ -724,12 +725,12 @@ def list_permission_options(
 
 @register_tool(
     description=(
-        "List roles assigned to a specific group. Shows which roles are associated with the group "
-        "through policies. Filter by role_name, role_description, role_display_name, or role_system (boolean). "
+        "List roles assigned to a specific group. Provide either group_uuid OR group_name. "
+        "Use group_name for convenience (case-insensitive lookup). "
+        "Example: list_group_roles(group_name='<group-name>') to see roles assigned to that group. "
+        "Filter results by role_name, role_description, role_display_name, or role_system. "
         "Order by: 'name', 'display_name', 'modified', 'policyCount' (prefix with '-' to reverse). "
-        "Set exclude='true' to list roles NOT in the group. "
-        "Returns: {meta: {count}, links, data: [{uuid, name, description, system, platform_default, ...}]}. "
-        "Calls: GET /api/v1/groups/{uuid}/roles/"
+        "Returns: {meta: {count}, links, data: [{uuid, name, description, system, ...}]}."
     ),
     requires_auth=True,
     api_version=ApiVersion.V1,
@@ -737,7 +738,8 @@ def list_permission_options(
 def list_group_roles(
     request: HttpRequest,
     *,
-    group_uuid: str,
+    group_uuid: str = "",
+    group_name: str = "",
     limit: int = 10,
     offset: int = 0,
     order_by: str = "",
@@ -748,6 +750,20 @@ def list_group_roles(
     exclude: str = "false",
 ) -> str:
     """List roles for a group by delegating to GroupViewSet.roles."""
+    tenant = getattr(request, "tenant", None)
+    if not tenant:
+        return json.dumps({"error": "No tenant context available"})
+
+    resolved_uuid = group_uuid
+    if not resolved_uuid and group_name:
+        group = Group.objects.filter(name__iexact=group_name, tenant=tenant).first()
+        if not group:
+            return json.dumps({"error": f"Group '{group_name}' not found"})
+        resolved_uuid = str(group.uuid)
+
+    if not resolved_uuid:
+        return json.dumps({"error": "Either group_uuid or group_name is required"})
+
     query_params: dict[str, str] = {
         "limit": str(limit),
         "offset": str(offset),
@@ -765,8 +781,8 @@ def list_group_roles(
     if exclude != "false":
         query_params["exclude"] = exclude
 
-    path = reverse("v1_management:group-roles", kwargs={"uuid": group_uuid})
-    return _call_view(request, _group_roles_view, path, query_params, uuid=group_uuid)
+    path = reverse("v1_management:group-roles", kwargs={"uuid": resolved_uuid})
+    return _call_view(request, _group_roles_view, path, query_params, uuid=resolved_uuid)
 
 
 @register_tool(

--- a/tests/management/test_mcp_views.py
+++ b/tests/management/test_mcp_views.py
@@ -1193,6 +1193,8 @@ class MCPViewTests(MCPToolTestMixin, IdentityRequest):
         self.assertFalse(data["result"]["isError"])
         tool_output = self._get_tool_output(response)
         self.assertIn("data", tool_output)
+        self.assertEqual(tool_output["meta"]["count"], 1)
+        self.assertEqual(tool_output["data"][0]["name"], "role_alpha")
 
     def test_list_group_roles_by_name_case_insensitive(self):
         """Positive: list_group_roles group_name lookup is case-insensitive."""
@@ -1206,6 +1208,9 @@ class MCPViewTests(MCPToolTestMixin, IdentityRequest):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         data = response.json()
         self.assertFalse(data["result"]["isError"])
+        tool_output = self._get_tool_output(response)
+        self.assertEqual(tool_output["meta"]["count"], 1)
+        self.assertEqual(tool_output["data"][0]["name"], "role_beta")
 
     def test_list_group_roles_missing_both_params_returns_error(self):
         """Negative: list_group_roles without group_uuid or group_name returns error."""

--- a/tests/management/test_mcp_views.py
+++ b/tests/management/test_mcp_views.py
@@ -949,6 +949,31 @@ class MCPViewTests(MCPToolTestMixin, IdentityRequest):
         self.assertEqual(len(tool_output["data"]), 0)
         self.assertEqual(tool_output["meta"]["count"], 1)
 
+    def test_list_audit_logs_filter_by_group_name(self):
+        """Positive: list_audit_logs filters by group_name in description."""
+        AuditLog.objects.create(
+            principal_username="user1",
+            resource_type=AuditLog.GROUP,
+            action=AuditLog.ADD,
+            description="Added role to group: target_group_alpha",
+            tenant=self.tenant,
+        )
+        AuditLog.objects.create(
+            principal_username="user2",
+            resource_type=AuditLog.GROUP,
+            action=AuditLog.ADD,
+            description="Added role to group: other_group_beta",
+            tenant=self.tenant,
+        )
+
+        response = self._call_tool("list_audit_logs", {"group_name": "target_group_alpha"})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        tool_output = self._get_tool_output(response)
+        self.assertEqual(tool_output["meta"]["count"], 1)
+        self.assertEqual(len(tool_output["data"]), 1)
+        self.assertIn("target_group_alpha", tool_output["data"][0]["description"])
+
     # --- list_groups / get_group / list_group_principals ---
 
     def test_list_groups_success(self):
@@ -1124,6 +1149,52 @@ class MCPViewTests(MCPToolTestMixin, IdentityRequest):
         data = response.json()
         self.assertIn("error", data)
         self.assertEqual(data["error"]["code"], -32000)
+
+    def test_list_group_roles_by_name(self):
+        """Positive: list_group_roles accepts group_name instead of group_uuid."""
+        group = Group.objects.create(name="group_for_roles_test", tenant=self.tenant)
+        role = Role.objects.create(name="role_alpha", tenant=self.tenant)
+        policy = Policy.objects.create(name="policy_alpha", group=group, tenant=self.tenant)
+        policy.roles.add(role)
+
+        response = self._call_tool("list_group_roles", {"group_name": "group_for_roles_test"})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertFalse(data["result"]["isError"])
+        tool_output = self._get_tool_output(response)
+        self.assertIn("data", tool_output)
+
+    def test_list_group_roles_by_name_case_insensitive(self):
+        """Positive: list_group_roles group_name lookup is case-insensitive."""
+        group = Group.objects.create(name="Group_With_Mixed_Case", tenant=self.tenant)
+        role = Role.objects.create(name="role_beta", tenant=self.tenant)
+        policy = Policy.objects.create(name="policy_beta", group=group, tenant=self.tenant)
+        policy.roles.add(role)
+
+        response = self._call_tool("list_group_roles", {"group_name": "group_with_mixed_case"})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertFalse(data["result"]["isError"])
+
+    def test_list_group_roles_missing_both_params_returns_error(self):
+        """Negative: list_group_roles without group_uuid or group_name returns error."""
+        response = self._call_tool("list_group_roles", {})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        tool_output = self._get_tool_output(response)
+        self.assertIn("error", tool_output)
+        self.assertIn("Either group_uuid or group_name is required", tool_output["error"])
+
+    def test_list_group_roles_group_not_found_returns_error(self):
+        """Negative: list_group_roles with non-existent group_name returns error."""
+        response = self._call_tool("list_group_roles", {"group_name": "nonexistent_group_xyz"})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        tool_output = self._get_tool_output(response)
+        self.assertIn("error", tool_output)
+        self.assertIn("not found", tool_output["error"])
 
     # --- list_role_access ---
 

--- a/tests/management/test_mcp_views.py
+++ b/tests/management/test_mcp_views.py
@@ -70,6 +70,10 @@ class MCPViewTests(MCPToolTestMixin, IdentityRequest):
 
     def tearDown(self):
         """Tear down MCP view tests."""
+        AuditLog.objects.all().delete()
+        Policy.objects.all().delete()
+        Role.objects.all().delete()
+        Group.objects.all().delete()
         Principal.objects.all().delete()
         super().tearDown()
 
@@ -955,14 +959,14 @@ class MCPViewTests(MCPToolTestMixin, IdentityRequest):
             principal_username="user1",
             resource_type=AuditLog.GROUP,
             action=AuditLog.ADD,
-            description="Added role to group: target_group_alpha",
+            description="role test_role added to group: target_group_alpha",
             tenant=self.tenant,
         )
         AuditLog.objects.create(
             principal_username="user2",
             resource_type=AuditLog.GROUP,
             action=AuditLog.ADD,
-            description="Added role to group: other_group_beta",
+            description="role other_role added to group: other_group_beta",
             tenant=self.tenant,
         )
 
@@ -973,6 +977,31 @@ class MCPViewTests(MCPToolTestMixin, IdentityRequest):
         self.assertEqual(tool_output["meta"]["count"], 1)
         self.assertEqual(len(tool_output["data"]), 1)
         self.assertIn("target_group_alpha", tool_output["data"][0]["description"])
+
+    def test_list_audit_logs_filter_by_role_name(self):
+        """Positive: list_audit_logs filters by role_name in description."""
+        AuditLog.objects.create(
+            principal_username="user1",
+            resource_type=AuditLog.GROUP,
+            action=AuditLog.ADD,
+            description="role target_role_alpha added to group: some_group",
+            tenant=self.tenant,
+        )
+        AuditLog.objects.create(
+            principal_username="user2",
+            resource_type=AuditLog.GROUP,
+            action=AuditLog.ADD,
+            description="role other_role_beta added to group: some_group",
+            tenant=self.tenant,
+        )
+
+        response = self._call_tool("list_audit_logs", {"role_name": "target_role_alpha"})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        tool_output = self._get_tool_output(response)
+        self.assertEqual(tool_output["meta"]["count"], 1)
+        self.assertEqual(len(tool_output["data"]), 1)
+        self.assertIn("target_role_alpha", tool_output["data"][0]["description"])
 
     # --- list_groups / get_group / list_group_principals ---
 


### PR DESCRIPTION
## Link(s) to Jira
https://redhat.atlassian.net/browse/RHCLOUD-47270

## Description of Intent of Change(s)
  Improves MCP audit tool accuracy by adding targeted filters that help the LLM narrow results instead of scanning
  hundreds of entries:

  - Add group_name and role_name filters to list_audit_logs for precise lookups
  - Allow list_group_roles to accept group_name instead of requiring UUID lookup first
  - Update tool descriptions to guide the LLM toward filtered queries

  Test plan

  - Verify list_audit_logs(group_name='...') filters entries containing that group name
  - Verify list_audit_logs(role_name='...') filters entries containing that role name
  - Verify list_group_roles(group_name='...') resolves the group and returns its roles
  - Verify error returned when group_name not found

## Local Testing
How can the feature be exercised?

pipenv run tox -e py312-fast -- tests.management.test_mcp_views


How can the bug be exploited and fix confirmed?
Is any special local setup required?

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Add support for group-based filtering in MCP audit and group role tools to make investigations and role lookups more precise.

New Features:
- Allow list_audit_logs to filter results by group_name via a case-insensitive search of the description field.
- Allow list_group_roles to accept either group_uuid or group_name (case-insensitive) for resolving the target group, including appropriate error responses when resolution fails.

Tests:
- Add tests covering audit log filtering by group_name and group role lookups by group_name, case-insensitivity, and error conditions when parameters are missing or groups are not found.