### PR TITLE
[RHCLOUD-47245] Add permission query filter to V2 roles list

### DIFF
--- a/rbac/management/mcp_views.py
+++ b/rbac/management/mcp_views.py
@@ -857,7 +857,7 @@ def search_roles(
     """Search roles, auto-detecting V1/V2 and delegating to the appropriate view."""
     tenant = getattr(request, "tenant", None)
     if tenant and is_v2_write_activated(tenant):
-        return _search_roles_v2(request, limit, offset, name, resource_type, order_by)
+        return _search_roles_v2(request, limit, offset, name, resource_type, permission, order_by)
     return _search_roles_v1(request, limit, offset, name, display_name, permission, application, system, order_by)
 
 
@@ -903,6 +903,7 @@ def _search_roles_v2(
     offset: int,
     name: str,
     resource_type: str,
+    permission: str,
     order_by: str,
 ) -> str:
     """Search roles using V2 API."""
@@ -914,6 +915,8 @@ def _search_roles_v2(
         query_params["name"] = name
     if resource_type:
         query_params["resource_type"] = resource_type
+    if permission:
+        query_params["permission"] = permission
     if order_by:
         query_params["order_by"] = order_by
 

--- a/rbac/management/role/v2_serializer.py
+++ b/rbac/management/role/v2_serializer.py
@@ -160,6 +160,11 @@ class RoleV2ListSerializer(serializers.Serializer):
         allow_blank=True,
         help_text="Filter by role name. Use * as wildcard for partial matching.",
     )
+    permission = serializers.CharField(
+        required=False,
+        allow_blank=True,
+        help_text="Filter by permission string (e.g. 'app:resource:verb'). Comma-separated for multiple.",
+    )
     resource_type = serializers.CharField(
         required=False, allow_blank=True, help_text="Filter roles by the resource type they are scoped to"
     )
@@ -175,7 +180,11 @@ class RoleV2ListSerializer(serializers.Serializer):
         }
         return super().to_internal_value(sanitized)
 
-    def validate_name(self, value):
+    def validate_name(self, value: str | None) -> str | None:
+        """Return None for empty values."""
+        return value or None
+
+    def validate_permission(self, value: str | None) -> str | None:
         """Return None for empty values."""
         return value or None
 

--- a/rbac/management/role/v2_service.py
+++ b/rbac/management/role/v2_service.py
@@ -285,7 +285,8 @@ class RoleV2Service:
         permission = params.get("permission")
         if permission:
             permission_values = [p.strip() for p in permission.split(",") if p.strip()]
-            queryset = queryset.filter(permissions__permission__in=permission_values).distinct()
+            if permission_values:
+                queryset = queryset.filter(permissions__permission__in=permission_values).distinct()
 
         return queryset
 

--- a/rbac/management/role/v2_service.py
+++ b/rbac/management/role/v2_service.py
@@ -282,6 +282,11 @@ class RoleV2Service:
         if name:
             queryset = queryset.named(name)
 
+        permission = params.get("permission")
+        if permission:
+            permission_values = [p.strip() for p in permission.split(",") if p.strip()]
+            queryset = queryset.filter(permissions__permission__in=permission_values).distinct()
+
         return queryset
 
     def _filter_by_resource_type(

--- a/tests/management/role/test_v2_view.py
+++ b/tests/management/role/test_v2_view.py
@@ -833,6 +833,58 @@ class RoleV2ViewSetTests(IdentityRequest):
         returned_names = {role["name"] for role in response.data["data"]}
         self.assertEqual(returned_names, {"Test_Role", "test_role"})
 
+    def test_list_roles_with_permission_filter(self):
+        """Test that permission filter returns only roles containing the specified permission."""
+        role_with_perm = RoleV2.objects.create(name="host_reader", tenant=self.tenant)
+        role_with_perm.permissions.add(self.permission2)
+
+        role_without_perm = RoleV2.objects.create(name="no_match_role", tenant=self.tenant)
+        role_without_perm.permissions.add(self.permission4)
+
+        url = f"{self.list_url}&permission=inventory:hosts:read"
+        response = self.client.get(url, **self.headers)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        role_names = [r["name"] for r in response.data["data"]]
+        self.assertIn("host_reader", role_names)
+        self.assertNotIn("no_match_role", role_names)
+
+    def test_list_roles_with_permission_filter_multiple(self):
+        """Test that comma-separated permissions return union of matches."""
+        role_a = RoleV2.objects.create(name="host_reader", tenant=self.tenant)
+        role_a.permissions.add(self.permission2)
+
+        role_b = RoleV2.objects.create(name="cost_reader", tenant=self.tenant)
+        role_b.permissions.add(self.permission4)
+
+        url = f"{self.list_url}&permission=inventory:hosts:read,cost:reports:read"
+        response = self.client.get(url, **self.headers)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        role_names = [r["name"] for r in response.data["data"]]
+        self.assertIn("host_reader", role_names)
+        self.assertIn("cost_reader", role_names)
+
+    def test_list_roles_with_permission_filter_no_match(self):
+        """Test that a non-existent permission returns empty results."""
+        url = f"{self.list_url}&permission=nonexistent:perm:here"
+        response = self.client.get(url, **self.headers)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data["data"]), 0)
+
+    def test_list_roles_with_permission_filter_distinct(self):
+        """Test that a role appears once even when it matches multiple comma-separated permissions."""
+        role = RoleV2.objects.create(name="multi_perm_role", tenant=self.tenant)
+        role.permissions.add(self.permission2, self.permission3)
+
+        url = f"{self.list_url}&permission=inventory:hosts:read,inventory:hosts:write"
+        response = self.client.get(url, **self.headers)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        role_names = [r["name"] for r in response.data["data"]]
+        self.assertEqual(role_names.count("multi_perm_role"), 1)
+
     def test_list_roles_with_permissions_field(self):
         """Test that requesting permissions field returns permissions array."""
         url = f"{self.list_url}&fields=id,name,permissions"

--- a/tests/management/test_mcp_views.py
+++ b/tests/management/test_mcp_views.py
@@ -1867,6 +1867,29 @@ class MCPUnifiedSearchRolesV2Tests(MCPToolTestMixin, IdentityRequest):
         role_names = [r["name"] for r in tool_output["data"]]
         self.assertIn("Cost Reader", role_names)
 
+    def test_search_roles_v2_filter_by_permission(self):
+        """Positive: search_roles on V2 org filters by permission."""
+        perm = Permission.objects.create(
+            application="inventory",
+            resource_type="hosts",
+            verb="read",
+            permission="inventory:hosts:read",
+            tenant=self.tenant,
+        )
+        matching_role = RoleV2.objects.create(name="Host Reader", tenant=self.tenant, type=RoleV2.Types.CUSTOM)
+        matching_role.permissions.add(perm)
+
+        RoleV2.objects.create(name="Empty Role", tenant=self.tenant, type=RoleV2.Types.CUSTOM)
+
+        response = self._call_tool("search_roles", {"permission": "inventory:hosts:read"})
+
+        self.assertEqual(response.status_code, 200)
+        tool_output = self._get_tool_output(response)
+        self.assertEqual(tool_output["org_version"], "v2")
+        role_names = [r["name"] for r in tool_output["data"]]
+        self.assertIn("Host Reader", role_names)
+        self.assertNotIn("Empty Role", role_names)
+
 
 @override_settings(BYPASS_BOP_VERIFICATION=True, V2_APIS_ENABLED=True)
 class MCPUnifiedGetRoleTests(MCPToolTestMixin, IdentityRequest):


### PR DESCRIPTION
## Link(s) to Jira
- [RHCLOUD-47245](https://issues.redhat.com/browse/RHCLOUD-47245)

## Description of Intent of Change(s)

**What:** Add a `permission` query parameter to the V2 roles list endpoint (`GET /api/v2/roles/`) and forward it through the unified `search_roles` MCP tool for V2 orgs.

**Why:** V1 already supports server-side permission filtering via `RoleFilter.permission_filter`, but V2 had no equivalent. This forced the MCP LLM agent to enumerate all roles and inspect each one individually to answer "which roles grant permission X?" -- slow and wasteful.

**How:**
- Added `permission` CharField to `RoleV2ListSerializer` with `validate_permission` for empty-string normalization
- Added filter block in `RoleV2Service.list()` that splits comma-separated values and uses `permissions__permission__in` with `.distinct()` (matching V1 semantics)
- Passed `permission` through to `_search_roles_v2` in the MCP layer (it was already accepted by `search_roles` but silently dropped for V2 orgs)

Supports single and comma-separated permission strings. Exact match only (no wildcards), consistent with V1.

```
GET /api/v2/roles/?permission=inventory:hosts:read
GET /api/v2/roles/?permission=inventory:hosts:read,cost:reports:read
```

## Local Testing

```bash
# Run the 5 new tests
tox -e py312-fast -- tests.management.role.test_v2_view.RoleV2ViewSetTests.test_list_roles_with_permission_filter tests.management.role.test_v2_view.RoleV2ViewSetTests.test_list_roles_with_permission_filter_multiple tests.management.role.test_v2_view.RoleV2ViewSetTests.test_list_roles_with_permission_filter_no_match tests.management.role.test_v2_view.RoleV2ViewSetTests.test_list_roles_with_permission_filter_distinct tests.management.test_mcp_views.MCPUnifiedSearchRolesV2Tests.test_search_roles_v2_filter_by_permission

# Full test suite (3120 tests pass)
tox -e py312-fast

# Linter
tox -e lint
```

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required?
- [x] are these changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices

[RHCLOUD-47245]: https://redhat.atlassian.net/browse/RHCLOUD-47245?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Add server-side permission-based filtering support to the V2 roles listing and MCP role search for V2 organizations.

New Features:
- Support filtering V2 roles by an exact permission or comma-separated list of permissions via the roles list API.
- Allow the unified MCP search_roles tool to filter V2 roles by permission when querying the V2 backend.

Tests:
- Add V2 roles list tests covering single, multiple, no-match, and distinct behavior for the permission filter.
- Add MCP search_roles V2 test verifying permission-based filtering behavior.