### PR TITLE
RHCLOUD-47726 - Add tool to MCP allowing auditing of CAR access in org

### DIFF
--- a/rbac/management/mcp_views.py
+++ b/rbac/management/mcp_views.py
@@ -26,7 +26,7 @@ import re
 import time
 import uuid
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from functools import lru_cache, wraps
 from typing import Any, Callable
 
@@ -1146,6 +1146,7 @@ def get_cross_account_request(
         "roles: [{name, permissions: [...]}], permission_summary}], analysis}."
     ),
     requires_auth=True,
+    api_version=ApiVersion.COMMON,
 )
 def investigate_tam_access(
     request: HttpRequest,
@@ -1365,7 +1366,7 @@ def audit_redhat_access(
         return json.dumps({"error": "No organization context available"})
 
     now = datetime.now(timezone.utc)
-    audit_since = now - datetime.timedelta(days=audit_days)
+    audit_since = now - timedelta(days=audit_days)
 
     # Query cross-account requests targeting this org
     queryset = CrossAccountRequest.objects.filter(target_org=org_id).prefetch_related(
@@ -1405,7 +1406,6 @@ def audit_redhat_access(
         if bop_resp.get("status_code") == 200:
             for principal in bop_resp.get("data", []):
                 user_info_map[str(principal.get("user_id", ""))] = {
-                    "user_id": principal.get("user_id", ""),
                     "first_name": principal.get("first_name", ""),
                     "last_name": principal.get("last_name", ""),
                     "email": principal.get("email", ""),
@@ -1461,10 +1461,10 @@ def audit_redhat_access(
             )
 
         # Get pre-fetched audit logs for this user
-        audit_activity: dict[str, Any] = {"total_actions": 0, "recent_actions": [], "summary": ""}
+        audit_activity: dict[str, Any] = {"recent_actions_count": 0, "recent_actions": [], "summary": ""}
         if username and car.status == "approved":
             audit_entries = audit_by_user.get(username, [])
-            audit_activity["total_actions"] = len(audit_entries)
+            audit_activity["recent_actions_count"] = len(audit_entries)
 
             if audit_entries:
                 for entry in audit_entries[:5]:

--- a/rbac/management/mcp_views.py
+++ b/rbac/management/mcp_views.py
@@ -354,6 +354,8 @@ def _call_view(
 # │ list_group_principals            │ common    │ GET /api/v1/groups/{uuid}/principals/      │
 # │ list_cross_account_requests      │ common    │ GET /api/v1/cross-account-requests/        │
 # │ get_cross_account_request        │ common    │ GET /api/v1/cross-account-requests/{id}/   │
+# │ investigate_tam_access           │ common    │ (orchestrates cross-account + roles)       │
+# │ audit_redhat_access              │ common    │ (cross-account + roles + audit logs)       │
 # │ list_workspaces                  │ common    │ GET /api/v2/workspaces/                    │
 # │ get_workspace                    │ common    │ GET /api/v2/workspaces/{uuid}/             │
 # │ search_roles                     │ unified   │ V1: GET /api/v1/roles/                     │
@@ -1331,6 +1333,212 @@ def investigate_tam_access(
             }
 
     return json.dumps({"requests": results, "analysis": analysis}, default=str)
+
+
+@register_tool(
+    description=(
+        "Audit all Red Hat cross-account access into your organization. "
+        "Returns a complete inventory of: (1) who from Red Hat has access, (2) what roles/permissions "
+        "they have, (3) when their access expires, and (4) what RBAC changes they've made. "
+        "SCENARIO: 'Who from Red Hat is in our org right now?' → call audit_redhat_access() to get "
+        "a summary of all active approved cross-account requests with audit activity. "
+        "Set include_inactive=true to also see expired or pending requests. "
+        "Set audit_days to control how far back to look in audit logs (default 30 days). "
+        "Returns: {active_access: [{user_info, roles, permissions, expires, days_remaining, "
+        "audit_activity: {total_actions, recent_actions, summary}}], summary: {total_users, "
+        "expiring_soon, unused_access}}."
+    ),
+    requires_auth=True,
+    api_version=ApiVersion.COMMON,
+)
+def audit_redhat_access(
+    request: HttpRequest,
+    *,
+    include_inactive: bool = False,
+    audit_days: int = 30,
+    limit: int = 50,
+) -> str:
+    """Audit Red Hat cross-account access into the organization."""
+    org_id = getattr(request.user, "org_id", None)
+    tenant = getattr(request, "tenant", None)
+    if not org_id or not tenant:
+        return json.dumps({"error": "No organization context available"})
+
+    now = datetime.now(timezone.utc)
+    audit_since = now - datetime.timedelta(days=audit_days)
+
+    # Query cross-account requests targeting this org
+    queryset = CrossAccountRequest.objects.filter(target_org=org_id).prefetch_related(
+        "roles", "roles__access__permission"
+    )
+
+    if not include_inactive:
+        queryset = queryset.filter(status="approved", start_date__lte=now, end_date__gte=now)
+    else:
+        queryset = queryset.filter(status__in=["approved", "pending", "expired"])
+
+    queryset = queryset.order_by("-end_date")[:limit]
+    requests_list = list(queryset)
+
+    if not requests_list:
+        return json.dumps(
+            {
+                "active_access": [],
+                "summary": {
+                    "total_users": 0,
+                    "expiring_soon": 0,
+                    "unused_access": 0,
+                    "message": "No cross-account requests found for this organization.",
+                    "hint": "Use list_cross_account_requests(query_by='target_org') to see all requests.",
+                },
+            }
+        )
+
+    # Get requester info from BOP for all user_ids
+    user_ids = list({car.user_id for car in requests_list})
+    user_info_map: dict[str, dict[str, Any]] = {}
+    try:
+        proxy = PrincipalProxy()
+        bop_resp = proxy.request_filtered_principals(
+            user_ids, org_id=None, options={"query_by": "user_id", "return_id": True}
+        )
+        if bop_resp.get("status_code") == 200:
+            for principal in bop_resp.get("data", []):
+                user_info_map[str(principal.get("user_id", ""))] = {
+                    "user_id": principal.get("user_id", ""),
+                    "first_name": principal.get("first_name", ""),
+                    "last_name": principal.get("last_name", ""),
+                    "email": principal.get("email", ""),
+                    "username": principal.get("username", ""),
+                }
+    except Exception:
+        logger.warning("mcp: failed to fetch requester info from BOP", exc_info=True)
+
+    # Batch query audit logs for all usernames
+    all_usernames = {info.get("username") for info in user_info_map.values() if info.get("username")}
+    audit_by_user: dict[str, list[AuditLog]] = {u: [] for u in all_usernames}
+    if all_usernames:
+        audit_qs = AuditLog.objects.filter(
+            tenant=tenant, principal_username__in=all_usernames, created__gte=audit_since
+        ).order_by("-created")
+        for entry in audit_qs:
+            if entry.principal_username in audit_by_user and len(audit_by_user[entry.principal_username]) < 10:
+                audit_by_user[entry.principal_username].append(entry)
+
+    # Build detailed response
+    results: list[dict[str, Any]] = []
+    expiring_soon_count = 0
+    unused_access_count = 0
+    all_permissions_granted: set[str] = set()
+
+    for car in requests_list:
+        days_remaining = (car.end_date - now).days if car.end_date else None
+        is_expiring_soon = days_remaining is not None and 0 < days_remaining <= 7 and car.status == "approved"
+        if is_expiring_soon:
+            expiring_soon_count += 1
+
+        requester_info = user_info_map.get(car.user_id, {"user_id": car.user_id})
+        username = requester_info.get("username", "")
+
+        # Collect roles and permissions
+        roles_data: list[dict[str, Any]] = []
+        permissions_list: list[str] = []
+        for role in car.roles.all():
+            role_perms: list[str] = []
+            for access in role.access.all():
+                if access.permission:
+                    perm_str = access.permission.permission
+                    role_perms.append(perm_str)
+                    permissions_list.append(perm_str)
+                    all_permissions_granted.add(perm_str)
+
+            roles_data.append(
+                {
+                    "name": role.display_name or role.name,
+                    "description": role.description or "",
+                    "permissions": sorted(role_perms),
+                }
+            )
+
+        # Get pre-fetched audit logs for this user
+        audit_activity: dict[str, Any] = {"total_actions": 0, "recent_actions": [], "summary": ""}
+        if username and car.status == "approved":
+            audit_entries = audit_by_user.get(username, [])
+            audit_activity["total_actions"] = len(audit_entries)
+
+            if audit_entries:
+                for entry in audit_entries[:5]:
+                    audit_activity["recent_actions"].append(
+                        {
+                            "action": entry.action,
+                            "resource_type": entry.resource_type,
+                            "description": entry.description,
+                            "date": entry.created.strftime("%Y-%m-%d %H:%M") if entry.created else None,
+                        }
+                    )
+                # Summarize activity types
+                action_counts: dict[str, int] = {}
+                for entry in audit_entries:
+                    action_counts[entry.action] = action_counts.get(entry.action, 0) + 1
+                summary_parts = [f"{count} {action}" for action, count in sorted(action_counts.items())]
+                audit_activity["summary"] = ", ".join(summary_parts) + f" action(s) in last {audit_days} days"
+            else:
+                audit_activity["summary"] = f"No RBAC activity in last {audit_days} days"
+                unused_access_count += 1
+
+        # Determine status display
+        status_display = car.status
+        if car.status == "approved":
+            if days_remaining is not None and days_remaining < 0:
+                status_display = "expired (just now)"
+            elif is_expiring_soon:
+                status_display = f"approved (expires in {days_remaining} day{'s' if days_remaining != 1 else ''})"
+
+        results.append(
+            {
+                "request_id": str(car.request_id),
+                "user_info": {
+                    "user_id": requester_info.get("user_id", car.user_id),
+                    "name": f"{requester_info.get('first_name', '')} {requester_info.get('last_name', '')}".strip()
+                    or car.user_id,
+                    "email": requester_info.get("email", ""),
+                    "username": username or f"user_{car.user_id}",
+                },
+                "status": status_display,
+                "start_date": car.start_date.strftime("%Y-%m-%d") if car.start_date else None,
+                "end_date": car.end_date.strftime("%Y-%m-%d") if car.end_date else None,
+                "days_remaining": days_remaining if car.status == "approved" else None,
+                "roles": roles_data,
+                "permissions_summary": f"{len(permissions_list)} permission(s) across {len(roles_data)} role(s)",
+                "audit_activity": audit_activity,
+            }
+        )
+
+    # Group permissions by application for summary
+    perm_by_app: dict[str, int] = {}
+    for perm in all_permissions_granted:
+        parts = perm.split(":")
+        if len(parts) >= 1:
+            app = parts[0]
+            perm_by_app[app] = perm_by_app.get(app, 0) + 1
+
+    # Build summary
+    summary: dict[str, Any] = {
+        "total_users": len(results),
+        "total_active": sum(1 for r in results if "approved" in r["status"]),
+        "expiring_soon": expiring_soon_count,
+        "unused_access": unused_access_count,
+        "permissions_by_application": {app: count for app, count in sorted(perm_by_app.items())},
+        "audit_period_days": audit_days,
+    }
+
+    if expiring_soon_count > 0:
+        summary["warning"] = f"{expiring_soon_count} access grant(s) expiring within 7 days"
+
+    if unused_access_count > 0:
+        summary["note"] = f"{unused_access_count} user(s) with access but no RBAC activity in last {audit_days} days"
+
+    return json.dumps({"active_access": results, "summary": summary}, default=str)
 
 
 @register_tool(

--- a/rbac/management/mcp_views.py
+++ b/rbac/management/mcp_views.py
@@ -31,6 +31,7 @@ from functools import lru_cache, wraps
 from typing import Any, Callable
 
 from django.conf import settings
+from django.db.models import Count
 from django.http import HttpRequest, HttpResponse, JsonResponse
 from django.test import RequestFactory
 from django.urls import reverse
@@ -1417,6 +1418,7 @@ def audit_redhat_access(
     # Batch query audit logs for all usernames
     all_usernames = {info.get("username") for info in user_info_map.values() if info.get("username")}
     audit_by_user: dict[str, list[AuditLog]] = {u: [] for u in all_usernames}
+    audit_counts_by_user: dict[str, int] = {}
     if all_usernames:
         audit_qs = AuditLog.objects.filter(
             tenant=tenant, principal_username__in=all_usernames, created__gte=audit_since
@@ -1424,6 +1426,14 @@ def audit_redhat_access(
         for entry in audit_qs:
             if entry.principal_username in audit_by_user and len(audit_by_user[entry.principal_username]) < 10:
                 audit_by_user[entry.principal_username].append(entry)
+
+        # Get true total counts per user
+        counts_qs = (
+            AuditLog.objects.filter(tenant=tenant, principal_username__in=all_usernames, created__gte=audit_since)
+            .values("principal_username")
+            .annotate(count=Count("id"))
+        )
+        audit_counts_by_user = {row["principal_username"]: row["count"] for row in counts_qs}
 
     # Build detailed response
     results: list[dict[str, Any]] = []
@@ -1461,10 +1471,10 @@ def audit_redhat_access(
             )
 
         # Get pre-fetched audit logs for this user
-        audit_activity: dict[str, Any] = {"recent_actions_count": 0, "recent_actions": [], "summary": ""}
+        audit_activity: dict[str, Any] = {"total_actions": 0, "recent_actions": [], "summary": ""}
         if username and car.status == "approved":
             audit_entries = audit_by_user.get(username, [])
-            audit_activity["recent_actions_count"] = len(audit_entries)
+            audit_activity["total_actions"] = audit_counts_by_user.get(username, 0)
 
             if audit_entries:
                 for entry in audit_entries[:5]:

--- a/tests/management/test_mcp_views.py
+++ b/tests/management/test_mcp_views.py
@@ -3220,3 +3220,276 @@ class MCPInvestigateTamAccessTests(MCPToolTestMixin, IdentityRequest):
         tool_output = self._get_tool_output(response)
         self.assertIn("permissions_by_application", tool_output["analysis"])
         self.assertIn("subscriptions", tool_output["analysis"]["permissions_by_application"])
+
+
+class AuditRedhatAccessTests(MCPToolTestMixin, IdentityRequest):
+    """Tests for the audit_redhat_access MCP tool."""
+
+    def setUp(self):
+        """Set up audit_redhat_access tests."""
+        super().setUp()
+        self.url = "/_private/_a2s/mcp/"
+        self.client = APIClient()
+
+        # Create a public tenant for system roles
+        self.public_tenant, _ = Tenant.objects.get_or_create(tenant_name="public")
+
+        # Create system roles with permissions
+        self.system_role = Role.objects.create(
+            name="Test role 1",
+            display_name="Test role 1",
+            description="Test role for audit tests",
+            system=True,
+            tenant=self.public_tenant,
+        )
+        self.perm = Permission.objects.create(
+            application="test-app",
+            resource_type="resources",
+            verb="read",
+            permission="test-app:resources:read",
+            tenant=self.public_tenant,
+        )
+        Access.objects.create(permission=self.perm, role=self.system_role, tenant=self.public_tenant)
+
+        # Create another role
+        self.other_role = Role.objects.create(
+            name="Test role 2",
+            display_name="Test role 2",
+            description="Another test role",
+            system=True,
+            tenant=self.public_tenant,
+        )
+        self.other_perm = Permission.objects.create(
+            application="other-app",
+            resource_type="items",
+            verb="read",
+            permission="other-app:items:read",
+            tenant=self.public_tenant,
+        )
+        Access.objects.create(permission=self.other_perm, role=self.other_role, tenant=self.public_tenant)
+
+        # Create a cross-account request
+        self.car = CrossAccountRequest.objects.create(
+            target_org=self.tenant.org_id,
+            user_id="10001",
+            status="approved",
+            start_date=timezone.now() - timezone.timedelta(days=1),
+            end_date=timezone.now() + timezone.timedelta(days=6),
+        )
+        self.car.roles.add(self.system_role)
+
+        # Create another request expiring soon
+        self.car_expiring = CrossAccountRequest.objects.create(
+            target_org=self.tenant.org_id,
+            user_id="10002",
+            status="approved",
+            start_date=timezone.now() - timezone.timedelta(days=10),
+            end_date=timezone.now() + timezone.timedelta(days=2),
+        )
+        self.car_expiring.roles.add(self.other_role)
+
+    def tearDown(self):
+        """Tear down audit_redhat_access tests."""
+        CrossAccountRequest.objects.all().delete()
+        AuditLog.objects.all().delete()
+        Access.objects.filter(tenant=self.public_tenant).delete()
+        Permission.objects.filter(tenant=self.public_tenant).delete()
+        Role.objects.filter(tenant=self.public_tenant).delete()
+        super().tearDown()
+
+    def test_audit_redhat_access_success(self):
+        """Positive: audit_redhat_access returns cross-account data with summary."""
+        response = self._call_tool("audit_redhat_access")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertFalse(data["result"]["isError"])
+        tool_output = self._get_tool_output(response)
+        self.assertIn("active_access", tool_output)
+        self.assertIn("summary", tool_output)
+
+    def test_audit_redhat_access_without_auth_returns_error(self):
+        """Permission: audit_redhat_access without auth returns auth error."""
+        response = self._call_tool("audit_redhat_access", use_auth=False)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertIn("error", data)
+        self.assertEqual(data["error"]["code"], -32000)
+
+    @patch("management.principal.proxy.PrincipalProxy.request_filtered_principals")
+    def test_audit_redhat_access_returns_user_info(self, mock_proxy):
+        """Positive: audit_redhat_access returns user information from BOP."""
+        mock_proxy.return_value = {
+            "status_code": 200,
+            "data": [
+                {
+                    "user_id": "10001",
+                    "first_name": "Test",
+                    "last_name": "User1",
+                    "email": "user1@example.com",
+                    "username": "testuser1",
+                },
+                {
+                    "user_id": "10002",
+                    "first_name": "Test",
+                    "last_name": "User2",
+                    "email": "user2@example.com",
+                    "username": "testuser2",
+                },
+            ],
+        }
+
+        response = self._call_tool("audit_redhat_access")
+
+        tool_output = self._get_tool_output(response)
+        self.assertEqual(len(tool_output["active_access"]), 2)
+
+        # Check first user
+        user1 = next(u for u in tool_output["active_access"] if "User1" in u["user_info"]["name"])
+        self.assertEqual(user1["user_info"]["email"], "user1@example.com")
+        self.assertIn("Test role 1", [r["name"] for r in user1["roles"]])
+
+    @patch("management.principal.proxy.PrincipalProxy.request_filtered_principals")
+    def test_audit_redhat_access_shows_expiring_soon(self, mock_proxy):
+        """Positive: audit_redhat_access identifies access expiring within 7 days."""
+        mock_proxy.return_value = {"status_code": 200, "data": []}
+
+        response = self._call_tool("audit_redhat_access")
+
+        tool_output = self._get_tool_output(response)
+        self.assertEqual(tool_output["summary"]["expiring_soon"], 1)
+        self.assertIn("warning", tool_output["summary"])
+
+    @patch("management.principal.proxy.PrincipalProxy.request_filtered_principals")
+    def test_audit_redhat_access_with_audit_activity(self, mock_proxy):
+        """Positive: audit_redhat_access includes audit log activity."""
+        mock_proxy.return_value = {
+            "status_code": 200,
+            "data": [
+                {
+                    "user_id": "10001",
+                    "first_name": "Test",
+                    "last_name": "User1",
+                    "email": "user1@example.com",
+                    "username": "testuser1",
+                }
+            ],
+        }
+
+        # Create some audit log entries for this user
+        AuditLog.objects.create(
+            principal_username="testuser1",
+            action="edit",
+            resource_type="group",
+            description="Edited group: Test Group",
+            tenant=self.tenant,
+        )
+        AuditLog.objects.create(
+            principal_username="testuser1",
+            action="add",
+            resource_type="user",
+            description="Added user to group",
+            tenant=self.tenant,
+        )
+
+        response = self._call_tool("audit_redhat_access")
+
+        tool_output = self._get_tool_output(response)
+        user_access = tool_output["active_access"][0]
+        self.assertEqual(user_access["audit_activity"]["total_actions"], 2)
+        self.assertIn("edit", user_access["audit_activity"]["summary"])
+        self.assertIn("add", user_access["audit_activity"]["summary"])
+
+    @patch("management.principal.proxy.PrincipalProxy.request_filtered_principals")
+    def test_audit_redhat_access_identifies_unused_access(self, mock_proxy):
+        """Positive: audit_redhat_access identifies users with no audit activity."""
+        mock_proxy.return_value = {
+            "status_code": 200,
+            "data": [
+                {
+                    "user_id": "10001",
+                    "first_name": "Test",
+                    "last_name": "User1",
+                    "email": "user1@example.com",
+                    "username": "testuser1",
+                },
+                {
+                    "user_id": "10002",
+                    "first_name": "Test",
+                    "last_name": "User2",
+                    "email": "user2@example.com",
+                    "username": "testuser2",
+                },
+            ],
+        }
+
+        response = self._call_tool("audit_redhat_access")
+
+        tool_output = self._get_tool_output(response)
+        self.assertEqual(tool_output["summary"]["unused_access"], 2)
+        self.assertIn("note", tool_output["summary"])
+
+    @patch("management.principal.proxy.PrincipalProxy.request_filtered_principals")
+    def test_audit_redhat_access_permissions_by_application(self, mock_proxy):
+        """Positive: audit_redhat_access groups permissions by application."""
+        mock_proxy.return_value = {"status_code": 200, "data": []}
+
+        response = self._call_tool("audit_redhat_access")
+
+        tool_output = self._get_tool_output(response)
+        self.assertIn("permissions_by_application", tool_output["summary"])
+        self.assertIn("test-app", tool_output["summary"]["permissions_by_application"])
+        self.assertIn("other-app", tool_output["summary"]["permissions_by_application"])
+
+    def test_audit_redhat_access_no_requests(self):
+        """Negative: audit_redhat_access returns empty when no requests exist."""
+        CrossAccountRequest.objects.all().delete()
+
+        response = self._call_tool("audit_redhat_access")
+
+        tool_output = self._get_tool_output(response)
+        self.assertEqual(len(tool_output["active_access"]), 0)
+        self.assertIn("message", tool_output["summary"])
+        self.assertIn("hint", tool_output["summary"])
+
+    @patch("management.principal.proxy.PrincipalProxy.request_filtered_principals")
+    def test_audit_redhat_access_include_inactive(self, mock_proxy):
+        """Positive: audit_redhat_access includes expired requests when include_inactive=true."""
+        mock_proxy.return_value = {"status_code": 200, "data": []}
+
+        # Create an expired request
+        expired_car = CrossAccountRequest.objects.create(
+            target_org=self.tenant.org_id,
+            user_id="10003",
+            status="expired",
+            start_date=timezone.now() - timezone.timedelta(days=30),
+            end_date=timezone.now() - timezone.timedelta(days=1),
+        )
+        expired_car.roles.add(self.system_role)
+
+        response = self._call_tool("audit_redhat_access", {"include_inactive": True})
+
+        tool_output = self._get_tool_output(response)
+        self.assertEqual(len(tool_output["active_access"]), 3)
+
+    @patch("management.principal.proxy.PrincipalProxy.request_filtered_principals")
+    def test_audit_redhat_access_custom_audit_days(self, mock_proxy):
+        """Positive: audit_redhat_access respects custom audit_days parameter."""
+        mock_proxy.return_value = {
+            "status_code": 200,
+            "data": [
+                {
+                    "user_id": "10001",
+                    "first_name": "Test",
+                    "last_name": "User1",
+                    "email": "user1@example.com",
+                    "username": "testuser1",
+                }
+            ],
+        }
+
+        response = self._call_tool("audit_redhat_access", {"audit_days": 7})
+
+        tool_output = self._get_tool_output(response)
+        self.assertEqual(tool_output["summary"]["audit_period_days"], 7)

--- a/tests/management/test_mcp_views.py
+++ b/tests/management/test_mcp_views.py
@@ -3268,13 +3268,13 @@ class AuditRedhatAccessTests(MCPToolTestMixin, IdentityRequest):
         )
         Access.objects.create(permission=self.other_perm, role=self.other_role, tenant=self.public_tenant)
 
-        # Create a cross-account request
+        # Create a cross-account request (not expiring soon)
         self.car = CrossAccountRequest.objects.create(
             target_org=self.tenant.org_id,
             user_id="10001",
             status="approved",
             start_date=timezone.now() - timezone.timedelta(days=1),
-            end_date=timezone.now() + timezone.timedelta(days=6),
+            end_date=timezone.now() + timezone.timedelta(days=30),
         )
         self.car.roles.add(self.system_role)
 


### PR DESCRIPTION
## Link(s) to Jira
https://redhat.atlassian.net/browse/RHCLOUD-47726

## Description of Intent of Change(s)
  Adds audit_redhat_access MCP tool to list all Red Hat cross-account access into an organization with audit log
  activity.

  Changes

  - rbac/management/mcp_views.py - new tool implementation
  - tests/management/test_mcp_views.py - 10 test cases

  Tool

  Returns: who has access, their roles/permissions, expiration dates, and recent RBAC activity.

  Parameters: include_inactive (bool), audit_days (int, default 30), limit (int, default 50)

## Local Testing
How can the feature be exercised?

pipenv run tox -e py312-fast -- tests.management.test_mcp_views.AuditRedhatAccessTests
 
How can the bug be exploited and fix confirmed?
Is any special local setup required?

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Introduce an MCP tool to audit Red Hat cross-account access into an organization and cover it with tests.

New Features:
- Add audit_redhat_access MCP tool to inventory Red Hat cross-account users, their roles, permissions, expirations, and recent RBAC activity, with optional inclusion of inactive requests and configurable audit window.

Tests:
- Add AuditRedhatAccessTests suite to validate successful responses, auth errors, user info enrichment, expiring and unused access detection, permissions aggregation, inclusion of audit logs, handling of no requests, include_inactive behavior, and custom audit_days handling.