### PR TITLE
[RHCLOUD-47352] Restrict the valid characters for workspace name

### DIFF
--- a/rbac/management/workspace/serializer.py
+++ b/rbac/management/workspace/serializer.py
@@ -17,10 +17,14 @@
 
 """Serializer for workspace management."""
 
+import re
+
 from management.workspace.service import WorkspaceService
 from rest_framework import serializers
 
 from .model import Workspace
+
+WORKSPACE_NAME_REGEX = re.compile(r"^[\w\s-]+$")
 
 
 class WorkspaceSerializer(serializers.ModelSerializer):
@@ -51,6 +55,19 @@ class WorkspaceSerializer(serializers.ModelSerializer):
     @property
     def _service(self) -> WorkspaceService:
         return self.context["view"]._service
+
+    def validate_name(self, value):
+        """Reject names with characters other than letters, numbers, spaces, hyphens, and underscores.
+
+        Existing names are grandfathered: skip validation when the name is unchanged on update.
+        """
+        if self.instance and self.instance.name == value:
+            return value
+        if not WORKSPACE_NAME_REGEX.match(value):
+            raise serializers.ValidationError(
+                "Workspace name may only contain letters, numbers, spaces, hyphens, and underscores."
+            )
+        return value
 
     def validate(self, attrs):
         """Require parent_id in the body for PUT (full update) requests."""

--- a/tests/management/workspace/test_serializer.py
+++ b/tests/management/workspace/test_serializer.py
@@ -18,6 +18,7 @@ from django.test import TestCase
 from unittest.mock import Mock
 from api.models import Tenant
 from management.models import Workspace
+from rest_framework import serializers
 from management.workspace.serializer import (
     WorkspaceAncestrySerializer,
     WorkspaceSerializer,
@@ -103,3 +104,24 @@ class WorkspaceSerializerTest(TestCase):
         expected_data = {"name": self.child.name, "parent_id": str(self.parent.id), "id": str(self.child.id)}
 
         self.assertDictEqual(serializer.data, expected_data)
+
+    def test_validate_name_rejects_special_characters(self):
+        """Test that names with disallowed characters are rejected."""
+        serializer = WorkspaceSerializer()
+        for invalid_name in ["ws@name", "ws#name", "ws!name", "ws.name", "ws/name"]:
+            with self.assertRaises(serializers.ValidationError, msg=f"Expected error for '{invalid_name}'"):
+                serializer.validate_name(invalid_name)
+
+    def test_validate_name_accepts_valid_characters(self):
+        """Test that names with allowed characters are accepted."""
+        serializer = WorkspaceSerializer()
+        for valid_name in ["My Workspace", "ws-name", "ws_name", "Workspace 123", "simple"]:
+            result = serializer.validate_name(valid_name)
+            self.assertEqual(result, valid_name)
+
+    def test_validate_name_allows_unchanged_legacy_name(self):
+        """Test that an unchanged legacy name (with special chars) passes validation."""
+        serializer = WorkspaceSerializer(instance=self.child)
+        self.child.name = "legacy@name"
+        result = serializer.validate_name("legacy@name")
+        self.assertEqual(result, "legacy@name")

--- a/tests/management/workspace/test_view.py
+++ b/tests/management/workspace/test_view.py
@@ -1315,6 +1315,110 @@ class WorkspaceTestsCreateUpdateDelete(TransactionalWorkspaceViewTests):
         self.assertEqual(response_message.get("name"), wsB.name)
         self.assertEqual(response_message.get("parent_id"), str(wsA.id))
 
+    def test_create_workspace_invalid_name_characters(self):
+        """Test that create rejects names with disallowed characters."""
+        client = APIClient()
+        url = reverse("v2_management:workspace-list")
+        for invalid_name in ["ws@name", "ws#name", "ws!name", "ws.name", "ws/name", "ws+name"]:
+            response = client.post(
+                url,
+                {"name": invalid_name, "parent_id": self.default_workspace.id},
+                format="json",
+                **self.headers,
+            )
+            self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, f"Expected 400 for '{invalid_name}'")
+
+    def test_create_workspace_valid_name_characters(self):
+        """Test that create accepts names with allowed characters."""
+        client = APIClient()
+        url = reverse("v2_management:workspace-list")
+        valid_names = ["My Workspace", "ws-name", "ws_name", "Workspace 123", "simple"]
+        for valid_name in valid_names:
+            response = client.post(
+                url,
+                {"name": valid_name, "parent_id": self.default_workspace.id},
+                format="json",
+                **self.headers,
+            )
+            self.assertEqual(response.status_code, status.HTTP_201_CREATED, f"Expected 201 for '{valid_name}'")
+
+    def test_update_workspace_invalid_name_characters(self):
+        """Test that PUT rejects a new name with disallowed characters."""
+        workspace = Workspace.objects.create(
+            name="Valid Name",
+            tenant=self.tenant,
+            parent=self.default_workspace,
+            type=Workspace.Types.STANDARD,
+        )
+        client = APIClient()
+        url = reverse("v2_management:workspace-detail", kwargs={"pk": workspace.id})
+        response = client.put(
+            url,
+            {"name": "invalid@name", "parent_id": workspace.parent_id},
+            format="json",
+            **self.headers,
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_partial_update_workspace_invalid_name_characters(self):
+        """Test that PATCH rejects a new name with disallowed characters."""
+        workspace = Workspace.objects.create(
+            name="Valid Name",
+            tenant=self.tenant,
+            parent=self.default_workspace,
+            type=Workspace.Types.STANDARD,
+        )
+        client = APIClient()
+        url = reverse("v2_management:workspace-detail", kwargs={"pk": workspace.id})
+        response = client.patch(url, {"name": "bad!name"}, format="json", **self.headers)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_update_workspace_legacy_name_unchanged(self):
+        """Test that PUT with an unchanged legacy name (with disallowed chars) succeeds."""
+        workspace = Workspace.objects.create(
+            name="legacy@name",
+            tenant=self.tenant,
+            parent=self.default_workspace,
+            type=Workspace.Types.STANDARD,
+        )
+        client = APIClient()
+        url = reverse("v2_management:workspace-detail", kwargs={"pk": workspace.id})
+        response = client.put(
+            url,
+            {"name": "legacy@name", "description": "updated desc", "parent_id": workspace.parent_id},
+            format="json",
+            **self.headers,
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["name"], "legacy@name")
+
+    def test_partial_update_workspace_legacy_name_not_sent(self):
+        """Test that PATCH without name field on a workspace with legacy name succeeds."""
+        workspace = Workspace.objects.create(
+            name="legacy@name",
+            tenant=self.tenant,
+            parent=self.default_workspace,
+            type=Workspace.Types.STANDARD,
+        )
+        client = APIClient()
+        url = reverse("v2_management:workspace-detail", kwargs={"pk": workspace.id})
+        response = client.patch(url, {"description": "updated desc"}, format="json", **self.headers)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["name"], "legacy@name")
+
+    def test_update_workspace_legacy_name_changed_to_invalid(self):
+        """Test that changing a legacy name to a different invalid name is rejected."""
+        workspace = Workspace.objects.create(
+            name="legacy@name",
+            tenant=self.tenant,
+            parent=self.default_workspace,
+            type=Workspace.Types.STANDARD,
+        )
+        client = APIClient()
+        url = reverse("v2_management:workspace-detail", kwargs={"pk": workspace.id})
+        response = client.patch(url, {"name": "other@invalid"}, format="json", **self.headers)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
     def test_update_workspace_invalid_uuid(self):
         """Test that update fails with 400 when workspace id is not a valid UUID."""
         client = APIClient()


### PR DESCRIPTION
## Link(s) to Jira
- https://redhat.atlassian.net/browse/RHCLOUD-47352

## Description of Intent of Change(s)
The HBI UI was restricting the workspace name for inventory groups. To be consistent, we should have same restriction in rbac workspace api

## Local Testing
Unit tests

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Enforce server-side validation on workspace names to restrict allowed characters while preserving existing legacy names.

Bug Fixes:
- Ensure workspace create and update endpoints reject names containing disallowed special characters.
- Allow existing workspaces with legacy names containing disallowed characters to be updated as long as the name itself is not changed.

Enhancements:
- Add serializer-level validation for workspace names limiting them to letters, numbers, spaces, hyphens, and underscores.

Tests:
- Add API tests covering valid and invalid workspace names for create, update, and partial update operations, including legacy-name scenarios.
- Add serializer tests verifying name validation behavior and grandfathering of existing invalid names.