### PR TITLE
RHCLOUD-47240: Add job to recompute tenant role bindings

### DIFF
--- a/rbac/internal/migrations/recompute_role_bindings.py
+++ b/rbac/internal/migrations/recompute_role_bindings.py
@@ -2,7 +2,7 @@ import itertools
 import logging
 from typing import Optional
 
-from django.db.models import Q, UUIDField, TextField, F
+from django.db.models import Q, UUIDField, F
 from django.db.models.functions import Cast
 from django.db.models.lookups import In
 

--- a/rbac/internal/migrations/recompute_role_bindings.py
+++ b/rbac/internal/migrations/recompute_role_bindings.py
@@ -1,0 +1,116 @@
+import itertools
+import logging
+from typing import Optional
+
+from django.db.models import Q, UUIDField, TextField, F
+from django.db.models.functions import Cast
+from django.db.models.lookups import In
+
+from api.models import Tenant
+from management.atomic_transactions import atomic, atomic_with_retry
+from management.relation_replicator.outbox_replicator import OutboxReplicator
+from management.relation_replicator.relation_replicator import (
+    RelationReplicator,
+    ReplicationEvent,
+    ReplicationEventType,
+    PartitionKey,
+)
+from management.role.model import BindingMapping
+from management.role.v2_model import RoleV2, CustomRoleV2
+from management.role_binding.model import RoleBinding
+from management.tenant_mapping.v2_activation import lock_tenant_version, TenantVersion
+from management.workspace.model import Workspace
+from migration_tool.migrate_binding_scope import migrate_all_role_bindings
+
+logger = logging.getLogger(__name__)
+
+
+@atomic
+def _do_tear_down_tenant(tenant: Tenant, replicator: RelationReplicator):
+    tenant_resource_id = tenant.tenant_resource_id()
+
+    if tenant_resource_id is None:
+        raise ValueError(f"Expected tenant to have resource ID; pk={tenant.pk!r}")
+
+    role_bindings = list(
+        RoleBinding.objects.filter(tenant=tenant)
+        .prefetch_related("role", "role__permissions", "principal_entries", "group_entries")
+        .select_for_update(of=["self"])
+    )
+
+    binding_mapping_predicate = Q(
+        resource_type_namespace="rbac",
+        resource_type_name="tenant",
+        resource_id=tenant_resource_id,
+    ) | (
+        Q(
+            resource_type_namespace="rbac",
+            resource_type_name="workspace",
+        )
+        & In(Cast(F("resource_id"), UUIDField()), Workspace.objects.filter(tenant=tenant).values("id"))
+    )
+
+    if len(role_bindings) > 0:
+        binding_mapping_predicate = binding_mapping_predicate | Q(
+            mappings__id__in=(str(rb.uuid) for rb in role_bindings)
+        )
+
+    binding_mappings = list(BindingMapping.objects.filter(binding_mapping_predicate).select_for_update())
+
+    v2_roles = list(
+        CustomRoleV2.objects.filter(tenant=tenant)
+        .prefetch_related("tenant", "permissions")
+        .select_for_update(of=["self"])
+    )
+
+    logger.info(
+        f"Found {len(binding_mappings)} BindingMappings, {len(role_bindings)} RoleBindings, and "
+        f"{len(v2_roles)} custom RoleV2s in tenant with pk={tenant.pk!r}. "
+        f"Deleting them in order to recompute all bindings."
+    )
+
+    tuples_to_remove = {
+        *itertools.chain.from_iterable(bm.as_tuples() for bm in binding_mappings),
+        *itertools.chain.from_iterable(rb.all_tuples() for rb in role_bindings),
+        *itertools.chain.from_iterable(RoleV2.tuples_for_delete(r) for r in v2_roles),
+    }
+
+    for batch in itertools.batched(tuples_to_remove, 1000):
+        replicator.replicate(
+            ReplicationEvent(
+                event_type=ReplicationEventType.REMIGRATE_ROLE_BINDING,
+                partition_key=PartitionKey.byEnvironment(),
+                remove=list(batch),
+                info={"org_id": tenant.org_id},
+            )
+        )
+
+    RoleBinding.objects.filter(pk__in=(rb.pk for rb in role_bindings)).delete()
+    BindingMapping.objects.filter(pk__in=(bm.pk for bm in binding_mappings)).delete()
+    CustomRoleV2.objects.filter(pk__in=(r.pk for r in v2_roles)).delete()
+
+
+@atomic_with_retry(retries=3)
+def _do_recreate_bindings(tenant: Tenant, replicator: RelationReplicator):
+    tenant = Tenant.objects.get(pk=tenant.pk)
+    tenant_version = lock_tenant_version(tenant)
+
+    if tenant_version != TenantVersion.VERSION_1:
+        logger.info(f"Not recreating role bindings for non-V1 tenant: pk={tenant.pk!r}")
+        return
+
+    _do_tear_down_tenant(tenant, replicator)
+    migrate_all_role_bindings(replicator=replicator, tenant=tenant)
+
+
+def recompute_tenant_role_bindings(tenant: Tenant, replicator: Optional[RelationReplicator] = None):
+    """Recompute all BindingMappings and RoleBindings for a V1 tenant."""
+    if replicator is None:
+        replicator = OutboxReplicator()
+
+    if tenant.tenant_name == "public":
+        raise ValueError("Cannot recompute bindings for the public tenant")
+
+    logger.info(f"Recomputing bindings for tenant: pk={tenant.pk!r}, org_id={tenant.org_id!r}")
+
+    _do_recreate_bindings(tenant, replicator)

--- a/rbac/internal/migrations/remove_orphan_relations.py
+++ b/rbac/internal/migrations/remove_orphan_relations.py
@@ -418,6 +418,7 @@ def _remove_orphaned_custom_role_relations(
             roles_by_id: dict[str, RoleV2] = {
                 str(r.uuid): r
                 for r in RoleV2.objects.filter(uuid__in=custom_role_ids)
+                .select_related("tenant")
                 .prefetch_related("permissions")
                 .select_for_update(of=["self"])
             }
@@ -430,15 +431,7 @@ def _remove_orphaned_custom_role_relations(
                 if local_role is None:
                     expected_relations: set[RelationTuple] = set()
                 else:
-                    expected_relations = {
-                        _as_relation_tuple(role_permission_tuple(role_id=role_id, permission=p.v2_string()))
-                        for p in local_role.permissions.all()
-                    }
-                    tenant_resource_id = local_role.tenant.tenant_resource_id()
-                    if tenant_resource_id:
-                        expected_relations.add(
-                            _as_relation_tuple(role_owner_relationship(local_role.uuid, tenant_resource_id))
-                        )
+                    expected_relations = set(RoleV2.tuples_for_create(local_role))
 
                 orphan_relations = actual_relations - expected_relations
 

--- a/rbac/internal/urls.py
+++ b/rbac/internal/urls.py
@@ -130,6 +130,7 @@ urlpatterns = [
         name="mcp-tool-descriptions-detail",
     ),
     path("api/utils/replicate_default_workspaces/", views.replicate_default_workspaces),
+    path("api/utils/recompute_tenant_role_bindings/<str:org_id>/", views.recompute_tenant_role_bindings),
 ]
 
 urlpatterns.extend(integration_urlpatterns)

--- a/rbac/internal/utils.py
+++ b/rbac/internal/utils.py
@@ -50,7 +50,7 @@ from management.relation_replicator.relation_replicator import (
 )
 from management.relation_replicator.relations_api_replicator import RelationsApiReplicator
 from management.relation_replicator.types import RelationTuple
-from management.role.v2_model import CustomRoleV2, RoleV2
+from management.role.v2_model import RoleV2
 from management.role_binding.model import RoleBinding, RoleBindingPrincipal
 from management.tenant_mapping.model import DefaultAccessType, TenantMapping
 from management.tenant_mapping.v2_activation import (
@@ -498,7 +498,7 @@ def _do_replicate_missing_binding_tuples_batch(tenant_id: int, raw_role_bindings
     role_bindings = list(
         RoleBinding.objects.filter(pk__in=(b.pk for b in raw_role_bindings))
         .exclude(uuid__in=builtin_binding_ids)
-        .select_related("role")
+        .select_related("role", "role__tenant")
         .prefetch_related("group_entries", "principal_entries", "role__permissions")
         .select_for_update(of=["self"])
     )
@@ -542,14 +542,7 @@ def _do_replicate_missing_binding_tuples_batch(tenant_id: int, raw_role_bindings
         # Ensure that we additionally re-replicate the relevant role (if it's a custom role).
         if role_binding.role.type == RoleV2.Types.CUSTOM:
             if role_binding.role.id not in role_tuples_by_role_id:
-                to_add, to_remove = CustomRoleV2.replication_tuples(
-                    role=role_binding.role, new_permissions=list(role_binding.role.permissions.all())
-                )
-
-                if len(to_remove) > 0:
-                    raise AssertionError(f"Should not have relations to remove, but got: {to_remove}")
-
-                role_tuples_by_role_id[role_binding.role.id] = to_add
+                role_tuples_by_role_id[role_binding.role.id] = RoleV2.tuples_for_create(role_binding.role)
 
     replicator = OutboxReplicator()
 

--- a/rbac/internal/views.py
+++ b/rbac/internal/views.py
@@ -92,6 +92,7 @@ from management.tasks import (
     fix_missing_binding_base_tuples_in_worker,
     migrate_binding_scope_in_worker,
     migrate_data_in_worker,
+    recompute_tenant_role_bindings_in_worker,
     remove_deleted_workspace_bindings_in_worker,
     remove_unassigned_system_binding_mappings_in_worker,
     replicate_default_workspaces_in_worker,
@@ -2598,3 +2599,29 @@ def replicate_default_workspaces(request):
     except Exception as e:
         logger.exception("Error replicating default workspaces", exc_info=True)
         return JsonResponse({"detail": f"Error replicating default workspaces: {str(e)}"}, status=500)
+
+
+@require_http_methods(["POST"])
+def recompute_tenant_role_bindings(request, org_id):
+    """
+    Recompute all role bindings for a tenant.
+
+    POST /_private/api/utils/recompute_tenant_role_bindings/<org_id>/
+
+    This endpoint should be used for V1 tenants that have gotten into an inconsistent V2 state.
+
+    Returns:
+        JSON response indicating the task has been queued
+    """
+    # Validate tenant exists
+    tenant = get_object_or_404(Tenant, org_id=org_id)
+
+    try:
+        recompute_tenant_role_bindings_in_worker.delay(org_id=tenant.org_id)
+        return JsonResponse({"message": "Job enqueued in background worker."}, status=202)
+    except Exception as e:
+        logger.exception(f"Error recomputing role bindings for tenant {org_id}")
+        return JsonResponse(
+            {"detail": f"Error recomputing role bindings for tenant: {str(e)}"},
+            status=500,
+        )

--- a/rbac/management/role/v2_model.py
+++ b/rbac/management/role/v2_model.py
@@ -197,7 +197,7 @@ class RoleV2(TenantAwareModel):
         The role's tenant will be loaded (and thus should be preloaded for bulk operations).
         If cached_permissions is not provided, the permissions from the role are loaded.
         """
-        return CustomRoleV2._permission_and_owner_tuples(role=role, cached_permissions=cached_permissions)
+        return RoleV2._permission_and_owner_tuples(role=role, cached_permissions=cached_permissions)
 
 
 class TypedRoleV2Manager(models.Manager):

--- a/rbac/management/role/v2_model.py
+++ b/rbac/management/role/v2_model.py
@@ -29,9 +29,10 @@ from django.utils import timezone
 from management.exceptions import RequiredFieldError
 from management.models import Permission, Role
 from management.rbac_fields import AutoDateTimeField
-from management.relation_replicator.types import ObjectReference, ObjectType, RelationTuple, SubjectReference
+from management.relation_replicator.types import RelationTuple
 from management.role.queryset import RoleV2QuerySet
-from migration_tool.models import V2role
+from management.role.relations import role_owner_relationship
+from migration_tool.models import V2role, role_permission_tuple
 from rest_framework import serializers
 from uuid_utils.compat import uuid7
 
@@ -113,6 +114,91 @@ class RoleV2(TenantAwareModel):
         """Get the set of V2 strings for the permissions of this role."""
         return set(p.v2_string() for p in self.permissions.all())
 
+    @staticmethod
+    def _permission_tuple(role: "RoleV2", permission: Permission) -> RelationTuple:
+        return role_permission_tuple(role_id=str(role.uuid), permission=permission.v2_string())
+
+    @staticmethod
+    def _permission_and_owner_tuples(role: "RoleV2", cached_permissions: Optional[Iterable[Permission]]):
+        tenant_resource_id = role.tenant.tenant_resource_id()
+
+        if role.type == RoleV2.Types.CUSTOM:
+            if tenant_resource_id is None:
+                raise RuntimeError(
+                    f"Expected custom roles to be created in a tenant with a valid resource ID; "
+                    f"got tenant pk={role.tenant.pk!r}"
+                )
+        else:
+            if tenant_resource_id is not None:
+                raise RuntimeError(
+                    f"Expected non-custom roles to be created in the public tenant "
+                    f"(which doesn't have a valid resource ID); "
+                    f"got tenant pk={role.tenant.pk!r}"
+                )
+
+        if cached_permissions is None:
+            cached_permissions = role.permissions.all()
+
+        tuples = list({RoleV2._permission_tuple(role, p) for p in cached_permissions})
+
+        if tenant_resource_id is not None:
+            tuples.append(role_owner_relationship(role_uuid=str(role.uuid), tenant_resource_id=tenant_resource_id))
+
+        return tuples
+
+    @staticmethod
+    def tuples_for_update(
+        role: "RoleV2",
+        *,
+        old_permissions: Iterable[Permission],
+        new_permissions: Iterable[Permission],
+    ) -> tuple[list[RelationTuple], list[RelationTuple]]:
+        """Get the tuples that should be added and removed when updating a role.
+
+        Args:
+            role: The role being created, updated, or deleted.
+            old_permissions: Permissions before mutation (empty for create).
+            new_permissions: Permissions after mutation (empty for delete).
+
+        Returns:
+            ``(tuples_to_add, tuples_to_remove)`` ready for replication.
+        """
+        old_set = set(old_permissions)
+        new_set = set(new_permissions)
+
+        tuples_to_add = [RoleV2._permission_tuple(role, p) for p in new_set - old_set]
+        tuples_to_remove = [RoleV2._permission_tuple(role, p) for p in old_set - new_set]
+
+        return tuples_to_add, tuples_to_remove
+
+    # Although create and delete happen to use the same tuples currently, they are semantically different operations.
+    # We use separate functions for them in order to be clearer at the call site and to ensure they can diverge in
+    # the future without having to update every call site.
+
+    @staticmethod
+    def tuples_for_create(
+        role: "RoleV2", cached_permissions: Optional[Iterable[Permission]] = None
+    ) -> list[RelationTuple]:
+        """
+        Get the tuples that should be added when creating a role.
+
+        The role's tenant will be loaded (and thus should be preloaded for bulk operations).
+        If cached_permissions is not provided, the permissions from the role are loaded.
+        """
+        return RoleV2._permission_and_owner_tuples(role=role, cached_permissions=cached_permissions)
+
+    @staticmethod
+    def tuples_for_delete(
+        role: "RoleV2", cached_permissions: Optional[Iterable[Permission]] = None
+    ) -> list[RelationTuple]:
+        """
+        Get the tuples that should be removed when deleting a role.
+
+        The role's tenant will be loaded (and thus should be preloaded for bulk operations).
+        If cached_permissions is not provided, the permissions from the role are loaded.
+        """
+        return CustomRoleV2._permission_and_owner_tuples(role=role, cached_permissions=cached_permissions)
+
 
 class TypedRoleV2Manager(models.Manager):
     """Manager for RoleV2 with a specific type."""
@@ -177,49 +263,6 @@ class CustomRoleV2(TypeValidatedRoleV2Mixin, RoleV2):
 
     _expected_type = RoleV2.Types.CUSTOM
     objects = TypedRoleV2Manager(role_type=_expected_type)
-
-    @staticmethod
-    def _permission_tuple(role: "CustomRoleV2", permission: Permission) -> RelationTuple:
-        """Build a single ``rbac/role:<uuid>#<perm>@rbac/principal:*`` tuple."""
-        return RelationTuple(
-            resource=ObjectReference(
-                type=ObjectType(namespace="rbac", name="role"),
-                id=str(role.uuid),
-            ),
-            relation=permission.v2_string(),
-            subject=SubjectReference(
-                subject=ObjectReference(
-                    type=ObjectType(namespace="rbac", name="principal"),
-                    id="*",
-                ),
-            ),
-        )
-
-    @staticmethod
-    def replication_tuples(
-        role: "CustomRoleV2",
-        old_permissions: Iterable[Permission] = (),
-        new_permissions: Iterable[Permission] = (),
-    ) -> tuple[list[RelationTuple], list[RelationTuple]]:
-        """Compute the delta (tuples to add vs. remove) for a role create, update, or delete.
-
-        Pure data transformation -- no DB writes.
-
-        Args:
-            role: The role being created, updated, or deleted.
-            old_permissions: Permissions before mutation (empty for create).
-            new_permissions: Permissions after mutation (empty for delete).
-
-        Returns:
-            ``(tuples_to_add, tuples_to_remove)`` ready for replication.
-        """
-        old_set = set(old_permissions)
-        new_set = set(new_permissions)
-
-        tuples_to_add = [CustomRoleV2._permission_tuple(role, p) for p in new_set - old_set]
-        tuples_to_remove = [CustomRoleV2._permission_tuple(role, p) for p in old_set - new_set]
-
-        return tuples_to_add, tuples_to_remove
 
     def update(self, name: str, description: str):
         """Update the role's mutable attributes."""

--- a/rbac/management/role/v2_service.py
+++ b/rbac/management/role/v2_service.py
@@ -46,7 +46,6 @@ from management.relation_replicator.relation_replicator import (
     ReplicationEvent,
     ReplicationEventType,
 )
-from management.role.relations import role_owner_relationship
 from management.role.v2_exceptions import (
     CustomRoleRequiredError,
     InvalidRolePermissionsError,
@@ -156,11 +155,7 @@ class RoleV2Service:
             role.save()
             role.permissions.set(permissions)
 
-            tuples_to_add, _ = CustomRoleV2.replication_tuples(role, new_permissions=permissions)
-
-            tenant_resource_id = tenant.tenant_resource_id()
-            if tenant_resource_id:
-                tuples_to_add.append(role_owner_relationship(role.uuid, tenant_resource_id))
+            tuples_to_add = RoleV2.tuples_for_create(role=role, cached_permissions=permissions)
 
             self._replicator.replicate(
                 ReplicationEvent(
@@ -229,7 +224,7 @@ class RoleV2Service:
             role.save()
             role.permissions.set(permissions)
 
-            tuples_to_add, tuples_to_remove = CustomRoleV2.replication_tuples(
+            tuples_to_add, tuples_to_remove = RoleV2.tuples_for_update(
                 role, old_permissions=old_permissions, new_permissions=permissions
             )
 
@@ -365,6 +360,7 @@ class RoleV2Service:
         # necessarily use SERIALIZABLE transactions.
         roles_to_remove = list(
             CustomRoleV2.objects.filter(pk__in=(r.pk for r in roles))
+            .select_related("tenant")
             .prefetch_related("permissions")
             .select_for_update(of=["self"])
         )
@@ -378,20 +374,7 @@ class RoleV2Service:
             binding_pks_to_remove.append(role_binding.pk)
 
         for role in roles_to_remove:
-            to_add, to_remove = CustomRoleV2.replication_tuples(
-                role=role,
-                old_permissions=list(role.permissions.all()),
-                new_permissions=[],
-            )
-
-            if len(to_add) != 0:
-                raise AssertionError("Relations should not be added while deleting roles.")
-
-            relations_to_remove.extend(to_remove)
-
-            tenant_resource_id = role.tenant.tenant_resource_id()
-            if tenant_resource_id:
-                relations_to_remove.append(role_owner_relationship(role.uuid, tenant_resource_id))
+            relations_to_remove.extend(RoleV2.tuples_for_delete(role=role))
 
         self._replicator.replicate(
             ReplicationEvent(

--- a/rbac/management/tasks.py
+++ b/rbac/management/tasks.py
@@ -22,6 +22,7 @@ from typing import Optional
 
 from celery import shared_task
 from django.core.management import call_command
+from internal.migrations.recompute_role_bindings import recompute_tenant_role_bindings
 from internal.migrations.remove_deleted_workspace_bindings import remove_deleted_workspace_bindings
 from internal.migrations.remove_orphan_relations import cleanup_tenant_orphan_bindings
 from internal.migrations.replicate_default_workspaces import replicate_default_workspaces
@@ -38,6 +39,8 @@ from management.principal.cleaner import (
 )
 from migration_tool.migrate import migrate_data
 from migration_tool.migrate_binding_scope import migrate_all_role_bindings
+
+from api.models import Tenant
 
 
 @shared_task
@@ -170,3 +173,9 @@ def remove_deleted_workspace_bindings_in_worker():
 def replicate_default_workspaces_in_worker(limit: Optional[int] = None):
     """Celery task to replicate default workspaces."""
     return replicate_default_workspaces(limit=limit)
+
+
+@shared_task
+def recompute_tenant_role_bindings_in_worker(org_id: str):
+    """Celery task to recompute role bindings for tenant."""
+    return recompute_tenant_role_bindings(tenant=Tenant.objects.get(org_id=org_id))

--- a/tests/internal/migrations/test_recompute_role_bindings.py
+++ b/tests/internal/migrations/test_recompute_role_bindings.py
@@ -1,0 +1,70 @@
+from django.db import transaction
+
+from internal.migrations.recompute_role_bindings import recompute_tenant_role_bindings
+from management.role.model import BindingMapping
+from management.role.v2_model import CustomRoleV2
+from management.role_binding.model import RoleBinding
+from migration_tool.in_memory_tuples import InMemoryRelationReplicator
+from tests.management.role.test_dual_write import DualWriteTestCase
+from django.test import override_settings
+
+from tests.util import assert_v1_v2_tuples_fully_consistent
+
+
+@override_settings(ATOMIC_RETRY_DISABLED=True, TENANT_SCOPE_PERMISSIONS="", ROOT_SCOPE_PERMISSIONS="")
+class RecomputeRoleBindingsTest(DualWriteTestCase):
+    def _do_test_recompute(self, delete_custom: bool, delete_v2: bool):
+        system_role = self.given_v1_system_role("system role", ["rbac:*:*"])
+        custom_role = self.given_v1_role("custom role", default=["rbac:*:*"])
+
+        group, _ = self.given_group("group", ["p1"])
+
+        def assert_assignments():
+            self.assertEqual(1, BindingMapping.objects.filter(role=system_role).count())
+            self.assertEqual(1, BindingMapping.objects.filter(role=custom_role).count())
+
+            self.assertEqual(1, RoleBinding.objects.filter(role__v1_source=system_role).count())
+            self.assertEqual(1, RoleBinding.objects.filter(role__v1_source=custom_role).count())
+
+            self.expect_1_role_binding_to_workspace(
+                self.default_workspace(),
+                for_v2_roles=[str(system_role.uuid)],
+                for_groups=[
+                    str(group.uuid),
+                ],
+            )
+
+            self.expect_1_role_binding_to_workspace(
+                self.default_workspace(),
+                for_v2_roles=[str(CustomRoleV2.objects.get(v1_source=custom_role).uuid)],
+                for_groups=[str(group.uuid)],
+            )
+
+        self.given_roles_assigned_to_group(group, [system_role, custom_role])
+        assert_assignments()
+
+        target_role = custom_role if delete_custom else system_role
+
+        if delete_v2:
+            _, deleted_counts = RoleBinding.objects.filter(role__v1_source=target_role).delete()
+            self.assertEqual(deleted_counts["management.RoleBinding"], 1)
+        else:
+            _, deleted_counts = BindingMapping.objects.filter(role=target_role).delete()
+            self.assertEqual(deleted_counts["management.BindingMapping"], 1)
+
+        recompute_tenant_role_bindings(tenant=self.tenant, replicator=InMemoryRelationReplicator(self.tuples))
+
+        assert_assignments()
+        assert_v1_v2_tuples_fully_consistent(test=self, tuples=self.tuples)
+
+    def test_recompute_system_missing_v1(self):
+        self._do_test_recompute(delete_custom=False, delete_v2=False)
+
+    def test_recompute_custom_missing_v1(self):
+        self._do_test_recompute(delete_custom=True, delete_v2=False)
+
+    def test_recompute_system_missing_v2(self):
+        self._do_test_recompute(delete_custom=False, delete_v2=True)
+
+    def test_recompute_custom_missing_v2(self):
+        self._do_test_recompute(delete_custom=True, delete_v2=True)

--- a/tests/internal/test_utils.py
+++ b/tests/internal/test_utils.py
@@ -254,7 +254,7 @@ class ReplicateMissingBindingTuplesTest(TestCase):
 
         replicate_missing_binding_tuples()
 
-        self.assertEqual(len(self.tuples), 4)
+        self.assertEqual(len(self.tuples), 5)
 
         self.assertEqual(
             1,
@@ -285,6 +285,17 @@ class ReplicateMissingBindingTuplesTest(TestCase):
                     resource("rbac", "role", str(role.uuid)),
                     relation("rbac_all_all"),
                     subject("rbac", "principal", "*"),
+                )
+            ),
+        )
+
+        self.assertEqual(
+            1,
+            self.tuples.count_tuples(
+                all_of(
+                    resource("rbac", "role", str(role.uuid)),
+                    relation("owner"),
+                    subject("rbac", "tenant", self.tenant.tenant_resource_id()),
                 )
             ),
         )

--- a/tests/management/role/test_v2_model.py
+++ b/tests/management/role/test_v2_model.py
@@ -33,7 +33,9 @@ from management.models import (
 )
 from management.principal.model import Principal
 from management.relation_replicator.types import ObjectReference, ObjectType, RelationTuple, SubjectReference
+from management.role.relations import role_owner_relationship
 from management.role_binding.model import RoleBindingPrincipal
+from migration_tool.models import role_permission_tuple
 from tests.identity_request import IdentityRequest
 from tests.v2_util import seed_v2_role_from_v1
 
@@ -518,8 +520,8 @@ class RoleV2QuerySetTests(IdentityRequest):
         self.assertEqual(RoleV2.objects.assignable().count(), 0)
 
 
-class CustomRoleV2ReplicationTupleTests(IdentityRequest):
-    """Tests for CustomRoleV2 relation tuple generation methods."""
+class RoleV2ReplicationTupleTests(IdentityRequest):
+    """Tests for RoleV2 relation tuple generation methods."""
 
     def setUp(self):
         """Set up test data."""
@@ -527,39 +529,26 @@ class CustomRoleV2ReplicationTupleTests(IdentityRequest):
         self.perm_read = Permission.objects.create(permission="app:resource:read", tenant=self.tenant)
         self.perm_write = Permission.objects.create(permission="app:resource:write", tenant=self.tenant)
         self.perm_delete = Permission.objects.create(permission="app:resource:delete", tenant=self.tenant)
-        self.role = CustomRoleV2.objects.create(name="test_role", tenant=self.tenant)
 
-    def tearDown(self):
-        """Tear down."""
-        RoleV2.objects.all().delete()
-        Permission.objects.filter(tenant=self.tenant).delete()
+        self.custom_role = CustomRoleV2.objects.create(name="test_role", tenant=self.tenant)
+        self.seeded_role = SeededRoleV2.objects.create(
+            name="system_role", tenant=Tenant.objects.get(tenant_name="public")
+        )
 
-    def _permission_tuple(self, permission: Permission) -> RelationTuple:
+    def _custom_role_owner_tuple(self) -> RelationTuple:
+        return role_owner_relationship(
+            role_uuid=str(self.custom_role.uuid), tenant_resource_id=self.tenant.tenant_resource_id()
+        )
+
+    def _permission_tuple(self, role: RoleV2, permission: Permission) -> RelationTuple:
         """Build the expected permission tuple for self.role."""
-        return RelationTuple(
-            resource=ObjectReference(type=ObjectType(namespace="rbac", name="role"), id=str(self.role.uuid)),
-            relation=permission.v2_string(),
-            subject=SubjectReference(
-                subject=ObjectReference(type=ObjectType(namespace="rbac", name="principal"), id="*")
-            ),
-        )
+        return role_permission_tuple(role_id=str(role.uuid), permission=permission.v2_string())
 
-    # ── _permission_tuple ─────────────────────────────────────────────
-
-    def test_permission_tuple_returns_exact_tuple(self):
-        """_permission_tuple builds rbac/role:<uuid>#<perm>@rbac/principal:*."""
-        self.assertEqual(
-            CustomRoleV2._permission_tuple(self.role, self.perm_read),
-            self._permission_tuple(self.perm_read),
-        )
-
-    # ── replication_tuples (permission delta) ─────────────────────────
-
-    def test_replication_tuples_computes_permission_diff(self):
-        """replication_tuples returns the exact delta for each role lifecycle operation."""
-        read = self._permission_tuple(self.perm_read)
-        write = self._permission_tuple(self.perm_write)
-        delete = self._permission_tuple(self.perm_delete)
+    def test_tuples_for_update_computes_permission_diff(self):
+        """Test that tuples_for_update correctly computes permission differences."""
+        read = self._permission_tuple(self.custom_role, self.perm_read)
+        write = self._permission_tuple(self.custom_role, self.perm_write)
+        delete = self._permission_tuple(self.custom_role, self.perm_delete)
 
         cases = [
             (
@@ -591,30 +580,51 @@ class CustomRoleV2ReplicationTupleTests(IdentityRequest):
                 {read, write},
             ),
         ]
+
         for label, old, new, expected_add, expected_remove in cases:
             with self.subTest(label):
-                to_add, to_remove = CustomRoleV2.replication_tuples(
-                    self.role, old_permissions=old, new_permissions=new
+                to_add, to_remove = RoleV2.tuples_for_update(
+                    self.custom_role, old_permissions=old, new_permissions=new
                 )
                 self.assertEqual(set(to_add), expected_add)
                 self.assertEqual(set(to_remove), expected_remove)
 
-    # ── replication_tuples (delete with bindings) ─────────────────────
+    def test_tuples_for_custom(self):
+        """Test that creating/deleting a custom role uses both permission tuples and the owner tuple."""
+        self.custom_role.permissions.set([self.perm_read])
 
-    def test_replication_tuples_delete_includes_binding_and_subject_tuples(self):
-        """Deleting a role removes permission tuples and all associated binding tuples."""
-        group = Group.objects.create(name="g1", tenant=self.tenant)
-        principal = Principal.objects.create(tenant=self.tenant, username="u1", user_id="uid1")
-        principal_resource_id = Principal.user_id_to_principal_resource_id(principal.user_id)
+        # These are semantically different, but they have the same behavior for the moment. We test them together for
+        # simplicity.
+        cases = [
+            ("create", RoleV2.tuples_for_create),
+            ("delete", RoleV2.tuples_for_delete),
+        ]
 
-        to_add, to_remove = CustomRoleV2.replication_tuples(
-            self.role,
-            old_permissions=[self.perm_read],
-        )
+        for label, function in cases:
+            with self.subTest(label):
+                self.assertCountEqual(
+                    function(self.custom_role),
+                    {
+                        self._permission_tuple(self.custom_role, self.perm_read),
+                        self._custom_role_owner_tuple(),
+                    },
+                )
 
-        expected_remove = {
-            self._permission_tuple(self.perm_read),
-        }
+    def test_tuples_for_delete_seeded(self):
+        """Test that creating/deleting a seeded role uses only permission tuples."""
+        self.seeded_role.permissions.set([self.perm_read])
 
-        self.assertEqual(set(to_add), set())
-        self.assertEqual(set(to_remove), expected_remove)
+        # Tested together for the reasons given above.
+        cases = [
+            ("create", RoleV2.tuples_for_create),
+            ("delete", RoleV2.tuples_for_delete),
+        ]
+
+        for label, function in cases:
+            with self.subTest(label):
+                self.assertCountEqual(
+                    function(self.seeded_role),
+                    {
+                        self._permission_tuple(self.seeded_role, self.perm_read),
+                    },
+                )


### PR DESCRIPTION
## Link(s) to Jira
[RHCLOUD-47240](https://redhat.atlassian.net/browse/RHCLOUD-47240)

## Description of Intent of Change(s)
Stage and prod each have one tenant with inconsistent `BindingMapping`s and `RoleBinding`s. Add a job to delete all V2 state from that tenant and start over from scratch.

[RHCLOUD-47240]: https://redhat.atlassian.net/browse/RHCLOUD-47240?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Add a background job and internal API to recompute all role bindings for a tenant with inconsistent V2 state, and centralize RoleV2 relation tuple generation for permissions and ownership across creation, update, deletion, and cleanup flows.

New Features:
- Introduce an internal POST endpoint to enqueue recomputation of all role bindings for a given tenant org ID.
- Add a Celery task and migration helper to tear down and fully recompute V2 role bindings and binding mappings for V1 tenants.

Enhancements:
- Unify RoleV2 relation tuple generation for permissions and owner relationships across create, update, delete, and cleanup logic.
- Ensure role and tenant relations are eagerly loaded where needed to support relation tuple recomputation and orphan cleanup.

Tests:
- Add tests covering RoleV2 relation tuple generation for custom and seeded roles.
- Add integration tests validating recomputation of tenant role bindings restores consistent V1/V2 state and tuples.
- Update existing internal utility tests to assert presence of role owner tuples in replicated bindings.