### PR TITLE
[RHCLOUD-46770] Add custom role permission parity checks to Kessel verification

### DIFF
--- a/rbac/management/inventory_checker/inventory_api_check.py
+++ b/rbac/management/inventory_checker/inventory_api_check.py
@@ -370,3 +370,32 @@ class RoleBindingInventoryChecker(InventoryApiBaseChecker):
         else:
             logger.info(f"RoleBinding: {binding_uuid} has the correct relations in inventory.")
         return binding_check
+
+
+class CustomRolePermissionChecker(InventoryApiBaseChecker):
+    """Subclass to check custom role permission relations are correct on inventory api."""
+
+    def check_custom_role_permissions(self, permission_tuples: Sequence[RelationTuple], role_uuid: str) -> bool:
+        """Core logic to check custom role permission relations on inventory api.
+
+        Each permission tuple represents: rbac/role:<uuid>#<permission>@rbac/principal:*
+
+        Args:
+            permission_tuples: List of RelationTuple objects from CustomRoleV2._permission_tuple()
+            role_uuid: UUID of the custom role being checked
+
+        Returns:
+            True if all relations exist in the inventory, False otherwise
+        """
+        if not permission_tuples:
+            logger.debug(f"CustomRole: {role_uuid} has no permissions, skipping check")
+            return True
+
+        check_requests = [relation_tuple_to_check_request(tuple_obj) for tuple_obj in permission_tuples]
+
+        permission_check = self.check_inventory_core(check_requests)
+        if not permission_check:
+            logger.warning(f"CustomRole: {role_uuid} does not have the expected permission relations in inventory.")
+        else:
+            logger.info(f"CustomRole: {role_uuid} has the correct permission relations in inventory.")
+        return permission_check

--- a/rbac/management/role/v2_view.py
+++ b/rbac/management/role/v2_view.py
@@ -134,7 +134,15 @@ class RoleV2ViewSet(AtomicOperationsMixin, BaseV2ViewSet):
             audit_log = AuditLog()
             audit_log.log_create(request=request, resource=AuditLog.ROLE_V2)
 
-        custom_v2_role_obj_change_notification_handler(role, "created", request.user)
+        try:
+            custom_v2_role_obj_change_notification_handler(role, "created", request.user)
+        except ValueError:
+            raise
+        except Exception:
+            logging.error(
+                f"Failed to send notification for created role: role pk={role.pk!r}, name={role.name!r}",
+                exc_info=True,
+            )
 
         # Build response with field selection (from context) and permission ordering
         input_permissions = request.data.get("permissions", [])
@@ -155,7 +163,15 @@ class RoleV2ViewSet(AtomicOperationsMixin, BaseV2ViewSet):
             serializer.is_valid(raise_exception=True)
             role = serializer.save()
 
-        custom_v2_role_obj_change_notification_handler(role, "updated", request.user)
+        try:
+            custom_v2_role_obj_change_notification_handler(role, "updated", request.user)
+        except ValueError:
+            raise
+        except Exception:
+            logging.error(
+                f"Failed to send notification for updated role: role pk={role.pk!r}, name={role.name!r}",
+                exc_info=True,
+            )
 
         # Build response with field selection (from context) and permission ordering
         input_permissions = request.data.get("permissions", [])

--- a/rbac/management/tasks.py
+++ b/rbac/management/tasks.py
@@ -36,12 +36,16 @@ from internal.utils import (
     replicate_missing_binding_tuples,
 )
 from management.health.healthcheck import redis_health
-from management.inventory_checker.inventory_api_check import WorkspaceRelationInventoryChecker
+from management.inventory_checker.inventory_api_check import (
+    CustomRolePermissionChecker,
+    WorkspaceRelationInventoryChecker,
+)
 from management.parity_check import run_parity_checks
 from management.principal.cleaner import (
     clean_tenants_principals,
     process_principal_events_from_umb,
 )
+from management.role.v2_model import CustomRoleV2
 from management.workspace.model import Workspace
 from migration_tool.migrate import migrate_data
 from migration_tool.migrate_binding_scope import migrate_all_role_bindings
@@ -231,6 +235,9 @@ def run_kessel_parity_checks_in_worker():
     Returns:
         dict: Summary statistics with checks performed, passed, and failed counts.
     """
+    if not getattr(settings, "PARITY_CHECK_ENABLED", False):
+        return {"message": "Parity checks disabled"}
+
     org_ids_str = settings.PARITY_CHECK_ORG_IDS
     org_ids = [org_id.strip() for org_id in org_ids_str.split(",") if org_id.strip()]
     # Deduplicate org_ids while preserving order to avoid redundant work and double-counting
@@ -245,6 +252,7 @@ def run_kessel_parity_checks_in_worker():
     stats = {
         "total_tenants": 0,
         "total_workspace_pairs_checked": 0,
+        "total_custom_roles_checked": 0,
         "passed_tenants": 0,
         "failed_tenants": 0,
         "tenants_not_found": 0,
@@ -252,7 +260,8 @@ def run_kessel_parity_checks_in_worker():
     }
     tenant_durations = []
 
-    checker = WorkspaceRelationInventoryChecker()
+    workspace_checker = WorkspaceRelationInventoryChecker()
+    role_permission_checker = CustomRolePermissionChecker()
 
     # Bulk fetch all tenants to avoid N+1 queries
     tenants = {t.org_id: t for t in Tenant.objects.filter(org_id__in=org_ids)}
@@ -264,24 +273,28 @@ def run_kessel_parity_checks_in_worker():
             stats["tenants_not_found"] += 1
             continue
 
+        pairs_count = 0
+        workspace_check_passed = False
+        role_results = []
+        custom_role_check_passed = True
+
         try:
             tenant_start = time.monotonic()
             logger.info(f"Running parity check for tenant {org_id}")
             stats["total_tenants"] += 1
 
             workspaces = (
-                Workspace.objects.filter(tenant=tenant)
+                Workspace.objects.filter(tenant=tenant, parent_id__isnull=False)
                 .exclude(type=Workspace.Types.ROOT)
                 .values_list("id", "parent_id")
             )
 
-            workspace_pairs = [(str(w_id), str(parent_id)) for (w_id, parent_id) in workspaces if parent_id]
+            workspace_pairs = [(str(w_id), str(parent_id)) for (w_id, parent_id) in workspaces]
             pairs_count = len(workspace_pairs)
 
-            workspace_check_passed = True
             if workspace_pairs:
                 logger.info(f"Checking {pairs_count} workspace parent relations for tenant {org_id}")
-                workspace_check_passed = checker.check_workspace_descendants(workspace_pairs)
+                workspace_check_passed = workspace_checker.check_workspace_descendants(workspace_pairs)
             else:
                 # No pairs means no default workspace with a parent — this is unexpected and should be flagged
                 logger.warning(f"No workspace pairs to check for tenant {org_id} — missing default workspace?")
@@ -289,7 +302,32 @@ def run_kessel_parity_checks_in_worker():
 
             stats["total_workspace_pairs_checked"] += pairs_count
 
-            if workspace_check_passed:
+            custom_roles = CustomRoleV2.objects.filter(tenant=tenant).prefetch_related("permissions")
+            custom_role_check_passed = True
+            role_results = []
+
+            for role in custom_roles:
+                permission_tuples = [CustomRoleV2._permission_tuple(role, perm) for perm in role.permissions.all()]
+                role_passed = role_permission_checker.check_custom_role_permissions(permission_tuples, str(role.uuid))
+                role_results.append(
+                    {
+                        "role_uuid": str(role.uuid),
+                        "role_name": role.name,
+                        "permission_count": len(permission_tuples),
+                        "passed": role_passed,
+                    }
+                )
+                if not role_passed:
+                    custom_role_check_passed = False
+
+            stats["total_custom_roles_checked"] += len(role_results)
+            if role_results:
+                logger.info(f"Checked {len(role_results)} custom role(s) for tenant {org_id}")
+
+            # Tenant passes only if BOTH workspace and custom role checks pass
+            tenant_passed = workspace_check_passed and custom_role_check_passed
+
+            if tenant_passed:
                 stats["passed_tenants"] += 1
                 logger.info(f"Parity check PASSED for tenant {org_id}")
             else:
@@ -304,7 +342,11 @@ def run_kessel_parity_checks_in_worker():
                 {
                     "org_id": org_id,
                     "workspace_pairs_checked": pairs_count,
-                    "passed": workspace_check_passed,
+                    "workspace_check_passed": workspace_check_passed,
+                    "custom_roles_checked": len(role_results),
+                    "custom_role_check_passed": custom_role_check_passed,
+                    "role_results": role_results,
+                    "passed": tenant_passed,
                     "duration_seconds": round(tenant_elapsed, 3),
                 }
             )
@@ -317,14 +359,17 @@ def run_kessel_parity_checks_in_worker():
             stats["tenants_checked"].append(
                 {
                     "org_id": org_id,
-                    "workspace_pairs_checked": 0,
+                    "workspace_pairs_checked": pairs_count,
+                    "workspace_check_passed": workspace_check_passed,
+                    "custom_roles_checked": len(role_results),
+                    "custom_role_check_passed": custom_role_check_passed,
+                    "role_results": role_results,
                     "passed": False,
                     "error": str(e),
                     "duration_seconds": round(tenant_elapsed, 3),
                 }
             )
 
-    # Compute timing percentiles
     timing_stats = {}
     if tenant_durations:
         sorted_durations = sorted(tenant_durations)
@@ -345,7 +390,8 @@ def run_kessel_parity_checks_in_worker():
         f"Passed: {stats['passed_tenants']}, "
         f"Failed: {stats['failed_tenants']}, "
         f"Not Found: {stats['tenants_not_found']}, "
-        f"Total workspace pairs: {stats['total_workspace_pairs_checked']}"
+        f"Total workspace pairs: {stats['total_workspace_pairs_checked']}, "
+        f"Total custom roles: {stats['total_custom_roles_checked']}"
     )
 
     stats["timing"] = timing_stats

--- a/tests/management/inventory_checker/test_custom_role_permission_checker.py
+++ b/tests/management/inventory_checker/test_custom_role_permission_checker.py
@@ -1,0 +1,171 @@
+#
+# Copyright 2026 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""Tests for CustomRolePermissionChecker."""
+
+from unittest.mock import MagicMock, patch
+
+from kessel.inventory.v1beta2.check_response_pb2 import CheckResponse
+from management.inventory_checker.inventory_api_check import CustomRolePermissionChecker
+from management.models import CustomRoleV2, Permission
+from tests.identity_request import IdentityRequest
+
+INVENTORY_STUB_PATH = "management.inventory_checker.inventory_api_check.inventory_service_pb2_grpc.KesselInventoryServiceStub"  # noqa: E501
+
+
+class CustomRolePermissionCheckerTest(IdentityRequest):
+    """Tests for the CustomRolePermissionChecker class."""
+
+    def setUp(self):
+        """Set up test data."""
+        super().setUp()
+
+        # Create a custom role
+        self.role = CustomRoleV2.objects.create(
+            name="test-role",
+            description="Test role description",
+            tenant=self.tenant,
+        )
+
+        # Create permissions
+        self.perm1 = Permission.objects.create(
+            permission="inventory:hosts:read",
+            tenant=self.tenant,
+        )
+        self.perm2 = Permission.objects.create(
+            permission="inventory:hosts:write",
+            tenant=self.tenant,
+        )
+        self.perm3 = Permission.objects.create(
+            permission="inventory:groups:read",
+            tenant=self.tenant,
+        )
+
+        self.checker = CustomRolePermissionChecker()
+
+    def _setup_inventory_mocks(self, mock_create_channel, mock_stub_responses):
+        """Helper to set up inventory API mocks.
+
+        Args:
+            mock_create_channel: Mock for create_client_channel_inventory
+            mock_stub_responses: Either a single response or list of responses for stub.Check
+
+        Returns:
+            mock_stub: The mocked KesselInventoryServiceStub
+        """
+        mock_stub = MagicMock()
+        if isinstance(mock_stub_responses, list):
+            mock_stub.Check.side_effect = mock_stub_responses
+        else:
+            mock_stub.Check.return_value = mock_stub_responses
+
+        mock_channel = MagicMock()
+        mock_channel.__enter__.return_value = mock_channel
+        mock_channel.__exit__.return_value = None
+        mock_create_channel.return_value = mock_channel
+
+        return mock_stub
+
+    @patch("management.inventory_checker.inventory_api_check.create_client_channel_inventory")
+    @patch("management.inventory_checker.inventory_api_check.json_format.MessageToDict")
+    def test_check_custom_role_permissions_all_exist(self, mock_message_to_dict, mock_create_channel):
+        """Test that check returns True when all permission relations exist in inventory."""
+        # Add permissions to role
+        self.role.permissions.add(self.perm1, self.perm2, self.perm3)
+
+        mock_response = MagicMock(spec=CheckResponse)
+        mock_stub = self._setup_inventory_mocks(mock_create_channel, mock_response)
+        mock_message_to_dict.return_value = {"allowed": "ALLOWED_TRUE"}
+
+        with patch(INVENTORY_STUB_PATH, return_value=mock_stub):
+            permission_tuples = [CustomRoleV2._permission_tuple(self.role, p) for p in self.role.permissions.all()]
+            result = self.checker.check_custom_role_permissions(permission_tuples, str(self.role.uuid))
+
+            self.assertTrue(result)
+            self.assertEqual(mock_stub.Check.call_count, 3)
+
+    @patch("management.inventory_checker.inventory_api_check.create_client_channel_inventory")
+    @patch("management.inventory_checker.inventory_api_check.json_format.MessageToDict")
+    def test_check_custom_role_permissions_missing_relation(self, mock_message_to_dict, mock_create_channel):
+        """Test that check returns False when a permission relation is missing in inventory."""
+        # Add permissions to role
+        self.role.permissions.add(self.perm1, self.perm2, self.perm3)
+
+        mock_responses = [
+            MagicMock(spec=CheckResponse),
+            MagicMock(spec=CheckResponse),
+            MagicMock(spec=CheckResponse),
+        ]
+        mock_stub = self._setup_inventory_mocks(mock_create_channel, mock_responses)
+        # Second permission is missing
+        mock_message_to_dict.side_effect = [
+            {"allowed": "ALLOWED_TRUE"},
+            {"allowed": "ALLOWED_FALSE"},
+            {"allowed": "ALLOWED_TRUE"},
+        ]
+
+        with patch(INVENTORY_STUB_PATH, return_value=mock_stub):
+            permission_tuples = [CustomRoleV2._permission_tuple(self.role, p) for p in self.role.permissions.all()]
+            result = self.checker.check_custom_role_permissions(permission_tuples, str(self.role.uuid))
+            self.assertFalse(result)
+
+    def test_check_custom_role_permissions_no_permissions(self):
+        """Test that check returns True when role has no permissions (empty tuple list)."""
+        # Role has no permissions
+        permission_tuples = []
+        result = self.checker.check_custom_role_permissions(permission_tuples, str(self.role.uuid))
+        self.assertTrue(result)
+
+    @patch("management.inventory_checker.inventory_api_check.create_client_channel_inventory")
+    @patch("management.inventory_checker.inventory_api_check.json_format.MessageToDict")
+    def test_check_custom_role_permissions_single_permission(self, mock_message_to_dict, mock_create_channel):
+        """Test checking a role with a single permission."""
+        # Add one permission
+        self.role.permissions.add(self.perm1)
+
+        mock_response = MagicMock(spec=CheckResponse)
+        mock_stub = self._setup_inventory_mocks(mock_create_channel, mock_response)
+        mock_message_to_dict.return_value = {"allowed": "ALLOWED_TRUE"}
+
+        with patch(INVENTORY_STUB_PATH, return_value=mock_stub):
+            permission_tuples = [CustomRoleV2._permission_tuple(self.role, p) for p in self.role.permissions.all()]
+            result = self.checker.check_custom_role_permissions(permission_tuples, str(self.role.uuid))
+
+            self.assertTrue(result)
+            self.assertEqual(mock_stub.Check.call_count, 1)
+
+    @patch("management.inventory_checker.inventory_api_check.create_client_channel_inventory")
+    @patch("management.inventory_checker.inventory_api_check.json_format.MessageToDict")
+    def test_check_custom_role_permissions_all_missing(self, mock_message_to_dict, mock_create_channel):
+        """Test that check returns False when all permission relations are missing."""
+        # Add permissions to role
+        self.role.permissions.add(self.perm1, self.perm2)
+
+        mock_responses = [
+            MagicMock(spec=CheckResponse),
+            MagicMock(spec=CheckResponse),
+        ]
+        mock_stub = self._setup_inventory_mocks(mock_create_channel, mock_responses)
+        # All permissions are missing
+        mock_message_to_dict.side_effect = [
+            {"allowed": "ALLOWED_FALSE"},
+            {"allowed": "ALLOWED_FALSE"},
+        ]
+
+        with patch(INVENTORY_STUB_PATH, return_value=mock_stub):
+            permission_tuples = [CustomRoleV2._permission_tuple(self.role, p) for p in self.role.permissions.all()]
+            result = self.checker.check_custom_role_permissions(permission_tuples, str(self.role.uuid))
+            self.assertFalse(result)

--- a/tests/management/test_parity_tasks.py
+++ b/tests/management/test_parity_tasks.py
@@ -16,9 +16,11 @@
 #
 """Test the parity check tasks module."""
 
+from unittest import mock
 from unittest.mock import patch
 
 from django.test import override_settings
+from management.models import CustomRoleV2, Permission
 from management.tasks import run_kessel_parity_checks_in_worker
 from management.workspace.model import Workspace
 from tests.identity_request import IdentityRequest
@@ -51,21 +53,21 @@ class ParityCheckTasksTest(IdentityRequest):
             parent=self.default_workspace,
         )
 
-    @override_settings(PARITY_CHECK_ORG_IDS="")
+    @override_settings(PARITY_CHECK_ENABLED=True, PARITY_CHECK_ORG_IDS="")
     def test_parity_check_task_no_org_ids_configured(self):
         """Test parity check task when no org_ids are configured."""
         result = run_kessel_parity_checks_in_worker()
 
         self.assertEqual(result, {"message": "No org_ids configured"})
 
-    @override_settings(PARITY_CHECK_ORG_IDS="   ,  ,  ")
+    @override_settings(PARITY_CHECK_ENABLED=True, PARITY_CHECK_ORG_IDS="   ,  ,  ")
     def test_parity_check_task_empty_org_ids_list(self):
         """Test parity check task when org_ids list is empty after stripping."""
         result = run_kessel_parity_checks_in_worker()
 
         self.assertEqual(result, {"message": "No org_ids configured"})
 
-    @override_settings(PARITY_CHECK_ORG_IDS="999999999")
+    @override_settings(PARITY_CHECK_ENABLED=True, PARITY_CHECK_ORG_IDS="999999999")
     def test_parity_check_task_tenant_not_found(self):
         """Test parity check task when tenant is not found."""
         result = run_kessel_parity_checks_in_worker()
@@ -75,7 +77,7 @@ class ParityCheckTasksTest(IdentityRequest):
         self.assertEqual(result["passed_tenants"], 0)
         self.assertEqual(result["failed_tenants"], 0)
 
-    @override_settings(PARITY_CHECK_ORG_IDS="test_org_id")
+    @override_settings(PARITY_CHECK_ENABLED=True, PARITY_CHECK_ORG_IDS="test_org_id")
     @patch(
         "management.inventory_checker.inventory_api_check.WorkspaceRelationInventoryChecker.check_workspace_descendants"
     )
@@ -103,7 +105,7 @@ class ParityCheckTasksTest(IdentityRequest):
         self.assertEqual(result["tenants_checked"][0]["workspace_pairs_checked"], 0)
         self.assertFalse(result["tenants_checked"][0]["passed"])
 
-    @override_settings(PARITY_CHECK_ORG_IDS="test_org_id")
+    @override_settings(PARITY_CHECK_ENABLED=True, PARITY_CHECK_ORG_IDS="test_org_id")
     @patch(
         "management.inventory_checker.inventory_api_check.WorkspaceRelationInventoryChecker.check_workspace_descendants"
     )
@@ -141,7 +143,7 @@ class ParityCheckTasksTest(IdentityRequest):
         self.assertIn("p95_seconds", result["timing"])
         self.assertIn("p99_seconds", result["timing"])
 
-    @override_settings(PARITY_CHECK_ORG_IDS="test_org_id")
+    @override_settings(PARITY_CHECK_ENABLED=True, PARITY_CHECK_ORG_IDS="test_org_id")
     @patch(
         "management.inventory_checker.inventory_api_check.WorkspaceRelationInventoryChecker.check_workspace_descendants"
     )
@@ -170,7 +172,30 @@ class ParityCheckTasksTest(IdentityRequest):
         self.assertEqual(result["tenants_checked"][0]["workspace_pairs_checked"], 2)
         self.assertFalse(result["tenants_checked"][0]["passed"])
 
-    @override_settings(PARITY_CHECK_ORG_IDS="test_org_1, test_org_2, 999999")
+    @override_settings(PARITY_CHECK_ENABLED=True, PARITY_CHECK_ORG_IDS="test_org_id, test_org_id")
+    @patch(
+        "management.inventory_checker.inventory_api_check.WorkspaceRelationInventoryChecker.check_workspace_descendants"
+    )
+    def test_parity_check_task_deduplicates_org_ids(self, mock_check_workspace):
+        """Test parity check task deduplicates org_ids and only processes a tenant once."""
+        # Update tenant org_id to match the duplicated org_id in settings
+        self.tenant.org_id = "test_org_id"
+        self.tenant.save()
+
+        # Mock the checker to return True
+        mock_check_workspace.return_value = True
+
+        result = run_kessel_parity_checks_in_worker()
+
+        # Only one tenant should be processed despite duplicate org_id
+        self.assertEqual(result["total_tenants"], 1)
+        self.assertEqual(len(result["tenants_checked"]), 1)
+        self.assertEqual(result["tenants_checked"][0]["org_id"], "test_org_id")
+
+        # Ensure the workspace checker is only called once (not twice)
+        mock_check_workspace.assert_called_once()
+
+    @override_settings(PARITY_CHECK_ENABLED=True, PARITY_CHECK_ORG_IDS="test_org_1, test_org_2, 999999")
     @patch(
         "management.inventory_checker.inventory_api_check.WorkspaceRelationInventoryChecker.check_workspace_descendants"
     )
@@ -223,7 +248,7 @@ class ParityCheckTasksTest(IdentityRequest):
         root2.delete()
         tenant2.delete()
 
-    @override_settings(PARITY_CHECK_ORG_IDS="test_org_id")
+    @override_settings(PARITY_CHECK_ENABLED=True, PARITY_CHECK_ORG_IDS="test_org_id")
     @patch(
         "management.inventory_checker.inventory_api_check.WorkspaceRelationInventoryChecker.check_workspace_descendants"
     )
@@ -256,7 +281,7 @@ class ParityCheckTasksTest(IdentityRequest):
         for workspace_id, parent_id in zip(workspace_ids, parent_ids):
             self.assertIn((workspace_id, parent_id), called_pairs)
 
-    @override_settings(PARITY_CHECK_ORG_IDS="test_org_id")
+    @override_settings(PARITY_CHECK_ENABLED=True, PARITY_CHECK_ORG_IDS="test_org_id")
     @patch(
         "management.inventory_checker.inventory_api_check.WorkspaceRelationInventoryChecker.check_workspace_descendants"
     )
@@ -280,7 +305,242 @@ class ParityCheckTasksTest(IdentityRequest):
         self.assertEqual(result["failed_tenants"], 1)
         self.assertEqual(len(result["tenants_checked"]), 1)
         self.assertEqual(result["tenants_checked"][0]["org_id"], "test_org_id")
-        self.assertEqual(result["tenants_checked"][0]["workspace_pairs_checked"], 0)
+        self.assertEqual(result["tenants_checked"][0]["workspace_pairs_checked"], 2)
+        self.assertFalse(result["tenants_checked"][0]["workspace_check_passed"])
         self.assertFalse(result["tenants_checked"][0]["passed"])
         self.assertIn("error", result["tenants_checked"][0])
         self.assertIn("gRPC connection timeout", result["tenants_checked"][0]["error"])
+
+    @override_settings(PARITY_CHECK_ENABLED=True, PARITY_CHECK_ORG_IDS="test_org_id")
+    @patch(
+        "management.inventory_checker.inventory_api_check.CustomRolePermissionChecker.check_custom_role_permissions"
+    )
+    @patch(
+        "management.inventory_checker.inventory_api_check.WorkspaceRelationInventoryChecker.check_workspace_descendants"
+    )
+    def test_parity_check_with_custom_roles_all_pass(self, mock_check_workspace, mock_check_role_perms):
+        """Test parity check when both workspace and custom role checks pass."""
+        # Update tenant org_id to match settings
+        self.tenant.org_id = "test_org_id"
+        self.tenant.save()
+
+        # Create custom roles with permissions
+        role1 = CustomRoleV2.objects.create(name="role1", tenant=self.tenant)
+        perm1 = Permission.objects.create(permission="inventory:hosts:read", tenant=self.tenant)
+        role1.permissions.add(perm1)
+
+        role2 = CustomRoleV2.objects.create(name="role2", tenant=self.tenant)
+        perm2 = Permission.objects.create(permission="inventory:hosts:write", tenant=self.tenant)
+        role2.permissions.add(perm2)
+
+        # Mock both checkers to return True
+        mock_check_workspace.return_value = True
+        mock_check_role_perms.return_value = True
+
+        result = run_kessel_parity_checks_in_worker()
+
+        # Verify workspace check was called
+        mock_check_workspace.assert_called_once()
+
+        # Verify custom role checks were called (once per role)
+        self.assertEqual(mock_check_role_perms.call_count, 2)
+
+        # Verify result
+        self.assertEqual(result["total_tenants"], 1)
+        self.assertEqual(result["total_workspace_pairs_checked"], 2)
+        self.assertEqual(result["total_custom_roles_checked"], 2)
+        self.assertEqual(result["passed_tenants"], 1)
+        self.assertEqual(result["failed_tenants"], 0)
+        self.assertEqual(len(result["tenants_checked"]), 1)
+
+        tenant_result = result["tenants_checked"][0]
+        self.assertEqual(tenant_result["org_id"], "test_org_id")
+        self.assertTrue(tenant_result["workspace_check_passed"])
+        self.assertTrue(tenant_result["custom_role_check_passed"])
+        self.assertTrue(tenant_result["passed"])
+        self.assertEqual(tenant_result["custom_roles_checked"], 2)
+        self.assertEqual(len(tenant_result["role_results"]), 2)
+
+    @override_settings(PARITY_CHECK_ENABLED=True, PARITY_CHECK_ORG_IDS="test_org_id")
+    @patch(
+        "management.inventory_checker.inventory_api_check.CustomRolePermissionChecker.check_custom_role_permissions"
+    )
+    @patch(
+        "management.inventory_checker.inventory_api_check.WorkspaceRelationInventoryChecker.check_workspace_descendants"
+    )
+    def test_parity_check_custom_role_fails_workspace_passes(self, mock_check_workspace, mock_check_role_perms):
+        """Test parity check when workspace passes but custom role check fails."""
+        # Update tenant org_id to match settings
+        self.tenant.org_id = "test_org_id"
+        self.tenant.save()
+
+        # Create a custom role
+        role1 = CustomRoleV2.objects.create(name="role1", tenant=self.tenant)
+        perm1 = Permission.objects.create(permission="inventory:hosts:read", tenant=self.tenant)
+        role1.permissions.add(perm1)
+
+        # Mock workspace check to pass, custom role check to fail
+        mock_check_workspace.return_value = True
+        mock_check_role_perms.return_value = False
+
+        result = run_kessel_parity_checks_in_worker()
+
+        # Verify result - tenant fails because custom role check failed
+        self.assertEqual(result["total_tenants"], 1)
+        self.assertEqual(result["passed_tenants"], 0)
+        self.assertEqual(result["failed_tenants"], 1)
+
+        tenant_result = result["tenants_checked"][0]
+        self.assertTrue(tenant_result["workspace_check_passed"])
+        self.assertFalse(tenant_result["custom_role_check_passed"])
+        self.assertFalse(tenant_result["passed"])
+
+    @override_settings(PARITY_CHECK_ENABLED=True, PARITY_CHECK_ORG_IDS="test_org_id")
+    @patch(
+        "management.inventory_checker.inventory_api_check.CustomRolePermissionChecker.check_custom_role_permissions"
+    )
+    @patch(
+        "management.inventory_checker.inventory_api_check.WorkspaceRelationInventoryChecker.check_workspace_descendants"
+    )
+    def test_parity_check_workspace_fails_custom_role_passes(self, mock_check_workspace, mock_check_role_perms):
+        """Test parity check when custom role passes but workspace check fails."""
+        # Update tenant org_id to match settings
+        self.tenant.org_id = "test_org_id"
+        self.tenant.save()
+
+        # Create a custom role
+        role1 = CustomRoleV2.objects.create(name="role1", tenant=self.tenant)
+        perm1 = Permission.objects.create(permission="inventory:hosts:read", tenant=self.tenant)
+        role1.permissions.add(perm1)
+
+        # Mock workspace check to fail, custom role check to pass
+        mock_check_workspace.return_value = False
+        mock_check_role_perms.return_value = True
+
+        result = run_kessel_parity_checks_in_worker()
+
+        # Verify result - tenant fails because workspace check failed
+        self.assertEqual(result["total_tenants"], 1)
+        self.assertEqual(result["passed_tenants"], 0)
+        self.assertEqual(result["failed_tenants"], 1)
+
+        tenant_result = result["tenants_checked"][0]
+        self.assertFalse(tenant_result["workspace_check_passed"])
+        self.assertTrue(tenant_result["custom_role_check_passed"])
+        self.assertFalse(tenant_result["passed"])
+
+    @override_settings(PARITY_CHECK_ENABLED=True, PARITY_CHECK_ORG_IDS="test_org_id")
+    @patch(
+        "management.inventory_checker.inventory_api_check.CustomRolePermissionChecker.check_custom_role_permissions"
+    )
+    @patch(
+        "management.inventory_checker.inventory_api_check.WorkspaceRelationInventoryChecker.check_workspace_descendants"
+    )
+    def test_parity_check_no_custom_roles(self, mock_check_workspace, mock_check_role_perms):
+        """Test parity check when tenant has no custom roles."""
+        # Update tenant org_id to match settings
+        self.tenant.org_id = "test_org_id"
+        self.tenant.save()
+
+        # Mock workspace check to pass
+        mock_check_workspace.return_value = True
+
+        result = run_kessel_parity_checks_in_worker()
+
+        # Verify custom role checker was never called
+        mock_check_role_perms.assert_not_called()
+
+        # Verify result - tenant passes based on workspace check only
+        self.assertEqual(result["total_tenants"], 1)
+        self.assertEqual(result["total_custom_roles_checked"], 0)
+        self.assertEqual(result["passed_tenants"], 1)
+        self.assertEqual(result["failed_tenants"], 0)
+
+        tenant_result = result["tenants_checked"][0]
+        self.assertTrue(tenant_result["workspace_check_passed"])
+        self.assertTrue(tenant_result["custom_role_check_passed"])
+        self.assertTrue(tenant_result["passed"])
+        self.assertEqual(tenant_result["custom_roles_checked"], 0)
+        self.assertEqual(len(tenant_result["role_results"]), 0)
+
+    @override_settings(PARITY_CHECK_ENABLED=False, PARITY_CHECK_ORG_IDS="test_org_id")
+    @mock.patch("management.tasks.CustomRolePermissionChecker")
+    @mock.patch("management.tasks.WorkspaceRelationInventoryChecker")
+    def test_parity_check_task_disabled(self, mock_workspace_checker_cls, mock_role_checker_cls):
+        """Test parity check task returns early when disabled."""
+        result = run_kessel_parity_checks_in_worker()
+
+        self.assertEqual(result, {"message": "Parity checks disabled"})
+        mock_workspace_checker_cls.assert_not_called()
+        mock_role_checker_cls.assert_not_called()
+
+    @override_settings(PARITY_CHECK_ENABLED=True, PARITY_CHECK_ORG_IDS="test_org_id")
+    @patch(
+        "management.inventory_checker.inventory_api_check.CustomRolePermissionChecker.check_custom_role_permissions"
+    )
+    @patch(
+        "management.inventory_checker.inventory_api_check.WorkspaceRelationInventoryChecker.check_workspace_descendants"
+    )
+    def test_parity_check_task_handles_custom_role_checker_exception(
+        self, mock_check_workspace, mock_check_role_perms
+    ):
+        """Test that the task handles exceptions from the custom role checker gracefully."""
+        self.tenant.org_id = "test_org_id"
+        self.tenant.save()
+
+        CustomRoleV2.objects.create(name="role1", tenant=self.tenant)
+
+        mock_check_workspace.return_value = True
+        mock_check_role_perms.side_effect = RuntimeError("gRPC connection timeout")
+
+        result = run_kessel_parity_checks_in_worker()
+
+        self.assertEqual(result["total_tenants"], 1)
+        self.assertEqual(result["passed_tenants"], 0)
+        self.assertEqual(result["failed_tenants"], 1)
+        self.assertEqual(len(result["tenants_checked"]), 1)
+        tenant_result = result["tenants_checked"][0]
+        self.assertFalse(tenant_result["passed"])
+        self.assertEqual(tenant_result["workspace_pairs_checked"], 2)
+        self.assertTrue(tenant_result["workspace_check_passed"])
+        self.assertIn("error", tenant_result)
+        self.assertIn("gRPC connection timeout", tenant_result["error"])
+
+    @override_settings(PARITY_CHECK_ENABLED=True, PARITY_CHECK_ORG_IDS="test_org_id")
+    @patch(
+        "management.inventory_checker.inventory_api_check.CustomRolePermissionChecker.check_custom_role_permissions"
+    )
+    @patch(
+        "management.inventory_checker.inventory_api_check.WorkspaceRelationInventoryChecker.check_workspace_descendants"
+    )
+    def test_parity_check_custom_role_with_no_permissions(self, mock_check_workspace, mock_check_role_perms):
+        """Test parity check when custom role has no permissions."""
+        # Update tenant org_id to match settings
+        self.tenant.org_id = "test_org_id"
+        self.tenant.save()
+
+        # Create a custom role with no permissions
+        CustomRoleV2.objects.create(name="empty-role", tenant=self.tenant)
+
+        # Mock workspace check to pass
+        mock_check_workspace.return_value = True
+        # Empty permission list returns True
+        mock_check_role_perms.return_value = True
+
+        result = run_kessel_parity_checks_in_worker()
+
+        # Verify custom role checker was called once (for the role with no permissions)
+        self.assertEqual(mock_check_role_perms.call_count, 1)
+        # Verify the call was with empty tuple list
+        call_args = mock_check_role_perms.call_args[0]
+        self.assertEqual(len(call_args[0]), 0)
+
+        # Verify result
+        self.assertEqual(result["total_tenants"], 1)
+        self.assertEqual(result["total_custom_roles_checked"], 1)
+        self.assertEqual(result["passed_tenants"], 1)
+
+        tenant_result = result["tenants_checked"][0]
+        self.assertTrue(tenant_result["passed"])
+        self.assertEqual(tenant_result["custom_roles_checked"], 1)
+        self.assertEqual(tenant_result["role_results"][0]["permission_count"], 0)


### PR DESCRIPTION
> **Note:** This replaces #2773, which was auto-closed when its base branch (`feature/RHCLOUD-46769`) was deleted after #2756 was squash-merged into master. The code is the same, rebased onto master. Review history from #2773: Sourcery comments addressed (exception narrowing, disabled-flag test, custom role exception test), lpichler reviewed the base PR (#2756, approved).

## Link(s) to Jira
- [RHCLOUD-46770](https://issues.redhat.com/browse/RHCLOUD-46770)

## Description of Intent of Change(s)

This PR extends the background Kessel-RBAC parity check system to verify custom role permissions in addition to workspace hierarchies. Before this change, the parity checker only validated workspace parent-child relationships in Kessel Inventory. This left a critical gap: custom roles grant permissions through tuples like "role:UUID has permission:foo" stored in Kessel, but we had no way to verify those permission tuples actually exist.

**WHAT**: Added a second check phase to the existing parity job that verifies all custom role permission tuples exist in Kessel Inventory.

**WHY**: If permission tuples are missing or inconsistent, users might see incorrect access control behavior. This provides comprehensive validation to catch data inconsistencies between Django database and Kessel.

**HOW**: 
- Created `CustomRolePermissionChecker` class following the same pattern as existing workspace checker
- Extended the `run_kessel_parity_checks_in_worker()` Celery task to include custom role checks after workspace checks
- Added per-tenant stats tracking for custom roles checked, pass/fail status, and per-role details
- A tenant now passes parity checks only if BOTH workspace hierarchy AND custom role permission checks pass
- Added `PARITY_CHECK_ENABLED` guard at task entry to prevent execution when disabled
- Wrapped notification calls in try-except for best-effort delivery (won't block CRUD operations)
- Error handler now preserves partial progress (reports actual workspace pairs checked and check status when exceptions occur mid-way through custom role checking)

## Local Testing

Since this is a background Celery task requiring Kessel Inventory gRPC connectivity, manual testing requires a full deployment environment. The automated tests mock the gRPC calls and cover all scenarios:

- All permission tuples exist (success)
- Some permission tuples missing (failure)
- Custom roles with no permissions (success, empty check)
- Single permission check
- Integration with workspace checks (both pass, workspace fails, role fails)
- Org ID deduplication
- Task disabled via PARITY_CHECK_ENABLED
- Error handler preserves partial progress from completed check phases

Unit tests: `pipenv run tox -e py312-fast -- tests.management.test_parity_tasks tests.management.inventory_checker.test_custom_role_permission_checker` (22 tests, all passing)

## Checklist
- [ ] if API spec changes are required, is the spec updated? N/A - background task only
- [ ] are there any pre/post merge actions required? if so, document here.
- [x] are theses changes covered by unit tests? Yes - 22 tests (5 for checker class, 17 for task integration)
- [ ] if warranted, are documentation changes accounted for? N/A - internal task
- [x] does this require migration changes? No
- [ ] is there known, direct impact to dependent teams/components? No

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices

[RHCLOUD-46770]: https://redhat.atlassian.net/browse/RHCLOUD-46770?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ