### PR TITLE
RHCLOUD-46930: Attempt two at HCC dashboard

### DIFF
--- a/dashboards/grafana-dashboard-insights-rbac-operations.configmap.yaml
+++ b/dashboards/grafana-dashboard-insights-rbac-operations.configmap.yaml
@@ -27,7 +27,7 @@ data:
       "editable": true,
       "fiscalYearStartMonth": 0,
       "graphTooltip": 0,
-      "id": 1025919,
+      "id": 1268004,
       "links": [],
       "panels": [
         {
@@ -4939,7 +4939,7 @@ data:
           {
             "current": {
               "text": "crcp01ue1-prometheus",
-              "value": "crcp01ue1-prometheus"
+              "value": "PC1EAC84DCBBF0697"
             },
             "includeAll": false,
             "label": "Datasource",
@@ -4951,7 +4951,14 @@ data:
             "type": "datasource"
           },
           {
-            "current": {},
+            "current": {
+              "text": [
+                "All"
+              ],
+              "value": [
+                "$__all"
+              ]
+            },
             "datasource": {
               "type": "prometheus",
               "uid": "$datasource"
@@ -4971,7 +4978,10 @@ data:
             "type": "query"
           },
           {
-            "current": {},
+            "current": {
+              "text": "rbac-prod",
+              "value": "rbac-prod"
+            },
             "datasource": {
               "type": "prometheus",
               "uid": "$datasource"
@@ -4994,11 +5004,11 @@ data:
         "from": "now-24h",
         "to": "now"
       },
+      "timepicker": {},
       "timezone": "",
       "title": "Operations - Rbac w/CPU",
       "uid": "TjP_nMWMk",
-      "version": 12,
-      "weekStart": ""
+      "version": 13
     }
 kind: ConfigMap
 metadata:


### PR DESCRIPTION
## Link(s) to Jira
[RHCLOUD-46930](https://redhat.atlassian.net/browse/RHCLOUD-46930)

## Description of Intent of Change(s)
Hopefully this will actually show data from the new HCC cluster deployment?

[RHCLOUD-46930]: https://redhat.atlassian.net/browse/RHCLOUD-46930?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Update the Insights RBAC operations Grafana dashboard configuration to point to the new Prometheus datasource and refresh default variable and time settings.

Enhancements:
- Point the dashboard to the new HCC Prometheus datasource and adjust the default datasource selection.
- Set sensible default values for namespace and cluster variables in the RBAC operations dashboard.
- Refresh dashboard metadata including ID, timepicker configuration, and version to align with the updated deployment.