### PR TITLE
Handle empty type name in tuple lookup

### DIFF
--- a/rbac/management/relation_replicator/relations_api_replicator.py
+++ b/rbac/management/relation_replicator/relations_api_replicator.py
@@ -264,6 +264,9 @@ class RelationsApiReplicator(RelationReplicator):
         if (pagination_limit is None) and (continuation_token is not None):
             raise TypeError("A pagination limit must be provided if a continuation token is.")
 
+        if not resource_type and not subject_type:
+            raise ValueError("At least one of resource_type and subject_type must be provided")
+
         if resource_namespace is None:
             resource_namespace = "rbac" if resource_type != "" else ""
 

--- a/rbac/management/relation_replicator/relations_api_replicator.py
+++ b/rbac/management/relation_replicator/relations_api_replicator.py
@@ -238,8 +238,8 @@ class RelationsApiReplicator(RelationReplicator):
         subject_type: str = "",
         subject_id: str = "",
         subject_relation: Optional[str] = None,
-        resource_namespace: str = "rbac",
-        subject_namespace: str = "rbac",
+        resource_namespace: Optional[str] = None,
+        subject_namespace: Optional[str] = None,
         pagination_limit: Optional[int] = None,
         continuation_token: Optional[str] = None,
     ) -> list[dict]:
@@ -263,6 +263,12 @@ class RelationsApiReplicator(RelationReplicator):
         """
         if (pagination_limit is None) and (continuation_token is not None):
             raise TypeError("A pagination limit must be provided if a continuation token is.")
+
+        if resource_namespace is None:
+            resource_namespace = "rbac" if resource_type != "" else ""
+
+        if subject_namespace is None:
+            subject_namespace = "rbac" if subject_type != "" else ""
 
         # Get JWT token for authentication
         token = jwt_manager.get_jwt_from_redis()

--- a/rbac/migration_tool/in_memory_tuples.py
+++ b/rbac/migration_tool/in_memory_tuples.py
@@ -439,14 +439,18 @@ def relation(relation: str) -> RelationPredicate:
     return TuplePredicate(predicate, f'relation("{relation}")')
 
 
-def subject_type(namespace: str, name: str, relation: Optional[str] = None) -> RelationPredicate:
+def subject_type(
+    namespace: str, name: str, relation: Optional[str] = None, any_relation: bool = False
+) -> RelationPredicate:
     """Return a predicate that is true if the subject type matches the given namespace and name."""
+    if any_relation and (relation is not None):
+        raise ValueError("Cannot both have any_relation set and provide a specific relation")
 
     def predicate(rel: RelationTuple) -> bool:
         return (
             rel.subject.subject.type.namespace == namespace
             and rel.subject.subject.type.name == name
-            and rel.subject.relation == relation
+            and (any_relation or rel.subject.relation == relation)
         )
 
     return TuplePredicate(predicate, f'subject_type("{namespace}", "{name}")')

--- a/tests/v2_util.py
+++ b/tests/v2_util.py
@@ -51,6 +51,9 @@ def make_read_tuples_mock(tuples: InMemoryTuples) -> Callable[[str, str, str, st
         # Build a filter based on the provided parameters
         filters = []
 
+        if not resource_type_name and not subject_type_name:
+            raise ValueError("At least one of resource_type_name and subject_type_name must be provided")
+
         if resource_type_name:
             filters.append(in_memory_tuples.resource_type("rbac", resource_type_name))
 

--- a/tests/v2_util.py
+++ b/tests/v2_util.py
@@ -13,11 +13,9 @@ from management.relation_replicator.relation_replicator import (
 from management.role.v2_model import SeededRoleV2
 from management.tenant_service import V2TenantBootstrapService
 from management.tenant_service.tenant_service import BootstrappedTenant
+from migration_tool import in_memory_tuples
 from migration_tool.in_memory_tuples import (
-    resource,
     all_of,
-    relation,
-    resource_type,
     InMemoryTuples,
     InMemoryRelationReplicator,
 )
@@ -51,13 +49,24 @@ def make_read_tuples_mock(tuples: InMemoryTuples) -> Callable[[str, str, str, st
     def read_tuples_fn(resource_type_name, resource_id, relation_name, subject_type_name, subject_id):
         """Mock function to read tuples from InMemoryTuples."""
         # Build a filter based on the provided parameters
-        filters = [resource_type("rbac", resource_type_name)]
+        filters = []
+
+        if resource_type_name:
+            filters.append(in_memory_tuples.resource_type("rbac", resource_type_name))
 
         if resource_id:
-            filters.append(resource("rbac", resource_type_name, resource_id))
+            filters.append(in_memory_tuples.resource_id(resource_id))
 
         if relation_name:
-            filters.append(relation(relation_name))
+            filters.append(in_memory_tuples.relation(relation_name))
+
+        if subject_type_name:
+            # Note that SpiceDB does not filter based on the subject relation unless it's explicitly provided (which
+            # we do not do here or in the actual lookup).
+            filters.append(in_memory_tuples.subject_type("rbac", subject_type_name, any_relation=True))
+
+        if subject_id:
+            filters.append(in_memory_tuples.subject_id(subject_id))
 
         found_tuples = tuples.find_tuples(all_of(*filters))
 
@@ -65,12 +74,6 @@ def make_read_tuples_mock(tuples: InMemoryTuples) -> Callable[[str, str, str, st
         # Format: {"tuple": {"resource": {...}, "relation": "...", "subject": {...}}, ...}
         result = []
         for t in found_tuples:
-            # Filter by subject type and id if provided
-            if subject_type_name and t.subject.subject.type.name != subject_type_name:
-                continue
-            if subject_id and t.subject.subject.id != subject_id:
-                continue
-
             subject_dict = {
                 "subject": {
                     "type": {


### PR DESCRIPTION
## Link(s) to Jira
N/A

## Description of Intent of Change(s)
Don't pass `rbac` as a type namespace when looking up tuples with unconstrained type. This was breaking the orphan removal script, which, since #2748, looks up tuples with an unconstrained subject type.

## Summary by Sourcery

Adjust tuple reading logic to avoid assuming the 'rbac' namespace when type names are unconstrained and align tests with SpiceDB filtering semantics.

Bug Fixes:
- Prevent orphan removal and tuple lookup failures when subject or resource type names are empty by not defaulting to the 'rbac' namespace in those cases.

Enhancements:
- Update test tuple filtering utilities to construct filters only for provided fields and to manually enforce subject type constraints consistent with SpiceDB behavior.