### PR TITLE
Update task references for konflux pipelines to latest stable

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,7 @@
 **
 
 # ... except for dependencies and source
+!LICENSE
 !Pipfile
 !Pipfile.lock
 !tox.ini

--- a/.tekton/insights-rbac-pull-request.yaml
+++ b/.tekton/insights-rbac-pull-request.yaml
@@ -127,7 +127,7 @@ spec:
         - name: name
           value: init
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-init:0.4@sha256:b797dd453ddad669365de6de4649e3a9e37e77aa26eb9862ca079a36cbfe64a4
+          value: quay.io/konflux-ci/tekton-catalog/task-init:0.4@sha256:5a423246792ac501ea279229b42ee57da9927da441c04b5c9ff86817b0856b08
         - name: kind
           value: task
         resolver: bundles
@@ -277,7 +277,7 @@ spec:
         - name: name
           value: prefetch-dependencies-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.3@sha256:1b209c0d93e52e418f3e6cd4b4fd915a84e4bd7f68e1cfd0d6446133540d7f43
+          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.3@sha256:a2efbcdcecfa5293a622eb356a18f5c88e5714046b214fe8730b43b1a7dbb77d
         - name: kind
           value: task
         resolver: bundles
@@ -365,7 +365,7 @@ spec:
         - name: name
           value: rpms-signature-scan
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:1d807f6be3be2bd8bff76321e9599bbafce8196dcd9597eeffd9df65466682af
+          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:cfdb76c67f27bc498132431f5a24fbc17dac1981d6f6e3da5cf5964ac5abdd20
         - name: kind
           value: task
         resolver: bundles
@@ -460,7 +460,7 @@ spec:
         - name: name
           value: deprecated-image-check
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.5@sha256:57d1f556982115311f603dd9a728c52a7a1d092f022e1db4560da01eca9e5d17
+          value: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.5@sha256:e78d0d3baf3c8cfc1a5ad278196b74032d9568b143a87c7a79ab780fedfb296e
         - name: kind
           value: task
         resolver: bundles
@@ -482,7 +482,7 @@ spec:
         - name: name
           value: clair-scan
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.3@sha256:cd49cdea7e5403a87c4774bd8ea10bc4e6aeb83841ff490cbe42b782779513a7
+          value: quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.3@sha256:8fad4c2e2f470f82ee43d6b2ac72327b4d9c6e9cb514a678911c1c9359c29894
         - name: kind
           value: task
         resolver: bundles
@@ -502,7 +502,7 @@ spec:
         - name: name
           value: ecosystem-cert-preflight-checks
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:25dcef1d9270b2e03fe6710a733171f7c7208e341fc627dac3a579088f44af34
+          value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:e2bcf1174a6dae9969b8f12e94babe2a5881bc77a509f10823b6a9eac6392850
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/insights-rbac-pull-request.yaml
+++ b/.tekton/insights-rbac-pull-request.yaml
@@ -365,7 +365,7 @@ spec:
         - name: name
           value: rpms-signature-scan
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:cfdb76c67f27bc498132431f5a24fbc17dac1981d6f6e3da5cf5964ac5abdd20
+          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:637ba7af7d2eea6d685127b000b9f6b23014ab71224311ce309cca169ace5d47
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/insights-rbac-push.yaml
+++ b/.tekton/insights-rbac-push.yaml
@@ -117,7 +117,7 @@ spec:
         - name: name
           value: init
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-init:0.4@sha256:b797dd453ddad669365de6de4649e3a9e37e77aa26eb9862ca079a36cbfe64a4
+          value: quay.io/konflux-ci/tekton-catalog/task-init:0.4@sha256:5a423246792ac501ea279229b42ee57da9927da441c04b5c9ff86817b0856b08
         - name: kind
           value: task
         resolver: bundles
@@ -164,7 +164,7 @@ spec:
         - name: name
           value: prefetch-dependencies-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.3@sha256:1b209c0d93e52e418f3e6cd4b4fd915a84e4bd7f68e1cfd0d6446133540d7f43
+          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.3@sha256:a2efbcdcecfa5293a622eb356a18f5c88e5714046b214fe8730b43b1a7dbb77d
         - name: kind
           value: task
         resolver: bundles
@@ -248,7 +248,7 @@ spec:
         - name: name
           value: rpms-signature-scan
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:1d807f6be3be2bd8bff76321e9599bbafce8196dcd9597eeffd9df65466682af
+          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:cfdb76c67f27bc498132431f5a24fbc17dac1981d6f6e3da5cf5964ac5abdd20
         - name: kind
           value: task
         resolver: bundles
@@ -345,7 +345,7 @@ spec:
         - name: name
           value: deprecated-image-check
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.5@sha256:57d1f556982115311f603dd9a728c52a7a1d092f022e1db4560da01eca9e5d17
+          value: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.5@sha256:e78d0d3baf3c8cfc1a5ad278196b74032d9568b143a87c7a79ab780fedfb296e
         - name: kind
           value: task
         resolver: bundles
@@ -367,7 +367,7 @@ spec:
         - name: name
           value: clair-scan
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.3@sha256:cd49cdea7e5403a87c4774bd8ea10bc4e6aeb83841ff490cbe42b782779513a7
+          value: quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.3@sha256:8fad4c2e2f470f82ee43d6b2ac72327b4d9c6e9cb514a678911c1c9359c29894
         - name: kind
           value: task
         resolver: bundles
@@ -387,7 +387,7 @@ spec:
         - name: name
           value: ecosystem-cert-preflight-checks
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:25dcef1d9270b2e03fe6710a733171f7c7208e341fc627dac3a579088f44af34
+          value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:e2bcf1174a6dae9969b8f12e94babe2a5881bc77a509f10823b6a9eac6392850
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/insights-rbac-push.yaml
+++ b/.tekton/insights-rbac-push.yaml
@@ -248,7 +248,7 @@ spec:
         - name: name
           value: rpms-signature-scan
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:cfdb76c67f27bc498132431f5a24fbc17dac1981d6f6e3da5cf5964ac5abdd20
+          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:637ba7af7d2eea6d685127b000b9f6b23014ab71224311ce309cca169ace5d47
         - name: kind
           value: task
         resolver: bundles

--- a/Dockerfile
+++ b/Dockerfile
@@ -88,6 +88,9 @@ ENV \
 # copy the src files into the workdir
 COPY . .
 
+# Copy license to /licenses for Red Hat certification
+RUN mkdir -p /licenses && cp LICENSE /licenses/
+
 # unleash cache dir
 RUN mkdir -p /tmp/unleash_cache && chmod -R 777 /tmp/unleash_cache
 

--- a/rbac/internal/views.py
+++ b/rbac/internal/views.py
@@ -371,7 +371,11 @@ def get_org_admin(request, org_or_account):
             }
         except requests.exceptions.ConnectionError as conn:
             bop_request_status_count.labels(method="GET", status=500).inc()
-            return HttpResponse(f"Unable to connect for URL {url} with error: {conn}", status=500)
+            return HttpResponse(
+                f"Unable to connect for URL {escape(url)} with error: {escape(str(conn))}",
+                status=500,
+                content_type="text/plain",
+            )
         if response.status_code == status.HTTP_200_OK:
             response_data = {}
             data = resp.get("data", [])
@@ -590,7 +594,11 @@ def run_seeds(request):
                 elif value == "false":
                     args[option] = False
                 else:
-                    return HttpResponse(f'Valid options for "{option}": {["true", "false"]}.', status=400)
+                    return HttpResponse(
+                        f'Valid options for "{escape(option)}": {["true", "false"]}.',
+                        status=400,
+                        content_type="text/plain",
+                    )
 
         if args.get(force_create_option, False) and args.get(force_update_option, False):
             return HttpResponse(
@@ -819,10 +827,10 @@ def role_removal(request):
                 dual_write_handler = SeedingRelationApiDualWriteHandler(role_obj)
                 dual_write_handler.replicate_deleted_system_role()
                 role_obj.delete()
-                return HttpResponse(f"Role '{role_name}' deleted.", status=204)
+                return HttpResponse(f"Role '{role_name}' deleted.", status=204, content_type="text/plain")
             except Exception:
-                return HttpResponse("Role cannot be deleted.", status=400)
-    return HttpResponse('Invalid method, only "DELETE" is allowed.', status=405)
+                return HttpResponse("Role cannot be deleted.", status=400, content_type="text/plain")
+    return HttpResponse('Invalid method, only "DELETE" is allowed.', status=405, content_type="text/plain")
 
 
 def permission_removal(request):
@@ -848,9 +856,11 @@ def permission_removal(request):
             try:
                 logger.warning(f"Deleting permission '{permission}'. Requested by '{request.user.username}'")
                 delete_permission(permission_obj)
-                return HttpResponse(f"Permission '{permission}' deleted.", status=204)
+                return HttpResponse(f"Permission '{permission}' deleted.", status=204, content_type="text/plain")
             except Exception as e:
-                return HttpResponse(f"Permission cannot be deleted. {str(e)}", status=400)
+                return HttpResponse(
+                    f"Permission cannot be deleted. {escape(str(e))}", status=400, content_type="text/plain"
+                )
     return HttpResponse('Invalid method, only "DELETE" is allowed.', status=405)
 
 
@@ -1022,7 +1032,11 @@ def bootstrap_tenant(request):
         for org_id in org_ids:
             tenant = get_object_or_404(Tenant, org_id=org_id)
             bootstrap_service.bootstrap_tenant(tenant, force=force)
-    return HttpResponse(f"Bootstrapping tenants with org_ids {org_ids} were finished.", status=200)
+    return HttpResponse(
+        f"Bootstrapping tenants with org_ids {escape(str(org_ids))} were finished.",
+        status=200,
+        content_type="text/plain",
+    )
 
 
 def list_or_delete_bindings_for_role(request, role_uuid):
@@ -1161,7 +1175,7 @@ def migration_resources(request):
         page = pg.paginate_queryset(resource_objs, request)
         page = [str(record.id) for record in page]
         return HttpResponse(json.dumps(page), content_type="application/json", status=200)
-    return HttpResponse(f"Invalid method, {request.method}", status=405)
+    return HttpResponse(f"Invalid method, {escape(request.method)}", status=405, content_type="text/plain")
 
 
 def reset_imported_tenants(request: HttpRequest) -> HttpResponse:
@@ -1552,8 +1566,9 @@ def principal_removal(request):
 
     if request.method == "GET":
         return HttpResponse(
-            f"Principals to be deleted: {principal_usernames}",
+            f"Principals to be deleted: {escape(str(principal_usernames))}",
             status=200,
+            content_type="text/plain",
         )
     if not destructive_ok("api"):
         return HttpResponse("Destructive operations disallowed.", status=400)
@@ -1572,7 +1587,9 @@ def principal_removal(request):
 
                 bootstrap_service.update_user(user)
 
-        return HttpResponse(f"Users deleted: {principal_usernames}", status=204)
+        return HttpResponse(
+            f"Users deleted: {escape(str(principal_usernames))}", status=204, content_type="text/plain"
+        )
 
 
 def retrieve_ungrouped_workspace(request):

--- a/rbac/internal/views.py
+++ b/rbac/internal/views.py
@@ -371,11 +371,7 @@ def get_org_admin(request, org_or_account):
             }
         except requests.exceptions.ConnectionError as conn:
             bop_request_status_count.labels(method="GET", status=500).inc()
-            return HttpResponse(
-                f"Unable to connect for URL {escape(url)} with error: {escape(str(conn))}",
-                status=500,
-                content_type="text/plain",
-            )
+            return HttpResponse(f"Unable to connect for URL {url} with error: {conn}", status=500)
         if response.status_code == status.HTTP_200_OK:
             response_data = {}
             data = resp.get("data", [])
@@ -594,11 +590,7 @@ def run_seeds(request):
                 elif value == "false":
                     args[option] = False
                 else:
-                    return HttpResponse(
-                        f'Valid options for "{escape(option)}": {["true", "false"]}.',
-                        status=400,
-                        content_type="text/plain",
-                    )
+                    return HttpResponse(f'Valid options for "{option}": {["true", "false"]}.', status=400)
 
         if args.get(force_create_option, False) and args.get(force_update_option, False):
             return HttpResponse(
@@ -827,10 +819,10 @@ def role_removal(request):
                 dual_write_handler = SeedingRelationApiDualWriteHandler(role_obj)
                 dual_write_handler.replicate_deleted_system_role()
                 role_obj.delete()
-                return HttpResponse(f"Role '{role_name}' deleted.", status=204, content_type="text/plain")
+                return HttpResponse(f"Role '{role_name}' deleted.", status=204)
             except Exception:
-                return HttpResponse("Role cannot be deleted.", status=400, content_type="text/plain")
-    return HttpResponse('Invalid method, only "DELETE" is allowed.', status=405, content_type="text/plain")
+                return HttpResponse("Role cannot be deleted.", status=400)
+    return HttpResponse('Invalid method, only "DELETE" is allowed.', status=405)
 
 
 def permission_removal(request):
@@ -856,11 +848,9 @@ def permission_removal(request):
             try:
                 logger.warning(f"Deleting permission '{permission}'. Requested by '{request.user.username}'")
                 delete_permission(permission_obj)
-                return HttpResponse(f"Permission '{permission}' deleted.", status=204, content_type="text/plain")
+                return HttpResponse(f"Permission '{permission}' deleted.", status=204)
             except Exception as e:
-                return HttpResponse(
-                    f"Permission cannot be deleted. {escape(str(e))}", status=400, content_type="text/plain"
-                )
+                return HttpResponse(f"Permission cannot be deleted. {str(e)}", status=400)
     return HttpResponse('Invalid method, only "DELETE" is allowed.', status=405)
 
 
@@ -1032,11 +1022,7 @@ def bootstrap_tenant(request):
         for org_id in org_ids:
             tenant = get_object_or_404(Tenant, org_id=org_id)
             bootstrap_service.bootstrap_tenant(tenant, force=force)
-    return HttpResponse(
-        f"Bootstrapping tenants with org_ids {escape(str(org_ids))} were finished.",
-        status=200,
-        content_type="text/plain",
-    )
+    return HttpResponse(f"Bootstrapping tenants with org_ids {org_ids} were finished.", status=200)
 
 
 def list_or_delete_bindings_for_role(request, role_uuid):
@@ -1175,7 +1161,7 @@ def migration_resources(request):
         page = pg.paginate_queryset(resource_objs, request)
         page = [str(record.id) for record in page]
         return HttpResponse(json.dumps(page), content_type="application/json", status=200)
-    return HttpResponse(f"Invalid method, {escape(request.method)}", status=405, content_type="text/plain")
+    return HttpResponse(f"Invalid method, {request.method}", status=405)
 
 
 def reset_imported_tenants(request: HttpRequest) -> HttpResponse:
@@ -1566,9 +1552,8 @@ def principal_removal(request):
 
     if request.method == "GET":
         return HttpResponse(
-            f"Principals to be deleted: {escape(str(principal_usernames))}",
+            f"Principals to be deleted: {principal_usernames}",
             status=200,
-            content_type="text/plain",
         )
     if not destructive_ok("api"):
         return HttpResponse("Destructive operations disallowed.", status=400)
@@ -1587,9 +1572,7 @@ def principal_removal(request):
 
                 bootstrap_service.update_user(user)
 
-        return HttpResponse(
-            f"Users deleted: {escape(str(principal_usernames))}", status=204, content_type="text/plain"
-        )
+        return HttpResponse(f"Users deleted: {principal_usernames}", status=204)
 
 
 def retrieve_ungrouped_workspace(request):


### PR DESCRIPTION
## Link(s) to Jira
-

## Description of Intent of Change(s)
Updates 6 outdated Tekton task references in the Konflux CI/CD pipelines to their latest versions, resolving warnings that would expire between July 3-5, 2026.

## Local Testing
How can the feature be exercised?
How can the bug be exploited and fix confirmed?
Is any special local setup required?

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

CI:
- Refresh Konflux Tekton task bundle digests (init, prefetch-dependencies-oci-ta, rpms-signature-scan, deprecated-image-check, clair-scan, ecosystem-cert-preflight-checks) in PR and push pipelines to the latest stable versions.