### PR TITLE
RHCLOUD-46930: Update dashboard to include new HCC cluster

### DIFF
--- a/dashboards/grafana-dashboard-insights-rbac-operations.configmap.yaml
+++ b/dashboards/grafana-dashboard-insights-rbac-operations.configmap.yaml
@@ -4947,7 +4947,7 @@ data:
             "options": [],
             "query": "prometheus",
             "refresh": 1,
-            "regex": "/.*crc[s|p].*/",
+            "regex": "/.*(crc|hcc)[s|p].*/",
             "type": "datasource"
           },
           {
@@ -4997,7 +4997,7 @@ data:
       "timezone": "",
       "title": "Operations - Rbac w/CPU",
       "uid": "TjP_nMWMk",
-      "version": 11,
+      "version": 12,
       "weekStart": ""
     }
 kind: ConfigMap


### PR DESCRIPTION
## Link(s) to Jira
[RHCLOUD-46930](https://redhat.atlassian.net/browse/RHCLOUD-46930)

## Description of Intent of Change(s)
Add new HCC cluster to dashboard so that new stage deployments can be monitored.

[RHCLOUD-46930]: https://redhat.atlassian.net/browse/RHCLOUD-46930?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Enhancements:
- Extend Prometheus datasource regex to include HCC clusters alongside existing CRC clusters in the RBAC operations dashboard.