### PR TITLE
RHCLOUD-47270 - Update mcp audit logs to return consistent response format

### DIFF
--- a/rbac/management/mcp_views.py
+++ b/rbac/management/mcp_views.py
@@ -431,7 +431,13 @@ def list_permissions(
         "role_name='Vulnerability administrator') "
         "Set include_authorization=true to see the role/permission that authorized the action. "
         "Order by: 'created', 'principal_username', 'resource_type', 'action' (prefix with '-' to reverse). "
-        "NOTE: Authorization shows actor's CURRENT role/permission — may differ from time of change."
+        "NOTE: Authorization shows actor's CURRENT role/permission — may differ from time of change. "
+        "RESPONSE FORMAT: When summarizing audit log entries, include the action, resource type, who performed it "
+        "(principal_username), the date and time (formatted as '14 April at 9:32 AM', not numeric like "
+        "'2025-04-14T09:32:15'), and the description field. When include_authorization=true, also state the "
+        "role name (authorized_by.role), "
+        "group name (authorized_by.via_group), and specific permission (authorized_by.permission) that "
+        "authorized the action."
     ),
     requires_auth=True,
 )


### PR DESCRIPTION
## Link(s) to Jira
https://redhat.atlassian.net/browse/RHCLOUD-47270

## Description of Intent of Change(s)
Added RESPONSE FORMAT guidance that instructs LLMs to include:

  1. Action - the type of action (add/edit/delete/create/remove)
  2. Resource type - what was changed (group/role/workspace/etc.)
  3. Who performed it - the principal_username
  4. Date and time - formatted as '14 April at 9:32 AM' (not ISO format)
  5. Description field - the RBAC-generated description of the change
  6. Authorization details (when include_authorization=true):
    - Role name (authorized_by.role)
    - Group name (authorized_by.via_group)
    - Specific permission (authorized_by.permission)

## Local Testing
How can the feature be exercised?
How can the bug be exploited and fix confirmed?
Is any special local setup required?

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Clarify the MCP audit logs endpoint help text to specify a consistent, human-readable response format for LLM-generated summaries, including optional authorization details when requested.

Enhancements:
- Document the expected audit log summary format, covering action, resource type, actor, localized date/time, and description fields.
- Describe how to include authorization details (role, group, and permission) in summaries when include_authorization=true.