### PR TITLE
RHCLOUD-47658 - RBAC - add database connection persistence to prevent connection exhaustion

### DIFF
--- a/rbac/rbac/database.py
+++ b/rbac/rbac/database.py
@@ -23,6 +23,10 @@ from .env import ENVIRONMENT
 
 def config():
     """Database config."""
+    # Connection persistence: reuse connections for up to N seconds (0 = close after each request).
+    # Set via DATABASE_CONN_MAX_AGE env var; default 60s in production to reduce connection churn.
+    conn_max_age = ENVIRONMENT.int("DATABASE_CONN_MAX_AGE", default=60)
+
     if ENVIRONMENT.bool("CLOWDER_ENABLED", default=False):
         db_obj = {
             "ENGINE": "django.db.backends.postgresql",
@@ -31,6 +35,8 @@ def config():
             "PASSWORD": LoadedConfig.database.password,
             "HOST": LoadedConfig.database.hostname,
             "PORT": LoadedConfig.database.port,
+            "CONN_MAX_AGE": conn_max_age,
+            "CONN_HEALTH_CHECKS": True,
         }
         if LoadedConfig.database.rdsCa:
             db_options = {
@@ -49,6 +55,8 @@ def config():
             "PASSWORD": ENVIRONMENT.get_value("DATABASE_PASSWORD", default=None),
             "HOST": ENVIRONMENT.get_value("DATABASE_HOST", default=None),
             "PORT": ENVIRONMENT.get_value("DATABASE_PORT", default=None),
+            "CONN_MAX_AGE": conn_max_age,
+            "CONN_HEALTH_CHECKS": True,
         }
         db_options = {
             "OPTIONS": {


### PR DESCRIPTION
## Link(s) to Jira
https://redhat.atlassian.net/browse/RHCLOUD-47658

## Description of Intent of Change(s)
  Summary:

  Adds CONN_MAX_AGE and CONN_HEALTH_CHECKS to the Django database configuration to prevent connection pool exhaustion under load.

  Problem:

  Production was hitting OperationalError: FATAL: remaining connection slots are reserved for roles with privileges of
  the "rds_reserved" role — all available RDS connections were consumed because Django was opening a new connection for
  every request and closing it afterward.

  Files changed:

  - rbac/rbac/database.py — Added connection persistence settings to both Clowder and local database configs

  Testing:

  - Verified config loads correctly with new settings
  - Default 60s is safe; can be tuned via DATABASE_CONN_MAX_AGE env var (set to 0 to disable if needed)

  Rollback:

  Set DATABASE_CONN_MAX_AGE=0 to restore previous behavior without code changes.

## Local Testing
How can the feature be exercised?
How can the bug be exploited and fix confirmed?
Is any special local setup required?

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Configure persistent Django database connections to reduce connection churn and avoid exhausting RDS connection slots under load.

Enhancements:
- Add configurable CONN_MAX_AGE for Django database connections with a sensible production default.
- Enable Django connection health checks for both Clowder-managed and local database configurations.