### PR TITLE
[RHCLOUD-47667] Add lock timeout when trying to aquire lock

### DIFF
--- a/rbac/rbac/database.py
+++ b/rbac/rbac/database.py
@@ -21,11 +21,25 @@ from app_common_python import LoadedConfig
 from .env import ENVIRONMENT
 
 
+def _pg_session_options() -> str:
+    """Build the PostgreSQL ``options`` string for session-level parameters.
+
+    lock_timeout: abort any statement waiting longer than this for a row lock.
+    Prevents zombie transactions from piling up when a single lock holder blocks
+    many concurrent requests (each blocked connection stays open until the lock
+    is released or the connection is killed).
+    RDS does not support this option, so we don't add it through app-interface.
+    """
+    lock_timeout_ms = ENVIRONMENT.int("DATABASE_LOCK_TIMEOUT_MS", default=60_000)
+    return f"-c lock_timeout={lock_timeout_ms}"
+
+
 def config():
     """Database config."""
     # Connection persistence: reuse connections for up to N seconds (0 = close after each request).
     # Set via DATABASE_CONN_MAX_AGE env var; default 60s in production to reduce connection churn.
     conn_max_age = ENVIRONMENT.int("DATABASE_CONN_MAX_AGE", default=60)
+    pg_options = _pg_session_options()
 
     if ENVIRONMENT.bool("CLOWDER_ENABLED", default=False):
         db_obj = {
@@ -43,10 +57,15 @@ def config():
                 "OPTIONS": {
                     "sslmode": ENVIRONMENT.get_value("PGSSLMODE", default="prefer"),
                     "sslrootcert": LoadedConfig.rds_ca(),
+                    "options": pg_options,
                 }
             }
         else:
-            db_options = {}
+            db_options = {
+                "OPTIONS": {
+                    "options": pg_options,
+                }
+            }
     else:
         db_obj = {
             "ENGINE": "django.db.backends.postgresql",
@@ -62,6 +81,7 @@ def config():
             "OPTIONS": {
                 "sslmode": ENVIRONMENT.get_value("PGSSLMODE", default="prefer"),
                 "sslrootcert": ENVIRONMENT.get_value("PGSSLROOTCERT", default="/etc/rds-certs/rds-cacert"),
+                "options": pg_options,
             }
         }
 


### PR DESCRIPTION
## Link(s) to Jira
- https://redhat.atlassian.net/browse/RHCLOUD-47667

## Description of Intent of Change(s)
The rbac db’s connections has been exhausted because the requests waiting for locks got timeout by gateway, so the connections are left open forever.

## Local Testing
NA

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Configure PostgreSQL session-level lock timeouts to prevent long-lived blocked connections from exhausting the RBAC database connection pool.

Bug Fixes:
- Abort long-running lock waits by setting a configurable PostgreSQL lock_timeout on all DB connections to avoid zombie transactions and connection leaks.

Enhancements:
- Introduce a helper to build session-level PostgreSQL options from environment variables and wire it into all Django database configurations.