### PR TITLE
RHCLOUD-47529 - Update group investigation mcp tool to not include caveats

### DIFF
--- a/rbac/management/mcp_views.py
+++ b/rbac/management/mcp_views.py
@@ -1832,13 +1832,7 @@ def get_rbac_recent_changes(
         "involving a specific role (e.g., 'Vulnerability administrator'). Set include_authorization=true "
         "(default) to see what role/permission authorized each action. "
         "RETURNS: {group: {uuid, name, current_roles}, audit_entries: [{actor, action, description, "
-        "created, authorized_by: {role, via_group, permission}}], caveats: [...]}. "
-        "CAVEATS (always communicate these): "
-        "(1) The audit log captures actor, action, resource type, and a description text field. "
-        "It does NOT capture IP address, session ID, or before/after state. "
-        "(2) The audit log API doesn't support date range filtering in query params — 'last week' "
-        "means paginating recent entries and filtering client-side. "
-        "(3) Authorization shows the actor's CURRENT role/permission — may differ from time of change. "
+        "created, authorized_by: {role, via_group, permission}}]}. "
         "RESPONSE FORMAT: State who performed the action, when (formatted as '14 April at 9:32 AM'), "
         "the description, and what authority they had. Example: 'The audit log shows jdoe added the "
         "Vulnerability administrator role to group Contractors on 14 April at 9:32 AM. jdoe currently "
@@ -1862,14 +1856,6 @@ def investigate_group_changes(
     tenant = getattr(request, "tenant", None)
     if not tenant:
         return json.dumps({"error": "No tenant context available"})
-
-    caveats = [
-        "The audit log captures actor, action, resource type, and a description text field. "
-        "It does NOT capture IP address, session ID, or before/after state.",
-        "The audit log API doesn't support date range filtering in query params — 'last week' "
-        "means paginating recent entries and filtering client-side.",
-        "Authorization shows the actor's CURRENT role/permission — may differ from time of change.",
-    ]
 
     # Step 1: Find the group by name
     group = Group.objects.filter(name__iexact=group_name, tenant=tenant).first()
@@ -1943,7 +1929,6 @@ def investigate_group_changes(
                     + (f" with role containing '{role_name}'" if role_name else "")
                     + (f" and action='{action}'" if action else ""),
                 },
-                "caveats": caveats,
             }
         )
 
@@ -2021,7 +2006,6 @@ def investigate_group_changes(
             "actors": list(actors_seen),
             "by_action": action_counts,
         },
-        "caveats": caveats,
         "hints": {
             "actor_details": "Use list_principals(usernames='<actor>', match_criteria='exact') to get actor details",
             "actor_permissions": "Use search_roles(username='<actor>') to see what roles they currently have",

--- a/tests/management/test_mcp_views.py
+++ b/tests/management/test_mcp_views.py
@@ -1146,8 +1146,6 @@ class MCPViewTests(MCPToolTestMixin, IdentityRequest):
         self.assertIn("audit_entries", tool_output)
         self.assertEqual(len(tool_output["audit_entries"]), 1)
         self.assertEqual(tool_output["audit_entries"][0]["actor"], "jdoe")
-        self.assertIn("caveats", tool_output)
-        self.assertEqual(len(tool_output["caveats"]), 3)
 
     def test_investigate_group_changes_without_auth_returns_error(self):
         """Permission: investigate_group_changes without auth returns auth error."""


### PR DESCRIPTION
## Link(s) to Jira
https://redhat.atlassian.net/browse/RHCLOUD-47529

## Description of Intent of Change(s)
The what, why and how.

## Local Testing
How can the feature be exercised?
How can the bug be exploited and fix confirmed?
Is any special local setup required?

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Update group investigation MCP tool output to exclude caveats from responses and documentation.

Enhancements:
- Remove caveats metadata from investigate_group_changes API responses for a simpler, more focused payload.
- Update RBAC recent changes tool description to no longer advertise caveats in the returned structure.

Tests:
- Adjust investigate_group_changes success test expectations to reflect removal of caveats from the tool output.