### PR TITLE
[RHCLOUD-46155] Remove tenant to workspace relationships

### DIFF
--- a/deploy/rbac-clowdapp.yml
+++ b/deploy/rbac-clowdapp.yml
@@ -1261,6 +1261,21 @@ objects:
               cpu: 50m
               memory: 512Mi
           env: *common_env_vars
+      - name: remove-legacy-root-workspace-tenant-parent
+        podSpec:
+          image: ${IMAGE}:${IMAGE_TAG}
+          command:
+            - /opt/rbac/rbac/manage.py
+            - remove_legacy_root_workspace_tenant_parent_relations
+            - "--all"
+          resources:
+            limits:
+              cpu: 300m
+              memory: 1Gi
+            requests:
+              cpu: 50m
+              memory: 512Mi
+          env: *common_env_vars
       - name: replicate-default-workspaces
         podSpec:
           image: ${IMAGE}:${IMAGE_TAG}

--- a/deploy/remove_legacy_root_workspace_tenant_parent.yml
+++ b/deploy/remove_legacy_root_workspace_tenant_parent.yml
@@ -1,0 +1,19 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: remove-legacy-root-workspace-tenant-parent
+objects:
+  - apiVersion: cloud.redhat.com/v1alpha1
+    kind: ClowdJobInvocation
+    metadata:
+      labels:
+        app: rbac
+      name: remove-legacy-root-workspace-tenant-parent-${RUN_NUMBER}
+    spec:
+      appName: rbac
+      jobs:
+        - remove-legacy-root-workspace-tenant-parent
+parameters:
+  - name: RUN_NUMBER
+    description: Used to track and re-run the job
+    value: '1'

--- a/rbac/internal/migrations/remove_orphan_relations.py
+++ b/rbac/internal/migrations/remove_orphan_relations.py
@@ -487,15 +487,19 @@ def _workspace_parent_relationship(workspace_id: str, parent: V2boundresource) -
     )
 
 
-def _collect_remote_workspaces(tenant_resource_id: str, read_tuples_typed: _ReadTuplesTyped) -> _RemoteWorkspaceData:
+def _collect_remote_workspaces(
+    tenant: Tenant, tenant_resource_id: str, read_tuples_typed: _ReadTuplesTyped
+) -> _RemoteWorkspaceData:
     """
     Discover all workspaces under a tenant in Kessel.
 
-    The hierarchy is: tenant -> root workspace -> default workspace -> other workspaces
-    Each workspace has a `parent` relation pointing to its parent (tenant or workspace).
+    The hierarchy is: tenant -> root workspace -> default workspace -> other workspaces.
+    Root workspaces are no longer discovered via workspace#parent@tenant reads alone (that tuple may be absent); we
+    seed DFS from the DB root workspace instead, then walk workspace#parent@workspace edges as before.
 
     Args:
-        tenant_resource_id: The tenant resource ID to search from
+        tenant: Tenant whose workspaces to traverse
+        tenant_resource_id: Canonical tenant resource ID for the seeded root parent edge
         read_tuples_typed: Function to read tuples from Kessel
 
     Returns:
@@ -511,18 +515,9 @@ def _collect_remote_workspaces(tenant_resource_id: str, read_tuples_typed: _Read
 
         workspace_data.add_workspace(workspace_id=workspace_id, parent_resource=parent_resource)
 
-    # Find root workspaces (workspace -> parent -> tenant)
-    # Query with empty resource_id to find all workspaces with this tenant as parent
-    root_tuples = read_tuples_typed(
-        resource_type="workspace",
-        resource_id="",
-        relation="parent",
-        subject_type="tenant",
-        subject_id=tenant_resource_id,
-    )
+    root = Workspace.objects.root(tenant=tenant)
 
-    for t in root_tuples:
-        add_seen_workspace(t.resource.id, V2boundresource(("rbac", "tenant"), tenant_resource_id))
+    add_seen_workspace(str(root.id), V2boundresource(("rbac", "tenant"), tenant_resource_id))
 
     # DFS to find child workspaces
     while stack:
@@ -713,6 +708,7 @@ def cleanup_tenant_orphaned_relationships(
         raise ValueError("Expected tenant's resource ID to be present (i.e. for it to have an org_id).")
 
     kessel_workspace_data = _collect_remote_workspaces(
+        tenant=tenant,
         tenant_resource_id=tenant_resource_id,
         read_tuples_typed=read_tuples_typed,
     )

--- a/rbac/internal/migrations/remove_orphan_relations.py
+++ b/rbac/internal/migrations/remove_orphan_relations.py
@@ -487,23 +487,23 @@ def _workspace_parent_relationship(workspace_id: str, parent: V2boundresource) -
     )
 
 
-def _collect_remote_workspaces(
-    tenant: Tenant, tenant_resource_id: str, read_tuples_typed: _ReadTuplesTyped
-) -> _RemoteWorkspaceData:
+def _collect_remote_workspaces(tenant: Tenant, read_tuples_typed: _ReadTuplesTyped) -> _RemoteWorkspaceData:
     """
-    Discover all workspaces under a tenant in Kessel.
+    Discover workspaces reachable in Kessel under the tenant's hierarchy.
 
-    The hierarchy is: tenant -> root workspace -> default workspace -> other workspaces.
-    Root workspaces are no longer discovered via workspace#parent@tenant reads alone (that tuple may be absent); we
-    seed DFS from the DB root workspace instead, then walk workspace#parent@workspace edges as before.
+    Bootstrapping may omit workspace(root)#parent@tenant, so we do not rely on that tuple for discovery. We seed DFS
+    from the DB root workspace, then walk workspace#parent@workspace edges. Only those edges are recorded in the
+    result; the root workspace ID itself is not inserted as a remote workspace with a synthetic tenant parent (that
+    would misrepresent Kessel and still would not enqueue removal of a stale root→tenant tuple here—we never read the
+    root's parent tuples). Clear legacy root→tenant edges via remove_legacy_root_workspace_tenant_parent_relations.
 
     Args:
         tenant: Tenant whose workspaces to traverse
-        tenant_resource_id: Canonical tenant resource ID for the seeded root parent edge
         read_tuples_typed: Function to read tuples from Kessel
 
     Returns:
-        dict: Mapping of workspace_id -> (parent_type, parent_id) for all workspaces found
+        Workspace parent edges discovered via workspace#parent@workspace (non-root workspaces only if the graph is
+        tree-shaped under the DB root).
     """
     workspace_data = _RemoteWorkspaceData()
     stack = []
@@ -517,7 +517,8 @@ def _collect_remote_workspaces(
 
     root = Workspace.objects.root(tenant=tenant)
 
-    add_seen_workspace(str(root.id), V2boundresource(("rbac", "tenant"), tenant_resource_id))
+    # DFS seed only: do not record workspace(root)#parent@tenant (may be absent or legacy); see docstring.
+    stack.append(str(root.id))
 
     # DFS to find child workspaces
     while stack:
@@ -707,11 +708,7 @@ def cleanup_tenant_orphaned_relationships(
     if tenant_resource_id is None:
         raise ValueError("Expected tenant's resource ID to be present (i.e. for it to have an org_id).")
 
-    kessel_workspace_data = _collect_remote_workspaces(
-        tenant=tenant,
-        tenant_resource_id=tenant_resource_id,
-        read_tuples_typed=read_tuples_typed,
-    )
+    kessel_workspace_data = _collect_remote_workspaces(tenant=tenant, read_tuples_typed=read_tuples_typed)
 
     workspace_ids_in_kessel = set(kessel_workspace_data.workspace_ids())
 

--- a/rbac/internal/utils.py
+++ b/rbac/internal/utils.py
@@ -242,7 +242,7 @@ def _build_workspace_graph(tenant) -> tuple[list, dict]:
 
     Returns:
         tuple of:
-        - root_workspace_ids: list of workspace IDs that have no parent (parent = tenant)
+        - root_workspace_ids: list of workspace IDs with no DB parent (typically root workspace)
         - children_by_parent: dict mapping parent_id -> list of child workspace_ids
     """
     db_workspaces = list(Workspace.objects.filter(tenant=tenant).order_by("id"))
@@ -376,11 +376,10 @@ def rebuild_tenant_workspace_relations(
     their parent relations exist in Kessel. This is a prerequisite for
     cleanup_tenant_orphaned_relationships to work correctly.
 
-    The hierarchy is: tenant -> root workspace -> default workspace -> other workspaces
-    - Root workspace has parent = tenant
-    - Other workspaces have parent = their parent workspace
+    Root workspaces are not linked to the tenant in relations; only workspace-to-workspace
+    parent edges are replicated (default -> root -> ...).
 
-    Uses BFS traversal starting from root workspace. For each workspace, locks the
+    Uses BFS traversal from each root workspace's children. For each workspace, locks the
     parent first, then locks the child, checks/replicates the parent relation,
     then moves to children. This minimizes lock contention.
 
@@ -395,8 +394,6 @@ def rebuild_tenant_workspace_relations(
     Returns:
         dict: Results including workspaces checked, relations added, etc.
     """
-    tenant_resource_id = tenant.tenant_resource_id()
-
     workspaces_checked = 0
     relations_added = 0
     relations_to_add_count = 0
@@ -405,10 +402,11 @@ def rebuild_tenant_workspace_relations(
     # Build workspace graph from DB
     root_workspace_ids, children_by_parent = _build_workspace_graph(tenant)
 
-    # Build BFS queue starting from root workspaces
+    # Build BFS queue from root workspaces' children only (no workspace#parent@tenant edge).
     queue = deque()
     for root_id in root_workspace_ids:
-        queue.append((root_id, "tenant", tenant_resource_id))
+        for child_id in children_by_parent.get(root_id, []):
+            queue.append((child_id, "workspace", str(root_id)))
 
     # BFS traversal - process each workspace in transaction
     while queue:
@@ -447,6 +445,64 @@ def rebuild_tenant_workspace_relations(
         "workspaces_missing_parent": workspaces_missing_parent_count,
         "relations_to_add": relations_to_add_count if dry_run else relations_added,
         "relations_added": relations_added,
+    }
+
+
+def remove_legacy_root_workspace_tenant_parent_relations() -> dict:
+    """
+    Enqueue removal of workspace(root)#parent@tenant relationship tuples.
+
+    Bootstrapping no longer creates this edge; this job clears stale tuples still present in Kessel.
+    """
+    if not settings.REPLICATION_TO_RELATION_ENABLED:
+        return {"skipped": True, "reason": "REPLICATION_TO_RELATION_ENABLED is False"}
+
+    replicator = OutboxReplicator()
+    qs = Tenant.objects.exclude(tenant_name="public").order_by("id")
+
+    batch: list[RelationTuple] = []
+    tenants_processed = 0
+    batch_size = 500
+    tenants_total = qs.count()
+
+    def flush_batch() -> None:
+        if not batch:
+            return
+        replicator.replicate(
+            ReplicationEvent(
+                event_type=ReplicationEventType.MIGRATE_TENANT_GROUPS,
+                info={"action": "remove_root_workspace_tenant_parent", "batch_size": len(batch)},
+                partition_key=PartitionKey.byEnvironment(),
+                add=[],
+                remove=batch,
+            )
+        )
+        batch.clear()
+        logger.info(f"Processed {tenants_processed} of {tenants_total} tenants")
+
+    for tenant in qs.iterator(chunk_size=500):
+        tenants_processed += 1
+        tenant_resource_id = tenant.tenant_resource_id()
+        if tenant_resource_id is None:
+            continue
+        root = Workspace.objects.root(tenant=tenant)
+        batch.append(
+            create_relationship(
+                ("rbac", "workspace"),
+                str(root.id),
+                ("rbac", "tenant"),
+                tenant_resource_id,
+                "parent",
+            )
+        )
+        if len(batch) >= batch_size:
+            flush_batch()
+
+    flush_batch()
+
+    return {
+        "skipped": False,
+        "tenants_processed": tenants_processed,
     }
 
 

--- a/rbac/internal/utils.py
+++ b/rbac/internal/utils.py
@@ -270,8 +270,7 @@ class WorkspaceProcessResult:
 
 def _process_workspace_in_transaction(
     ws_id_uuid,
-    expected_parent_type: str,
-    expected_parent_id: str,
+    expected_parent_workspace_id: str,
     tenant,
     read_tuples_fn,
     replicator,
@@ -280,13 +279,12 @@ def _process_workspace_in_transaction(
     """
     Process a single workspace within a transaction.
 
-    Locks parent (if workspace) and child, verifies parent hasn't changed,
+    Locks parent workspace then child, verifies parent hasn't changed,
     checks if parent relation exists in Kessel, and replicates if missing.
 
     Args:
         ws_id_uuid: The workspace UUID to process
-        expected_parent_type: "tenant" or "workspace"
-        expected_parent_id: The expected parent ID
+        expected_parent_workspace_id: Expected parent workspace UUID (DB `parent_id`)
         tenant: The Tenant object
         read_tuples_fn: Function to read tuples from Kessel
         replicator: The replicator to use for writing relations
@@ -298,13 +296,13 @@ def _process_workspace_in_transaction(
     result = WorkspaceProcessResult()
 
     with transaction.atomic():
-        # Lock parent first (if it's a workspace, not tenant)
-        if expected_parent_type == "workspace":
-            try:
-                Workspace.objects.select_for_update().get(id=expected_parent_id)
-            except Workspace.DoesNotExist:
-                logger.warning(f"Parent workspace {expected_parent_id} no longer exists, skipping child {ws_id_uuid}")
-                return result
+        try:
+            Workspace.objects.select_for_update().get(id=expected_parent_workspace_id)
+        except Workspace.DoesNotExist:
+            logger.warning(
+                f"Parent workspace {expected_parent_workspace_id} no longer exists, skipping child {ws_id_uuid}"
+            )
+            return result
 
         # Lock the child workspace
         try:
@@ -318,17 +316,14 @@ def _process_workspace_in_transaction(
 
         # Verify parent hasn't changed (in case of concurrent modification)
         actual_parent_id = str(ws.parent_id) if ws.parent_id else None
-        if expected_parent_type == "tenant" and actual_parent_id is not None:
-            logger.warning(f"Workspace {ws_id} parent changed from tenant to {actual_parent_id}, skipping")
-            return result
-        if expected_parent_type == "workspace" and actual_parent_id != expected_parent_id:
+        if actual_parent_id != expected_parent_workspace_id:
             logger.warning(
-                f"Workspace {ws_id} parent changed from {expected_parent_id} to {actual_parent_id}, skipping"
+                f"Workspace {ws_id} parent changed from {expected_parent_workspace_id} to {actual_parent_id}, skipping"
             )
             return result
 
         # Check if parent relation exists in Kessel
-        parent_tuples = read_tuples_fn("workspace", ws_id, "parent", expected_parent_type, expected_parent_id)
+        parent_tuples = read_tuples_fn("workspace", ws_id, "parent", "workspace", expected_parent_workspace_id)
         if parent_tuples:
             return result
 
@@ -339,8 +334,8 @@ def _process_workspace_in_transaction(
         relation = create_relationship(
             ("rbac", "workspace"),
             ws_id,
-            ("rbac", expected_parent_type),
-            expected_parent_id,
+            ("rbac", "workspace"),
+            expected_parent_workspace_id,
             "parent",
         )
 
@@ -355,10 +350,10 @@ def _process_workspace_in_transaction(
                 )
             )
             result.relations_added = 1
-            logger.info(f"Added parent relation: workspace:{ws_id}#parent@{expected_parent_type}:{expected_parent_id}")
+            logger.info(f"Added parent relation: workspace:{ws_id}#parent@workspace:{expected_parent_workspace_id}")
         else:
             result.relations_to_add_count = 1
-            logger.info(f"DRY RUN: Would add: workspace:{ws_id}#parent@{expected_parent_type}:{expected_parent_id}")
+            logger.info(f"DRY RUN: Would add: workspace:{ws_id}#parent@workspace:{expected_parent_workspace_id}")
 
     return result
 
@@ -406,17 +401,16 @@ def rebuild_tenant_workspace_relations(
     queue = deque()
     for root_id in root_workspace_ids:
         for child_id in children_by_parent.get(root_id, []):
-            queue.append((child_id, "workspace", str(root_id)))
+            queue.append((child_id, str(root_id)))
 
     # BFS traversal - process each workspace in transaction
     while queue:
-        ws_id_uuid, expected_parent_type, expected_parent_id = queue.popleft()
+        ws_id_uuid, expected_parent_workspace_id = queue.popleft()
 
         # Process workspace in transaction (locks parent then child)
         result = _process_workspace_in_transaction(
             ws_id_uuid,
-            expected_parent_type,
-            expected_parent_id,
+            expected_parent_workspace_id,
             tenant,
             read_tuples_fn,
             replicator,
@@ -433,7 +427,7 @@ def rebuild_tenant_workspace_relations(
         # Add children to queue for BFS (outside transaction to release locks)
         if ws_id_uuid in children_by_parent:
             for child_id in children_by_parent[ws_id_uuid]:
-                queue.append((child_id, "workspace", str(ws_id_uuid)))
+                queue.append((child_id, str(ws_id_uuid)))
 
     if dry_run and relations_to_add_count:
         logger.info(f"DRY RUN: Would add {relations_to_add_count} parent relations for tenant {tenant.org_id}")

--- a/rbac/management/management/commands/remove_legacy_root_workspace_tenant_parent_relations.py
+++ b/rbac/management/management/commands/remove_legacy_root_workspace_tenant_parent_relations.py
@@ -62,6 +62,4 @@ class Command(BaseCommand):
             "Processed %s tenants; enqueued %s tuple removals.",
             result["tenants_processed"],
         )
-        self.stdout.write(
-            f"tenants_processed={result['tenants_processed']} relations_enqueued={result['relations_enqueued']}"
-        )
+        self.stdout.write(f"tenants_processed={result['tenants_processed']}")

--- a/rbac/management/management/commands/remove_legacy_root_workspace_tenant_parent_relations.py
+++ b/rbac/management/management/commands/remove_legacy_root_workspace_tenant_parent_relations.py
@@ -1,0 +1,67 @@
+"""Management command to delete stale workspace(root)#parent@tenant tuples."""
+
+#
+# Copyright 2026 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+import logging
+
+from django.core.management import BaseCommand, CommandError
+from internal.utils import remove_legacy_root_workspace_tenant_parent_relations
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    """Remove legacy workspace(root)#parent@tenant tuples via the outbox."""
+
+    help = (
+        "Enqueue removal of legacy workspace(root)#parent@tenant relationship tuples "
+        "(superseded hierarchy; bootstrapping no longer creates this edge)."
+    )
+
+    def add_arguments(self, parser):
+        """Add arguments for the command."""
+        parser.add_argument(
+            "--all",
+            action="store_true",
+            help="process all non-public tenants",
+        )
+
+    def handle(self, *args, **options):
+        """Execute the command."""
+        if not options["all"]:
+            raise CommandError(
+                "Must pass --all to process all non-public tenants.",
+                returncode=2,
+            )
+
+        logger.info("Removing legacy root workspace parent=tenant tuples for all non-public tenants.")
+
+        result = remove_legacy_root_workspace_tenant_parent_relations()
+
+        if result.get("skipped"):
+            reason = result.get("reason", "skipped")
+            logger.info("Skipped: %s", reason)
+            self.stdout.write(self.style.WARNING(reason))
+            return
+
+        logger.info(
+            "Processed %s tenants; enqueued %s tuple removals.",
+            result["tenants_processed"],
+        )
+        self.stdout.write(
+            f"tenants_processed={result['tenants_processed']} relations_enqueued={result['relations_enqueued']}"
+        )

--- a/rbac/management/management/commands/remove_legacy_root_workspace_tenant_parent_relations.py
+++ b/rbac/management/management/commands/remove_legacy_root_workspace_tenant_parent_relations.py
@@ -54,12 +54,7 @@ class Command(BaseCommand):
 
         if result.get("skipped"):
             reason = result.get("reason", "skipped")
-            logger.info("Skipped: %s", reason)
-            self.stdout.write(self.style.WARNING(reason))
+            logger.warning("Skipped: %s", reason)
             return
 
-        logger.info(
-            "Processed %s tenants; enqueued %s tuple removals.",
-            result["tenants_processed"],
-        )
-        self.stdout.write(f"tenants_processed={result['tenants_processed']}")
+        logger.info("Processed %s tenants", result["tenants_processed"])

--- a/rbac/management/tenant_service/v2.py
+++ b/rbac/management/tenant_service/v2.py
@@ -820,7 +820,7 @@ class V2TenantBootstrapService:
         return tuples_to_add, tuples_to_remove
 
     def _built_in_hierarchy_tuples(self, default_workspace_id, root_workspace_id, org_id) -> List[RelationTuple]:
-        """Create the tuples used to bootstrap the hierarchy of default->root->tenant->platform."""
+        """Create tuples for default->root workspace parents and tenant->platform."""
         tenant_id = f"{self._user_domain}/{org_id}"
 
         return [
@@ -830,9 +830,6 @@ class V2TenantBootstrapService:
                 ("rbac", "workspace"),
                 str(root_workspace_id),
                 "parent",
-            ),
-            create_relationship(
-                ("rbac", "workspace"), str(root_workspace_id), ("rbac", "tenant"), tenant_id, "parent"
             ),
             # Include platform for tenant
             create_relationship(("rbac", "tenant"), tenant_id, ("rbac", "platform"), settings.ENV_NAME, "platform"),

--- a/tests/internal/test_cleanup_orphan_bindings.py
+++ b/tests/internal/test_cleanup_orphan_bindings.py
@@ -1378,7 +1378,9 @@ class RebuildTenantWorkspaceRelationsTest(DualWriteTestCase):
             dry_run=True,
         )
 
-        # Verify DFS discovered all 4 workspaces (traverses all 4 layers)
+        # Verification traverses parent edges only; root has no parent tuple so it is not counted.
         self.assertEqual(
-            cleanup_result["workspaces_discovered_count"], 4, "DFS should discover all 4 workspaces after rebuild"
+            cleanup_result["workspaces_discovered_count"],
+            3,
+            "DFS records workspaces reached via workspace#parent@workspace (not the root)",
         )

--- a/tests/internal/test_cleanup_orphan_bindings.py
+++ b/tests/internal/test_cleanup_orphan_bindings.py
@@ -1008,12 +1008,12 @@ class RebuildTenantWorkspaceRelationsTest(DualWriteTestCase):
         # Verify result
         self.assertEqual(result["org_id"], self.tenant.org_id)
         self.assertFalse(result["dry_run"])
-        self.assertEqual(result["workspaces_checked"], 2)  # root + default
-        self.assertEqual(result["workspaces_missing_parent"], 2)
-        self.assertEqual(result["relations_to_add"], 2)
-        self.assertEqual(result["relations_added"], 2)
+        self.assertEqual(result["workspaces_checked"], 1)
+        self.assertEqual(result["workspaces_missing_parent"], 1)
+        self.assertEqual(result["relations_to_add"], 1)
+        self.assertEqual(result["relations_added"], 1)
 
-        # Verify root workspace now has parent tuple -> tenant
+        # Root workspaces are not linked to the tenant in Kessel.
         root_parent_after = self.tuples.find_tuples(
             all_of(
                 resource("rbac", "workspace", root_ws_id),
@@ -1021,7 +1021,7 @@ class RebuildTenantWorkspaceRelationsTest(DualWriteTestCase):
                 subject("rbac", "tenant", tenant_resource_id),
             )
         )
-        self.assertEqual(len(root_parent_after), 1, "Root workspace should have parent tuple to tenant")
+        self.assertEqual(len(root_parent_after), 0, "Root workspace should not get a parent tuple to tenant")
 
         # Verify default workspace now has parent tuple -> root workspace
         default_parent_after = self.tuples.find_tuples(
@@ -1096,7 +1096,7 @@ class RebuildTenantWorkspaceRelationsTest(DualWriteTestCase):
         # Verify workspace with missing parent was detected
         self.assertGreater(result["workspaces_missing_parent"], 0, "Should detect workspaces with missing parent")
 
-        # Verify parent relation was created
+        # Verify parent relation was created (default -> root chain only)
         parent_after = self.tuples.find_tuples(
             all_of(
                 resource("rbac", "workspace", default_ws_id),
@@ -1143,7 +1143,7 @@ class RebuildTenantWorkspaceRelationsTest(DualWriteTestCase):
 
         # Verify dry_run flag in result
         self.assertTrue(result["dry_run"])
-        self.assertGreater(result["relations_to_add"], 0, "Should have relations to add")
+        self.assertEqual(result["relations_to_add"], 1, "Should only plan default workspace parent relation")
         self.assertEqual(result["relations_added"], 0, "Should not have added relations in dry run")
 
         # Verify tuple count unchanged
@@ -1206,7 +1206,7 @@ class RebuildTenantWorkspaceRelationsTest(DualWriteTestCase):
         )
         self.assertEqual(len(default_parent_before), 0, "Default workspace should have no parent tuple")
 
-        # Run rebuild
+        # Run rebuild (legacy root->tenant tuple is ignored for rebuild purposes)
         result = rebuild_tenant_workspace_relations(
             tenant=self.tenant,
             read_tuples_fn=self._create_kessel_read_tuples_mock(),
@@ -1214,20 +1214,20 @@ class RebuildTenantWorkspaceRelationsTest(DualWriteTestCase):
             dry_run=False,
         )
 
-        # Verify only 1 workspace was missing parent (default)
-        self.assertEqual(result["workspaces_checked"], 2)
+        # Verify only the default workspace was checked (root is not replicated to tenant)
+        self.assertEqual(result["workspaces_checked"], 1)
         self.assertEqual(result["workspaces_missing_parent"], 1)
         self.assertEqual(result["relations_to_add"], 1)
         self.assertEqual(result["relations_added"], 1)
 
-        # Verify root still has exactly 1 parent tuple (not duplicated)
+        # Legacy root parent tuple remains until removed by cleanup/cron
         root_parent_after = self.tuples.find_tuples(
             all_of(
                 resource("rbac", "workspace", root_ws_id),
                 relation("parent"),
             )
         )
-        self.assertEqual(len(root_parent_after), 1, "Root workspace should still have exactly 1 parent tuple")
+        self.assertEqual(len(root_parent_after), 1, "Legacy root parent tuple should be unchanged")
 
         # Verify default now has parent tuple
         default_parent_after = self.tuples.find_tuples(
@@ -1248,16 +1248,7 @@ class RebuildTenantWorkspaceRelationsTest(DualWriteTestCase):
         """
         Integration test: rebuild workspace relations, then cleanup can discover all workspaces.
 
-        This tests the recommended flow with 4 layers of workspaces:
-        - Layer 1: Root workspace (parent = tenant)
-        - Layer 2: Default workspace (parent = root)
-        - Layer 3: Child workspace (parent = default)
-        - Layer 4: Grandchild workspace (parent = child)
-
-        Steps:
-        1. Run rebuild to fix missing parent relations
-        2. Run cleanup which uses DFS to discover workspaces
-        3. DFS should now find all workspaces because parent relations exist
+        Uses DB-backed workspace seeds for Kessel reads; root workspaces are not parent-linked to the tenant.
         """
         # Redirect replicator to in-memory tuples
         mock_replicate.side_effect = InMemoryRelationReplicator(self.tuples).replicate
@@ -1327,14 +1318,10 @@ class RebuildTenantWorkspaceRelationsTest(DualWriteTestCase):
             dry_run=False,
         )
 
-        # Verify all 4 workspaces have parent relations now
-        # Layer 1: root -> parent -> tenant
-        # Layer 2: default -> parent -> root
-        # Layer 3: child -> parent -> default
-        # Layer 4: grandchild -> parent -> child
-        self.assertEqual(rebuild_result["workspaces_checked"], 4)  # root + default + child + grandchild
-        self.assertEqual(rebuild_result["relations_to_add"], 4)
-        self.assertEqual(rebuild_result["relations_added"], 4)
+        # Verify default + nested workspaces get parent relations (root has no parent tuple)
+        self.assertEqual(rebuild_result["workspaces_checked"], 3)
+        self.assertEqual(rebuild_result["relations_to_add"], 3)
+        self.assertEqual(rebuild_result["relations_added"], 3)
 
         # Verify parent tuples were created
         all_parent_after = self.tuples.find_tuples(
@@ -1343,20 +1330,18 @@ class RebuildTenantWorkspaceRelationsTest(DualWriteTestCase):
                 relation("parent"),
             )
         )
-        self.assertEqual(len(all_parent_after), 4, "Should have 4 parent tuples after rebuild")
+        self.assertEqual(len(all_parent_after), 3, "Should have 3 parent tuples after rebuild")
 
-        # Verify each layer's parent relation
-        # Layer 1: root -> parent -> tenant
+        # Root should remain without a parent tuple
         root_parent = self.tuples.find_tuples(
             all_of(
                 resource("rbac", "workspace", root_ws_id),
                 relation("parent"),
-                subject("rbac", "tenant", self.tenant.tenant_resource_id()),
             )
         )
-        self.assertEqual(len(root_parent), 1, "Root should have parent = tenant")
+        self.assertEqual(len(root_parent), 0, "Root should have no parent tuples")
 
-        # Layer 2: default -> parent -> root
+        # Default -> root
         default_parent = self.tuples.find_tuples(
             all_of(
                 resource("rbac", "workspace", default_ws_id),

--- a/tests/internal/test_utils.py
+++ b/tests/internal/test_utils.py
@@ -1116,12 +1116,12 @@ class RemoveLegacyRootWorkspaceTenantParentRelationsTest(TestCase):
             result = remove_legacy_root_workspace_tenant_parent_relations()
         self.assertTrue(result["skipped"])
 
-    @patch("internal.utils.OutboxReplicator")
-    def test_enqueues_delete_for_legacy_tuple(self, mock_outbox_cls):
+    @patch("management.relation_replicator.outbox_replicator.OutboxReplicator.replicate")
+    def test_enqueues_delete_for_legacy_tuple(self, mock_replicate):
         from internal.utils import remove_legacy_root_workspace_tenant_parent_relations
 
         root = Workspace.objects.root(tenant=self.tenant)
-        mock_outbox_cls.return_value = InMemoryRelationReplicator(self.tuples)
+        mock_replicate.side_effect = InMemoryRelationReplicator(self.tuples).replicate
 
         tenant_rid = self.tenant.tenant_resource_id()
         self.tuples.add(

--- a/tests/internal/test_utils.py
+++ b/tests/internal/test_utils.py
@@ -59,6 +59,7 @@ from internal.utils import (
     expire_orphaned_cross_account_requests,
 )
 from migration_tool.models import V2role, V2rolebinding, V2boundresource
+from migration_tool.utils import create_relationship
 from rbac.settings import ROOT_SCOPE_PERMISSIONS, TENANT_SCOPE_PERMISSIONS
 from tests.management.role.test_dual_write import DualWriteTestCase
 from tests.util import assert_v2_tuples_consistent, assert_v1_v2_tuples_fully_consistent
@@ -1097,3 +1098,51 @@ class ExpireOrphanCrossAccountRequests(DualWriteTestCase):
         self.assertEqual(car.status, "approved")
 
         expect_exists()
+
+
+@override_settings(REPLICATION_TO_RELATION_ENABLED=True)
+class RemoveLegacyRootWorkspaceTenantParentRelationsTest(TestCase):
+    """Tests for remove_legacy_root_workspace_tenant_parent_relations."""
+
+    def setUp(self):
+        self.tenant = Tenant.objects.create(tenant_name="legacy_root_cleanup", org_id="9918877")
+        self.tuples = InMemoryTuples()
+        bootstrap_tenant_for_v2_test(self.tenant, tuples=self.tuples)
+
+    def test_skipped_when_replication_disabled(self):
+        from internal.utils import remove_legacy_root_workspace_tenant_parent_relations
+
+        with override_settings(REPLICATION_TO_RELATION_ENABLED=False):
+            result = remove_legacy_root_workspace_tenant_parent_relations()
+        self.assertTrue(result["skipped"])
+
+    @patch("internal.utils.OutboxReplicator")
+    def test_enqueues_delete_for_legacy_tuple(self, mock_outbox_cls):
+        from internal.utils import remove_legacy_root_workspace_tenant_parent_relations
+
+        root = Workspace.objects.root(tenant=self.tenant)
+        mock_outbox_cls.return_value = InMemoryRelationReplicator(self.tuples)
+
+        tenant_rid = self.tenant.tenant_resource_id()
+        self.tuples.add(
+            create_relationship(
+                ("rbac", "workspace"),
+                str(root.id),
+                ("rbac", "tenant"),
+                tenant_rid,
+                "parent",
+            )
+        )
+
+        result = remove_legacy_root_workspace_tenant_parent_relations()
+        self.assertFalse(result["skipped"])
+        self.assertGreaterEqual(result["tenants_processed"], 1)
+
+        remaining = self.tuples.find_tuples(
+            all_of(
+                resource("rbac", "workspace", str(root.id)),
+                relation("parent"),
+                subject("rbac", "tenant", tenant_rid),
+            )
+        )
+        self.assertEqual(len(remaining), 0)

--- a/tests/internal/test_views.py
+++ b/tests/internal/test_views.py
@@ -1176,7 +1176,7 @@ class InternalViewsetTests(BaseInternalViewsetTests):
         self.assertIsNotNone(Workspace.objects.root(tenant=tenant))
         self.assertIsNotNone(Workspace.objects.default(tenant=tenant))
         self.assertTrue(getattr(tenant, "tenant_mapping"))
-        self.assertEqual(len(tuples), 21)
+        self.assertEqual(len(tuples), 20)
 
     @patch("management.relation_replicator.outbox_replicator.OutboxReplicator.replicate")
     def test_bootstrapping_multiple_tenants(self, replicate):
@@ -1215,8 +1215,8 @@ class InternalViewsetTests(BaseInternalViewsetTests):
             self.assertTrue(getattr(tenant, "tenant_mapping"))
         self.assertEqual(
             len(tuples),
-            21 + 21 + 21,
-        )  # orgs: 3 for workspaces, (3 for default and 3 for admin default access) for each of 3 scopes
+            20 + 20 + 20,
+        )  # orgs: per tenant, workspace hierarchy + default access (root no longer has workspace#parent@tenant)
 
     @patch("management.relation_replicator.outbox_replicator.OutboxReplicator.replicate")
     def test_bootstrapping_existing_tenant_without_force_does_nothing(self, replicate):
@@ -1271,7 +1271,7 @@ class InternalViewsetTests(BaseInternalViewsetTests):
         )
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(len(tuples), 21)
+        self.assertEqual(len(tuples), 20)
 
     @override_settings(REPLICATION_TO_RELATION_ENABLED=True)
     def test_cannot_force_bootstrapping_while_replication_enabled(self):

--- a/tests/management/management/commands/test_remove_legacy_root_workspace_tenant_parent_relations.py
+++ b/tests/management/management/commands/test_remove_legacy_root_workspace_tenant_parent_relations.py
@@ -1,0 +1,47 @@
+"""Tests for remove_legacy_root_workspace_tenant_parent_relations management command."""
+
+#
+# Copyright 2026 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+from io import StringIO
+from unittest.mock import patch
+
+from django.core.management import CommandError, call_command
+from django.test import TestCase, override_settings
+
+
+class RemoveLegacyRootWorkspaceTenantParentRelationsCommandTests(TestCase):
+    """Tests for remove_legacy_root_workspace_tenant_parent_relations."""
+
+    def test_requires_all(self):
+        with self.assertRaises(CommandError):
+            call_command("remove_legacy_root_workspace_tenant_parent_relations")
+
+    @override_settings(REPLICATION_TO_RELATION_ENABLED=False)
+    def test_skipped_writes_reason_to_stdout(self):
+        out = StringIO()
+        call_command(
+            "remove_legacy_root_workspace_tenant_parent_relations",
+            "--all",
+            stdout=out,
+        )
+        self.assertIn("REPLICATION_TO_RELATION_ENABLED", out.getvalue())
+
+    @patch(
+        "management.management.commands.remove_legacy_root_workspace_tenant_parent_relations."
+        "remove_legacy_root_workspace_tenant_parent_relations"
+    )
+    def test_all_invokes_util(self, mock_remove):
+        mock_remove.return_value = {
+            "skipped": False,
+            "tenants_processed": 2,
+        }
+        out = StringIO()
+        call_command("remove_legacy_root_workspace_tenant_parent_relations", "--all", stdout=out)
+        mock_remove.assert_called_once_with()
+        self.assertIn("tenants_processed=2", out.getvalue())

--- a/tests/management/management/commands/test_remove_legacy_root_workspace_tenant_parent_relations.py
+++ b/tests/management/management/commands/test_remove_legacy_root_workspace_tenant_parent_relations.py
@@ -8,8 +8,7 @@
 # published by the Free Software Foundation, either version 3 of the
 # License, or (at your option) any later version.
 #
-from io import StringIO
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 
 from django.core.management import CommandError, call_command
 from django.test import TestCase, override_settings
@@ -23,25 +22,26 @@ class RemoveLegacyRootWorkspaceTenantParentRelationsCommandTests(TestCase):
             call_command("remove_legacy_root_workspace_tenant_parent_relations")
 
     @override_settings(REPLICATION_TO_RELATION_ENABLED=False)
-    def test_skipped_writes_reason_to_stdout(self):
-        out = StringIO()
+    @patch("management.management.commands.remove_legacy_root_workspace_tenant_parent_relations.logger")
+    def test_skipped_logs_reason(self, mock_logger):
         call_command(
             "remove_legacy_root_workspace_tenant_parent_relations",
             "--all",
-            stdout=out,
         )
-        self.assertIn("REPLICATION_TO_RELATION_ENABLED", out.getvalue())
+        mock_logger.warning.assert_called_once_with("Skipped: %s", ANY)
+        _, reason = mock_logger.warning.call_args[0]
+        self.assertIn("REPLICATION_TO_RELATION_ENABLED", reason)
 
     @patch(
         "management.management.commands.remove_legacy_root_workspace_tenant_parent_relations."
         "remove_legacy_root_workspace_tenant_parent_relations"
     )
-    def test_all_invokes_util(self, mock_remove):
+    @patch("management.management.commands.remove_legacy_root_workspace_tenant_parent_relations.logger")
+    def test_all_invokes_util(self, mock_logger, mock_remove):
         mock_remove.return_value = {
             "skipped": False,
             "tenants_processed": 2,
         }
-        out = StringIO()
-        call_command("remove_legacy_root_workspace_tenant_parent_relations", "--all", stdout=out)
+        call_command("remove_legacy_root_workspace_tenant_parent_relations", "--all")
         mock_remove.assert_called_once_with()
-        self.assertIn("tenants_processed=2", out.getvalue())
+        mock_logger.info.assert_any_call("Processed %s tenants", 2)

--- a/tests/management/tenant/test_model.py
+++ b/tests/management/tenant/test_model.py
@@ -89,7 +89,7 @@ class V2TenantBootstrapServiceTest(TestCase):
             ),
         )
         self.assertEqual(
-            1,
+            0,
             self.tuples.count_tuples(
                 all_of(
                     resource("rbac", "workspace", root.id),
@@ -305,9 +305,9 @@ class V2TenantBootstrapServiceTest(TestCase):
         # Admins get 2, otherwise 1
         num_group_membership_tuples = 2 + 1 + 2 + 1 + 1 + 1
         # o1 is already bootstrapped, should get 0
-        # existing unbootstrapped custom group tenants get 12
-        # new or otherwise unbootstrapped tenants get 21
-        num_tenant_bootstrapping_tuples = 0 + 21 + 12 + 21
+        # existing unbootstrapped custom group tenants get 11 (one fewer hierarchy tuple vs full bootstrap)
+        # new or otherwise unbootstrapped tenants get 20 (root workspace no longer gets workspace#parent@tenant)
+        num_tenant_bootstrapping_tuples = 0 + 20 + 11 + 20
 
         self.assertEqual(num_group_membership_tuples + num_tenant_bootstrapping_tuples, self.tuples.count_tuples())
 
@@ -645,7 +645,7 @@ class V2TenantBootstrapServiceTest(TestCase):
             f"Expected default workspace to be child of root workspace for tenant {org_id}",
         )
         self.assertEqual(
-            1,
+            0,
             self.tuples.count_tuples(
                 all_of(
                     resource("rbac", "workspace", root.id),
@@ -653,7 +653,7 @@ class V2TenantBootstrapServiceTest(TestCase):
                     subject("rbac", "tenant", f"localhost/{org_id}"),
                 )
             ),
-            f"Expected root workspace to be child of tenant for tenant {org_id}",
+            f"Expected root workspace not to replicate workspace#parent@tenant for tenant {org_id}",
         )
         self.assertEqual(
             1,


### PR DESCRIPTION
## Link(s) to Jira
- https://redhat.atlassian.net/browse/RHCLOUD-46155

## Description of Intent of Change(s)
We wanna stop the inheritance from tenant to workspace

## Local Testing
Unit test

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Remove legacy tenant-to-workspace parent relationships from hierarchy and cleanup tooling, ensuring only workspace-to-workspace parent edges are maintained and migrated.

New Features:
- Add a management utility and scheduled job to enqueue removal of legacy root workspace parent relations to tenants.
- Introduce an OpenShift template and ClowdApp job configuration to run the legacy workspace-to-tenant parent cleanup in production.

Enhancements:
- Change workspace hierarchy replication and cleanup logic to stop creating or traversing tenant-to-root-workspace parent relations, seeding traversal from DB-backed roots instead.
- Update tenant bootstrapping to omit creation of root-workspace-to-tenant parent tuples so new tenants conform to the workspace-only hierarchy model.

Deployment:
- Add a dedicated OpenShift template for invoking the legacy root-workspace-to-tenant parent cleanup job on demand.

Tests:
- Extend and adjust internal cleanup and rebuild tests to reflect the new workspace-only parent hierarchy and counts.
- Add unit tests for the new utility and management command that remove legacy root workspace parent relations, including CLI behavior and replication gating.