### PR TITLE
RHCLOUD-44659: Get specific role relations in orphan removal script

### DIFF
--- a/rbac/internal/migrations/remove_orphan_relations.py
+++ b/rbac/internal/migrations/remove_orphan_relations.py
@@ -200,20 +200,24 @@ def _collect_remote_relations_for_binding(
 
 def _collect_role_resource_relations(role_id: str, read_tuples_typed: _ReadTuplesTyped) -> list[RelationTuple]:
     """
-    Collect all relations whose resource is rbac/role:<role_id> (permissions, owner, etc.).
-
-    Permission-only reads miss tuples such as ``#owner@rbac/tenant:...`` that V1 dual-write creates
-    alongside permission edges; those must be included when reconciling or removing a deleted role.
+    Collect all known tuples whose resource is rbac/role:<role_id> (permissions and owner).
     """
-    return list(
-        read_tuples_typed(
+    return [
+        *read_tuples_typed(
             resource_type="role",
             resource_id=role_id,
             relation="",
-            subject_type="",
+            subject_type="principal",
+            subject_id="*",
+        ),
+        *read_tuples_typed(
+            resource_type="role",
+            resource_id=role_id,
+            relation="owner",
+            subject_type="tenant",
             subject_id="",
-        )
-    )
+        ),
+    ]
 
 
 @dataclasses.dataclass

--- a/rbac/management/relation_replicator/relations_api_replicator.py
+++ b/rbac/management/relation_replicator/relations_api_replicator.py
@@ -264,8 +264,9 @@ class RelationsApiReplicator(RelationReplicator):
         if (pagination_limit is None) and (continuation_token is not None):
             raise TypeError("A pagination limit must be provided if a continuation token is.")
 
-        if not resource_type and not subject_type:
-            raise ValueError("At least one of resource_type and subject_type must be provided")
+        # TODO: replace this check with (not resource_type and not subject_type) if Kessel gets fixed.
+        if not resource_type or not subject_type:
+            raise ValueError("Both resource_type and subject_type must be provided (due to a Kessel limitation)")
 
         if resource_namespace is None:
             resource_namespace = "rbac" if resource_type != "" else ""

--- a/tests/v2_util.py
+++ b/tests/v2_util.py
@@ -51,8 +51,10 @@ def make_read_tuples_mock(tuples: InMemoryTuples) -> Callable[[str, str, str, st
         # Build a filter based on the provided parameters
         filters = []
 
-        if not resource_type_name and not subject_type_name:
-            raise ValueError("At least one of resource_type_name and subject_type_name must be provided")
+        # TODO: replace this check with (not resource_type and not subject_type) if RelationsApiReplicator.read_tuples
+        #  is updated.
+        if not resource_type_name or not subject_type_name:
+            raise ValueError("Both resource_type and subject_type must be provided (due to a Kessel limitation)")
 
         if resource_type_name:
             filters.append(in_memory_tuples.resource_type("rbac", resource_type_name))


### PR DESCRIPTION
## Link(s) to Jira
[RHCLOUD-44659](https://redhat.atlassian.net/browse/RHCLOUD-44659)

## Description of Intent of Change(s)
Even after #2827, we're still getting errors in the orphan removal script:
```
status = StatusCode.INVALID_ARGUMENT
details = "error received from Zanzibar backend while streaming tuples: rpc error: code = InvalidArgument desc = invalid ReadRelationshipsRequest.RelationshipFilter: embedded message failed validation | caused by: invalid RelationshipFilter.OptionalSubjectFilter: embedded message failed validation | caused by: invalid SubjectFilter.SubjectType: value does not match regex pattern "^([a-z][a-z0-9_]{1,61}[a-z0-9]/)*[a-z][a-z0-9_]{1,62}[a-z0-9]$""
debug_error_string = "UNKNOWN:Error received from peer {grpc_message:"error received from Zanzibar backend while streaming tuples: rpc error: code = InvalidArgument desc = invalid ReadRelationshipsRequest.RelationshipFilter: embedded message failed validation | caused by: invalid RelationshipFilter.OptionalSubjectFilter: embedded message failed validation | caused by: invalid SubjectFilter.SubjectType: value does not match regex pattern \"^([a-z][a-z0-9_]{1,61}[a-z0-9]/)*[a-z][a-z0-9_]{1,62}[a-z0-9]$\"", grpc_status:3}"
>
[2026-05-06 11:57:03,878] ERROR: Failed to remove orphan relations for tenant with org_id='20238712': Error during cleanup: <_MultiThreadedRendezvous of RPC that terminated with:
```

I think this is due to [how Kessel `relations-api` is constructing the filter](https://github.com/project-kessel/relations-api/blob/ce36163593378cbf7ee7cc6b08653fd042dfbe78/internal/data/spicedb.go#L812-L815), since it's always providing a subject type argument that's sometimes empty. Rather than try to fix Kessel, just look up both types of relations that we know exist.

[RHCLOUD-44659]: https://redhat.atlassian.net/browse/RHCLOUD-44659?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Restrict orphan role relation cleanup and tuple reads to specific, known subject types to avoid invalid Zanzibar relationship filters caused by empty subject types.

Bug Fixes:
- Ensure orphan role cleanup fetches both principal permission tuples and tenant owner tuples explicitly instead of relying on empty subject type filters that can be invalid.
- Tighten tuple read validation so both resource_type and subject_type must be provided, preventing construction of invalid relationship filters against the relations API.

Tests:
- Update in-memory tuple reader utility to enforce non-empty resource_type and subject_type, aligning tests with the stricter relations API contract.