### PR TITLE
fix(auth): Prevent username query param from affecting Kessel authorization

### DIFF
--- a/rbac/management/principal/proxy.py
+++ b/rbac/management/principal/proxy.py
@@ -371,10 +371,10 @@ def get_user_id_from_request(request) -> str | None:
     Returns:
         str: The user_id, or None if not found
     """
-    from management.utils import get_principal_from_request
+    from management.utils import get_principal_for_auth
 
     # 1. Try to get from Principal in database
-    principal = get_principal_from_request(request)
+    principal = get_principal_for_auth(request)
     if principal is not None:
         user_id = getattr(principal, "user_id", None)
         if user_id:

--- a/rbac/management/principal/proxy.py
+++ b/rbac/management/principal/proxy.py
@@ -361,7 +361,7 @@ def get_user_id_from_request(request) -> str | None:
     Get user_id from a request using multiple lookup strategies.
 
     Tries to get user_id from (in order of precedence):
-    1. Principal from database (via get_principal_from_request)
+    1. Principal from database (via get_principal_for_auth)
     2. request.user.user_id attached to the request
     3. IT service via PrincipalProxy
 

--- a/rbac/management/utils.py
+++ b/rbac/management/utils.py
@@ -266,13 +266,14 @@ def build_system_user_from_token(request, token_validator: TokenValidator) -> Op
         return None
 
 
-def get_principal_from_request(request, *, for_auth=False):
+def get_principal_from_request(request, *, ignore_username_query_param=False):
     """Obtain principal from the request object.
 
     Args:
         request: The HTTP request object
-        for_auth: If True, ignore username query parameter and always use request.user.username.
-                 This should be True for authorization checks to prevent privilege confusion.
+        ignore_username_query_param: If True, ignore the username query parameter and always
+                                     use request.user.username. This should be True for
+                                     authorization checks to prevent privilege confusion.
 
     Returns:
         Principal object for the resolved username
@@ -281,7 +282,7 @@ def get_principal_from_request(request, *, for_auth=False):
     username = current_user
     from_query = False
 
-    if not for_auth:
+    if not ignore_username_query_param:
         qs_user = request.query_params.get(USERNAME_KEY)
         if qs_user and not PRINCIPAL_PERMISSION_INSTANCE.has_permission(request=request, view=None):
             raise PermissionDenied()
@@ -305,7 +306,7 @@ def get_principal_for_auth(request):
     Returns:
         Principal object for the authenticated user
     """
-    return get_principal_from_request(request, for_auth=True)
+    return get_principal_from_request(request, ignore_username_query_param=True)
 
 
 def get_principal(

--- a/rbac/management/utils.py
+++ b/rbac/management/utils.py
@@ -266,20 +266,46 @@ def build_system_user_from_token(request, token_validator: TokenValidator) -> Op
         return None
 
 
-def get_principal_from_request(request):
-    """Obtain principal from the request object."""
+def get_principal_from_request(request, *, for_auth=False):
+    """Obtain principal from the request object.
+
+    Args:
+        request: The HTTP request object
+        for_auth: If True, ignore username query parameter and always use request.user.username.
+                 This should be True for authorization checks to prevent privilege confusion.
+
+    Returns:
+        Principal object for the resolved username
+    """
     current_user = request.user.username
-    qs_user = request.query_params.get(USERNAME_KEY)
     username = current_user
     from_query = False
-    if qs_user and not PRINCIPAL_PERMISSION_INSTANCE.has_permission(request=request, view=None):
-        raise PermissionDenied()
 
-    if qs_user:
-        username = qs_user
-        from_query = True
+    if not for_auth:
+        qs_user = request.query_params.get(USERNAME_KEY)
+        if qs_user and not PRINCIPAL_PERMISSION_INSTANCE.has_permission(request=request, view=None):
+            raise PermissionDenied()
+        if qs_user:
+            username = qs_user
+            from_query = True
 
-    return get_principal(username, request, verify_principal=bool(qs_user), from_query=from_query)
+    return get_principal(username, request, verify_principal=from_query, from_query=from_query)
+
+
+def get_principal_for_auth(request):
+    """Get principal from request for authorization purposes.
+
+    This helper ensures the principal is resolved from the authenticated user
+    (request.user.username) and never from a query parameter, preventing
+    privilege confusion in authorization checks.
+
+    Args:
+        request: The HTTP request object
+
+    Returns:
+        Principal object for the authenticated user
+    """
+    return get_principal_from_request(request, for_auth=True)
 
 
 def get_principal(

--- a/rbac/management/workspace/utils/access.py
+++ b/rbac/management/workspace/utils/access.py
@@ -30,7 +30,7 @@ from management.permissions.workspace_inventory_access import (
 )
 from management.principal.model import Principal
 from management.principal.proxy import PrincipalProxy
-from management.utils import get_principal_from_request, roles_for_principal
+from management.utils import get_principal_for_auth, get_principal_from_request, roles_for_principal
 from rest_framework.serializers import ValidationError
 
 from rbac import settings
@@ -271,7 +271,7 @@ def is_user_allowed_v2(request, required_operation, target_workspace):
 
         # Try to get user_id from principal, request.user, or IT service API
         with record_timing(timings, "get_principal_id"):
-            principal = get_principal_from_request(request)
+            principal = get_principal_for_auth(request)
             if principal is not None and principal.user_id is not None:
                 user_id = principal.user_id
             elif (user_id := getattr(request.user, "user_id", None)) is not None:

--- a/tests/management/test_utils.py
+++ b/tests/management/test_utils.py
@@ -23,6 +23,7 @@ from management.models import Access, Group, Permission, Principal, Policy, Role
 from management.principal.view import VALID_PRINCIPAL_TYPE_VALUE
 from management.utils import (
     access_for_principal,
+    get_principal_for_auth,
     get_principal_from_request,
     groups_for_principal,
     policies_for_principal,
@@ -413,6 +414,104 @@ class UtilsTests(IdentityRequest):
         created_principal = Principal.objects.get(username=username)
         self.assertEqual(created_principal.type, "user")
         self.assertEqual(created_principal.username, username)
+
+    @mock.patch(
+        "management.principal.proxy.PrincipalProxy.request_filtered_principals",
+        return_value={
+            "status_code": 200,
+            "data": [
+                {
+                    "org_id": "100001",
+                    "is_org_admin": False,
+                    "is_internal": False,
+                    "id": 52567473,
+                    "username": "other_user",
+                    "account_number": "1111111",
+                    "is_active": True,
+                }
+            ],
+        },
+    )
+    def test_get_principal_from_request_for_auth_ignores_query_param(self, mock_request_principals):
+        """Test that for_auth=True ignores the username query parameter."""
+        Principal.objects.create(username="other_user", tenant=self.tenant, user_id="other-uid")
+        self.principal.user_id = "principal-a-uid"
+        self.principal.save()
+
+        request = mock.Mock()
+        request.tenant = self.tenant
+        request.user = User()
+        request.user.username = self.principal.username
+        request.query_params = {"username": "other_user"}
+
+        result = get_principal_from_request(request=request, for_auth=True)
+        self.assertEqual(result.username, self.principal.username)
+        mock_request_principals.assert_not_called()
+
+    @mock.patch(
+        "management.principal.proxy.PrincipalProxy.request_filtered_principals",
+        return_value={
+            "status_code": 200,
+            "data": [
+                {
+                    "org_id": "100001",
+                    "is_org_admin": False,
+                    "is_internal": False,
+                    "id": 52567473,
+                    "username": "other_user",
+                    "account_number": "1111111",
+                    "is_active": True,
+                }
+            ],
+        },
+    )
+    def test_get_principal_for_auth_helper(self, mock_request_principals):
+        """Test that get_principal_for_auth helper ignores the username query parameter."""
+        Principal.objects.create(username="other_user", tenant=self.tenant, user_id="other-uid")
+        self.principal.user_id = "principal-a-uid"
+        self.principal.save()
+
+        request = mock.Mock()
+        request.tenant = self.tenant
+        request.user = User()
+        request.user.username = self.principal.username
+        request.query_params = {"username": "other_user"}
+
+        result = get_principal_for_auth(request)
+        self.assertEqual(result.username, self.principal.username)
+        mock_request_principals.assert_not_called()
+
+    @mock.patch(
+        "management.principal.proxy.PrincipalProxy.request_filtered_principals",
+        return_value={
+            "status_code": 200,
+            "data": [
+                {
+                    "org_id": "100001",
+                    "is_org_admin": False,
+                    "is_internal": False,
+                    "id": 52567473,
+                    "username": "other_user",
+                    "account_number": "1111111",
+                    "is_active": True,
+                }
+            ],
+        },
+    )
+    def test_get_principal_from_request_default_uses_query_param(self, mock_request_principals):
+        """Test that default behavior still uses the username query parameter."""
+        Principal.objects.create(username="other_user", tenant=self.tenant, user_id="other-uid")
+
+        request = mock.Mock()
+        request.tenant = self.tenant
+        request.user = User()
+        request.user.username = self.principal.username
+        request.user.admin = True
+        request.query_params = {"username": "other_user"}
+
+        result = get_principal_from_request(request=request)
+        mock_request_principals.assert_called_once()
+        self.assertEqual(result.username, "other_user")
 
     def test_validate_and_get_key_success(self):
         """Test we can validate the query param value."""

--- a/tests/management/test_utils.py
+++ b/tests/management/test_utils.py
@@ -432,8 +432,8 @@ class UtilsTests(IdentityRequest):
             ],
         },
     )
-    def test_get_principal_from_request_for_auth_ignores_query_param(self, mock_request_principals):
-        """Test that for_auth=True ignores the username query parameter."""
+    def test_get_principal_from_request_ignore_username_query_param(self, mock_request_principals):
+        """Test that ignore_username_query_param=True ignores the username query parameter."""
         Principal.objects.create(username="other_user", tenant=self.tenant, user_id="other-uid")
         self.principal.user_id = "principal-a-uid"
         self.principal.save()
@@ -444,7 +444,7 @@ class UtilsTests(IdentityRequest):
         request.user.username = self.principal.username
         request.query_params = {"username": "other_user"}
 
-        result = get_principal_from_request(request=request, for_auth=True)
+        result = get_principal_from_request(request=request, ignore_username_query_param=True)
         self.assertEqual(result.username, self.principal.username)
         mock_request_principals.assert_not_called()
 

--- a/tests/management/workspace/test_workspace_inventory_access.py
+++ b/tests/management/workspace/test_workspace_inventory_access.py
@@ -1381,13 +1381,13 @@ class WorkspaceInventoryAccessV2Tests(TransactionIdentityRequest):
     @patch("management.inventory_client.create_client_channel_inventory")
     @patch("management.workspace.utils.access.PrincipalProxy")
     @patch(
-        "management.workspace.utils.access.get_principal_from_request",
+        "management.workspace.utils.access.get_principal_for_auth",
         return_value=None,
     )
     def test_workspace_access_with_none_principal_fallback_to_it_service(
         self, mock_get_principal, mock_proxy_class, mock_channel
     ):
-        """Test workspace access when get_principal_from_request returns None, falls back to IT service."""
+        """Test workspace access when get_principal_for_auth returns None, falls back to IT service."""
         # Mock PrincipalProxy to return user_id from IT service
         test_user_id = "it-service-user-456"
         mock_proxy = MagicMock()
@@ -1437,7 +1437,7 @@ class WorkspaceInventoryAccessV2Tests(TransactionIdentityRequest):
 
     @patch("management.workspace.utils.access.PrincipalProxy")
     @patch(
-        "management.workspace.utils.access.get_principal_from_request",
+        "management.workspace.utils.access.get_principal_for_auth",
         return_value=None,
     )
     def test_workspace_access_with_none_principal_it_service_failure(self, mock_get_principal, mock_proxy_class):
@@ -1474,7 +1474,7 @@ class WorkspaceInventoryAccessV2Tests(TransactionIdentityRequest):
 
     @patch("management.workspace.utils.access.PrincipalProxy")
     @patch(
-        "management.workspace.utils.access.get_principal_from_request",
+        "management.workspace.utils.access.get_principal_for_auth",
         return_value=None,
     )
     def test_workspace_access_with_none_principal_it_service_empty_response(
@@ -1512,11 +1512,11 @@ class WorkspaceInventoryAccessV2Tests(TransactionIdentityRequest):
             )
 
     @patch(
-        "management.workspace.utils.access.get_principal_from_request",
+        "management.workspace.utils.access.get_principal_for_auth",
         return_value=None,
     )
     def test_workspace_access_with_none_principal_and_no_username(self, mock_get_principal):
-        """Test workspace access when get_principal_from_request returns None and no username available."""
+        """Test workspace access when get_principal_for_auth returns None and no username available."""
 
         # Create a mock request with no username and no user_id
         mock_request = Mock()
@@ -1536,11 +1536,11 @@ class WorkspaceInventoryAccessV2Tests(TransactionIdentityRequest):
             mock_logger.warning.assert_called_once_with("No username available from request.user, denying access")
 
     @patch(
-        "management.workspace.utils.access.get_principal_from_request",
+        "management.workspace.utils.access.get_principal_for_auth",
         return_value=None,
     )
     def test_workspace_access_with_none_principal_and_no_org_id(self, mock_get_principal):
-        """Test workspace access when get_principal_from_request returns None and no org_id available."""
+        """Test workspace access when get_principal_for_auth returns None and no org_id available."""
 
         # Create a mock request with username but no org_id or user_id
         mock_request = Mock()
@@ -1563,7 +1563,7 @@ class WorkspaceInventoryAccessV2Tests(TransactionIdentityRequest):
     @patch("management.inventory_client.create_client_channel_inventory")
     @patch("management.workspace.utils.access.PrincipalProxy")
     @patch(
-        "management.workspace.utils.access.get_principal_from_request",
+        "management.workspace.utils.access.get_principal_for_auth",
         return_value=None,
     )
     def test_workspace_access_with_none_principal_logs_debug_for_it_service(
@@ -2800,7 +2800,7 @@ class WorkspaceInventoryAccessV2Tests(TransactionIdentityRequest):
             self.assertFalse(request_proto.HasField("consistency"))
 
     @patch("management.inventory_client.create_client_channel_inventory")
-    @patch("management.workspace.utils.access.get_principal_from_request")
+    @patch("management.workspace.utils.access.get_principal_for_auth")
     def test_is_user_allowed_v2_reloads_tenant_for_fresh_consistency_token(self, mock_get_principal, mock_channel):
         """Test that is_user_allowed_v2 reloads tenant from DB to get the latest consistency token.
 


### PR DESCRIPTION
## Link(s) to Jira
- [RHCLOUD-46125](https://redhat.atlassian.net/browse/RHCLOUD-46125)

## Description of Intent of Change(s)
Prevent username query param from affecting kessel authorization

When a v2 API request included ?username=another_user, the Kessel permission check incorrectly resolved the principal for that user instead of the authenticated requester. This was a privilege confusion bug where authorization was checked against the wrong identity.

The fix adds a for_auth parameter to get_principal_from_request() that, when True, ignores the username query parameter and always resolves from request.user.username. Updated get_kessel_principal_id() and is_user_allowed_v2() to pass for_auth=True for all authorization checks.

V1 callers remain unchanged and continue to honor the username parameter for data retrieval operations.

## Local Testing
How can the feature be exercised?
How can the bug be exploited and fix confirmed?
Is any special local setup required?

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

[RHCLOUD-46125]: https://redhat.atlassian.net/browse/RHCLOUD-46125?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Ensure authorization checks always use the authenticated principal rather than any username query parameter.

Bug Fixes:
- Prevent v2 authorization logic from resolving principals based on the username query parameter instead of the authenticated user.

Tests:
- Add tests verifying that get_principal_from_request ignores the username query parameter when used for authorization while preserving the existing behavior for non-authorization calls.