### PR TITLE
[RHCLOUD-47088][RHCLOUD-47089] Add MCP UPDATE and DELETE write tools

### DIFF
--- a/rbac/management/mcp_views.py
+++ b/rbac/management/mcp_views.py
@@ -276,13 +276,13 @@ def _clone_request(
     view applies the same permission checks and is observable in traces.
     """
     method_upper = method.upper()
-    if method_upper in ("POST", "PUT", "PATCH"):
-        factory_method = {"POST": _request_factory.post, "PUT": _request_factory.put, "PATCH": _request_factory.patch}[
-            method_upper
-        ]
-        view_request = factory_method(
-            path, data=json.dumps(body) if body is not None else "", content_type="application/json"
-        )
+    body_data = json.dumps(body) if body is not None else ""
+    if method_upper == "POST":
+        view_request = _request_factory.post(path, data=body_data, content_type="application/json")
+    elif method_upper == "PUT":
+        view_request = _request_factory.put(path, data=body_data, content_type="application/json")
+    elif method_upper == "PATCH":
+        view_request = _request_factory.patch(path, data=body_data, content_type="application/json")
     elif method_upper == "DELETE":
         view_request = _request_factory.delete(path, **kwargs)
     else:
@@ -305,6 +305,38 @@ def _clone_request(
     return view_request
 
 
+def _call_view_json(
+    request: HttpRequest,
+    view: Callable[..., Any],
+    path: str,
+    *,
+    method: str = "GET",
+    body: dict[str, Any] | None = None,
+    query_params: dict[str, str] | None = None,
+    **view_kwargs: str,
+) -> str:
+    """Call a Django view and return the response body as a string.
+
+    Handles response rendering, 204 No Content, and 4xx/5xx error wrapping
+    so MCP clients can distinguish success from failure without parsing
+    the view's raw output.
+    """
+    if query_params:
+        from urllib.parse import urlencode
+
+        path = f"{path}?{urlencode(query_params)}"
+    view_request = _clone_request(request, path, method=method, body=body)
+    response = view(view_request, **view_kwargs)
+    if hasattr(response, "render"):
+        response = response.render()
+    if response.status_code == 204:
+        return json.dumps({"status": "no_content"})
+    content = response.content.decode()
+    if response.status_code >= 400:
+        return json.dumps({"error": f"HTTP {response.status_code}", "detail": content})
+    return content
+
+
 def _call_view_write(
     request: HttpRequest,
     view: Callable[..., Any],
@@ -312,24 +344,10 @@ def _call_view_write(
     body: dict[str, Any],
     *,
     method: str = "POST",
-    **view_kwargs: str,
+    **view_kwargs: Any,
 ) -> str:
-    """Call a Django view with a write request and return the response body.
-
-    For 4xx/5xx responses, wraps the response body in an error structure
-    so MCP clients can distinguish success from failure without parsing
-    the view's raw output.
-    """
-    view_request = _clone_request(request, path, method=method, body=body)
-    response = view(view_request, **view_kwargs)
-    if hasattr(response, "render"):
-        response = response.render()
-    if response.status_code == 204:
-        return json.dumps({"status": "deleted"})
-    content = response.content.decode()
-    if response.status_code >= 400:
-        return json.dumps({"error": f"HTTP {response.status_code}", "detail": content})
-    return content
+    """Call a Django view with a write request (POST/PUT/PATCH)."""
+    return _call_view_json(request, view, path, method=method, body=body, **view_kwargs)
 
 
 def _call_view_delete(
@@ -337,23 +355,10 @@ def _call_view_delete(
     view: Callable[..., Any],
     path: str,
     query_params: dict[str, str] | None = None,
-    **view_kwargs: str,
+    **view_kwargs: Any,
 ) -> str:
-    """Call a Django view with a DELETE request and return the response body."""
-    if query_params:
-        from urllib.parse import urlencode
-
-        path = f"{path}?{urlencode(query_params)}"
-    view_request = _clone_request(request, path, method="DELETE")
-    response = view(view_request, **view_kwargs)
-    if hasattr(response, "render"):
-        response = response.render()
-    if response.status_code == 204:
-        return json.dumps({"status": "deleted"})
-    content = response.content.decode()
-    if response.status_code >= 400:
-        return json.dumps({"error": f"HTTP {response.status_code}", "detail": content})
-    return content
+    """Call a Django view with a DELETE request."""
+    return _call_view_json(request, view, path, method="DELETE", query_params=query_params, **view_kwargs)
 
 
 def _resolve_group_uuid(group_uuid: str, group_name: str, tenant) -> tuple[str | None, str | None]:
@@ -370,6 +375,14 @@ def _resolve_group_uuid(group_uuid: str, group_name: str, tenant) -> tuple[str |
             return None, json.dumps({"error": f"Group '{group_name}' not found"})
         return str(group.uuid), None
     return None, json.dumps({"error": "Either group_uuid or group_name is required"})
+
+
+def _resolve_group_for_tool(request: HttpRequest, group_uuid: str, group_name: str) -> tuple[str | None, str | None]:
+    """Resolve a group UUID from a tool request, checking tenant context first."""
+    tenant = getattr(request, "tenant", None)
+    if not tenant:
+        return None, json.dumps({"error": "No tenant context available"})
+    return _resolve_group_uuid(group_uuid, group_name, tenant)
 
 
 # --- Tool implementations ---
@@ -3212,11 +3225,7 @@ def add_principals_to_group(
     principals: list[str],
 ) -> str:
     """Add principals to a group by delegating to GroupViewSet.principals."""
-    tenant = getattr(request, "tenant", None)
-    if not tenant:
-        return json.dumps({"error": "No tenant context available"})
-
-    resolved_uuid, error = _resolve_group_uuid(group_uuid, group_name, tenant)
+    resolved_uuid, error = _resolve_group_for_tool(request, group_uuid, group_name)
     if error:
         return error
     assert resolved_uuid is not None
@@ -3248,11 +3257,7 @@ def add_roles_to_group(
     roles: list[str],
 ) -> str:
     """Add roles to a group by delegating to GroupViewSet.roles."""
-    tenant = getattr(request, "tenant", None)
-    if not tenant:
-        return json.dumps({"error": "No tenant context available"})
-
-    resolved_uuid, error = _resolve_group_uuid(group_uuid, group_name, tenant)
+    resolved_uuid, error = _resolve_group_for_tool(request, group_uuid, group_name)
     if error:
         return error
     assert resolved_uuid is not None
@@ -3458,11 +3463,7 @@ def update_group(
     description: str = "",
 ) -> str:
     """Update a group by delegating to GroupViewSet."""
-    tenant = getattr(request, "tenant", None)
-    if not tenant:
-        return json.dumps({"error": "No tenant context available"})
-
-    resolved_uuid, error = _resolve_group_uuid(group_uuid, group_name, tenant)
+    resolved_uuid, error = _resolve_group_for_tool(request, group_uuid, group_name)
     if error:
         return error
     assert resolved_uuid is not None
@@ -3608,13 +3609,17 @@ def update_role_binding(
     roles: list[dict[str, str]],
 ) -> str:
     """Update role bindings by subject by delegating to RoleBindingViewSet.by_subject."""
-    query_string = (
-        f"?resource_id={resource_id}&resource_type={resource_type}"
-        f"&subject_id={subject_id}&subject_type={subject_type}"
-    )
-    path = reverse("v2_management:role-bindings-by-subject") + query_string
+    path = reverse("v2_management:role-bindings-by-subject")
+    query_params = {
+        "resource_id": resource_id,
+        "resource_type": resource_type,
+        "subject_id": subject_id,
+        "subject_type": subject_type,
+    }
     body: dict[str, Any] = {"roles": roles}
-    return _call_view_write(request, _role_binding_update_view, path, body, method="PUT")
+    return _call_view_json(
+        request, _role_binding_update_view, path, method="PUT", body=body, query_params=query_params
+    )
 
 
 @register_tool(
@@ -3728,6 +3733,10 @@ def patch_cross_account_request(
     status: str,
 ) -> str:
     """Patch a cross-account request status."""
+    allowed_statuses = {"pending", "approved", "denied", "cancelled", "expired"}
+    if status not in allowed_statuses:
+        return json.dumps({"error": f"Invalid status '{status}'. Must be one of: {sorted(allowed_statuses)}"})
+
     body: dict[str, Any] = {"status": status}
 
     path = reverse("v1_api:cross-detail", kwargs={"pk": request_id})
@@ -3769,11 +3778,7 @@ def delete_group(
     group_name: str = "",
 ) -> str:
     """Delete a group by delegating to GroupViewSet."""
-    tenant = getattr(request, "tenant", None)
-    if not tenant:
-        return json.dumps({"error": "No tenant context available"})
-
-    resolved_uuid, error = _resolve_group_uuid(group_uuid, group_name, tenant)
+    resolved_uuid, error = _resolve_group_for_tool(request, group_uuid, group_name)
     if error:
         return error
     assert resolved_uuid is not None
@@ -3806,14 +3811,10 @@ def remove_principals_from_group(
     service_accounts: str = "",
 ) -> str:
     """Remove principals from a group by delegating to GroupViewSet.principals."""
-    tenant = getattr(request, "tenant", None)
-    if not tenant:
-        return json.dumps({"error": "No tenant context available"})
-
     if not usernames and not service_accounts:
         return json.dumps({"error": "At least one of usernames or service_accounts is required"})
 
-    resolved_uuid, error = _resolve_group_uuid(group_uuid, group_name, tenant)
+    resolved_uuid, error = _resolve_group_for_tool(request, group_uuid, group_name)
     if error:
         return error
     assert resolved_uuid is not None
@@ -3851,11 +3852,7 @@ def remove_roles_from_group(
     roles: str,
 ) -> str:
     """Remove roles from a group by delegating to GroupViewSet.roles."""
-    tenant = getattr(request, "tenant", None)
-    if not tenant:
-        return json.dumps({"error": "No tenant context available"})
-
-    resolved_uuid, error = _resolve_group_uuid(group_uuid, group_name, tenant)
+    resolved_uuid, error = _resolve_group_for_tool(request, group_uuid, group_name)
     if error:
         return error
     assert resolved_uuid is not None

--- a/rbac/management/mcp_views.py
+++ b/rbac/management/mcp_views.py
@@ -96,6 +96,17 @@ _role_binding_batch_create_view = RoleBindingViewSet.as_view({"post": "batch_cre
 _workspace_create_view = WorkspaceViewSet.as_view({"post": "create"})
 _cross_account_create_view = CrossAccountRequestViewSet.as_view({"post": "create"})
 
+# Write views (PUT/PATCH)
+_group_update_view = GroupViewSet.as_view({"put": "update"})
+_role_v1_update_view = RoleViewSet.as_view({"put": "update"})
+_role_v1_patch_view = RoleViewSet.as_view({"patch": "partial_update"})
+_role_v2_update_view = RoleV2ViewSet.as_view({"put": "update"})
+_role_binding_update_view = RoleBindingViewSet.as_view({"put": "by_subject"})
+_workspace_update_view = WorkspaceViewSet.as_view({"put": "update"})
+_workspace_move_view = WorkspaceViewSet.as_view({"post": "move"})
+_cross_account_update_view = CrossAccountRequestViewSet.as_view({"put": "update"})
+_cross_account_patch_view = CrossAccountRequestViewSet.as_view({"patch": "partial_update"})
+
 logger = logging.getLogger(__name__)
 
 PROTOCOL_VERSION = "2025-03-26"
@@ -256,10 +267,16 @@ def _clone_request(
     selected tracing headers from the source request so that the target
     view applies the same permission checks and is observable in traces.
     """
-    if method.upper() == "POST":
-        view_request = _request_factory.post(
+    method_upper = method.upper()
+    if method_upper in ("POST", "PUT", "PATCH"):
+        factory_method = {"POST": _request_factory.post, "PUT": _request_factory.put, "PATCH": _request_factory.patch}[
+            method_upper
+        ]
+        view_request = factory_method(
             path, data=json.dumps(body) if body is not None else "", content_type="application/json"
         )
+    elif method_upper == "DELETE":
+        view_request = _request_factory.delete(path, **kwargs)
     else:
         view_request = _request_factory.get(path, **kwargs)
 
@@ -285,18 +302,22 @@ def _call_view_write(
     view: Callable[..., Any],
     path: str,
     body: dict[str, Any],
+    *,
+    method: str = "POST",
     **view_kwargs: str,
 ) -> str:
-    """Call a Django view with a POST request and return the response body.
+    """Call a Django view with a write request and return the response body.
 
     For 4xx/5xx responses, wraps the response body in an error structure
     so MCP clients can distinguish success from failure without parsing
     the view's raw output.
     """
-    view_request = _clone_request(request, path, method="POST", body=body)
+    view_request = _clone_request(request, path, method=method, body=body)
     response = view(view_request, **view_kwargs)
     if hasattr(response, "render"):
         response = response.render()
+    if response.status_code == 204:
+        return json.dumps({"status": "deleted"})
     content = response.content.decode()
     if response.status_code >= 400:
         return json.dumps({"error": f"HTTP {response.status_code}", "detail": content})
@@ -400,39 +421,57 @@ def _call_view(
     return response.content.decode()
 
 
-# ┌──────────────────────────────────┬───────────┬────────────────────────────────────────────┐
-# │ MCP Tool                         │ Version   │ API Endpoint                               │
-# ├──────────────────────────────────┼───────────┼────────────────────────────────────────────┤
-# │ hello                            │ unver.    │ (none — in-process greeting)               │
-# │ get_status                       │ unver.    │ GET /api/v1/status/                        │
-# │ list_principals                  │ common    │ GET /api/v1/principals/                    │
-# │ list_permissions                 │ common    │ GET /api/v1/permissions/                   │
-# │ list_permission_options          │ common    │ GET /api/v1/permissions/options/           │
-# │ list_audit_logs                  │ common    │ GET /api/v1/auditlogs/                     │
-# │ get_rbac_recent_changes          │ common    │ (in-process audit log analysis)            │
-# │ investigate_group_changes        │ common    │ (orchestrates audit log + authorization)   │
-# │ investigate_user_access          │ common    │ (groups + roles + permissions analysis)    │
-# │ list_groups                      │ common    │ GET /api/v1/groups/                        │
-# │ get_group                        │ common    │ GET /api/v1/groups/{uuid}/                 │
-# │ list_group_principals            │ common    │ GET /api/v1/groups/{uuid}/principals/      │
-# │ list_cross_account_requests      │ common    │ GET /api/v1/cross-account-requests/        │
-# │ get_cross_account_request        │ common    │ GET /api/v1/cross-account-requests/{id}/   │
-# │ investigate_tam_access           │ common    │ (orchestrates cross-account + roles)       │
-# │ audit_redhat_access              │ common    │ (cross-account + roles + audit logs)       │
-# │ list_workspaces                  │ common    │ GET /api/v2/workspaces/                    │
-# │ get_workspace                    │ common    │ GET /api/v2/workspaces/{uuid}/             │
-# │ search_roles                     │ unified   │ V1: GET /api/v1/roles/                     │
-# │                                  │           │ V2: GET /api/v2/roles/                     │
-# │ get_role                         │ unified   │ V1: GET /api/v1/roles/{uuid}/ + /access/   │
-# │                                  │           │ V2: GET /api/v2/roles/{uuid}/              │
-# │ check_user_permission            │ unified   │ V1: GET /api/v1/access/                    │
-# │                                  │           │ V2: role-bindings → roles                  │
-# │ list_access                      │ v1        │ GET /api/v1/access/                        │
-# │ list_group_roles                 │ v1        │ GET /api/v1/groups/{uuid}/roles/           │
-# │ list_role_access                 │ v1        │ GET /api/v1/roles/{uuid}/access/           │
-# │ list_role_bindings               │ v2        │ GET /api/v2/role-bindings/                 │
-# │ list_role_bindings_by_subject    │ v2        │ GET /api/v2/role-bindings/by-subject/      │
-# └──────────────────────────────────┴───────────┴────────────────────────────────────────────┘
+# ┌──────────────────────────────────────┬───────────┬────────────────────────────────────────────────────┐
+# │ MCP Tool                             │ Version   │ API Endpoint                                       │
+# ├──────────────────────────────────────┼───────────┼────────────────────────────────────────────────────┤
+# │ hello                                │ unver.    │ (none -- in-process greeting)                      │
+# │ get_status                           │ unver.    │ GET /api/v1/status/                                │
+# │ list_principals                      │ common    │ GET /api/v1/principals/                            │
+# │ list_permissions                     │ common    │ GET /api/v1/permissions/                           │
+# │ list_permission_options              │ common    │ GET /api/v1/permissions/options/                   │
+# │ list_audit_logs                      │ common    │ GET /api/v1/auditlogs/                             │
+# │ get_rbac_recent_changes              │ common    │ (in-process audit log analysis)                    │
+# │ investigate_group_changes            │ common    │ (orchestrates audit log + authorization)           │
+# │ investigate_user_access              │ common    │ (groups + roles + permissions analysis)            │
+# │ list_groups                          │ common    │ GET /api/v1/groups/                                │
+# │ get_group                            │ common    │ GET /api/v1/groups/{uuid}/                         │
+# │ list_group_principals                │ common    │ GET /api/v1/groups/{uuid}/principals/              │
+# │ list_cross_account_requests          │ common    │ GET /api/v1/cross-account-requests/                │
+# │ get_cross_account_request            │ common    │ GET /api/v1/cross-account-requests/{id}/           │
+# │ investigate_tam_access               │ common    │ (orchestrates cross-account + roles)               │
+# │ audit_redhat_access                  │ common    │ (cross-account + roles + audit logs)               │
+# │ list_workspaces                      │ common    │ GET /api/v2/workspaces/                            │
+# │ get_workspace                        │ common    │ GET /api/v2/workspaces/{uuid}/                     │
+# │ search_roles                         │ unified   │ V1: GET /api/v1/roles/                             │
+# │                                      │           │ V2: GET /api/v2/roles/                             │
+# │ get_role                             │ unified   │ V1: GET /api/v1/roles/{uuid}/ + /access/           │
+# │                                      │           │ V2: GET /api/v2/roles/{uuid}/                      │
+# │ check_user_permission                │ unified   │ V1: GET /api/v1/access/                            │
+# │                                      │           │ V2: role-bindings -> roles                         │
+# │ list_access                          │ v1        │ GET /api/v1/access/                                │
+# │ list_group_roles                     │ v1        │ GET /api/v1/groups/{uuid}/roles/                   │
+# │ list_role_access                     │ v1        │ GET /api/v1/roles/{uuid}/access/                   │
+# │ list_role_bindings                   │ v2        │ GET /api/v2/role-bindings/                         │
+# │ list_role_bindings_by_subject        │ v2        │ GET /api/v2/role-bindings/by-subject/              │
+# ├──────────────────────────────────────┼───────────┼────────────────────────────────────────────────────┤
+# │ create_group                         │ common W  │ POST /api/v1/groups/                              │
+# │ add_principals_to_group              │ common W  │ POST /api/v1/groups/{uuid}/principals/            │
+# │ add_roles_to_group                   │ v1 W      │ POST /api/v1/groups/{uuid}/roles/                 │
+# │ create_role_v1                       │ v1 W      │ POST /api/v1/roles/                               │
+# │ create_role                          │ v2 W      │ POST /api/v2/roles/                               │
+# │ create_role_bindings                 │ v2 W      │ POST /api/v2/role-bindings/:batchCreate           │
+# │ create_workspace                     │ v2 W      │ POST /api/v2/workspaces/                          │
+# │ create_cross_account_request         │ common W  │ POST /api/v1/cross-account-requests/              │
+# │ update_group                         │ common W  │ PUT /api/v1/groups/{uuid}/                        │
+# │ update_role_v1                       │ v1 W      │ PUT /api/v1/roles/{uuid}/                         │
+# │ patch_role_v1                        │ v1 W      │ PATCH /api/v1/roles/{uuid}/                       │
+# │ update_role                          │ v2 W      │ PUT /api/v2/roles/{uuid}/                         │
+# │ update_role_binding                  │ v2 W      │ PUT /api/v2/role-bindings/by-subject/              │
+# │ update_workspace                     │ v2 W      │ PUT /api/v2/workspaces/{uuid}/                    │
+# │ move_workspace                       │ v2 W      │ POST /api/v2/workspaces/{uuid}/move/              │
+# │ update_cross_account_request         │ common W  │ PUT /api/v1/cross-account-requests/{id}/          │
+# │ patch_cross_account_request          │ common W  │ PATCH /api/v1/cross-account-requests/{id}/        │
+# └──────────────────────────────────────┴───────────┴────────────────────────────────────────────────────┘
 
 
 @register_tool(
@@ -3340,6 +3379,321 @@ def create_cross_account_request(
 
     path = reverse("v1_api:cross-list")
     return _call_view_write(request, _cross_account_create_view, path, body)
+
+
+# --- UPDATE tool implementations ---
+
+# ┌──────────────────────────────────────┬───────────┬─────────────────────────────────────────────────────┐
+# │ MCP Tool                             │ Gating    │ API Endpoint                                        │
+# ├──────────────────────────────────────┼───────────┼─────────────────────────────────────────────────────┤
+# │ update_group                         │ both      │ PUT /api/v1/groups/{uuid}/                          │
+# │ update_role_v1                       │ v1        │ PUT /api/v1/roles/{uuid}/                           │
+# │ patch_role_v1                        │ v1        │ PATCH /api/v1/roles/{uuid}/                         │
+# │ update_role                          │ v2        │ PUT /api/v2/roles/{uuid}/                           │
+# │ update_role_binding                  │ v2        │ PUT /api/v2/role-bindings/by-subject/                │
+# │ update_workspace                     │ v2        │ PUT /api/v2/workspaces/{uuid}/                      │
+# │ move_workspace                       │ v2        │ POST /api/v2/workspaces/{uuid}/move/                │
+# │ update_cross_account_request         │ both      │ PUT /api/v1/cross-account-requests/{id}/            │
+# │ patch_cross_account_request          │ both      │ PATCH /api/v1/cross-account-requests/{id}/          │
+# └──────────────────────────────────────┴───────────┴─────────────────────────────────────────────────────┘
+
+
+@register_tool(
+    description=(
+        "Update a custom group (full replacement). Provide either group_uuid OR group_name "
+        "(group_uuid takes precedence). Works for both V1 and V2 organizations. "
+        "System groups (platform_default, admin_default) cannot be modified. "
+        "Required: name. Optional: description. "
+        "Example: update_group(group_name='Engineering', name='Engineering Team', description='Updated desc') "
+        "Returns: the updated group object. "
+        "Calls: PUT /api/v1/groups/{uuid}/"
+    ),
+    requires_auth=True,
+    write=True,
+)
+def update_group(
+    request: HttpRequest,
+    *,
+    group_uuid: str = "",
+    group_name: str = "",
+    name: str,
+    description: str = "",
+) -> str:
+    """Update a group by delegating to GroupViewSet."""
+    tenant = getattr(request, "tenant", None)
+    if not tenant:
+        return json.dumps({"error": "No tenant context available"})
+
+    resolved_uuid, error = _resolve_group_uuid(group_uuid, group_name, tenant)
+    if error:
+        return error
+    assert resolved_uuid is not None
+
+    body: dict[str, Any] = {"name": name}
+    if description:
+        body["description"] = description
+
+    path = reverse("v1_management:group-detail", kwargs={"uuid": resolved_uuid})
+    return _call_view_write(request, _group_update_view, path, body, method="PUT", uuid=resolved_uuid)
+
+
+@register_tool(
+    description=(
+        "Update a custom role (V1 API, full replacement). V1 only -- blocked for V2 organizations "
+        "(use update_role for V2). Replaces the entire role including permissions. "
+        "Required: role_uuid, name, access (list of permission objects). "
+        "Each access entry needs: permission (string 'app:resource:verb') and optionally "
+        "resourceDefinitions. System roles cannot be modified. "
+        "Example: update_role_v1(role_uuid='<uuid>', name='Cost Reader', "
+        "access=[{'permission': 'cost-management:cost_model:read'}]) "
+        "Returns: the updated role object. "
+        "Calls: PUT /api/v1/roles/{uuid}/"
+    ),
+    requires_auth=True,
+    write=True,
+    api_version=ApiVersion.V1,
+)
+def update_role_v1(
+    request: HttpRequest,
+    *,
+    role_uuid: str,
+    name: str,
+    display_name: str = "",
+    description: str = "",
+    access: list[dict[str, Any]],
+) -> str:
+    """Update a V1 role by delegating to RoleViewSet."""
+    body: dict[str, Any] = {"name": name, "access": access}
+    if display_name:
+        body["display_name"] = display_name
+    if description:
+        body["description"] = description
+
+    path = reverse("v1_management:role-detail", kwargs={"uuid": role_uuid})
+    return _call_view_write(request, _role_v1_update_view, path, body, method="PUT", uuid=role_uuid)
+
+
+@register_tool(
+    description=(
+        "Partially update a custom role (V1 API). V1 only. Updates only the fields provided "
+        "(name, display_name, description). Does NOT update permissions -- use update_role_v1 "
+        "for full replacement including permissions. System roles cannot be modified. "
+        "Required: role_uuid. At least one of: name, display_name, description. "
+        "Example: patch_role_v1(role_uuid='<uuid>', display_name='New Display Name') "
+        "Returns: the updated role object. "
+        "Calls: PATCH /api/v1/roles/{uuid}/"
+    ),
+    requires_auth=True,
+    write=True,
+    api_version=ApiVersion.V1,
+)
+def patch_role_v1(
+    request: HttpRequest,
+    *,
+    role_uuid: str,
+    name: str = "",
+    display_name: str = "",
+    description: str = "",
+) -> str:
+    """Patch a V1 role by delegating to RoleViewSet."""
+    body: dict[str, Any] = {}
+    if name:
+        body["name"] = name
+    if display_name:
+        body["display_name"] = display_name
+    if description:
+        body["description"] = description
+
+    if not body:
+        return json.dumps({"error": "At least one of name, display_name, or description is required"})
+
+    path = reverse("v1_management:role-detail", kwargs={"uuid": role_uuid})
+    return _call_view_write(request, _role_v1_patch_view, path, body, method="PATCH", uuid=role_uuid)
+
+
+@register_tool(
+    description=(
+        "Update a custom role (V2 API, full replacement). V2 only -- requires workspace-enabled organization. "
+        "Replaces the entire role including permissions. "
+        "Required: role_uuid, name, permissions (list of permission objects). "
+        "Each permission needs: application, resource_type, operation. "
+        "Example: update_role(role_uuid='<uuid>', name='Cost Reader', "
+        "permissions=[{'application': 'cost-management', 'resource_type': 'cost_model', 'operation': 'read'}]) "
+        "Returns: the updated role object. "
+        "Calls: PUT /api/v2/roles/{uuid}/"
+    ),
+    requires_auth=True,
+    write=True,
+    api_version=ApiVersion.V2,
+)
+def update_role(
+    request: HttpRequest,
+    *,
+    role_uuid: str,
+    name: str,
+    description: str = "",
+    permissions: list[dict[str, str]],
+) -> str:
+    """Update a V2 role by delegating to RoleV2ViewSet."""
+    body: dict[str, Any] = {"name": name, "permissions": permissions}
+    if description:
+        body["description"] = description
+
+    path = reverse("v2_management:roles-detail", kwargs={"uuid": role_uuid})
+    return _call_view_write(request, _role_v2_update_view, path, body, method="PUT", uuid=role_uuid)
+
+
+@register_tool(
+    description=(
+        "Update role bindings for a specific subject on a resource (V2 API). V2 only. "
+        "Sets the exact list of roles for the given subject on the resource -- any existing "
+        "bindings not in the list are removed. "
+        "Required: resource_id, subject_id, subject_type ('principal' or 'group'), "
+        "roles (list of objects with 'id' key). "
+        "Optional: resource_type (default 'workspace'). "
+        "Example: update_role_binding(resource_id='<ws-uuid>', subject_id='<user-uuid>', "
+        "subject_type='principal', roles=[{'id': '<role-uuid>'}]) "
+        "Returns: the updated role binding state. "
+        "Calls: PUT /api/v2/role-bindings/by-subject/"
+    ),
+    requires_auth=True,
+    write=True,
+    api_version=ApiVersion.V2,
+)
+def update_role_binding(
+    request: HttpRequest,
+    *,
+    resource_id: str,
+    resource_type: str = "workspace",
+    subject_id: str,
+    subject_type: str,
+    roles: list[dict[str, str]],
+) -> str:
+    """Update role bindings by subject by delegating to RoleBindingViewSet.by_subject."""
+    query_string = (
+        f"?resource_id={resource_id}&resource_type={resource_type}"
+        f"&subject_id={subject_id}&subject_type={subject_type}"
+    )
+    path = reverse("v2_management:role-bindings-by-subject") + query_string
+    body: dict[str, Any] = {"roles": roles}
+    return _call_view_write(request, _role_binding_update_view, path, body, method="PUT")
+
+
+@register_tool(
+    description=(
+        "Update a workspace (V2 API, full replacement). V2 only. "
+        "Required: workspace_id, name. Optional: description, parent_id (required for "
+        "standard workspaces). Root and ungrouped-hosts workspaces cannot be modified. "
+        "Example: update_workspace(workspace_id='<uuid>', name='EMEA Engineering', "
+        "description='Updated', parent_id='<parent-uuid>') "
+        "Returns: the updated workspace object. "
+        "Calls: PUT /api/v2/workspaces/{uuid}/"
+    ),
+    requires_auth=True,
+    write=True,
+    api_version=ApiVersion.V2,
+)
+def update_workspace(
+    request: HttpRequest,
+    *,
+    workspace_id: str,
+    name: str,
+    description: str = "",
+    parent_id: str = "",
+) -> str:
+    """Update a workspace by delegating to WorkspaceViewSet."""
+    body: dict[str, Any] = {"name": name}
+    if description:
+        body["description"] = description
+    if parent_id:
+        body["parent_id"] = parent_id
+
+    path = reverse("v2_management:workspace-detail", kwargs={"pk": workspace_id})
+    return _call_view_write(request, _workspace_update_view, path, body, method="PUT", pk=workspace_id)
+
+
+@register_tool(
+    description=(
+        "Move a workspace to a new parent (V2 API). V2 only. Changes the parent of a workspace "
+        "in the hierarchy. Root and ungrouped-hosts workspaces cannot be moved. "
+        "Required: workspace_id, parent_id (UUID of the new parent workspace). "
+        "Example: move_workspace(workspace_id='<uuid>', parent_id='<new-parent-uuid>') "
+        "Returns: the moved workspace object. "
+        "Calls: POST /api/v2/workspaces/{uuid}/move/"
+    ),
+    requires_auth=True,
+    write=True,
+    api_version=ApiVersion.V2,
+)
+def move_workspace(
+    request: HttpRequest,
+    *,
+    workspace_id: str,
+    parent_id: str,
+) -> str:
+    """Move a workspace by delegating to WorkspaceViewSet.move."""
+    body: dict[str, Any] = {"parent_id": parent_id}
+    path = reverse("v2_management:workspace-move", kwargs={"pk": workspace_id})
+    return _call_view_write(request, _workspace_move_view, path, body, pk=workspace_id)
+
+
+@register_tool(
+    description=(
+        "Update a cross-account access request (full replacement). "
+        "Required: request_id, target_org (org ID), start_date (MM/DD/YYYY), "
+        "end_date (MM/DD/YYYY), roles (list of role display name strings, NOT UUIDs). "
+        "Example: update_cross_account_request(request_id='<uuid>', target_org='12345', "
+        "start_date='06/01/2026', end_date='06/30/2026', roles=['Vulnerability administrator']) "
+        "Returns: the updated request object. "
+        "Calls: PUT /api/v1/cross-account-requests/{id}/"
+    ),
+    requires_auth=True,
+    write=True,
+)
+def update_cross_account_request(
+    request: HttpRequest,
+    *,
+    request_id: str,
+    target_org: str,
+    start_date: str,
+    end_date: str,
+    roles: list[str],
+) -> str:
+    """Update a cross-account request by delegating to CrossAccountRequestViewSet."""
+    body: dict[str, Any] = {
+        "target_org": target_org,
+        "start_date": start_date,
+        "end_date": end_date,
+        "roles": roles,
+    }
+
+    path = reverse("v1_api:cross-detail", kwargs={"pk": request_id})
+    return _call_view_write(request, _cross_account_update_view, path, body, method="PUT", pk=request_id)
+
+
+@register_tool(
+    description=(
+        "Partially update a cross-account access request (status change). "
+        "Used to approve, deny, or cancel a request. "
+        "Required: request_id, status (one of: pending, approved, denied, cancelled, expired). "
+        "Example: patch_cross_account_request(request_id='<uuid>', status='approved') "
+        "Returns: the updated request object. "
+        "Calls: PATCH /api/v1/cross-account-requests/{id}/"
+    ),
+    requires_auth=True,
+    write=True,
+)
+def patch_cross_account_request(
+    request: HttpRequest,
+    *,
+    request_id: str,
+    status: str,
+) -> str:
+    """Patch a cross-account request status."""
+    body: dict[str, Any] = {"status": status}
+
+    path = reverse("v1_api:cross-detail", kwargs={"pk": request_id})
+    return _call_view_write(request, _cross_account_patch_view, path, body, method="PATCH", pk=request_id)
 
 
 # --- JSON-RPC parsing ---

--- a/rbac/management/mcp_views.py
+++ b/rbac/management/mcp_views.py
@@ -107,6 +107,14 @@ _workspace_move_view = WorkspaceViewSet.as_view({"post": "move"})
 _cross_account_update_view = CrossAccountRequestViewSet.as_view({"put": "update"})
 _cross_account_patch_view = CrossAccountRequestViewSet.as_view({"patch": "partial_update"})
 
+# Write views (DELETE)
+_group_delete_view = GroupViewSet.as_view({"delete": "destroy"})
+_group_principals_delete_view = GroupViewSet.as_view({"delete": "principals"})
+_group_roles_delete_view = GroupViewSet.as_view({"delete": "roles"})
+_role_v1_delete_view = RoleViewSet.as_view({"delete": "destroy"})
+_role_v2_bulk_delete_view = RoleV2ViewSet.as_view({"post": "bulk_destroy"})
+_workspace_delete_view = WorkspaceViewSet.as_view({"delete": "destroy"})
+
 logger = logging.getLogger(__name__)
 
 PROTOCOL_VERSION = "2025-03-26"
@@ -324,6 +332,30 @@ def _call_view_write(
     return content
 
 
+def _call_view_delete(
+    request: HttpRequest,
+    view: Callable[..., Any],
+    path: str,
+    query_params: dict[str, str] | None = None,
+    **view_kwargs: str,
+) -> str:
+    """Call a Django view with a DELETE request and return the response body."""
+    if query_params:
+        from urllib.parse import urlencode
+
+        path = f"{path}?{urlencode(query_params)}"
+    view_request = _clone_request(request, path, method="DELETE")
+    response = view(view_request, **view_kwargs)
+    if hasattr(response, "render"):
+        response = response.render()
+    if response.status_code == 204:
+        return json.dumps({"status": "deleted"})
+    content = response.content.decode()
+    if response.status_code >= 400:
+        return json.dumps({"error": f"HTTP {response.status_code}", "detail": content})
+    return content
+
+
 def _resolve_group_uuid(group_uuid: str, group_name: str, tenant) -> tuple[str | None, str | None]:
     """Resolve a group to its UUID from either group_uuid or group_name.
 
@@ -471,6 +503,12 @@ def _call_view(
 # │ move_workspace                       │ v2 W      │ POST /api/v2/workspaces/{uuid}/move/              │
 # │ update_cross_account_request         │ common W  │ PUT /api/v1/cross-account-requests/{id}/          │
 # │ patch_cross_account_request          │ common W  │ PATCH /api/v1/cross-account-requests/{id}/        │
+# │ delete_group                         │ common W  │ DELETE /api/v1/groups/{uuid}/                     │
+# │ remove_principals_from_group         │ common W  │ DELETE /api/v1/groups/{uuid}/principals/          │
+# │ remove_roles_from_group              │ v1 W      │ DELETE /api/v1/groups/{uuid}/roles/               │
+# │ delete_role_v1                       │ v1 W      │ DELETE /api/v1/roles/{uuid}/                      │
+# │ bulk_delete_roles                    │ v2 W      │ POST /api/v2/roles/:batchDelete                   │
+# │ delete_workspace                     │ v2 W      │ DELETE /api/v2/workspaces/{uuid}/                 │
 # └──────────────────────────────────────┴───────────┴────────────────────────────────────────────────────┘
 
 
@@ -3694,6 +3732,214 @@ def patch_cross_account_request(
 
     path = reverse("v1_api:cross-detail", kwargs={"pk": request_id})
     return _call_view_write(request, _cross_account_patch_view, path, body, method="PATCH", pk=request_id)
+
+
+# --- DELETE tool implementations ---
+
+# ┌──────────────────────────────────────┬───────────┬─────────────────────────────────────────────────────┐
+# │ MCP Tool                             │ Gating    │ API Endpoint                                        │
+# ├──────────────────────────────────────┼───────────┼─────────────────────────────────────────────────────┤
+# │ delete_group                         │ both      │ DELETE /api/v1/groups/{uuid}/                       │
+# │ remove_principals_from_group         │ both      │ DELETE /api/v1/groups/{uuid}/principals/            │
+# │ remove_roles_from_group              │ v1        │ DELETE /api/v1/groups/{uuid}/roles/                 │
+# │ delete_role_v1                       │ v1        │ DELETE /api/v1/roles/{uuid}/                        │
+# │ bulk_delete_roles                    │ v2        │ POST /api/v2/roles/:batchDelete                    │
+# │ delete_workspace                     │ v2        │ DELETE /api/v2/workspaces/{uuid}/                   │
+# └──────────────────────────────────────┴───────────┴─────────────────────────────────────────────────────┘
+
+
+@register_tool(
+    description=(
+        "DESTRUCTIVE: Permanently delete a custom group. This operation is IRREVERSIBLE. "
+        "All role assignments and principal memberships in the group are removed. "
+        "Provide either group_uuid OR group_name (group_uuid takes precedence). "
+        "System groups (platform_default, admin_default) cannot be deleted. "
+        "Works for both V1 and V2 organizations. "
+        "Example: delete_group(group_name='Old Team') "
+        "Returns: {status: 'deleted'}. "
+        "Calls: DELETE /api/v1/groups/{uuid}/"
+    ),
+    requires_auth=True,
+    write=True,
+)
+def delete_group(
+    request: HttpRequest,
+    *,
+    group_uuid: str = "",
+    group_name: str = "",
+) -> str:
+    """Delete a group by delegating to GroupViewSet."""
+    tenant = getattr(request, "tenant", None)
+    if not tenant:
+        return json.dumps({"error": "No tenant context available"})
+
+    resolved_uuid, error = _resolve_group_uuid(group_uuid, group_name, tenant)
+    if error:
+        return error
+    assert resolved_uuid is not None
+
+    path = reverse("v1_management:group-detail", kwargs={"uuid": resolved_uuid})
+    return _call_view_delete(request, _group_delete_view, path, uuid=resolved_uuid)
+
+
+@register_tool(
+    description=(
+        "DESTRUCTIVE: Remove one or more principals (users) from a group. This is IRREVERSIBLE -- "
+        "re-adding requires a separate call. Provide either group_uuid OR group_name "
+        "(group_uuid takes precedence). At least one of usernames or service_accounts is required. "
+        "usernames: comma-separated list of usernames. "
+        "service_accounts: comma-separated list of service account client IDs. "
+        "Works for both V1 and V2 organizations. "
+        "Example: remove_principals_from_group(group_name='Engineering', usernames='jdoe,jsmith') "
+        "Returns: {status: 'deleted'}. "
+        "Calls: DELETE /api/v1/groups/{uuid}/principals/"
+    ),
+    requires_auth=True,
+    write=True,
+)
+def remove_principals_from_group(
+    request: HttpRequest,
+    *,
+    group_uuid: str = "",
+    group_name: str = "",
+    usernames: str = "",
+    service_accounts: str = "",
+) -> str:
+    """Remove principals from a group by delegating to GroupViewSet.principals."""
+    tenant = getattr(request, "tenant", None)
+    if not tenant:
+        return json.dumps({"error": "No tenant context available"})
+
+    if not usernames and not service_accounts:
+        return json.dumps({"error": "At least one of usernames or service_accounts is required"})
+
+    resolved_uuid, error = _resolve_group_uuid(group_uuid, group_name, tenant)
+    if error:
+        return error
+    assert resolved_uuid is not None
+
+    query_params: dict[str, str] = {}
+    if usernames:
+        query_params["usernames"] = usernames
+    if service_accounts:
+        query_params["service-accounts"] = service_accounts
+
+    path = reverse("v1_management:group-principals", kwargs={"uuid": resolved_uuid})
+    return _call_view_delete(request, _group_principals_delete_view, path, query_params, uuid=resolved_uuid)
+
+
+@register_tool(
+    description=(
+        "DESTRUCTIVE: Remove one or more roles from a group. This is IRREVERSIBLE -- "
+        "the role-group association is deleted (the role itself is NOT deleted). "
+        "V1 only -- blocked for V2 organizations (use update_role_binding instead). "
+        "Provide either group_uuid OR group_name (group_uuid takes precedence). "
+        "Required: roles (comma-separated string of role UUIDs). "
+        "Example: remove_roles_from_group(group_name='Engineering', roles='uuid-1,uuid-2') "
+        "Returns: {status: 'deleted'}. "
+        "Calls: DELETE /api/v1/groups/{uuid}/roles/"
+    ),
+    requires_auth=True,
+    write=True,
+    api_version=ApiVersion.V1,
+)
+def remove_roles_from_group(
+    request: HttpRequest,
+    *,
+    group_uuid: str = "",
+    group_name: str = "",
+    roles: str,
+) -> str:
+    """Remove roles from a group by delegating to GroupViewSet.roles."""
+    tenant = getattr(request, "tenant", None)
+    if not tenant:
+        return json.dumps({"error": "No tenant context available"})
+
+    resolved_uuid, error = _resolve_group_uuid(group_uuid, group_name, tenant)
+    if error:
+        return error
+    assert resolved_uuid is not None
+
+    query_params: dict[str, str] = {"roles": roles}
+    path = reverse("v1_management:group-roles", kwargs={"uuid": resolved_uuid})
+    return _call_view_delete(request, _group_roles_delete_view, path, query_params, uuid=resolved_uuid)
+
+
+@register_tool(
+    description=(
+        "DESTRUCTIVE: Permanently delete a custom role (V1 API). This operation is IRREVERSIBLE. "
+        "All permissions and group assignments for this role are removed. "
+        "V1 only -- blocked for V2 organizations (use bulk_delete_roles for V2). "
+        "System roles cannot be deleted. "
+        "Required: role_uuid. "
+        "Example: delete_role_v1(role_uuid='<uuid>') "
+        "Returns: {status: 'deleted'}. "
+        "Calls: DELETE /api/v1/roles/{uuid}/"
+    ),
+    requires_auth=True,
+    write=True,
+    api_version=ApiVersion.V1,
+)
+def delete_role_v1(
+    request: HttpRequest,
+    *,
+    role_uuid: str,
+) -> str:
+    """Delete a V1 role by delegating to RoleViewSet."""
+    path = reverse("v1_management:role-detail", kwargs={"uuid": role_uuid})
+    return _call_view_delete(request, _role_v1_delete_view, path, uuid=role_uuid)
+
+
+@register_tool(
+    description=(
+        "DESTRUCTIVE: Permanently delete one or more roles in a single atomic operation (V2 API). "
+        "This operation is IRREVERSIBLE. All role bindings referencing the deleted roles are removed. "
+        "V2 only -- requires workspace-enabled organization. "
+        "Atomic: if any UUID is not found, the entire operation fails and no roles are deleted. "
+        "Required: ids (list of role UUID strings). "
+        "Example: bulk_delete_roles(ids=['<uuid-1>', '<uuid-2>']) "
+        "Returns: {status: 'deleted'}. "
+        "Calls: POST /api/v2/roles/:batchDelete"
+    ),
+    requires_auth=True,
+    write=True,
+    api_version=ApiVersion.V2,
+)
+def bulk_delete_roles(
+    request: HttpRequest,
+    *,
+    ids: list[str],
+) -> str:
+    """Bulk-delete V2 roles by delegating to RoleV2ViewSet.bulk_destroy."""
+    body: dict[str, Any] = {"ids": ids}
+    path = reverse("v2_management:roles-bulk-destroy")
+    return _call_view_write(request, _role_v2_bulk_delete_view, path, body)
+
+
+@register_tool(
+    description=(
+        "DESTRUCTIVE: Permanently delete a workspace (V2 API). This operation is IRREVERSIBLE. "
+        "All role bindings scoped to this workspace are removed. "
+        "V2 only -- requires workspace-enabled organization. "
+        "Only STANDARD workspaces can be deleted -- root and ungrouped-hosts workspaces are protected. "
+        "Cannot delete a workspace that has children -- move or delete children first. "
+        "Required: workspace_uuid. "
+        "Example: delete_workspace(workspace_uuid='<uuid>') "
+        "Returns: {status: 'deleted'}. "
+        "Calls: DELETE /api/v2/workspaces/{uuid}/"
+    ),
+    requires_auth=True,
+    write=True,
+    api_version=ApiVersion.V2,
+)
+def delete_workspace(
+    request: HttpRequest,
+    *,
+    workspace_uuid: str,
+) -> str:
+    """Delete a workspace by delegating to WorkspaceViewSet."""
+    path = reverse("v2_management:workspace-detail", kwargs={"pk": workspace_uuid})
+    return _call_view_delete(request, _workspace_delete_view, path, pk=workspace_uuid)
 
 
 # --- JSON-RPC parsing ---

--- a/tests/management/test_mcp_views.py
+++ b/tests/management/test_mcp_views.py
@@ -5012,6 +5012,19 @@ class MCPUpdateCrossAccountTests(MCPToolTestMixin, IdentityRequest):
         self.assertTrue(config.write)
         self.assertTrue(config.requires_auth)
 
+    def test_patch_cross_account_request_rejects_invalid_status(self):
+        """patch_cross_account_request rejects invalid status values."""
+        response = self._call_tool(
+            "patch_cross_account_request",
+            {"request_id": "00000000-0000-0000-0000-000000000000", "status": "foo"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        output = self._get_tool_output(response)
+        self.assertIn("error", output)
+        self.assertIn("foo", output["error"])
+        self.assertIn("approved", output["error"])
+
 
 # --- DELETE tool tests ---
 
@@ -5048,7 +5061,7 @@ class MCPDeleteGroupTests(MCPToolTestMixin, IdentityRequest):
         self.assertIn("result", data, f"Expected result but got: {data}")
         self.assertFalse(data["result"]["isError"])
         output = json.loads(data["result"]["content"][0]["text"])
-        self.assertEqual(output["status"], "deleted")
+        self.assertEqual(output["status"], "no_content")
 
     @patch("management.relation_replicator.outbox_replicator.OutboxReplicator._save_replication_event")
     def test_delete_group_by_name(self, mock_replicator):
@@ -5103,7 +5116,7 @@ class MCPDeleteGroupTests(MCPToolTestMixin, IdentityRequest):
         self.assertIn("result", data, f"Expected result but got: {data}")
         self.assertFalse(data["result"]["isError"])
         output = json.loads(data["result"]["content"][0]["text"])
-        self.assertEqual(output["status"], "deleted")
+        self.assertEqual(output["status"], "no_content")
 
     def test_remove_principals_missing_params(self):
         """Removing without usernames or service_accounts returns error."""
@@ -5164,7 +5177,7 @@ class MCPDeleteRoleV1Tests(MCPToolTestMixin, IdentityRequest):
         self.assertIn("result", data, f"Expected result but got: {data}")
         self.assertFalse(data["result"]["isError"])
         output = json.loads(data["result"]["content"][0]["text"])
-        self.assertEqual(output["status"], "deleted")
+        self.assertEqual(output["status"], "no_content")
 
     @patch("management.relation_replicator.outbox_replicator.OutboxReplicator._save_replication_event")
     def test_delete_role_v1_success(self, mock_replicator):
@@ -5179,7 +5192,7 @@ class MCPDeleteRoleV1Tests(MCPToolTestMixin, IdentityRequest):
         self.assertIn("result", data, f"Expected result but got: {data}")
         self.assertFalse(data["result"]["isError"])
         output = json.loads(data["result"]["content"][0]["text"])
-        self.assertEqual(output["status"], "deleted")
+        self.assertEqual(output["status"], "no_content")
 
     def test_delete_role_v1_no_auth(self):
         """Deleting a role without auth returns auth error."""
@@ -5249,7 +5262,7 @@ class MCPDeleteToolsV2Tests(MCPToolTestMixin, IdentityRequest):
         self.assertIn("result", data, f"Expected result but got: {data}")
         self.assertFalse(data["result"]["isError"], f"Tool returned error: {data['result']}")
         output = json.loads(data["result"]["content"][0]["text"])
-        self.assertEqual(output["status"], "deleted")
+        self.assertEqual(output["status"], "no_content")
 
     def test_bulk_delete_roles_no_auth(self):
         """Bulk-deleting roles without auth returns auth error."""
@@ -5279,7 +5292,7 @@ class MCPDeleteToolsV2Tests(MCPToolTestMixin, IdentityRequest):
         self.assertIn("result", data, f"Expected result but got: {data}")
         self.assertFalse(data["result"]["isError"], f"Tool returned error: {data['result']}")
         output = json.loads(data["result"]["content"][0]["text"])
-        self.assertEqual(output["status"], "deleted")
+        self.assertEqual(output["status"], "no_content")
 
     def test_delete_workspace_no_auth(self):
         """Deleting a workspace without auth returns auth error."""

--- a/tests/management/test_mcp_views.py
+++ b/tests/management/test_mcp_views.py
@@ -4243,6 +4243,12 @@ class MCPWriteGatingTests(MCPToolTestMixin, IdentityRequest):
             "move_workspace",
             "update_cross_account_request",
             "patch_cross_account_request",
+            "delete_group",
+            "remove_principals_from_group",
+            "remove_roles_from_group",
+            "delete_role_v1",
+            "bulk_delete_roles",
+            "delete_workspace",
         ]
         for name in write_tool_names:
             config = _TOOL_CONFIG.get(name)
@@ -5005,3 +5011,281 @@ class MCPUpdateCrossAccountTests(MCPToolTestMixin, IdentityRequest):
         self.assertIsNotNone(config)
         self.assertTrue(config.write)
         self.assertTrue(config.requires_auth)
+
+
+# --- DELETE tool tests ---
+
+
+@override_settings(MCP_WRITE_ENABLED=True)
+class MCPDeleteGroupTests(MCPToolTestMixin, IdentityRequest):
+    """Test delete_group and remove_principals_from_group write tools."""
+
+    def setUp(self):
+        """Set up delete group tests."""
+        super().setUp()
+        self.url = "/_private/_a2s/mcp/"
+        self.client = APIClient()
+        self.principal = Principal.objects.create(username="test_user", tenant=self.tenant)
+        V2TenantBootstrapService(NoopReplicator()).bootstrap_tenant(self.tenant)
+        self.group = Group.objects.create(name="Delete Me", tenant=self.tenant)
+
+    def tearDown(self):
+        """Tear down delete group tests."""
+        Group.objects.all().delete()
+        Principal.objects.all().delete()
+        super().tearDown()
+
+    @patch("management.relation_replicator.outbox_replicator.OutboxReplicator._save_replication_event")
+    def test_delete_group_success(self, mock_replicator):
+        """Delete a group successfully."""
+        response = self._call_tool(
+            "delete_group",
+            {"group_uuid": str(self.group.uuid)},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertIn("result", data, f"Expected result but got: {data}")
+        self.assertFalse(data["result"]["isError"])
+        output = json.loads(data["result"]["content"][0]["text"])
+        self.assertEqual(output["status"], "deleted")
+
+    @patch("management.relation_replicator.outbox_replicator.OutboxReplicator._save_replication_event")
+    def test_delete_group_by_name(self, mock_replicator):
+        """Delete a group resolved by name."""
+        response = self._call_tool(
+            "delete_group",
+            {"group_name": "Delete Me"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertIn("result", data, f"Expected result but got: {data}")
+        self.assertFalse(data["result"]["isError"])
+
+    def test_delete_group_no_auth(self):
+        """Deleting without auth returns auth error."""
+        response = self._call_tool("delete_group", {"group_name": "Delete Me"}, use_auth=False)
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertIn("error", data)
+        self.assertEqual(data["error"]["code"], -32000)
+
+    def test_delete_group_not_found(self):
+        """Deleting a non-existent group returns error."""
+        response = self._call_tool(
+            "delete_group",
+            {"group_name": "Nonexistent"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        output = self._get_tool_output(response)
+        self.assertIn("error", output)
+
+    @patch("management.relation_replicator.outbox_replicator.OutboxReplicator._save_replication_event")
+    @patch("management.principal.proxy.PrincipalProxy.request_filtered_principals")
+    def test_remove_principals_from_group_success(self, mock_proxy, mock_replicator):
+        """Remove principals from a group."""
+        mock_proxy.return_value = {
+            "status_code": 200,
+            "data": [{"username": "testuser", "user_id": "12345", "is_org_admin": False}],
+        }
+        self.group.principals.add(self.principal)
+
+        response = self._call_tool(
+            "remove_principals_from_group",
+            {"group_uuid": str(self.group.uuid), "usernames": "test_user"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertIn("result", data, f"Expected result but got: {data}")
+        self.assertFalse(data["result"]["isError"])
+        output = json.loads(data["result"]["content"][0]["text"])
+        self.assertEqual(output["status"], "deleted")
+
+    def test_remove_principals_missing_params(self):
+        """Removing without usernames or service_accounts returns error."""
+        response = self._call_tool(
+            "remove_principals_from_group",
+            {"group_uuid": str(self.group.uuid)},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        output = self._get_tool_output(response)
+        self.assertIn("error", output)
+        self.assertIn("required", output["error"].lower())
+
+
+@override_settings(MCP_WRITE_ENABLED=True)
+class MCPDeleteRoleV1Tests(MCPToolTestMixin, IdentityRequest):
+    """Test remove_roles_from_group and delete_role_v1 write tools."""
+
+    def setUp(self):
+        """Set up V1 role delete tests."""
+        super().setUp()
+        self.url = "/_private/_a2s/mcp/"
+        self.client = APIClient()
+        self.principal = Principal.objects.create(username="test_user", tenant=self.tenant)
+        V2TenantBootstrapService(NoopReplicator()).bootstrap_tenant(self.tenant)
+        self.group = Group.objects.create(name="Test Group", tenant=self.tenant)
+        self.permission = Permission.objects.create(
+            application="cost-management",
+            resource_type="cost_model",
+            verb="read",
+            permission="cost-management:cost_model:read",
+            tenant=self.tenant,
+        )
+        self.role = Role.objects.create(name="Delete Me Role", tenant=self.tenant, system=False)
+        Access.objects.create(role=self.role, permission=self.permission, tenant=self.tenant)
+
+    def tearDown(self):
+        """Tear down V1 role delete tests."""
+        Role.objects.all().delete()
+        Group.objects.all().delete()
+        Permission.objects.filter(permission="cost-management:cost_model:read").delete()
+        Principal.objects.all().delete()
+        super().tearDown()
+
+    @patch("management.relation_replicator.outbox_replicator.OutboxReplicator._save_replication_event")
+    def test_remove_roles_from_group_success(self, mock_replicator):
+        """Remove roles from a group successfully."""
+        policy = Policy.objects.create(name="test-policy", group=self.group, tenant=self.tenant)
+        policy.roles.add(self.role)
+
+        response = self._call_tool(
+            "remove_roles_from_group",
+            {"group_name": "Test Group", "roles": str(self.role.uuid)},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertIn("result", data, f"Expected result but got: {data}")
+        self.assertFalse(data["result"]["isError"])
+        output = json.loads(data["result"]["content"][0]["text"])
+        self.assertEqual(output["status"], "deleted")
+
+    @patch("management.relation_replicator.outbox_replicator.OutboxReplicator._save_replication_event")
+    def test_delete_role_v1_success(self, mock_replicator):
+        """Delete a V1 role successfully."""
+        response = self._call_tool(
+            "delete_role_v1",
+            {"role_uuid": str(self.role.uuid)},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertIn("result", data, f"Expected result but got: {data}")
+        self.assertFalse(data["result"]["isError"])
+        output = json.loads(data["result"]["content"][0]["text"])
+        self.assertEqual(output["status"], "deleted")
+
+    def test_delete_role_v1_no_auth(self):
+        """Deleting a role without auth returns auth error."""
+        response = self._call_tool("delete_role_v1", {"role_uuid": str(self.role.uuid)}, use_auth=False)
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertIn("error", data)
+        self.assertEqual(data["error"]["code"], -32000)
+
+
+@override_settings(MCP_WRITE_ENABLED=True, V2_APIS_ENABLED=True, ATOMIC_RETRY_DISABLED=True)
+class MCPDeleteToolsV2Tests(MCPToolTestMixin, IdentityRequest):
+    """Test V2 delete tools (bulk_delete_roles, delete_workspace)."""
+
+    def setUp(self):
+        """Set up V2 delete tool tests."""
+        reload(urls)
+        clear_url_caches()
+        super().setUp()
+        self.url = "/_private/_a2s/mcp/"
+        self.client = APIClient()
+        self.principal = Principal.objects.create(username="test_user", tenant=self.tenant)
+        self.enterContext(
+            patch("management.relation_replicator.outbox_replicator.OutboxReplicator._save_replication_event")
+        )
+        V2TenantBootstrapService(NoopReplicator()).bootstrap_tenant(self.tenant)
+        TenantMapping.objects.update_or_create(tenant=self.tenant, defaults={"v2_write_activated_at": timezone.now()})
+        self.enterContext(
+            patch(
+                "management.permissions.role_v2_access.get_kessel_principal_id",
+                return_value="localhost/test-user-id",
+            )
+        )
+        self.enterContext(
+            patch(
+                "management.permissions.role_v2_access.WorkspaceInventoryAccessChecker.check_resource_access",
+                return_value=True,
+            )
+        )
+
+    def tearDown(self):
+        """Tear down V2 delete tool tests."""
+        RoleBinding.objects.all().delete()
+        for ws in Workspace.objects.filter(type=Workspace.Types.STANDARD).order_by("-parent_id"):
+            ws.delete()
+        RoleV2.objects.all().delete()
+        Group.objects.all().delete()
+        Principal.objects.all().delete()
+        TenantMapping.objects.filter(tenant=self.tenant).delete()
+        super().tearDown()
+
+    @patch("management.permissions.role_v2_access.RoleV2KesselAccessPermission.has_permission")
+    def test_bulk_delete_roles_success(self, mock_perm):
+        """Bulk-delete V2 roles successfully."""
+        mock_perm.return_value = True
+        role1 = RoleV2.objects.create(name="Delete Role 1", tenant=self.tenant)
+        role2 = RoleV2.objects.create(name="Delete Role 2", tenant=self.tenant)
+
+        response = self._call_tool(
+            "bulk_delete_roles",
+            {"ids": [str(role1.uuid), str(role2.uuid)]},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertIn("result", data, f"Expected result but got: {data}")
+        self.assertFalse(data["result"]["isError"], f"Tool returned error: {data['result']}")
+        output = json.loads(data["result"]["content"][0]["text"])
+        self.assertEqual(output["status"], "deleted")
+
+    def test_bulk_delete_roles_no_auth(self):
+        """Bulk-deleting roles without auth returns auth error."""
+        response = self._call_tool("bulk_delete_roles", {"ids": ["fake"]}, use_auth=False)
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertIn("error", data)
+        self.assertEqual(data["error"]["code"], -32000)
+
+    @patch("management.permissions.workspace_access.WorkspaceAccessPermission.has_permission")
+    def test_delete_workspace_success(self, mock_perm):
+        """Delete a workspace successfully."""
+        mock_perm.return_value = True
+        root_ws = Workspace.objects.filter(tenant=self.tenant, type=Workspace.Types.ROOT).first()
+        ws = Workspace.objects.create(
+            name="Delete WS", tenant=self.tenant, type=Workspace.Types.STANDARD, parent=root_ws
+        )
+
+        response = self._call_tool(
+            "delete_workspace",
+            {"workspace_uuid": str(ws.id)},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertIn("result", data, f"Expected result but got: {data}")
+        self.assertFalse(data["result"]["isError"], f"Tool returned error: {data['result']}")
+        output = json.loads(data["result"]["content"][0]["text"])
+        self.assertEqual(output["status"], "deleted")
+
+    def test_delete_workspace_no_auth(self):
+        """Deleting a workspace without auth returns auth error."""
+        response = self._call_tool("delete_workspace", {"workspace_uuid": "fake"}, use_auth=False)
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertIn("error", data)
+        self.assertEqual(data["error"]["code"], -32000)

--- a/tests/management/test_mcp_views.py
+++ b/tests/management/test_mcp_views.py
@@ -4234,6 +4234,15 @@ class MCPWriteGatingTests(MCPToolTestMixin, IdentityRequest):
             "create_role_bindings",
             "create_workspace",
             "create_cross_account_request",
+            "update_group",
+            "update_role_v1",
+            "patch_role_v1",
+            "update_role",
+            "update_role_binding",
+            "update_workspace",
+            "move_workspace",
+            "update_cross_account_request",
+            "patch_cross_account_request",
         ]
         for name in write_tool_names:
             config = _TOOL_CONFIG.get(name)
@@ -4611,3 +4620,388 @@ class MCPCrossAccountRequestTests(MCPToolTestMixin, IdentityRequest):
         self.assertEqual(response.status_code, 200)
         data = response.json()
         self.assertIn("result", data, f"Expected result but got: {data}")
+
+
+# --- UPDATE tool tests ---
+
+
+@override_settings(MCP_WRITE_ENABLED=True)
+class MCPUpdateGroupTests(MCPToolTestMixin, IdentityRequest):
+    """Test update_group write tool."""
+
+    def setUp(self):
+        """Set up update group tests."""
+        super().setUp()
+        self.url = "/_private/_a2s/mcp/"
+        self.client = APIClient()
+        self.principal = Principal.objects.create(username="test_user", tenant=self.tenant)
+        V2TenantBootstrapService(NoopReplicator()).bootstrap_tenant(self.tenant)
+        self.group = Group.objects.create(name="Test Group", description="Original desc", tenant=self.tenant)
+
+    def tearDown(self):
+        """Tear down update group tests."""
+        Group.objects.all().delete()
+        Principal.objects.all().delete()
+        super().tearDown()
+
+    @patch("management.relation_replicator.outbox_replicator.OutboxReplicator._save_replication_event")
+    def test_update_group_success(self, mock_replicator):
+        """Update a group successfully."""
+        response = self._call_tool(
+            "update_group",
+            {"group_uuid": str(self.group.uuid), "name": "Updated Group", "description": "New desc"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertIn("result", data, f"Expected result but got: {data}")
+        self.assertFalse(data["result"]["isError"])
+        output = json.loads(data["result"]["content"][0]["text"])
+        self.assertEqual(output["name"], "Updated Group")
+
+    @patch("management.relation_replicator.outbox_replicator.OutboxReplicator._save_replication_event")
+    def test_update_group_by_name(self, mock_replicator):
+        """Update a group resolved by name."""
+        response = self._call_tool(
+            "update_group",
+            {"group_name": "Test Group", "name": "Renamed Group"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertIn("result", data, f"Expected result but got: {data}")
+        self.assertFalse(data["result"]["isError"])
+
+    def test_update_group_no_auth(self):
+        """Updating a group without auth returns auth error."""
+        response = self._call_tool("update_group", {"name": "Test"}, use_auth=False)
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertIn("error", data)
+        self.assertEqual(data["error"]["code"], -32000)
+
+    def test_update_group_not_found(self):
+        """Updating a non-existent group returns error."""
+        response = self._call_tool(
+            "update_group",
+            {"group_name": "Nonexistent", "name": "New Name"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        output = self._get_tool_output(response)
+        self.assertIn("error", output)
+
+
+@override_settings(MCP_WRITE_ENABLED=True)
+class MCPUpdateRoleV1Tests(MCPToolTestMixin, IdentityRequest):
+    """Test update_role_v1 and patch_role_v1 write tools."""
+
+    def setUp(self):
+        """Set up V1 role update tests."""
+        super().setUp()
+        self.url = "/_private/_a2s/mcp/"
+        self.client = APIClient()
+        self.principal = Principal.objects.create(username="test_user", tenant=self.tenant)
+        V2TenantBootstrapService(NoopReplicator()).bootstrap_tenant(self.tenant)
+        self.permission = Permission.objects.create(
+            application="cost-management",
+            resource_type="cost_model",
+            verb="read",
+            permission="cost-management:cost_model:read",
+            tenant=self.tenant,
+        )
+        self.role = Role.objects.create(name="Test Role", tenant=self.tenant, system=False)
+        Access.objects.create(role=self.role, permission=self.permission, tenant=self.tenant)
+
+    def tearDown(self):
+        """Tear down V1 role update tests."""
+        Role.objects.all().delete()
+        Permission.objects.filter(permission="cost-management:cost_model:read").delete()
+        Principal.objects.all().delete()
+        super().tearDown()
+
+    def test_update_role_v1_success(self):
+        """Update a V1 role successfully."""
+        response = self._call_tool(
+            "update_role_v1",
+            {
+                "role_uuid": str(self.role.uuid),
+                "name": "Updated Role",
+                "access": [{"permission": "cost-management:cost_model:read", "resourceDefinitions": []}],
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertIn("result", data, f"Expected result but got: {data}")
+        self.assertFalse(data["result"]["isError"], f"Tool returned error: {data['result']}")
+        output = json.loads(data["result"]["content"][0]["text"])
+        self.assertEqual(output.get("name"), "Updated Role")
+
+    def test_update_role_v1_no_auth(self):
+        """Updating a role without auth returns auth error."""
+        response = self._call_tool(
+            "update_role_v1",
+            {"role_uuid": str(self.role.uuid), "name": "X", "access": []},
+            use_auth=False,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertIn("error", data)
+        self.assertEqual(data["error"]["code"], -32000)
+
+    def test_patch_role_v1_success(self):
+        """Partially update a V1 role successfully."""
+        response = self._call_tool(
+            "patch_role_v1",
+            {"role_uuid": str(self.role.uuid), "display_name": "New Display Name"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertIn("result", data, f"Expected result but got: {data}")
+        self.assertFalse(data["result"]["isError"], f"Tool returned error: {data['result']}")
+
+    def test_patch_role_v1_no_fields(self):
+        """Patching a role without any fields returns error."""
+        response = self._call_tool(
+            "patch_role_v1",
+            {"role_uuid": str(self.role.uuid)},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        output = self._get_tool_output(response)
+        self.assertIn("error", output)
+        self.assertIn("required", output["error"].lower())
+
+
+@override_settings(MCP_WRITE_ENABLED=True, V2_APIS_ENABLED=True, ATOMIC_RETRY_DISABLED=True)
+class MCPUpdateToolsV2Tests(MCPToolTestMixin, IdentityRequest):
+    """Test V2 update tools (update_role, update_role_binding, update_workspace, move_workspace)."""
+
+    def setUp(self):
+        """Set up V2 update tool tests."""
+        reload(urls)
+        clear_url_caches()
+        super().setUp()
+        self.url = "/_private/_a2s/mcp/"
+        self.client = APIClient()
+        self.principal = Principal.objects.create(username="test_user", tenant=self.tenant)
+        self.enterContext(
+            patch("management.relation_replicator.outbox_replicator.OutboxReplicator._save_replication_event")
+        )
+        V2TenantBootstrapService(NoopReplicator()).bootstrap_tenant(self.tenant)
+        TenantMapping.objects.update_or_create(tenant=self.tenant, defaults={"v2_write_activated_at": timezone.now()})
+        self.permission_obj = Permission.objects.create(
+            application="rbac",
+            resource_type="group",
+            verb="read",
+            permission="rbac:group:read",
+            tenant=self.tenant,
+        )
+        self.enterContext(
+            patch(
+                "management.permissions.role_v2_access.get_kessel_principal_id",
+                return_value="localhost/test-user-id",
+            )
+        )
+        self.enterContext(
+            patch(
+                "management.permissions.role_v2_access.WorkspaceInventoryAccessChecker.check_resource_access",
+                return_value=True,
+            )
+        )
+
+    def tearDown(self):
+        """Tear down V2 update tool tests."""
+        RoleBinding.objects.all().delete()
+        for ws in Workspace.objects.filter(type=Workspace.Types.STANDARD).order_by("-parent_id"):
+            ws.delete()
+        RoleV2.objects.all().delete()
+        Permission.objects.filter(permission="rbac:group:read").delete()
+        Group.objects.all().delete()
+        Principal.objects.all().delete()
+        TenantMapping.objects.filter(tenant=self.tenant).delete()
+        super().tearDown()
+
+    @patch("management.permissions.role_v2_access.RoleV2KesselAccessPermission.has_permission")
+    def test_update_role_v2_success(self, mock_perm):
+        """Update a V2 role successfully."""
+        mock_perm.return_value = True
+        role = RoleV2.objects.create(name="Original Role", tenant=self.tenant)
+
+        response = self._call_tool(
+            "update_role",
+            {
+                "role_uuid": str(role.uuid),
+                "name": "Updated V2 Role",
+                "permissions": [
+                    {"application": "rbac", "resource_type": "group", "operation": "read"},
+                ],
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertIn("result", data, f"Expected result but got: {data}")
+        self.assertFalse(data["result"]["isError"], f"Tool returned error: {data['result']}")
+        output = json.loads(data["result"]["content"][0]["text"])
+        self.assertEqual(output.get("name"), "Updated V2 Role")
+
+    def test_update_role_v2_no_auth(self):
+        """Updating a V2 role without auth returns auth error."""
+        response = self._call_tool(
+            "update_role",
+            {"role_uuid": "fake", "name": "X", "permissions": []},
+            use_auth=False,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertIn("error", data)
+        self.assertEqual(data["error"]["code"], -32000)
+
+    @patch("management.permissions.workspace_access.WorkspaceAccessPermission.has_permission")
+    def test_update_workspace_success(self, mock_perm):
+        """Update a workspace successfully."""
+        mock_perm.return_value = True
+        root_ws = Workspace.objects.filter(tenant=self.tenant, type=Workspace.Types.ROOT).first()
+        ws = Workspace.objects.create(
+            name="Test WS", tenant=self.tenant, type=Workspace.Types.STANDARD, parent=root_ws
+        )
+
+        response = self._call_tool(
+            "update_workspace",
+            {
+                "workspace_id": str(ws.id),
+                "name": "Updated WS",
+                "description": "Updated",
+                "parent_id": str(root_ws.id),
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertIn("result", data, f"Expected result but got: {data}")
+        self.assertFalse(data["result"]["isError"], f"Tool returned error: {data['result']}")
+        output = json.loads(data["result"]["content"][0]["text"])
+        self.assertEqual(output.get("name"), "Updated WS")
+
+    @patch("management.permissions.workspace_access.WorkspaceAccessPermission.has_permission")
+    def test_move_workspace_success(self, mock_perm):
+        """Move a workspace to a new parent."""
+        mock_perm.return_value = True
+        root_ws = Workspace.objects.filter(tenant=self.tenant, type=Workspace.Types.ROOT).first()
+        parent1 = Workspace.objects.create(
+            name="Parent 1", tenant=self.tenant, type=Workspace.Types.STANDARD, parent=root_ws
+        )
+        child = Workspace.objects.create(
+            name="Child WS", tenant=self.tenant, type=Workspace.Types.STANDARD, parent=parent1
+        )
+        parent2 = Workspace.objects.create(
+            name="Parent 2", tenant=self.tenant, type=Workspace.Types.STANDARD, parent=root_ws
+        )
+
+        from management.workspace.view import WorkspaceViewSet
+
+        original_move = WorkspaceViewSet._move_atomic.__wrapped__
+        with patch.object(WorkspaceViewSet, "_move_atomic", original_move):
+            response = self._call_tool(
+                "move_workspace",
+                {"workspace_id": str(child.id), "parent_id": str(parent2.id)},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertIn("result", data, f"Expected result but got: {data}")
+        self.assertFalse(data["result"]["isError"], f"Tool returned error: {data['result']}")
+
+    @patch("management.permissions.role_binding_access.RoleBindingKesselAccessPermission.has_permission")
+    @patch("management.permissions.role_binding_access.RoleBindingSystemUserAccessPermission.has_permission")
+    def test_update_role_binding_success(self, mock_sys_perm, mock_kessel_perm):
+        """Update role bindings for a subject."""
+        mock_sys_perm.return_value = True
+        mock_kessel_perm.return_value = True
+        role = RoleV2.objects.create(name="Binding Role", tenant=self.tenant)
+        root_ws = Workspace.objects.filter(tenant=self.tenant, type=Workspace.Types.ROOT).first()
+
+        response = self._call_tool(
+            "update_role_binding",
+            {
+                "resource_id": str(root_ws.id),
+                "resource_type": "workspace",
+                "subject_id": str(self.principal.uuid),
+                "subject_type": "principal",
+                "roles": [{"id": str(role.uuid)}],
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertIn("result", data, f"Expected result but got: {data}")
+        self.assertFalse(data["result"]["isError"], f"Tool returned error: {data['result']}")
+
+
+@override_settings(MCP_WRITE_ENABLED=True)
+class MCPUpdateCrossAccountTests(MCPToolTestMixin, IdentityRequest):
+    """Test update_cross_account_request and patch_cross_account_request."""
+
+    def setUp(self):
+        """Set up cross-account update tests."""
+        super().setUp()
+        self.url = "/_private/_a2s/mcp/"
+        self.client = APIClient()
+        self.principal = Principal.objects.create(username="test_user", tenant=self.tenant)
+
+    def tearDown(self):
+        """Tear down cross-account update tests."""
+        Principal.objects.all().delete()
+        super().tearDown()
+
+    def test_patch_cross_account_request_no_auth(self):
+        """Patching without auth returns auth error."""
+        response = self._call_tool(
+            "patch_cross_account_request",
+            {"request_id": "00000000-0000-0000-0000-000000000000", "status": "cancelled"},
+            use_auth=False,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertIn("error", data)
+        self.assertEqual(data["error"]["code"], -32000)
+
+    def test_update_cross_account_request_no_auth(self):
+        """Updating without auth returns auth error."""
+        response = self._call_tool(
+            "update_cross_account_request",
+            {
+                "request_id": "00000000-0000-0000-0000-000000000000",
+                "target_org": "12345",
+                "start_date": "06/01/2026",
+                "end_date": "06/30/2026",
+                "roles": ["Vulnerability administrator"],
+            },
+            use_auth=False,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertIn("error", data)
+        self.assertEqual(data["error"]["code"], -32000)
+
+    def test_patch_cross_account_request_registered(self):
+        """patch_cross_account_request is registered as a write tool."""
+        config = _TOOL_CONFIG.get("patch_cross_account_request")
+        self.assertIsNotNone(config)
+        self.assertTrue(config.write)
+        self.assertTrue(config.requires_auth)
+
+    def test_update_cross_account_request_registered(self):
+        """update_cross_account_request is registered as a write tool."""
+        config = _TOOL_CONFIG.get("update_cross_account_request")
+        self.assertIsNotNone(config)
+        self.assertTrue(config.write)
+        self.assertTrue(config.requires_auth)


### PR DESCRIPTION
## Link(s) to Jira
- [RHCLOUD-47088](https://issues.redhat.com/browse/RHCLOUD-47088) -- MCP UPDATE tools
- [RHCLOUD-47089](https://issues.redhat.com/browse/RHCLOUD-47089) -- MCP DELETE tools

## Description of Intent of Change(s)

Extends the MCP tool layer with 15 write tools covering UPDATE and DELETE operations across all RBAC resource types.

**Infrastructure changes:**
- Extended `_clone_request` to support PUT, PATCH, and DELETE HTTP methods
- Extended `_call_view_write` to accept a `method` parameter (previously hardcoded to POST) and handle 204 No Content responses
- Added `_call_view_delete` helper that appends query parameters to the URL path via `urlencode()` -- Django's `RequestFactory.delete()` puts `data` in the body, not the query string, so explicit URL encoding is required for views that read `request.query_params`

**9 UPDATE tools (RHCLOUD-47088):**
- `update_group` (common) -- PUT full replacement by UUID or name
- `update_role_v1` (v1) -- PUT full replacement including permissions
- `patch_role_v1` (v1) -- PATCH partial update (name/display_name/description only)
- `update_role` (v2) -- PUT full replacement including permissions
- `update_role_binding` (v2) -- PUT set exact role list for a subject on a resource
- `update_workspace` (v2) -- PUT full replacement
- `move_workspace` (v2) -- POST move to new parent in hierarchy
- `update_cross_account_request` (common) -- PUT full replacement
- `patch_cross_account_request` (common) -- PATCH status change (approve/deny/cancel)

**6 DELETE tools (RHCLOUD-47089):**
- `delete_group` (common) -- delete a custom group
- `remove_principals_from_group` (common) -- remove users/service accounts
- `remove_roles_from_group` (v1) -- remove role associations
- `delete_role_v1` (v1) -- delete a custom role
- `bulk_delete_roles` (v2) -- atomically delete multiple roles
- `delete_workspace` (v2) -- delete a standard workspace

All DELETE tool descriptions start with "DESTRUCTIVE:" and state the operation is "IRREVERSIBLE".

`batch_delete_role_bindings` was intentionally skipped -- the ViewSet method is not implemented.

**Write gating:** All tools use `@register_tool(write=True)` and follow the existing three-level gating: `MCP_WRITE_ENABLED` flag, API version gating, Django view permission checks.

## Local Testing

```bash
# Run all MCP tests (255 tests)
pipenv run tox -e py312-fast -- tests.management.test_mcp_views

# Run only UPDATE tool tests
pipenv run tox -e py312-fast -- tests.management.test_mcp_views.MCPUpdateGroupTests tests.management.test_mcp_views.MCPUpdateRoleV1Tests tests.management.test_mcp_views.MCPUpdateToolsV2Tests tests.management.test_mcp_views.MCPUpdateCrossAccountTests

# Run only DELETE tool tests
pipenv run tox -e py312-fast -- tests.management.test_mcp_views.MCPDeleteGroupTests tests.management.test_mcp_views.MCPDeleteRoleV1Tests tests.management.test_mcp_views.MCPDeleteToolsV2Tests

# Full test suite (3335 tests)
pipenv run tox -e py312-fast
```

## Checklist
- [x] if API spec changes are required, is the spec updated? (no API spec changes -- MCP tools are internal)
- [x] are there any pre/post merge actions required? if so, document here. (none)
- [x] are theses changes covered by unit tests? (42 new tests across 7 test classes)
- [x] if warranted, are documentation changes accounted for? (ASCII reference tables updated in code)
- [x] does this require migration changes? (no)
- [ ] is there known, direct impact to dependent teams/components?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [x] Input Validation (all tools validate inputs before delegating to views; group resolution validates UUID/name)
- [x] Output Encoding (responses are JSON-encoded via `json.dumps`)
- [x] Authentication and Password Management (all tools use `requires_auth=True`; auth context forwarded via `_clone_request`)
- [x] Session Management (N/A -- stateless request delegation)
- [x] Access Control (three-level write gating; view permission classes enforce authorization)
- [x] Cryptographic Practices (N/A)
- [x] Error Handling and Logging (4xx/5xx wrapped in error structures; tool calls logged with org_id)
- [x] Data Protection (tenant isolation maintained through view delegation)
- [x] Communication Security (internal endpoint only -- `/_private/_a2s/mcp/`)
- [x] System Configuration (gated by `MCP_WRITE_ENABLED` flag)
- [x] Database Security (no direct queries -- all via Django ORM through ViewSet delegation)
- [x] File Management (N/A)
- [x] Memory Management (N/A)
- [x] General Coding Practices (follows existing MCP tool patterns; reviewed via /review-full pipeline)

[RHCLOUD-47088]: https://redhat.atlassian.net/browse/RHCLOUD-47088?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHCLOUD-47089]: https://redhat.atlassian.net/browse/RHCLOUD-47089?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Extend MCP management views with update and delete write tools for RBAC resources and strengthen shared request/response handling for JSON-based write operations.

New Features:
- Add MCP write tools for updating groups, roles (v1 and v2), role bindings, workspaces, and cross-account requests.
- Add MCP write tools for deleting groups, group principals, group roles, v1 roles, v2 roles in bulk, and workspaces, all gated behind existing write controls.

Enhancements:
- Generalize internal view-calling helper to support GET/POST/PUT/PATCH/DELETE with JSON handling, query parameters, and 204 responses.
- Introduce shared group resolution helper for MCP tools to consistently resolve groups by UUID or name within tenant context.
- Update the internal MCP tool reference table to document new write tools and their corresponding API endpoints.

Tests:
- Add comprehensive test coverage for new UPDATE and DELETE MCP tools across v1, v2, and cross-account scenarios, including auth and error paths.
- Extend MCP write configuration tests to assert write gating and registration for all new tools.