### PR TITLE
RHCLOUD-47422 - RBAC - Add get_rbac_recent_changes tool for mcp server

### DIFF
--- a/rbac/management/mcp_views.py
+++ b/rbac/management/mcp_views.py
@@ -345,6 +345,7 @@ def _call_view(
 # │ list_permissions                 │ common    │ GET /api/v1/permissions/                   │
 # │ list_permission_options          │ common    │ GET /api/v1/permissions/options/            │
 # │ list_audit_logs                  │ common    │ GET /api/v1/auditlogs/                     │
+# │ get_rbac_recent_changes               │ common    │ (in-process audit log analysis)            │
 # │ list_groups                      │ common    │ GET /api/v1/groups/                        │
 # │ get_group                        │ common    │ GET /api/v1/groups/{uuid}/                 │
 # │ list_group_principals            │ common    │ GET /api/v1/groups/{uuid}/principals/      │
@@ -1723,6 +1724,101 @@ def _get_user_access_v1(request: HttpRequest, username: str) -> list[dict[str, A
             logger.warning("mcp: failed to get V1 access for user=%s app=%s", username, app, exc_info=True)
 
     return access_list
+
+
+@register_tool(
+    description=(
+        "Get a summary of recent RBAC changes. Returns changes grouped by resource type and action, "
+        "with statistics. Set 'days' (1-30, default 7) to control how far back to look. "
+        "Returns: total change count, changes by resource type (group/role/role_v2/workspace/role_binding), "
+        "changes by action (create/delete/edit/add/remove), top actors with change counts, "
+        "and the 100 most recent changes. "
+        "Use this tool to get an overview of what changed, then use list_audit_logs for details. "
+        "RESPONSE FORMAT: Consolidate by actor. For each actor: '<actor>: <count> <action> actions on "
+        "<resource_type> (<day of week>). <actor> holds <role name if known>.' "
+        "Note patterns like 'Matches expected automation pattern' for service accounts. "
+        "Format dates as day of week (Monday, Tuesday, etc.), not ISO timestamps."
+    ),
+    requires_auth=True,
+)
+def get_rbac_recent_changes(
+    request: HttpRequest,
+    *,
+    days: int = 7,
+) -> str:
+    """Get a summary of recent RBAC changes."""
+    days = min(max(days, 1), 30)
+
+    tenant = getattr(request, "tenant", None)
+    if not tenant:
+        return json.dumps({"error": "No tenant context available"})
+
+    cutoff = datetime.now(timezone.utc) - __import__("datetime").timedelta(days=days)
+
+    entries = AuditLog.objects.filter(tenant=tenant, created__gte=cutoff).order_by("-created")
+
+    total_count = entries.count()
+    if total_count == 0:
+        return json.dumps(
+            {
+                "summary": {
+                    "days_reviewed": days,
+                    "total_changes": 0,
+                    "message": f"No RBAC changes in the last {days} days.",
+                },
+                "by_resource_type": {},
+                "by_action": {},
+                "by_actor": {},
+                "recent_changes": [],
+            }
+        )
+
+    by_resource: dict[str, int] = {}
+    by_action: dict[str, int] = {}
+    by_actor: dict[str, int] = {}
+
+    entry_list = list(entries[:500])
+
+    for entry in entry_list:
+        rt = entry.resource_type
+        by_resource[rt] = by_resource.get(rt, 0) + 1
+
+        act = entry.action
+        by_action[act] = by_action.get(act, 0) + 1
+
+        actor = entry.principal_username
+        by_actor[actor] = by_actor.get(actor, 0) + 1
+
+    recent_changes = [
+        {
+            "actor": entry.principal_username,
+            "action": entry.action,
+            "resource_type": entry.resource_type,
+            "description": entry.description[:200],
+            "created": entry.created.isoformat() if entry.created else None,
+        }
+        for entry in entry_list[:100]
+    ]
+
+    sorted_actors = sorted(by_actor.items(), key=lambda x: x[1], reverse=True)[:10]
+    by_resource_sorted = dict(sorted(by_resource.items(), key=lambda x: x[1], reverse=True))
+    by_action_sorted = dict(sorted(by_action.items(), key=lambda x: x[1], reverse=True))
+
+    result = {
+        "summary": {
+            "days_reviewed": days,
+            "total_changes": total_count,
+            "unique_actors": len(by_actor),
+            "period_start": cutoff.isoformat(),
+            "period_end": datetime.now(timezone.utc).isoformat(),
+        },
+        "by_resource_type": by_resource_sorted,
+        "by_action": by_action_sorted,
+        "by_actor": dict(sorted_actors),
+        "recent_changes": recent_changes,
+    }
+
+    return json.dumps(result, default=str)
 
 
 def _get_user_access_v2(request: HttpRequest, principal: Principal, tenant: Any) -> list[dict[str, Any]]:

--- a/tests/management/test_mcp_views.py
+++ b/tests/management/test_mcp_views.py
@@ -660,6 +660,7 @@ class MCPViewTests(MCPToolTestMixin, IdentityRequest):
             "list_permissions",
             "list_permission_options",
             "list_audit_logs",
+            "get_rbac_recent_changes",
             "search_roles",
             "get_role",
             "list_role_access",
@@ -1010,6 +1011,117 @@ class MCPViewTests(MCPToolTestMixin, IdentityRequest):
         self.assertEqual(tool_output["meta"]["count"], 1)
         self.assertEqual(len(tool_output["data"]), 1)
         self.assertIn("target_role_alpha", tool_output["data"][0]["description"])
+
+    # --- get_rbac_recent_changes ---
+
+    def test_get_rbac_recent_changes_success(self):
+        """Positive: get_rbac_recent_changes returns summary of recent changes."""
+        response = self._call_tool("get_rbac_recent_changes")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertFalse(data["result"]["isError"])
+        tool_output = self._get_tool_output(response)
+        self.assertIn("summary", tool_output)
+        self.assertIn("by_resource_type", tool_output)
+        self.assertIn("by_action", tool_output)
+        self.assertIn("by_actor", tool_output)
+        self.assertIn("recent_changes", tool_output)
+
+    def test_get_rbac_recent_changes_without_auth_returns_error(self):
+        """Permission: get_rbac_recent_changes without auth returns auth error."""
+        response = self._call_tool("get_rbac_recent_changes", use_auth=False)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertIn("error", data)
+        self.assertEqual(data["error"]["code"], -32000)
+
+    def test_get_rbac_recent_changes_with_audit_data(self):
+        """Positive: get_rbac_recent_changes groups and summarizes audit data."""
+        AuditLog.objects.create(
+            principal_username="actor1",
+            resource_type=AuditLog.GROUP,
+            action=AuditLog.ADD,
+            description="user added to group",
+            tenant=self.tenant,
+        )
+        AuditLog.objects.create(
+            principal_username="actor1",
+            resource_type=AuditLog.ROLE,
+            action=AuditLog.CREATE,
+            description="Created role: test_role",
+            tenant=self.tenant,
+        )
+        AuditLog.objects.create(
+            principal_username="actor2",
+            resource_type=AuditLog.GROUP,
+            action=AuditLog.DELETE,
+            description="Deleted group: old_group",
+            tenant=self.tenant,
+        )
+
+        response = self._call_tool("get_rbac_recent_changes", {"days": 7})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        tool_output = self._get_tool_output(response)
+        self.assertEqual(tool_output["summary"]["total_changes"], 3)
+        self.assertEqual(tool_output["summary"]["unique_actors"], 2)
+        self.assertIn("group", tool_output["by_resource_type"])
+        self.assertIn("role", tool_output["by_resource_type"])
+        self.assertIn("add", tool_output["by_action"])
+        self.assertIn("create", tool_output["by_action"])
+        self.assertIn("delete", tool_output["by_action"])
+
+    def test_get_rbac_recent_changes_days_parameter(self):
+        """Positive: get_rbac_recent_changes respects days parameter."""
+        old_entry = AuditLog.objects.create(
+            principal_username="old_actor",
+            resource_type=AuditLog.GROUP,
+            action=AuditLog.ADD,
+            description="old action",
+            tenant=self.tenant,
+        )
+        old_entry.created = timezone.now() - __import__("datetime").timedelta(days=10)
+        old_entry.save()
+
+        AuditLog.objects.create(
+            principal_username="recent_actor",
+            resource_type=AuditLog.GROUP,
+            action=AuditLog.ADD,
+            description="recent action",
+            tenant=self.tenant,
+        )
+
+        response = self._call_tool("get_rbac_recent_changes", {"days": 7})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        tool_output = self._get_tool_output(response)
+        self.assertEqual(tool_output["summary"]["total_changes"], 1)
+        self.assertIn("recent_actor", tool_output["by_actor"])
+        self.assertNotIn("old_actor", tool_output["by_actor"])
+
+    def test_get_rbac_recent_changes_empty_result(self):
+        """Positive: get_rbac_recent_changes returns clean empty state when no changes."""
+        response = self._call_tool("get_rbac_recent_changes", {"days": 1})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        tool_output = self._get_tool_output(response)
+        self.assertEqual(tool_output["summary"]["total_changes"], 0)
+        self.assertEqual(tool_output["by_resource_type"], {})
+        self.assertEqual(tool_output["by_action"], {})
+
+    def test_get_rbac_recent_changes_clamps_days(self):
+        """Positive: get_rbac_recent_changes clamps days to valid range (1-30)."""
+        response = self._call_tool("get_rbac_recent_changes", {"days": 100})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        tool_output = self._get_tool_output(response)
+        self.assertEqual(tool_output["summary"]["days_reviewed"], 30)
+
+        response = self._call_tool("get_rbac_recent_changes", {"days": 0})
+        tool_output = self._get_tool_output(response)
+        self.assertEqual(tool_output["summary"]["days_reviewed"], 1)
 
     # --- list_groups / get_group / list_group_principals ---
 


### PR DESCRIPTION
## Link(s) to Jira
https://redhat.atlassian.net/browse/RHCLOUD-47422

## Description of Intent of Change(s)
  - Adds new MCP tool get_rbac_recent_changes that returns a grouped summary of recent RBAC changes
  - Provides statistics by resource type, action, and actor for quick overview
  - Returns up to 100 most recent changes with details
  - Supports configurable time window (1-30 days, default 7)

## Local Testing
How can the feature be exercised?
How can the bug be exploited and fix confirmed?
Is any special local setup required?

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Add a new MCP tool to provide a summarized view of recent RBAC changes based on audit logs.

New Features:
- Introduce the get_rbac_recent_changes MCP tool to summarize recent RBAC activity by resource type, action, and actor and list recent changes.

Tests:
- Add test coverage for get_rbac_recent_changes, including auth behavior, time-window filtering, empty states, and bounds on the days parameter.