### PR TITLE
RHCLOUD-40442: Replicate default workspaces

### DIFF
--- a/deploy/rbac-clowdapp.yml
+++ b/deploy/rbac-clowdapp.yml
@@ -1238,6 +1238,21 @@ objects:
               cpu: 50m
               memory: 512Mi
           env: *common_env_vars
+      - name: replicate-default-workspaces
+        podSpec:
+          image: ${IMAGE}:${IMAGE_TAG}
+          command:
+            - /opt/rbac/rbac/manage.py
+            - replicate-default-workspaces
+            - "--all"
+          resources:
+            limits:
+              cpu: 300m
+              memory: 1Gi
+            requests:
+              cpu: 50m
+              memory: 512Mi
+          env: *common_env_vars
 - apiVersion: v1
   kind: ConfigMap
   metadata:

--- a/deploy/replicate_default_workspaces.yml
+++ b/deploy/replicate_default_workspaces.yml
@@ -1,0 +1,19 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: replicate-default-workspaces
+objects:
+  - apiVersion: cloud.redhat.com/v1alpha1
+    kind: ClowdJobInvocation
+    metadata:
+      labels:
+        app: rbac
+      name: replicate-default-workspaces-${RUN_NUMBER}
+    spec:
+      appName: rbac
+      jobs:
+        - replicate-default-workspaces
+parameters:
+  - name: RUN_NUMBER
+    description: Used to track and re-run the job
+    value: '1'

--- a/rbac/api/cross_access/relation_api_dual_write_cross_access_handler.py
+++ b/rbac/api/cross_access/relation_api_dual_write_cross_access_handler.py
@@ -32,6 +32,7 @@ from management.relation_replicator.relation_replicator import (
     ReplicationEvent,
     ReplicationEventType,
     WorkspaceEvent,
+    WorkspaceEventStream,
 )
 from management.role.model import BindingMapping, Role
 from management.role.v2_model import SeededRoleV2
@@ -54,7 +55,7 @@ class _LocalReplicator(RelationReplicator):
         self._handler.relations_to_remove.extend(event.remove)
         self._handler.relations_to_add.extend(event.add)
 
-    def replicate_workspace(self, event: WorkspaceEvent):
+    def replicate_workspace(self, event: WorkspaceEvent, event_stream: WorkspaceEventStream):
         raise NotImplementedError("workspace events not unsupported")
 
 

--- a/rbac/internal/migrations/replicate_default_workspaces.py
+++ b/rbac/internal/migrations/replicate_default_workspaces.py
@@ -27,6 +27,9 @@ def _do_replicate_batch(replicator: RelationReplicator, raw_workspaces: list[Wor
     )
 
     for workspace in workspaces:
+        # It's okay to use the BULK stream here because default workspaces cannot currently (as of 2026-04-28) be
+        # modified or deleted, so there's no race condition. At worst, we will replicate a default workspace that's
+        # already been replicated, but HBI will just ignore it in that case.
         replicator.replicate_workspace(
             make_workspace_event(workspace=workspace, event_type=ReplicationEventType.CREATE_WORKSPACE),
             WorkspaceEventStream.BULK,

--- a/rbac/internal/migrations/replicate_default_workspaces.py
+++ b/rbac/internal/migrations/replicate_default_workspaces.py
@@ -61,7 +61,7 @@ def replicate_default_workspaces(replicator: Optional[RelationReplicator] = None
     actual_count = 0
     error = False
 
-    for raw_batch in itertools.batched(query, 500):
+    for raw_batch in itertools.batched(query.iterator(), 500):
         try:
             actual_count += _do_replicate_batch(replicator, list(raw_batch))
             logger.info(f"Replicated {actual_count}/~{expected_count} default workspaces.")

--- a/rbac/internal/migrations/replicate_default_workspaces.py
+++ b/rbac/internal/migrations/replicate_default_workspaces.py
@@ -27,9 +27,11 @@ def _do_replicate_batch(replicator: RelationReplicator, raw_workspaces: list[Wor
     )
 
     for workspace in workspaces:
-        # It's okay to use the BULK stream here because default workspaces cannot currently (as of 2026-04-28) be
-        # modified or deleted, so there's no race condition. At worst, we will replicate a default workspace that's
-        # already been replicated, but HBI will just ignore it in that case.
+        # We can unconditionally replicate a create event, since the HBI consumer will ignore any duplicate workspaces.
+        #
+        # If a workspace is concurrently modified, that modification will replicate a creation event as well as an
+        # update event; see WorkspaceService.update. Whichever creation event is processed later will be ignored,
+        # but the update event will then ensure that the HBI consumer ultimately sees the correct state.
         replicator.replicate_workspace(
             make_workspace_event(workspace=workspace, event_type=ReplicationEventType.CREATE_WORKSPACE),
             WorkspaceEventStream.BULK,

--- a/rbac/internal/migrations/replicate_default_workspaces.py
+++ b/rbac/internal/migrations/replicate_default_workspaces.py
@@ -1,0 +1,70 @@
+import itertools
+import logging
+from typing import Optional
+
+from management.atomic_transactions import atomic_with_retry
+from management.relation_replicator.outbox_replicator import OutboxReplicator
+from management.relation_replicator.relation_replicator import (
+    RelationReplicator,
+    ReplicationEventType,
+    WorkspaceEventStream,
+)
+from management.workspace.model import Workspace
+from management.workspace.utils.event import make_workspace_event
+
+
+@atomic_with_retry(retries=3)
+def _do_replicate_batch(replicator: RelationReplicator, raw_workspaces: list[Workspace]) -> int:
+    """Replicates a batch of workspaces and returns the number actually replicated."""
+    if len(raw_workspaces) == 0:
+        return 0
+
+    workspaces = list(
+        Workspace.objects.filter(type=Workspace.Types.DEFAULT)
+        .filter(pk__in=(w.pk for w in raw_workspaces))
+        .select_related("tenant")
+        .select_for_update(of=["self"])
+    )
+
+    for workspace in workspaces:
+        replicator.replicate_workspace(
+            make_workspace_event(workspace=workspace, event_type=ReplicationEventType.CREATE_WORKSPACE),
+            WorkspaceEventStream.BULK,
+        )
+
+    return len(workspaces)
+
+
+logger = logging.getLogger(__name__)
+
+
+def replicate_default_workspaces(replicator: Optional[RelationReplicator] = None, limit: Optional[int] = None):
+    if replicator is None:
+        replicator = OutboxReplicator()
+
+    query = Workspace.objects.filter(type=Workspace.Types.DEFAULT)
+    total_count = query.count()
+
+    if limit is not None:
+        query = query[:limit]
+        expected_count = min(total_count, limit)
+    else:
+        expected_count = total_count
+
+    logger.info(f"About to replicate ~{expected_count} (out of a total of ~{total_count}) default workspaces.")
+
+    actual_count = 0
+    error = False
+
+    for raw_batch in itertools.batched(query, 500):
+        try:
+            actual_count += _do_replicate_batch(replicator, list(raw_batch))
+            logger.info(f"Replicated {actual_count}/~{expected_count} default workspaces.")
+        except Exception:
+            logger.error("Failed to replicate batch of default workspaces", exc_info=True)
+            error = True
+
+    logger.info(f"Replicated a total of {actual_count} default workspaces.")
+
+    if error:
+        raise RuntimeError("Failed to replicate all default workspaces")

--- a/rbac/internal/urls.py
+++ b/rbac/internal/urls.py
@@ -129,6 +129,7 @@ urlpatterns = [
         views.mcp_tool_descriptions,
         name="mcp-tool-descriptions-detail",
     ),
+    path("api/utils/replicate_default_workspaces/", views.replicate_default_workspaces),
 ]
 
 urlpatterns.extend(integration_urlpatterns)

--- a/rbac/internal/views.py
+++ b/rbac/internal/views.py
@@ -94,6 +94,7 @@ from management.tasks import (
     migrate_data_in_worker,
     remove_deleted_workspace_bindings_in_worker,
     remove_unassigned_system_binding_mappings_in_worker,
+    replicate_default_workspaces_in_worker,
     run_migrations_in_worker,
     run_ocm_performance_in_worker,
     run_seeds_in_worker,
@@ -2572,3 +2573,28 @@ def mcp_tool_descriptions(request, tool_name=None):
         return JsonResponse(
             {"tool_name": tool_name, "override_description": None, "active_description": default_desc}, status=200
         )
+
+
+@require_http_methods(["POST"])
+def replicate_default_workspaces(request):
+    """Replicate existing default workspaces.
+
+    POST /_private/api/utils/replicate_default_workspaces/?limit=<limit>
+
+    Replicates existing default workspaces to the outbox using the BULK WorkspaceEventStream.
+
+    If limit is passed, only the specified number of workspaces are replicated. Otherwise, all default workspaces
+    are replicated.
+
+    Returns:
+        JSON response indicating the task has been queued
+    """
+    raw_limit = request.GET.get("limit")
+    limit = int(raw_limit) if raw_limit is not None else None
+
+    try:
+        replicate_default_workspaces_in_worker.delay(limit=limit)
+        return JsonResponse({"message": "Replication enqueued in background worker."}, status=202)
+    except Exception as e:
+        logger.exception("Error replicating default workspaces", exc_info=True)
+        return JsonResponse({"detail": f"Error replicating default workspaces: {str(e)}"}, status=500)

--- a/rbac/management/management/commands/replicate_default_workspaces.py
+++ b/rbac/management/management/commands/replicate_default_workspaces.py
@@ -1,4 +1,4 @@
-"""Command to handle tenant bootstrapping."""
+"""Command to replicate existing default workspaces."""
 
 from django.core.management import BaseCommand, CommandError
 from internal.migrations.replicate_default_workspaces import replicate_default_workspaces

--- a/rbac/management/management/commands/replicate_default_workspaces.py
+++ b/rbac/management/management/commands/replicate_default_workspaces.py
@@ -1,0 +1,25 @@
+"""Command to handle tenant bootstrapping."""
+
+from django.core.management import BaseCommand, CommandError
+from internal.migrations.replicate_default_workspaces import replicate_default_workspaces
+
+
+class Command(BaseCommand):
+    """Command for replicating existing default workspaces."""
+
+    help = "Replicate existing default workspaces."
+
+    def add_arguments(self, parser):
+        """Parse command arguments."""
+        parser.add_argument(
+            "--all",
+            action="store_true",
+            help="whether to replicate all default workspaces (required for forwards compatibility)",
+        )
+
+    def handle(self, **options):
+        """Run the command."""
+        if not options["all"]:
+            raise CommandError("Must pass --all to request replicating all default workspaces", returncode=1)
+
+        replicate_default_workspaces()

--- a/rbac/management/relation_replicator/outbox_replicator.py
+++ b/rbac/management/relation_replicator/outbox_replicator.py
@@ -31,6 +31,7 @@ from management.relation_replicator.relation_replicator import (
     ReplicationEvent,
     ReplicationEventType,
     WorkspaceEvent,
+    WorkspaceEventStream,
 )
 from management.relation_replicator.types import RelationTuple
 from prometheus_client import Counter
@@ -107,7 +108,7 @@ class OutboxReplicator(RelationReplicator):
                 f"Total relationships: {len(relationships)}, Duplicates: {len(duplicates)}"
             )
 
-    def replicate_workspace(self, event: WorkspaceEvent):
+    def replicate_workspace(self, event: WorkspaceEvent, event_stream: WorkspaceEventStream):
         """Replicate the event of workspace."""
         payload = WorkspaceEventPayload(
             org_id=event.org_id,
@@ -115,7 +116,13 @@ class OutboxReplicator(RelationReplicator):
             workspace=event.workspace,
             operation=OPERATION_MAPPING[event.event_type],
         )
-        self._save_workspace_event(payload, event.event_type, str(event.partition_key))
+
+        self._save_workspace_event(
+            payload=payload,
+            event_type=event.event_type,
+            aggregatetype=event_stream.aggregate_type(),
+            aggregateid=str(event.partition_key),
+        )
 
     @staticmethod
     def _relation_to_dict(rel: Union[RelationTuple, common_pb2.Relationship]) -> dict[str, Any]:
@@ -189,13 +196,14 @@ class OutboxReplicator(RelationReplicator):
         self,
         payload: WorkspaceEventPayload,
         event_type: ReplicationEventType,
+        aggregatetype: AggregateTypes,
         aggregateid: str,
     ):
         """Save replication event."""
         transaction.on_commit(workspace_replication_event_total.inc)
 
         outbox = Outbox(
-            aggregatetype=AggregateTypes.WORKSPACE,
+            aggregatetype=aggregatetype.value,
             aggregateid=aggregateid,
             event_type=event_type,
             payload=payload,

--- a/rbac/management/relation_replicator/relation_replicator.py
+++ b/rbac/management/relation_replicator/relation_replicator.py
@@ -217,7 +217,7 @@ class AggregateTypes(str, Enum):
 
 class WorkspaceEventStream(Enum):
     """
-    The class that a WorkspoceEvent belongs to.
+    The class that a WorkspaceEvent belongs to.
 
     As opposed to PartitionKey (which, for Kafka replicators, represents a partition within the same topic),
     different WorkspaceEventClasses represent entirely different Kafka topics.

--- a/rbac/management/relation_replicator/relation_replicator.py
+++ b/rbac/management/relation_replicator/relation_replicator.py
@@ -212,6 +212,29 @@ class AggregateTypes(str, Enum):
 
     RELATIONS = "relations-replication-event"
     WORKSPACE = "workspace"
+    WORKSPACE_BULK = "workspace-bulk"
+
+
+class WorkspaceEventStream(Enum):
+    """
+    The class that a WorkspoceEvent belongs to.
+
+    As opposed to PartitionKey (which, for Kafka replicators, represents a partition within the same topic),
+    different WorkspaceEventClasses represent entirely different Kafka topics.
+    """
+
+    STANDARD = "standard"
+    BULK = "bulk"
+
+    def aggregate_type(self) -> AggregateTypes:
+        """Get the AggregateType that should be used for this stream in a Kafka replicator."""
+        if self == WorkspaceEventStream.STANDARD:
+            return AggregateTypes.WORKSPACE
+
+        if self == WorkspaceEventStream.BULK:
+            return AggregateTypes.WORKSPACE_BULK
+
+        raise AssertionError(f"Unexpected WorkspaceEventClass: {self!r}")
 
 
 class RelationReplicator(ABC):
@@ -222,7 +245,7 @@ class RelationReplicator(ABC):
         """Replicate the given event to Kessel Relations."""
         pass
 
-    def replicate_workspace(self, event: WorkspaceEvent):
+    def replicate_workspace(self, event: WorkspaceEvent, event_stream: WorkspaceEventStream):
         """Replicate the given workspace event to Kessel Relations."""
         pass
 

--- a/rbac/management/tasks.py
+++ b/rbac/management/tasks.py
@@ -24,6 +24,7 @@ from celery import shared_task
 from django.core.management import call_command
 from internal.migrations.remove_deleted_workspace_bindings import remove_deleted_workspace_bindings
 from internal.migrations.remove_orphan_relations import cleanup_tenant_orphan_bindings
+from internal.migrations.replicate_default_workspaces import replicate_default_workspaces
 from internal.utils import (
     clean_invalid_workspace_resource_definitions,
     expire_orphaned_cross_account_requests,
@@ -163,3 +164,9 @@ def expire_orphaned_cross_account_requests_in_worker():
 def remove_deleted_workspace_bindings_in_worker():
     """Celery task to remove role bindings that reference deleted workspaces."""
     return remove_deleted_workspace_bindings()
+
+
+@shared_task
+def replicate_default_workspaces_in_worker(limit: Optional[int] = None):
+    """Celery task to replicate default workspaces."""
+    return replicate_default_workspaces(limit=limit)

--- a/rbac/management/tenant_service/v2.py
+++ b/rbac/management/tenant_service/v2.py
@@ -760,9 +760,12 @@ class V2TenantBootstrapService:
 
         if (len(replication_entries) == 0) != (len(relationships) == 0):
             raise AssertionError(
-                f"Expected relationships to be empty iff nothing to replicate, but got: "
+                f"Expected relationships to be empty if and only if nothing to replicate, but got: "
                 f"{replication_entries=}, {relationships=}"
             )
+
+        if len(replication_entries) == 0:
+            return
 
         if bulk:
             event_type = ReplicationEventType.BULK_BOOTSTRAP_TENANT

--- a/rbac/management/tenant_service/v2.py
+++ b/rbac/management/tenant_service/v2.py
@@ -14,6 +14,7 @@ from management.relation_replicator.relation_replicator import (
     RelationReplicator,
     ReplicationEvent,
     ReplicationEventType,
+    WorkspaceEventStream,
 )
 from management.relation_replicator.types import RelationTuple
 from management.tenant_mapping.model import DefaultAccessType, TenantMapping, logger
@@ -21,6 +22,7 @@ from management.tenant_service.relations import default_role_binding_tuples
 from management.tenant_service.tenant_service import BootstrappedTenant
 from management.tenant_service.tenant_service import _ensure_principal_with_user_id_in_tenant
 from management.workspace.model import Workspace
+from management.workspace.utils.event import make_workspace_event
 from migration_tool.utils import create_relationship
 
 
@@ -140,6 +142,30 @@ def lock_tenant_for_bootstrap(tenant: Tenant) -> TenantBootstrapLock:
         raise TenantNotBootstrappedError(f"Tenant {tenant} not bootstrapped.")
 
     return result
+
+
+@dataclasses.dataclass(frozen=True)
+class _BootstrapReplicationEntry:
+    tenant: Tenant
+    default_workspace: Workspace
+
+    def __post_init__(self):
+        if not isinstance(self.tenant, Tenant):
+            raise TypeError(f"Expected tenant, but got: {self.tenant!r}")
+
+        if not isinstance(self.default_workspace, Workspace):
+            raise TypeError(f"Expected default_workspace to be a workspace, but got: {self.default_workspace!r}")
+
+        if self.default_workspace.tenant_id != self.tenant.id:
+            raise ValueError(
+                f"Expected default_workspace to be in tenant with id={self.tenant.id}, "
+                f"but got tenant with id={self.default_workspace.tenant_id}"
+            )
+
+        if self.default_workspace.type != Workspace.Types.DEFAULT:
+            raise ValueError(
+                f"Expected default_workspace to be a default workspace, but was {self.default_workspace.type}"
+            )
 
 
 class V2TenantBootstrapService:
@@ -503,6 +529,7 @@ class V2TenantBootstrapService:
 
         # Build relationships for all tenants
         all_relationships = []
+        replication_entries = []
 
         for tenant, mapping in tenants_with_mappings:
             tenant_workspaces = workspaces_by_tenant.get(tenant.id)
@@ -513,7 +540,7 @@ class V2TenantBootstrapService:
             root = tenant_workspaces.get(Workspace.Types.ROOT)
             default = tenant_workspaces.get(Workspace.Types.DEFAULT)
 
-            if root is None or default is None:
+            if (root is None) or (default is None):
                 raise RuntimeError(
                     f"Missing workspaces for tenant with pk={tenant.pk} during bulk re-replication. "
                     f"Has root: {bool(root)}, has default: {bool(default)}"
@@ -533,8 +560,13 @@ class V2TenantBootstrapService:
                 )
             )
 
-        self._send_bootstrap_event(
-            tenants=[t for t, _ in tenants_with_mappings],
+            # mypy complains about default possibly being None, even though we've check it above.
+            replication_entries.append(
+                _BootstrapReplicationEntry(tenant=tenant, default_workspace=default)  # type: ignore
+            )
+
+        self._send_bootstrap_events(
+            replication_entries=replication_entries,
             relationships=all_relationships,
             bulk=bulk,
             forced=True,
@@ -634,7 +666,16 @@ class V2TenantBootstrapService:
             raise RuntimeError(f"Bulk bootstrapping is required unless exactly one tenant is present, got: {tenants}")
 
         bootstrapped, relationships = self._bootstrap_tenants_no_replicate(tenants)
-        self._send_bootstrap_event(tenants=tenants, relationships=relationships, bulk=bulk)
+        assert len(bootstrapped) == len(tenants)
+
+        self._send_bootstrap_events(
+            replication_entries=[
+                _BootstrapReplicationEntry(tenant=b.tenant, default_workspace=b.default_workspace)  # type: ignore
+                for b in bootstrapped
+            ],
+            relationships=relationships,
+            bulk=bulk,
+        )
 
         return bootstrapped
 
@@ -699,28 +740,36 @@ class V2TenantBootstrapService:
 
         return bootstrapped_tenants, relationships
 
-    def _send_bootstrap_event(
-        self, tenants: list[Tenant], relationships: list[RelationTuple], *, bulk: bool, forced: bool = False
+    def _send_bootstrap_events(
+        self,
+        *,
+        replication_entries: list[_BootstrapReplicationEntry],
+        relationships: list[RelationTuple],
+        bulk: bool,
+        forced: bool = False,
     ):
         """
         Replicate the relationships for bootstrapping the provided tenants.
 
         If bulk is false, then exactly one tenant must be provided, and the non-bulk ReplicationEventType will be used.
         """
-        if not bulk and len(tenants) != 1:
-            raise ValueError(f"Expected bulk replication except for exactly one tenant, but got: {tenants}")
+        if not bulk and len(replication_entries) != 1:
+            raise ValueError(
+                f"Expected bulk replication except for exactly one tenant, but got: {replication_entries}"
+            )
 
-        if (len(tenants) == 0) != (len(relationships) == 0):
+        if (len(replication_entries) == 0) != (len(relationships) == 0):
             raise AssertionError(
-                f"Expected relationships to be empty iff tenants is empty, but got: " f"{tenants=}, {relationships=}"
+                f"Expected relationships to be empty iff nothing to replicate, but got: "
+                f"{replication_entries=}, {relationships=}"
             )
 
         if bulk:
             event_type = ReplicationEventType.BULK_BOOTSTRAP_TENANT
-            info = {"num_tenants": len(tenants), "first_org_id": tenants[0].org_id if tenants else None}
+            info = {"num_tenants": len(replication_entries), "first_org_id": replication_entries[0].tenant.org_id}
         else:
             event_type = ReplicationEventType.BOOTSTRAP_TENANT
-            info = {"org_id": tenants[0].org_id}
+            info = {"org_id": replication_entries[0].tenant.org_id}
 
         if forced:
             info["forced"] = True
@@ -733,6 +782,17 @@ class V2TenantBootstrapService:
                 add=relationships,
             )
         )
+
+        for entry in replication_entries:
+            # We always use the STANDARD stream here; the BULK stream is intended for things like "replicating every
+            # default workspace that exists". The bulk parameter here is just used for determining which type of
+            # replication event to send.
+            self._replicator.replicate_workspace(
+                make_workspace_event(
+                    workspace=entry.default_workspace, event_type=ReplicationEventType.CREATE_WORKSPACE
+                ),
+                WorkspaceEventStream.STANDARD,
+            )
 
     def _default_group_tuple_edits(self, user: User, mapping) -> tuple[list[RelationTuple], list[RelationTuple]]:
         """Get the tuples to add and remove for a user."""

--- a/rbac/management/tenant_service/v2.py
+++ b/rbac/management/tenant_service/v2.py
@@ -180,7 +180,7 @@ class V2TenantBootstrapService:
             return self._bootstrap_tenant(tenant)
 
         if force:
-            self._replicate_bootstrap(tenant, lock_result.tenant_mapping)
+            self._replicate_bootstraps([(tenant, lock_result.tenant_mapping)], bulk=False)
 
         return BootstrappedTenant(tenant=tenant, mapping=lock_result.tenant_mapping)
 
@@ -470,64 +470,28 @@ class V2TenantBootstrapService:
         return bootstrapped_tenants[0]
 
     def _bootstrap_tenant(self, tenant: Tenant) -> BootstrappedTenant:
-        bootstrapped_tenants, relationships = self._bootstrap_tenants_no_replicate([tenant])
+        bootstrapped_tenants = self._bootstrap_tenants([tenant], bulk=False)
+
         assert len(bootstrapped_tenants) == 1
+        return bootstrapped_tenants[0]
 
-        bootstrapped_tenant = bootstrapped_tenants[0]
-        assert bootstrapped_tenant.default_workspace is not None
+    # Here, and in various other functions, we accept a "bulk" parameter to decide what event to use, rather than using
+    # separate functions for bulk and non-bulk bootstrapping. This is to ensure that we don't accidentally let the
+    # bulk and non-bulk paths diverge (as we have done in the past).
 
-        self._replicator.replicate(
-            ReplicationEvent(
-                event_type=ReplicationEventType.BOOTSTRAP_TENANT,
-                info={"org_id": tenant.org_id, "default_workspace_id": str(bootstrapped_tenant.default_workspace.id)},
-                partition_key=PartitionKey.byEnvironment(),
-                add=relationships,
-            )
-        )
-
-        return bootstrapped_tenant
-
-    def _replicate_bootstrap(self, tenant: Tenant, mapping: TenantMapping):
-        """Replicate the bootstrapping of a tenant."""
-        built_in_workspaces = Workspace.objects.built_in(tenant=tenant)
-        root = next(ws for ws in built_in_workspaces if ws.type == Workspace.Types.ROOT)
-        default = next(ws for ws in built_in_workspaces if ws.type == Workspace.Types.DEFAULT)
-
-        relationships = []
-
-        relationships.extend(self._built_in_hierarchy_tuples(default.id, root.id, tenant.org_id))
-
-        relationships.extend(
-            self._bootstrap_default_access(
-                tenant,
-                mapping,
-                TenantScopeResources.for_models(
-                    tenant=tenant,
-                    root_workspace=root,
-                    default_workspace=default,
-                ),
-            )
-        )
-
-        self._replicator.replicate(
-            ReplicationEvent(
-                event_type=ReplicationEventType.BOOTSTRAP_TENANT,
-                info={"org_id": tenant.org_id, "forced": True},
-                partition_key=PartitionKey.byEnvironment(),
-                add=relationships,
-            )
-        )
-
-    def _replicate_bootstraps(self, tenants_with_mappings: list[tuple[Tenant, TenantMapping]]):
+    def _replicate_bootstraps(self, tenants_with_mappings: list[tuple[Tenant, TenantMapping]], bulk: bool = True):
         """Replicate the bootstrapping of multiple tenants efficiently."""
+        if not bulk and len(tenants_with_mappings) != 1:
+            raise ValueError(
+                f"Bulk replication is required except for exactly one tenant; got: {tenants_with_mappings}"
+            )
+
         if not tenants_with_mappings:
             return
 
-        tenant_ids = [t.id for t, _ in tenants_with_mappings]
-
         # Bulk query all workspaces for all tenants at once
         all_workspaces = Workspace.objects.filter(
-            tenant_id__in=tenant_ids, type__in=[Workspace.Types.ROOT, Workspace.Types.DEFAULT]
+            tenant__in=[t for t, _ in tenants_with_mappings], type__in=[Workspace.Types.ROOT, Workspace.Types.DEFAULT]
         )
 
         # Group workspaces by tenant_id for fast lookup
@@ -541,16 +505,19 @@ class V2TenantBootstrapService:
         all_relationships = []
 
         for tenant, mapping in tenants_with_mappings:
-            tenant_workspaces = workspaces_by_tenant.get(tenant.id, {})
+            tenant_workspaces = workspaces_by_tenant.get(tenant.id)
+
+            if tenant_workspaces is None:
+                raise RuntimeError(f"Found no built-in workspace for tenant with pk={tenant.pk}")
+
             root = tenant_workspaces.get(Workspace.Types.ROOT)
             default = tenant_workspaces.get(Workspace.Types.DEFAULT)
 
-            if not root or not default:
-                logger.warning(
-                    f"Missing workspaces for tenant {tenant.org_id} during bulk re-replication. "
+            if root is None or default is None:
+                raise RuntimeError(
+                    f"Missing workspaces for tenant with pk={tenant.pk} during bulk re-replication. "
                     f"Has root: {bool(root)}, has default: {bool(default)}"
                 )
-                continue
 
             all_relationships.extend(self._built_in_hierarchy_tuples(default.id, root.id, tenant.org_id))
 
@@ -566,18 +533,11 @@ class V2TenantBootstrapService:
                 )
             )
 
-        # Single bulk replication event for all tenants
-        self._replicator.replicate(
-            ReplicationEvent(
-                event_type=ReplicationEventType.BULK_BOOTSTRAP_TENANT,
-                info={
-                    "num_tenants": len(tenants_with_mappings),
-                    "first_org_id": tenants_with_mappings[0][0].org_id if tenants_with_mappings else None,
-                    "forced": True,
-                },
-                partition_key=PartitionKey.byEnvironment(),
-                add=all_relationships,
-            )
+        self._send_bootstrap_event(
+            tenants=[t for t, _ in tenants_with_mappings],
+            relationships=all_relationships,
+            bulk=bulk,
+            forced=True,
         )
 
     def _query_with_default_groups(self, query_set: QuerySet) -> QuerySet:
@@ -615,10 +575,10 @@ class V2TenantBootstrapService:
         account_number_by_org_id: dict[str, Optional[str]],
         bulk: bool,
     ) -> list[BootstrappedTenant]:
+        """Bootstrap list of tenants, used by import_bulk_users."""
         if not bulk and len(org_ids) != 1:
             raise ValueError("Bulk bootstrapping is required unless exactly one org_id is present.")
 
-        """Bootstrap list of tenants, used by import_bulk_users."""
         # Fetch existing tenants
         existing_tenants: dict[str, Tenant] = {
             tenant.org_id: tenant for tenant in Tenant.objects.filter(org_id__in=org_ids)
@@ -669,17 +629,12 @@ class V2TenantBootstrapService:
 
         return bootstrapped_list
 
-    def _bootstrap_tenants(self, tenants: list[Tenant]) -> list[BootstrappedTenant]:
-        bootstrapped, relationships = self._bootstrap_tenants_no_replicate(tenants)
+    def _bootstrap_tenants(self, tenants: list[Tenant], bulk: bool = True) -> list[BootstrappedTenant]:
+        if not bulk and len(tenants) != 1:
+            raise RuntimeError(f"Bulk bootstrapping is required unless exactly one tenant is present, got: {tenants}")
 
-        self._replicator.replicate(
-            ReplicationEvent(
-                event_type=ReplicationEventType.BULK_BOOTSTRAP_TENANT,
-                info={"num_tenants": len(tenants), "first_org_id": tenants[0].org_id if tenants else None},
-                partition_key=PartitionKey.byEnvironment(),
-                add=relationships,
-            )
-        )
+        bootstrapped, relationships = self._bootstrap_tenants_no_replicate(tenants)
+        self._send_bootstrap_event(tenants=tenants, relationships=relationships, bulk=bulk)
 
         return bootstrapped
 
@@ -743,6 +698,41 @@ class V2TenantBootstrapService:
             )
 
         return bootstrapped_tenants, relationships
+
+    def _send_bootstrap_event(
+        self, tenants: list[Tenant], relationships: list[RelationTuple], *, bulk: bool, forced: bool = False
+    ):
+        """
+        Replicate the relationships for bootstrapping the provided tenants.
+
+        If bulk is false, then exactly one tenant must be provided, and the non-bulk ReplicationEventType will be used.
+        """
+        if not bulk and len(tenants) != 1:
+            raise ValueError(f"Expected bulk replication except for exactly one tenant, but got: {tenants}")
+
+        if (len(tenants) == 0) != (len(relationships) == 0):
+            raise AssertionError(
+                f"Expected relationships to be empty iff tenants is empty, but got: " f"{tenants=}, {relationships=}"
+            )
+
+        if bulk:
+            event_type = ReplicationEventType.BULK_BOOTSTRAP_TENANT
+            info = {"num_tenants": len(tenants), "first_org_id": tenants[0].org_id if tenants else None}
+        else:
+            event_type = ReplicationEventType.BOOTSTRAP_TENANT
+            info = {"org_id": tenants[0].org_id}
+
+        if forced:
+            info["forced"] = True
+
+        self._replicator.replicate(
+            ReplicationEvent(
+                event_type=event_type,
+                info=info,
+                partition_key=PartitionKey.byEnvironment(),
+                add=relationships,
+            )
+        )
 
     def _default_group_tuple_edits(self, user: User, mapping) -> tuple[list[RelationTuple], list[RelationTuple]]:
         """Get the tuples to add and remove for a user."""

--- a/rbac/management/workspace/relation_api_dual_write_workspace_handler.py
+++ b/rbac/management/workspace/relation_api_dual_write_workspace_handler.py
@@ -29,6 +29,7 @@ from management.relation_replicator.relation_replicator import (
     ReplicationEvent,
     ReplicationEventType,
     WorkspaceEvent,
+    WorkspaceEventStream,
 )
 from management.role.relation_api_dual_write_handler import BaseRelationApiDualWriteHandler
 from migration_tool.utils import create_relationship
@@ -106,7 +107,8 @@ class RelationApiDualWriteWorkspaceHandler(BaseRelationApiDualWriteHandler):
                         workspace=WorkspaceEventSerializer(self.workspace).data,
                         event_type=self.event_type,
                         partition_key=PartitionKey.byEnvironment(),
-                    )
+                    ),
+                    WorkspaceEventStream.STANDARD,
                 )
         except OperationalError:
             logger.warning(

--- a/rbac/management/workspace/relation_api_dual_write_workspace_handler.py
+++ b/rbac/management/workspace/relation_api_dual_write_workspace_handler.py
@@ -68,12 +68,22 @@ class RelationApiDualWriteWorkspaceHandler(BaseRelationApiDualWriteHandler):
         self.generate_relations_to_add_workspace()
         self._replicate()
 
-    def replicate_updated_workspace(self, previous_parent, skip_ws_events: bool = False):
-        """Replicate updated principals into group."""
+    def replicate_updated_workspace(
+        self, previous_parent, *, skip_ws_events: bool = False, force_create: bool = False
+    ):
+        """
+        Replicate updated principals into group.
+
+        skip_ws_events can be used for events that are known to not need replication (e.g. moves, since the
+        replication event doesn't include parent information).
+
+        force_create should be used for workspaces that have not necessarily had a create event sent before being
+        updated.
+        """
         if not self.replication_enabled():
             return
         self.generate_relations_to_update_workspace(previous_parent)
-        self._replicate(skip_ws_events=skip_ws_events)
+        self._replicate(skip_ws_events=skip_ws_events, force_create=force_create)
 
     def replicate_deleted_workspace(self):
         """Replicate deleted principals into group."""
@@ -82,10 +92,17 @@ class RelationApiDualWriteWorkspaceHandler(BaseRelationApiDualWriteHandler):
         self.generate_relations_to_remove_workspace()
         self._replicate()
 
-    def _replicate(self, skip_ws_events: bool = False) -> None:
+    def _replicate(self, skip_ws_events: bool = False, force_create: bool = False) -> None:
         if not self.replication_enabled():
             return
         try:
+            if force_create:
+                if skip_ws_events:
+                    raise ValueError("Cannot have skip_ws_events and force_create both be set")
+
+                if self.event_type != ReplicationEventType.UPDATE_WORKSPACE:
+                    raise ValueError("Expected force_create to be true only for UPDATE_WORKSPACE events")
+
             if self.relations_to_remove or self.relations_to_add:
                 self._replicator.replicate(
                     ReplicationEvent(
@@ -97,8 +114,23 @@ class RelationApiDualWriteWorkspaceHandler(BaseRelationApiDualWriteHandler):
                     ),
                 )
             if not skip_ws_events:
+                if force_create:
+                    # If force_create is set, we may not have previously sent a creation event for this workspace,
+                    # which we must do before updating it. If we *have* previously sent a creation event for this
+                    # workspace, the HBI consumer will just ignore it.
+                    self._replicator.replicate_workspace(
+                        make_workspace_event(
+                            workspace=self.workspace,
+                            event_type=ReplicationEventType.CREATE_WORKSPACE,
+                        ),
+                        WorkspaceEventStream.STANDARD,
+                    )
+
                 self._replicator.replicate_workspace(
-                    make_workspace_event(workspace=self.workspace, event_type=self.event_type),
+                    make_workspace_event(
+                        workspace=self.workspace,
+                        event_type=self.event_type,
+                    ),
                     WorkspaceEventStream.STANDARD,
                 )
         except OperationalError:

--- a/rbac/management/workspace/relation_api_dual_write_workspace_handler.py
+++ b/rbac/management/workspace/relation_api_dual_write_workspace_handler.py
@@ -179,10 +179,3 @@ class RelationApiDualWriteWorkspaceHandler(BaseRelationApiDualWriteHandler):
             return
         # Remove parent relationship
         self.relations_to_remove.append(self._get_workspace_relationship(self.workspace, self.workspace.parent))
-
-    def replicate(self):
-        """Replicate generated relations."""
-        if not self.replication_enabled():
-            return
-
-        self._replicate()

--- a/rbac/management/workspace/relation_api_dual_write_workspace_handler.py
+++ b/rbac/management/workspace/relation_api_dual_write_workspace_handler.py
@@ -28,10 +28,10 @@ from management.relation_replicator.relation_replicator import (
     RelationReplicator,
     ReplicationEvent,
     ReplicationEventType,
-    WorkspaceEvent,
     WorkspaceEventStream,
 )
 from management.role.relation_api_dual_write_handler import BaseRelationApiDualWriteHandler
+from management.workspace.utils.event import make_workspace_event
 from migration_tool.utils import create_relationship
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
@@ -83,9 +83,6 @@ class RelationApiDualWriteWorkspaceHandler(BaseRelationApiDualWriteHandler):
         self._replicate()
 
     def _replicate(self, skip_ws_events: bool = False) -> None:
-        # To avoid Circular Dependency
-        from management.workspace.serializer import WorkspaceEventSerializer
-
         if not self.replication_enabled():
             return
         try:
@@ -101,13 +98,7 @@ class RelationApiDualWriteWorkspaceHandler(BaseRelationApiDualWriteHandler):
                 )
             if not skip_ws_events:
                 self._replicator.replicate_workspace(
-                    WorkspaceEvent(
-                        account_number=self.workspace.tenant.account_id,
-                        org_id=str(self.workspace.tenant.org_id),
-                        workspace=WorkspaceEventSerializer(self.workspace).data,
-                        event_type=self.event_type,
-                        partition_key=PartitionKey.byEnvironment(),
-                    ),
+                    make_workspace_event(workspace=self.workspace, event_type=self.event_type),
                     WorkspaceEventStream.STANDARD,
                 )
         except OperationalError:

--- a/rbac/management/workspace/service.py
+++ b/rbac/management/workspace/service.py
@@ -415,13 +415,14 @@ class WorkspaceService:
                 raise serializers.ValidationError("Can't update the 'parent_id' on a workspace directly")
             setattr(instance, attr, value)
 
-        # Skip Workspace Events for DEFAULT workspaces
-        skip_ws_events = instance.type == Workspace.Types.DEFAULT
+        # Previously, we didn't replicate the creation of default workspaces, so we have to create them before
+        # updating them.
+        force_create = instance.type == Workspace.Types.DEFAULT
 
         try:
             instance.save()
             dual_write_handler = self._dual_write_handler(instance, ReplicationEventType.UPDATE_WORKSPACE)
-            dual_write_handler.replicate_updated_workspace(instance.parent, skip_ws_events)
+            dual_write_handler.replicate_updated_workspace(instance.parent, force_create=force_create)
         except ValidationError as e:
             message = e.message_dict
             if hasattr(e, "error_dict") and "__all__" in e.error_dict:

--- a/rbac/management/workspace/utils/event.py
+++ b/rbac/management/workspace/utils/event.py
@@ -1,0 +1,39 @@
+#
+# Copyright 2026 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""Workspace event utilities."""
+
+from management.relation_replicator.relation_replicator import PartitionKey, ReplicationEventType, WorkspaceEvent
+from management.workspace.model import Workspace
+from management.workspace.serializer import WorkspaceEventSerializer
+
+
+def make_workspace_event(workspace: Workspace, event_type: ReplicationEventType):
+    """Create a WorkspaceEvent with the provided workspace and event type."""
+    if event_type not in (
+        ReplicationEventType.CREATE_WORKSPACE,
+        ReplicationEventType.UPDATE_WORKSPACE,
+        ReplicationEventType.DELETE_WORKSPACE,
+    ):
+        raise ValueError(f"Unexpected event_type: {event_type}")
+
+    return WorkspaceEvent(
+        account_number=workspace.tenant.account_id,
+        org_id=str(workspace.tenant.org_id),
+        workspace=WorkspaceEventSerializer(workspace).data,
+        event_type=event_type,
+        partition_key=PartitionKey.byEnvironment(),
+    )

--- a/rbac/management/workspace/utils/event.py
+++ b/rbac/management/workspace/utils/event.py
@@ -18,11 +18,13 @@
 
 from management.relation_replicator.relation_replicator import PartitionKey, ReplicationEventType, WorkspaceEvent
 from management.workspace.model import Workspace
-from management.workspace.serializer import WorkspaceEventSerializer
 
 
 def make_workspace_event(workspace: Workspace, event_type: ReplicationEventType):
     """Create a WorkspaceEvent with the provided workspace and event type."""
+    # To avoid circular dependency.
+    from management.workspace.serializer import WorkspaceEventSerializer
+
     if event_type not in (
         ReplicationEventType.CREATE_WORKSPACE,
         ReplicationEventType.UPDATE_WORKSPACE,

--- a/tests/internal/migrations/test_replicate_default_workspaces.py
+++ b/tests/internal/migrations/test_replicate_default_workspaces.py
@@ -1,0 +1,68 @@
+from django.test import TestCase
+
+from api.models import Tenant
+from internal.migrations.replicate_default_workspaces import replicate_default_workspaces
+from management.relation_replicator.noop_replicator import NoopReplicator
+from management.relation_replicator.relation_replicator import WorkspaceEventStream, ReplicationEventType, PartitionKey
+from management.tenant_service import V2TenantBootstrapService
+from management.workspace.model import Workspace
+from tests.v2_util import WorkspaceCacheReplicator
+
+from django.test import override_settings
+
+
+@override_settings(ATOMIC_RETRY_DISABLED=True)
+class ReplicateDefaultWorkspacesTest(TestCase):
+    def _bulk_bootstrapped_tenants(self, count: int) -> list[Tenant]:
+        bootstrap_service = V2TenantBootstrapService(NoopReplicator())
+
+        return [
+            b.tenant
+            for b in bootstrap_service.bootstrap_tenants(
+                Tenant.objects.bulk_create(
+                    [
+                        Tenant(tenant_name=f"test-tenant-{i}", org_id=f"test-tenant-{i}", account_id=f"acct-{i}")
+                        for i in range(count)
+                    ]
+                )
+            )
+        ]
+
+    def test_replication(self):
+        Tenant.objects.exclude(tenant_name="public").delete()
+        tenants = self._bulk_bootstrapped_tenants(1000)
+
+        tenants_by_org_id = {t.org_id: t for t in tenants}
+        default_workspaces_by_org_id = {
+            w.tenant.org_id: w for w in Workspace.objects.filter(type=Workspace.Types.DEFAULT).select_related("tenant")
+        }
+
+        replicator = WorkspaceCacheReplicator(NoopReplicator())
+
+        replicate_default_workspaces(replicator=replicator)
+
+        self.assertEqual(len(replicator.workspace_events_for(WorkspaceEventStream.STANDARD)), 0)
+        self.assertEqual(len(replicator.workspace_events_for(WorkspaceEventStream.BULK)), len(tenants))
+
+        events = replicator.workspace_events_for(WorkspaceEventStream.BULK)
+
+        self.assertEqual(set(e.org_id for e in events), set(t.org_id for t in tenants))
+
+        for event in events:
+            self.assertEqual(event.event_type, ReplicationEventType.CREATE_WORKSPACE)
+            self.assertEqual(event.account_number, tenants_by_org_id[event.org_id].account_id)
+            self.assertEqual(str(event.partition_key), str(PartitionKey.byEnvironment()))
+            self.assertEqual(event.workspace["id"], str(default_workspaces_by_org_id[event.org_id].id))
+            self.assertEqual(event.workspace["type"], Workspace.Types.DEFAULT)
+            self.assertEqual(event.workspace["name"], Workspace.SpecialNames.DEFAULT)
+
+    def test_replication_limit(self):
+        Tenant.objects.exclude(tenant_name="public").delete()
+        tenants = self._bulk_bootstrapped_tenants(1000)
+
+        replicator = WorkspaceCacheReplicator(NoopReplicator())
+
+        replicate_default_workspaces(replicator=replicator, limit=500)
+
+        self.assertEqual(len(replicator.workspace_events_for(WorkspaceEventStream.STANDARD)), 0)
+        self.assertEqual(len(replicator.workspace_events_for(WorkspaceEventStream.BULK)), 500)

--- a/tests/management/relation_replicator/test_outbox_replicator.py
+++ b/tests/management/relation_replicator/test_outbox_replicator.py
@@ -20,10 +20,26 @@ import logging
 from unittest.mock import ANY
 from uuid import uuid4
 from django.test import TestCase, override_settings
-from management.relation_replicator.outbox_replicator import InMemoryLog, OutboxReplicator, OutboxWAL
-from management.relation_replicator.relation_replicator import PartitionKey, ReplicationEvent, ReplicationEventType
+
+from api.models import Tenant
+from management.relation_replicator.outbox_replicator import (
+    InMemoryLog,
+    OutboxReplicator,
+    OutboxWAL,
+    WorkspaceEventPayload,
+)
+from management.relation_replicator.relation_replicator import (
+    PartitionKey,
+    ReplicationEvent,
+    ReplicationEventType,
+    WorkspaceEvent,
+    WorkspaceEventStream,
+)
+from management.workspace.serializer import WorkspaceEventSerializer
 from migration_tool.utils import create_relationship
 from prometheus_client import REGISTRY
+
+from tests.v2_util import bootstrap_tenant_for_v2_test
 
 
 @override_settings(
@@ -471,6 +487,46 @@ class OutboxReplicatorTest(TestCase):
         error_message = str(context.exception)
         self.assertIn("duplicate relationships", error_message)
         self.assertIn("role_binding", error_message)
+
+    def _do_test_workspace_event_for_stream(self, stream: WorkspaceEventStream, aggregate_type: str):
+        tenant = Tenant.objects.create(tenant_name="some tenant", org_id="some_org", account_id="some_acct")
+        bootstrap_result = bootstrap_tenant_for_v2_test(tenant)
+
+        workspace_data = WorkspaceEventSerializer(bootstrap_result.default_workspace).data
+
+        self.replicator.replicate_workspace(
+            WorkspaceEvent(
+                org_id=tenant.org_id,
+                account_number=tenant.account_id,
+                workspace=workspace_data,
+                event_type=ReplicationEventType.CREATE_WORKSPACE,
+                partition_key=PartitionKey.byEnvironment(),
+            ),
+            stream,
+        )
+
+        self.assertEqual(len(self.log), 1)
+        event = self.log.first()
+
+        self.assertEqual(event.aggregatetype, aggregate_type)
+        self.assertEqual(event.aggregateid, str(PartitionKey.byEnvironment()))
+        self.assertEqual(event.event_type, ReplicationEventType.CREATE_WORKSPACE)
+
+        self.assertEqual(
+            event.payload,
+            WorkspaceEventPayload(
+                org_id=tenant.org_id,
+                account_number=tenant.account_id,
+                workspace=workspace_data,
+                operation="create",
+            ),
+        )
+
+    def test_workspace_event(self):
+        self._do_test_workspace_event_for_stream(WorkspaceEventStream.STANDARD, "workspace")
+
+    def test_workspace_bulk_event(self):
+        self._do_test_workspace_event_for_stream(WorkspaceEventStream.BULK, "workspace-bulk")
 
 
 class OutboxReplicatorPrometheusTest(TestCase):

--- a/tests/management/tenant/test_model.py
+++ b/tests/management/tenant/test_model.py
@@ -47,30 +47,9 @@ from migration_tool.in_memory_tuples import (
 )
 from migration_tool.models import V2boundresource
 from tests.management.role.test_dual_write import RbacFixture
+from tests.v2_util import WorkspaceCacheReplicator
 
 from api.models import Tenant, User
-
-
-class _WorkspaceCacheReplicator(RelationReplicator):
-    _base_replicator: RelationReplicator
-    _workspace_events: dict[WorkspaceEventStream, list[WorkspaceEvent]]
-
-    def __init__(self, base_replicator: RelationReplicator):
-        self._base_replicator = base_replicator
-        self._workspace_events = {}
-
-    def replicate(self, event: ReplicationEvent):
-        return self._base_replicator.replicate(event)
-
-    def replicate_workspace(self, event: WorkspaceEvent, event_stream: WorkspaceEventStream):
-        self._workspace_events.setdefault(event_stream, []).append(event)
-        return self._base_replicator.replicate_workspace(event, event_stream)
-
-    def workspace_events_for(self, stream: WorkspaceEventStream) -> list[WorkspaceEvent]:
-        return self._workspace_events.get(stream, [])
-
-    def clear_events(self):
-        self._workspace_events = {}
 
 
 class V2TenantBootstrapServiceTest(TestCase):
@@ -78,13 +57,13 @@ class V2TenantBootstrapServiceTest(TestCase):
 
     service: V2TenantBootstrapService
     tuples: InMemoryTuples
-    replicator: _WorkspaceCacheReplicator
+    replicator: WorkspaceCacheReplicator
     fixture: RbacFixture
 
     def setUp(self):
         # Clear any existing state first
         self.tuples = InMemoryTuples()
-        self.replicator = _WorkspaceCacheReplicator(InMemoryRelationReplicator(self.tuples))
+        self.replicator = WorkspaceCacheReplicator(InMemoryRelationReplicator(self.tuples))
         self.service = V2TenantBootstrapService(self.replicator)
         self.fixture = RbacFixture(self.service)
         self.fixture.new_system_role("System Role", ["app1:foo:read"], platform_default=True)

--- a/tests/management/tenant/test_model.py
+++ b/tests/management/tenant/test_model.py
@@ -26,6 +26,14 @@ from management.group.definer import seed_group
 from management.group.model import Group
 from management.policy.model import Policy
 from management.principal.model import Principal
+from management.relation_replicator.relation_replicator import (
+    RelationReplicator,
+    WorkspaceEvent,
+    WorkspaceEventStream,
+    ReplicationEvent,
+    ReplicationEventType,
+    PartitionKey,
+)
 from management.tenant_mapping.model import TenantMapping
 from management.tenant_service.v2 import V2TenantBootstrapService
 from management.workspace.model import Workspace
@@ -43,17 +51,41 @@ from tests.management.role.test_dual_write import RbacFixture
 from api.models import Tenant, User
 
 
+class _WorkspaceCacheReplicator(RelationReplicator):
+    _base_replicator: RelationReplicator
+    _workspace_events: dict[WorkspaceEventStream, list[WorkspaceEvent]]
+
+    def __init__(self, base_replicator: RelationReplicator):
+        self._base_replicator = base_replicator
+        self._workspace_events = {}
+
+    def replicate(self, event: ReplicationEvent):
+        return self._base_replicator.replicate(event)
+
+    def replicate_workspace(self, event: WorkspaceEvent, event_stream: WorkspaceEventStream):
+        self._workspace_events.setdefault(event_stream, []).append(event)
+        return self._base_replicator.replicate_workspace(event, event_stream)
+
+    def workspace_events_for(self, stream: WorkspaceEventStream) -> list[WorkspaceEvent]:
+        return self._workspace_events.get(stream, [])
+
+    def clear_events(self):
+        self._workspace_events = {}
+
+
 class V2TenantBootstrapServiceTest(TestCase):
     """Test cases for Tenant bootstrapping logic."""
 
     service: V2TenantBootstrapService
     tuples: InMemoryTuples
+    replicator: _WorkspaceCacheReplicator
     fixture: RbacFixture
 
     def setUp(self):
         # Clear any existing state first
         self.tuples = InMemoryTuples()
-        self.service = V2TenantBootstrapService(InMemoryRelationReplicator(self.tuples))
+        self.replicator = _WorkspaceCacheReplicator(InMemoryRelationReplicator(self.tuples))
+        self.service = V2TenantBootstrapService(self.replicator)
         self.fixture = RbacFixture(self.service)
         self.fixture.new_system_role("System Role", ["app1:foo:read"], platform_default=True)
         self.default_group, self.admin_group = seed_group()
@@ -257,7 +289,7 @@ class V2TenantBootstrapServiceTest(TestCase):
 
     def test_bulk_adding_updating_users(self):
         bootstrapped = self.fixture.new_tenant(org_id="o1")
-        self.tuples.clear()
+        self._clear_state()
 
         # Set up another org with custom default group but not bootstrapped
         # Create the custom default group directly to avoid triggering auto-bootstrap
@@ -321,7 +353,7 @@ class V2TenantBootstrapServiceTest(TestCase):
 
     def test_bulk_import_updates_user_ids_on_principals_but_does_not_add_principals(self):
         bootstrapped = self.fixture.new_tenant(org_id="o1")
-        self.tuples.clear()
+        self._clear_state()
 
         # Set up another org with custom default group but not bootstrapped
         o3_tenant = self.fixture.new_unbootstrapped_tenant(org_id="o3")
@@ -406,7 +438,7 @@ class V2TenantBootstrapServiceTest(TestCase):
 
     def test_force_bootstrap_replicates_already_bootstrapped_unready_tenants(self):
         bootstrapped = self.fixture.new_tenant(org_id="o1")
-        self.tuples.clear()
+        self._clear_state()
 
         original_mapping = TenantMapping.objects.get(tenant=bootstrapped.tenant)
         original_workspaces = list(Workspace.objects.filter(tenant=bootstrapped.tenant))
@@ -425,7 +457,7 @@ class V2TenantBootstrapServiceTest(TestCase):
         bootstrapped = self.fixture.new_tenant(org_id="o1")
         bootstrapped.tenant.ready = True
         bootstrapped.tenant.save()
-        self.tuples.clear()
+        self._clear_state()
 
         original_mapping = TenantMapping.objects.get(tenant=bootstrapped.tenant)
         original_workspaces = list(Workspace.objects.filter(tenant=bootstrapped.tenant))
@@ -470,7 +502,7 @@ class V2TenantBootstrapServiceTest(TestCase):
         ws_id_2 = uuid.uuid4()
         root_id = uuid.uuid4()
         default_id = uuid.uuid4()
-        self.tuples.clear()
+        self._clear_state()
         pairs = [
             (ws_id_1, root_id),
             (ws_id_2, default_id),
@@ -514,7 +546,7 @@ class V2TenantBootstrapServiceTest(TestCase):
         o3_tenant = self.fixture.new_unbootstrapped_tenant(org_id="o3")
 
         self.service.bootstrap_tenants([o1_tenant, o2_tenant, o3_tenant])
-        self.tuples.clear()
+        self._clear_state()
 
         # Re-bootstrapping without forcing should have no effect.
         self.service.bootstrap_tenants([o1_tenant, o2_tenant, o3_tenant])
@@ -534,7 +566,7 @@ class V2TenantBootstrapServiceTest(TestCase):
         o3_tenant = self.fixture.new_unbootstrapped_tenant(org_id="o3")
 
         self.service.bootstrap_tenant(o1_tenant)
-        self.tuples.clear()
+        self._clear_state()
 
         self.service.bootstrap_tenants([o1_tenant, o2_tenant, o3_tenant])
 
@@ -587,6 +619,10 @@ class V2TenantBootstrapServiceTest(TestCase):
                 )
             ),
         )
+
+    def _clear_state(self):
+        self.tuples.clear()
+        self.replicator.clear_events()
 
     def assertTenantBootstrapped(
         self, org_id: str, with_custom_default_group: Optional[Group] = None, existing: bool = False
@@ -757,5 +793,20 @@ class V2TenantBootstrapServiceTest(TestCase):
             role_uuid=settings.SYSTEM_ADMIN_TENANT_ROLE_UUID,
             role_binding_uuid=mapping.tenant_scope_default_admin_role_binding_uuid,
         )
+
+        default_workspace_events = [
+            e
+            for e in self.replicator.workspace_events_for(WorkspaceEventStream.STANDARD)
+            if e.event_type == ReplicationEventType.CREATE_WORKSPACE and e.workspace["id"] == str(default.id)
+        ]
+
+        self.assertEqual(len(default_workspace_events), 1)
+        default_workspace_event = default_workspace_events[0]
+
+        self.assertEqual(default_workspace_event.org_id, org_id)
+        self.assertEqual(default_workspace_event.account_number, tenant.account_id)
+        self.assertEqual(str(default_workspace_event.partition_key), str(PartitionKey.byEnvironment()))
+        self.assertEqual(default_workspace_event.workspace["name"], Workspace.SpecialNames.DEFAULT)
+        self.assertEqual(default_workspace_event.workspace["type"], Workspace.Types.DEFAULT)
 
         return tenant, mapping, root, default

--- a/tests/management/workspace/test_service.py
+++ b/tests/management/workspace/test_service.py
@@ -272,6 +272,7 @@ class WorkspaceServiceUpdateTests(WorkspaceServiceTestBase):
             self.assertEqual(event.account_number, self.tenant.account_id)
             self.assertEqual(str(event.partition_key), str(PartitionKey.byEnvironment()))
             self.assertEqual(event.workspace["id"], str(updated_instance.id))
+            self.assertEqual(event.workspace["type"], Workspace.Types.DEFAULT.value)
             self.assertEqual(event.workspace["name"], updated_instance.name)
 
         self.assertEqual(len(self.replicator.workspace_events_for(WorkspaceEventStream.BULK)), 0)

--- a/tests/management/workspace/test_service.py
+++ b/tests/management/workspace/test_service.py
@@ -29,7 +29,8 @@ from rest_framework import serializers
 from api.models import Tenant
 from management.group.relation_api_dual_write_group_handler import RelationApiDualWriteGroupHandler
 from management.models import Access, BindingMapping, Group, Permission, Policy, ResourceDefinition, Role, Workspace
-from management.relation_replicator.relation_replicator import ReplicationEventType
+from management.relation_replicator.outbox_replicator import OutboxReplicator
+from management.relation_replicator.relation_replicator import ReplicationEventType, WorkspaceEventStream, PartitionKey
 from management.role.relation_api_dual_write_handler import RelationApiDualWriteHandler
 from management.role.v2_model import RoleV2, CustomRoleV2
 from management.role_binding.model import RoleBinding
@@ -46,7 +47,7 @@ from migration_tool.in_memory_tuples import (
 )
 from tests.management.role.test_dual_write import RbacFixture
 from tests.util import assert_v2_tuples_consistent
-from tests.v2_util import bootstrap_tenant_for_v2_test, seed_v2_role_from_v1
+from tests.v2_util import bootstrap_tenant_for_v2_test, seed_v2_role_from_v1, WorkspaceCacheReplicator
 
 
 @dataclass
@@ -159,7 +160,6 @@ class WorkspaceServiceTestBase(TestCase):
     @classmethod
     def setUpTestData(cls):
         """Set up workspace service tests."""
-        cls.service = WorkspaceService()
         cls.tenant = Tenant.objects.create(tenant_name="Foo Tenant", org_id="1234567", account_id="7654321")
 
         bootstrap_result = bootstrap_tenant_for_v2_test(cls.tenant)
@@ -178,6 +178,12 @@ class WorkspaceServiceTestBase(TestCase):
 
         cls.tuples = InMemoryTuples()
         cls.in_memory_replicator = InMemoryRelationReplicator(cls.tuples)
+
+    def setUp(self):
+        super().setUp()
+
+        self.replicator = WorkspaceCacheReplicator(OutboxReplicator())
+        self.service = WorkspaceService(replicator=self.replicator)
 
     def tearDown(self):
         with self.subTest(msg="tuple consistency"):
@@ -246,9 +252,8 @@ class WorkspaceServiceUpdateTests(WorkspaceServiceTestBase):
 
     @override_settings(REPLICATION_TO_RELATION_ENABLED=True)
     @patch("management.relation_replicator.outbox_replicator.OutboxReplicator.replicate")
-    @patch("management.relation_replicator.outbox_replicator.OutboxReplicator.replicate_workspace")
-    def test_update_default_workspace_event(self, replicate_workspace, replicate):
-        """Test the default workspace update does not create a Workspace Event."""
+    def test_update_default_workspace_event(self, replicate):
+        """Test the default workspace update sends both creation and update Workspace Events."""
         replicate.side_effect = self.in_memory_replicator.replicate
 
         validated_data = {"name": "Bar Name", "description": "Bar Desc"}
@@ -256,8 +261,20 @@ class WorkspaceServiceUpdateTests(WorkspaceServiceTestBase):
         self.assertEqual(updated_instance.name, validated_data["name"])
         self.assertEqual(updated_instance.description, validated_data["description"])
 
-        replicate_workspace.assert_not_called()
+        events = self.replicator.workspace_events_for(WorkspaceEventStream.STANDARD)
+        self.assertEqual(len(events), 2)
 
+        self.assertEqual(events[0].event_type, ReplicationEventType.CREATE_WORKSPACE)
+        self.assertEqual(events[1].event_type, ReplicationEventType.UPDATE_WORKSPACE)
+
+        for event in events:
+            self.assertEqual(event.org_id, self.tenant.org_id)
+            self.assertEqual(event.account_number, self.tenant.account_id)
+            self.assertEqual(str(event.partition_key), str(PartitionKey.byEnvironment()))
+            self.assertEqual(event.workspace["id"], str(updated_instance.id))
+            self.assertEqual(event.workspace["name"], updated_instance.name)
+
+        self.assertEqual(len(self.replicator.workspace_events_for(WorkspaceEventStream.BULK)), 0)
         self.assertEqual(len(self.tuples), 0)
 
     def test_update_parent_id_same(self):

--- a/tests/management/workspace/test_service.py
+++ b/tests/management/workspace/test_service.py
@@ -18,15 +18,32 @@
 
 from collections import deque
 from dataclasses import dataclass
-from unittest.mock import Mock, call, patch
+from unittest.mock import Mock
+from unittest.mock import patch
 
+from django.conf import settings
 from django.test import TestCase
+from django.test.utils import override_settings
+from rest_framework import serializers
 
+from api.models import Tenant
 from management.group.relation_api_dual_write_group_handler import RelationApiDualWriteGroupHandler
-from management.role.v2_model import RoleV2, CustomRoleV2, PlatformRoleV2
+from management.models import Access, BindingMapping, Group, Permission, Policy, ResourceDefinition, Role, Workspace
+from management.relation_replicator.relation_replicator import ReplicationEventType
+from management.role.relation_api_dual_write_handler import RelationApiDualWriteHandler
+from management.role.v2_model import RoleV2, CustomRoleV2
 from management.role_binding.model import RoleBinding
 from management.role_binding.service import RoleBindingService
 from management.tenant_mapping.v2_activation import ensure_v2_write_activated
+from management.workspace.service import WorkspaceService
+from migration_tool.in_memory_tuples import (
+    InMemoryTuples,
+    InMemoryRelationReplicator,
+    all_of,
+    relation,
+    subject_type,
+    resource,
+)
 from tests.management.role.test_dual_write import RbacFixture
 from tests.util import assert_v2_tuples_consistent
 from tests.v2_util import bootstrap_tenant_for_v2_test, seed_v2_role_from_v1
@@ -133,45 +150,6 @@ class WorkspaceServiceTest(TestCase):
         executed_sql_calls = [args[0] for args, _ in mock_cursor.execute.call_args_list]
         self.assertTrue(any("LISTEN" in str(c) for c in executed_sql_calls))
         self.assertTrue(any("UNLISTEN" in str(c) for c in executed_sql_calls))
-
-
-#
-# Copyright 2025 Red Hat, Inc.
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as
-# published by the Free Software Foundation, either version 3 of the
-# License, or (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-#
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
-#
-from unittest.mock import patch
-
-from django.test import TestCase
-from rest_framework import serializers
-from api.models import Tenant
-from management.models import Access, BindingMapping, Group, Permission, Policy, ResourceDefinition, Role, Workspace
-from management.relation_replicator.relation_replicator import ReplicationEventType
-from management.role.relation_api_dual_write_handler import RelationApiDualWriteHandler
-from management.workspace.service import WorkspaceService
-from django.conf import settings
-from django.core.exceptions import ValidationError
-from django.test.utils import override_settings
-
-from migration_tool.in_memory_tuples import (
-    InMemoryTuples,
-    InMemoryRelationReplicator,
-    all_of,
-    relation,
-    subject_type,
-    resource,
-)
 
 
 @override_settings(ATOMIC_RETRY_DISABLED=True)

--- a/tests/v2_util.py
+++ b/tests/v2_util.py
@@ -4,6 +4,12 @@ from api.models import Tenant
 from management.group.platform import GlobalPolicyIdService
 from management.models import Permission, Role
 from management.relation_replicator.noop_replicator import NoopReplicator
+from management.relation_replicator.relation_replicator import (
+    RelationReplicator,
+    WorkspaceEventStream,
+    WorkspaceEvent,
+    ReplicationEvent,
+)
 from management.role.v2_model import SeededRoleV2
 from management.tenant_service import V2TenantBootstrapService
 from management.tenant_service.tenant_service import BootstrappedTenant
@@ -108,3 +114,25 @@ def bootstrap_tenant_for_v2_test(tenant: Tenant, tuples: Optional[InMemoryTuples
 
     replicator = InMemoryRelationReplicator(tuples) if tuples is not None else NoopReplicator()
     return V2TenantBootstrapService(replicator=replicator).bootstrap_tenant(tenant, force=True)
+
+
+class WorkspaceCacheReplicator(RelationReplicator):
+    _base_replicator: RelationReplicator
+    _workspace_events: dict[WorkspaceEventStream, list[WorkspaceEvent]]
+
+    def __init__(self, base_replicator: RelationReplicator):
+        self._base_replicator = base_replicator
+        self._workspace_events = {}
+
+    def replicate(self, event: ReplicationEvent):
+        return self._base_replicator.replicate(event)
+
+    def replicate_workspace(self, event: WorkspaceEvent, event_stream: WorkspaceEventStream):
+        self._workspace_events.setdefault(event_stream, []).append(event)
+        return self._base_replicator.replicate_workspace(event, event_stream)
+
+    def workspace_events_for(self, stream: WorkspaceEventStream) -> list[WorkspaceEvent]:
+        return self._workspace_events.get(stream, [])
+
+    def clear_events(self):
+        self._workspace_events = {}


### PR DESCRIPTION
## Link(s) to Jira
[RHCLOUD-40442](https://redhat.atlassian.net/browse/RHCLOUD-40442)

## Description of Intent of Change(s)
Add support for an additional workspace event topic, then add a migration to replicate all existing default workspaces to that topic.

The additional topic is added so that HBI can spin up a separate instance of the consumer to process the bulk events, thus ensuring that normal workspace events are still processed promptly.

[RHCLOUD-40442]: https://redhat.atlassian.net/browse/RHCLOUD-40442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Introduce bulk workspace workspace-event replication and a migration pathway to backfill existing default workspaces into the new stream.

New Features:
- Add a separate BULK workspace event stream and wire workspace replication to target either the standard or bulk stream.
- Add a migration utility, Django management command, internal HTTP endpoint, Celery task, and ClowdJobInvocation to replicate all existing default workspaces via bulk events.

Enhancements:
- Refactor tenant bootstrapping to centralize replication event emission and ensure default workspaces always emit corresponding workspace events.
- Introduce shared helpers for constructing workspace events and for caching workspace events in tests.
- Tighten validation and error handling around tenant bootstrapping and workspace replication paths.

Deployment:
- Add a dedicated ClowdApp job and OpenShift template to run the default workspace replication as a one-off job in production.

Tests:
- Extend and add tests to cover bulk workspace event streaming, default workspace replication backfill, updated workspace event behavior, and tenant bootstrapping event expectations.