### PR TITLE
RHCLOUD-47240: Don't modify built-in role bindings when recomputing V2 state

### DIFF
--- a/rbac/internal/migrations/recompute_role_bindings.py
+++ b/rbac/internal/migrations/recompute_role_bindings.py
@@ -19,6 +19,7 @@ from management.role.model import BindingMapping
 from management.role.v2_model import RoleV2, CustomRoleV2
 from management.role_binding.model import RoleBinding
 from management.tenant_mapping.v2_activation import lock_tenant_version, TenantVersion
+from management.tenant_service.v2 import lock_tenant_for_bootstrap
 from management.workspace.model import Workspace
 from migration_tool.migrate_binding_scope import migrate_all_role_bindings
 
@@ -32,8 +33,11 @@ def _do_tear_down_tenant(tenant: Tenant, replicator: RelationReplicator):
     if tenant_resource_id is None:
         raise ValueError(f"Expected tenant to have resource ID; pk={tenant.pk!r}")
 
+    tenant_lock = lock_tenant_for_bootstrap(tenant)
+
     role_bindings = list(
         RoleBinding.objects.filter(tenant=tenant)
+        .exclude(uuid__in=tenant_lock.tenant_mapping.role_binding_ids())
         .prefetch_related("role", "role__permissions", "principal_entries", "group_entries")
         .select_for_update(of=["self"])
     )

--- a/tests/internal/migrations/test_recompute_role_bindings.py
+++ b/tests/internal/migrations/test_recompute_role_bindings.py
@@ -1,18 +1,33 @@
-from django.db import transaction
-
 from internal.migrations.recompute_role_bindings import recompute_tenant_role_bindings
+from management.group.definer import seed_group
+from management.group.platform import GlobalPolicyIdService
+from management.permission.scope_service import Scope
+from management.role.definer import seed_roles
 from management.role.model import BindingMapping
+from management.role.platform import platform_v2_role_uuid_for
 from management.role.v2_model import CustomRoleV2
 from management.role_binding.model import RoleBinding
-from migration_tool.in_memory_tuples import InMemoryRelationReplicator
+from management.role_binding.service import RoleBindingService
+from management.tenant_mapping.model import DefaultAccessType, TenantMapping
+from migration_tool.in_memory_tuples import InMemoryRelationReplicator, all_of, relation, subject, resource
 from tests.management.role.test_dual_write import DualWriteTestCase
 from django.test import override_settings
 
 from tests.util import assert_v1_v2_tuples_fully_consistent
+from tests.v2_util import bootstrap_tenant_for_v2_test
 
 
-@override_settings(ATOMIC_RETRY_DISABLED=True, TENANT_SCOPE_PERMISSIONS="", ROOT_SCOPE_PERMISSIONS="")
+@override_settings(
+    ATOMIC_RETRY_DISABLED=True,
+    TENANT_SCOPE_PERMISSIONS="",
+    ROOT_SCOPE_PERMISSIONS="",
+    V2_BOOTSTRAP_TENANT=True,
+    REPLICATION_TO_RELATION_ENABLED=True,
+)
 class RecomputeRoleBindingsTest(DualWriteTestCase):
+    def _do_recompute(self):
+        recompute_tenant_role_bindings(tenant=self.tenant, replicator=InMemoryRelationReplicator(self.tuples))
+
     def _do_test_recompute(self, delete_custom: bool, delete_v2: bool):
         system_role = self.given_v1_system_role("system role", ["rbac:*:*"])
         custom_role = self.given_v1_role("custom role", default=["rbac:*:*"])
@@ -52,7 +67,7 @@ class RecomputeRoleBindingsTest(DualWriteTestCase):
             _, deleted_counts = BindingMapping.objects.filter(role=target_role).delete()
             self.assertEqual(deleted_counts["management.BindingMapping"], 1)
 
-        recompute_tenant_role_bindings(tenant=self.tenant, replicator=InMemoryRelationReplicator(self.tuples))
+        self._do_recompute()
 
         assert_assignments()
         assert_v1_v2_tuples_fully_consistent(test=self, tuples=self.tuples)
@@ -68,3 +83,92 @@ class RecomputeRoleBindingsTest(DualWriteTestCase):
 
     def test_recompute_custom_missing_v2(self):
         self._do_test_recompute(delete_custom=True, delete_v2=True)
+
+    def _do_test_preserve_default_access(self, *, custom_default_group: bool):
+        # Create default access roles and groups, which are needed by RoleBindingService to create default access
+        # bindings.
+        seed_roles()
+        seed_group()
+
+        bootstrap_tenant_for_v2_test(self.tenant, tuples=self.tuples)
+
+        tenant_mapping: TenantMapping = self.tenant.tenant_mapping
+        replicator = InMemoryRelationReplicator(self.tuples)
+
+        def assert_default_binding_models_exist(value: bool):
+            builtin_binding_ids = {
+                tenant_mapping.default_role_binding_uuid_for(access_type, scope)
+                for access_type in DefaultAccessType
+                for scope in Scope
+                if not (custom_default_group and access_type == DefaultAccessType.USER)
+            }
+
+            self.assertEqual(
+                RoleBinding.objects.filter(tenant=self.tenant).filter(uuid__in=builtin_binding_ids).distinct().count(),
+                len(builtin_binding_ids) if value else 0,
+            )
+
+        def assert_default_binding_tuples_exist():
+            policy_service = GlobalPolicyIdService()
+
+            for access_type in DefaultAccessType:
+                for scope in Scope:
+                    binding_id = str(tenant_mapping.default_role_binding_uuid_for(access_type, scope))
+                    role_id = str(platform_v2_role_uuid_for(access_type, scope, policy_service))
+
+                    self.assertEqual(
+                        (0 if (access_type == DefaultAccessType.USER and custom_default_group) else 1),
+                        self.tuples.count_tuples(
+                            all_of(
+                                relation("binding"),
+                                subject("rbac", "role_binding", binding_id),
+                            )
+                        ),
+                    )
+
+                    self.assertEqual(
+                        1,
+                        self.tuples.count_tuples(
+                            all_of(
+                                resource("rbac", "role_binding", binding_id),
+                                relation("subject"),
+                            )
+                        ),
+                    )
+
+                    self.assertEqual(
+                        1,
+                        self.tuples.count_tuples(
+                            all_of(
+                                resource("rbac", "role_binding", binding_id),
+                                relation("role"),
+                                subject("rbac", "role", role_id),
+                            )
+                        ),
+                    )
+
+        if custom_default_group:
+            self.given_custom_default_group()
+
+        assert_default_binding_models_exist(False)
+        assert_default_binding_tuples_exist()
+
+        # Solely for side-effect of creating RoleBinding models for built-in role bindings.
+        RoleBindingService(tenant=self.tenant, replicator=replicator).get_role_bindings_by_subject(
+            {"resource_type": "workspace", "resource_id": self.default_workspace()}
+        )
+
+        assert_default_binding_models_exist(True)
+        assert_default_binding_tuples_exist()
+
+        self._do_recompute()
+
+        assert_default_binding_models_exist(True)
+        assert_default_binding_tuples_exist()
+
+    def test_preserve_default_access(self):
+        """Test that RoleBindings for built-in bindings are not removed when recomputing."""
+        self._do_test_preserve_default_access(custom_default_group=False)
+
+    def test_preserve_default_access_with_default_group(self):
+        self._do_test_preserve_default_access(custom_default_group=True)


### PR DESCRIPTION
## Link(s) to Jira
[RHCLOUD-47240](https://redhat.atlassian.net/browse/RHCLOUD-47240)

## Description of Intent of Change(s)
Don't delete built-in role bindings when recomputing a tenant's V2 state; we don't rebootstrap the tenant, so they won't be recreated. This casued an issue in the QA tenant in stage.

[RHCLOUD-47240]: https://redhat.atlassian.net/browse/RHCLOUD-47240?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Preserve built-in role bindings when recomputing tenant role bindings and add coverage to ensure default access bindings remain intact.

Bug Fixes:
- Prevent deletion of built-in role bindings during tenant role binding recomputation by excluding their UUIDs from teardown.
- Ensure default access role bindings and their tuples are preserved across recomputation for tenants with and without custom default groups.

Tests:
- Extend recompute role bindings tests to cover preservation of default access bindings and associated tuples under various tenant configurations.
- Enable V2 tenant bootstrap and relation replication in tests to validate behavior against the relation replicator-backed state.