### PR TITLE
[RHCLOUD-46771] Add seeded role hierarchy parity checker

### DIFF
--- a/rbac/management/inventory_checker/inventory_api_check.py
+++ b/rbac/management/inventory_checker/inventory_api_check.py
@@ -32,7 +32,12 @@ from kessel.inventory.v1beta2 import (
 )
 from kessel.inventory.v1beta2.check_request_pb2 import CheckRequest
 from management.cache import JWTCache
+from management.group.platform import DefaultGroupNotAvailableError, GlobalPolicyIdService
+from management.permission.scope_service import ImplicitResourceService
 from management.relation_replicator.types import RelationTuple
+from management.role.platform import admin_platform_parent_scope_for_seeded_system_role, platform_v2_role_uuid_for
+from management.role.relations import role_child_relationship
+from management.tenant_mapping.model import DefaultAccessType
 from management.utils import create_client_channel_inventory
 
 jwt_cache = JWTCache()
@@ -399,3 +404,81 @@ class CustomRolePermissionChecker(InventoryApiBaseChecker):
         else:
             logger.info(f"CustomRole: {role_uuid} has the correct permission relations in inventory.")
         return permission_check
+
+
+def generate_seeded_role_hierarchy_tuples(
+    seeded_role, implicit_resource_service: ImplicitResourceService | None = None
+) -> list[RelationTuple]:
+    """Generate expected parent-child tuples for a seeded role.
+
+    Replicates the logic from SeedingRelationApiDualWriteHandler._check_create_admin_platform_relation()
+    to determine what parent-child relationships should exist in Kessel for a given seeded role.
+
+    Args:
+        seeded_role: A SeededRoleV2 instance with v1_source (and v1_source.access) prefetched.
+        implicit_resource_service: Optional shared instance to avoid repeated construction in loops.
+
+    Returns:
+        List of RelationTuple objects representing expected parent-child relationships.
+    """
+    v1_role = seeded_role.v1_source
+    if v1_role is None:
+        logger.warning(f"SeededRole {seeded_role.uuid} has no v1_source, cannot generate hierarchy tuples")
+        return []
+
+    if not v1_role.admin_default and not v1_role.platform_default:
+        return []
+
+    if implicit_resource_service is None:
+        implicit_resource_service = ImplicitResourceService.from_settings()
+    scope = implicit_resource_service.scope_for_role(v1_role)
+    policy_service = GlobalPolicyIdService.shared()
+    tuples = []
+
+    if v1_role.admin_default:
+        try:
+            admin_scope = admin_platform_parent_scope_for_seeded_system_role(
+                v1_role.name, v1_role.admin_default, scope, apply_override=True
+            )
+            parent_uuid = platform_v2_role_uuid_for(DefaultAccessType.ADMIN, admin_scope, policy_service)
+            tuples.append(role_child_relationship(parent_uuid, seeded_role.uuid))
+        except DefaultGroupNotAvailableError:
+            logger.warning(f"Default admin group not available for seeded role {seeded_role.uuid}")
+
+    if v1_role.platform_default:
+        try:
+            parent_uuid = platform_v2_role_uuid_for(DefaultAccessType.USER, scope, policy_service)
+            tuples.append(role_child_relationship(parent_uuid, seeded_role.uuid))
+        except DefaultGroupNotAvailableError:
+            logger.warning(f"Default platform group not available for seeded role {seeded_role.uuid}")
+
+    return tuples
+
+
+class SeededRoleHierarchyChecker(InventoryApiBaseChecker):
+    """Subclass to check seeded role parent-child hierarchy relations on inventory api."""
+
+    def check_seeded_role_hierarchy(self, hierarchy_tuples: Sequence[RelationTuple], role_uuid: str) -> bool:
+        """Core logic to check seeded role parent-child relations on inventory api.
+
+        Each hierarchy tuple represents: rbac/role:<parent_platform_uuid>#child@rbac/role:<child_seeded_uuid>
+
+        Args:
+            hierarchy_tuples: List of RelationTuple objects from generate_seeded_role_hierarchy_tuples()
+            role_uuid: UUID of the seeded role being checked
+
+        Returns:
+            True if all relations exist in the inventory, False otherwise
+        """
+        if not hierarchy_tuples:
+            logger.debug(f"SeededRole: {role_uuid} has no parent-child relations, skipping check")
+            return True
+
+        check_requests = [relation_tuple_to_check_request(tuple_obj) for tuple_obj in hierarchy_tuples]
+
+        hierarchy_check = self.check_inventory_core(check_requests)
+        if not hierarchy_check:
+            logger.warning(f"SeededRole: {role_uuid} does not have the expected parent-child relations in inventory.")
+        else:
+            logger.info(f"SeededRole: {role_uuid} has the correct parent-child relations in inventory.")
+        return hierarchy_check

--- a/rbac/management/tasks.py
+++ b/rbac/management/tasks.py
@@ -38,14 +38,17 @@ from internal.utils import (
 from management.health.healthcheck import redis_health
 from management.inventory_checker.inventory_api_check import (
     CustomRolePermissionChecker,
+    SeededRoleHierarchyChecker,
     WorkspaceRelationInventoryChecker,
+    generate_seeded_role_hierarchy_tuples,
 )
+from management.permission.scope_service import ImplicitResourceService
 from management.parity_check import run_parity_checks
 from management.principal.cleaner import (
     clean_tenants_principals,
     process_principal_events_from_umb,
 )
-from management.role.v2_model import CustomRoleV2
+from management.role.v2_model import CustomRoleV2, SeededRoleV2
 from management.workspace.model import Workspace
 from migration_tool.migrate import migrate_data
 from migration_tool.migrate_binding_scope import migrate_all_role_bindings
@@ -253,15 +256,72 @@ def run_kessel_parity_checks_in_worker():
         "total_tenants": 0,
         "total_workspace_pairs_checked": 0,
         "total_custom_roles_checked": 0,
+        "total_seeded_roles_checked": 0,
         "passed_tenants": 0,
         "failed_tenants": 0,
         "tenants_not_found": 0,
+        "seeded_role_hierarchy": {},
         "tenants_checked": [],
     }
     tenant_durations = []
 
     workspace_checker = WorkspaceRelationInventoryChecker()
     role_permission_checker = CustomRolePermissionChecker()
+    hierarchy_checker = SeededRoleHierarchyChecker()
+
+    # Seeded role hierarchy check (global, not per-tenant)
+    seeded_start = time.monotonic()
+    seeded_role_results = []
+    seeded_hierarchy_passed = True
+
+    seeded_roles = SeededRoleV2.objects.select_related("v1_source").prefetch_related("v1_source__access")
+    implicit_resource_service = ImplicitResourceService.from_settings() if seeded_roles.exists() else None
+
+    for seeded_role in seeded_roles:
+        try:
+            hierarchy_tuples = generate_seeded_role_hierarchy_tuples(seeded_role, implicit_resource_service)
+            if not hierarchy_tuples:
+                continue
+            role_passed = hierarchy_checker.check_seeded_role_hierarchy(hierarchy_tuples, str(seeded_role.uuid))
+            seeded_role_results.append(
+                {
+                    "role_uuid": str(seeded_role.uuid),
+                    "role_name": seeded_role.name,
+                    "v1_role_name": seeded_role.v1_source.name if seeded_role.v1_source else None,
+                    "tuple_count": len(hierarchy_tuples),
+                    "passed": role_passed,
+                }
+            )
+            if not role_passed:
+                seeded_hierarchy_passed = False
+        except Exception as e:
+            logger.exception("Error checking seeded role hierarchy for role %s", seeded_role.name)
+            seeded_hierarchy_passed = False
+            seeded_role_results.append(
+                {
+                    "role_uuid": str(seeded_role.uuid),
+                    "role_name": seeded_role.name,
+                    "v1_role_name": seeded_role.v1_source.name if seeded_role.v1_source else None,
+                    "passed": False,
+                    "error": str(e),
+                }
+            )
+
+    seeded_elapsed = time.monotonic() - seeded_start
+    stats["total_seeded_roles_checked"] = len(seeded_role_results)
+    stats["seeded_role_hierarchy"] = {
+        "total_seeded_roles": seeded_roles.count(),
+        "roles_with_hierarchy_checked": len(seeded_role_results),
+        "passed": seeded_hierarchy_passed,
+        "role_results": seeded_role_results,
+        "duration_seconds": round(seeded_elapsed, 3),
+    }
+
+    if seeded_role_results:
+        logger.info(
+            f"Seeded role hierarchy check: {len(seeded_role_results)} role(s) with hierarchy checked, "
+            f"passed={seeded_hierarchy_passed}, took {seeded_elapsed:.3f}s"
+        )
 
     # Bulk fetch all tenants to avoid N+1 queries
     tenants = {t.org_id: t for t in Tenant.objects.filter(org_id__in=org_ids)}
@@ -391,7 +451,8 @@ def run_kessel_parity_checks_in_worker():
         f"Failed: {stats['failed_tenants']}, "
         f"Not Found: {stats['tenants_not_found']}, "
         f"Total workspace pairs: {stats['total_workspace_pairs_checked']}, "
-        f"Total custom roles: {stats['total_custom_roles_checked']}"
+        f"Total custom roles: {stats['total_custom_roles_checked']}, "
+        f"Total seeded roles: {stats['total_seeded_roles_checked']}"
     )
 
     stats["timing"] = timing_stats

--- a/tests/management/inventory_checker/test_seeded_role_hierarchy_checker.py
+++ b/tests/management/inventory_checker/test_seeded_role_hierarchy_checker.py
@@ -1,0 +1,267 @@
+#
+# Copyright 2026 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""Tests for SeededRoleHierarchyChecker and generate_seeded_role_hierarchy_tuples."""
+
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+from kessel.inventory.v1beta2.check_response_pb2 import CheckResponse
+from management.group.platform import DefaultGroupNotAvailableError
+from management.inventory_checker.inventory_api_check import (
+    SeededRoleHierarchyChecker,
+    generate_seeded_role_hierarchy_tuples,
+)
+from management.models import Access, Permission, Role
+from management.role.v2_model import SeededRoleV2
+from tests.identity_request import IdentityRequest
+
+from api.models import Tenant
+
+INVENTORY_STUB_PATH = "management.inventory_checker.inventory_api_check.inventory_service_pb2_grpc.KesselInventoryServiceStub"  # noqa: E501
+
+
+class GenerateSeededRoleHierarchyTuplesTest(IdentityRequest):
+    """Tests for generate_seeded_role_hierarchy_tuples()."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Set up the public tenant and test data."""
+        super().setUpClass()
+        cls.public_tenant, _ = Tenant.objects.get_or_create(tenant_name="public")
+
+    def _create_system_role(
+        self, name, admin_default=False, platform_default=False, permission_str="app:resource:read"
+    ):
+        """Helper to create a V1 system role with a seeded V2 equivalent."""
+        role = Role.objects.create(
+            name=name,
+            system=True,
+            admin_default=admin_default,
+            platform_default=platform_default,
+            tenant=self.public_tenant,
+        )
+        perm = Permission.objects.create(permission=permission_str, tenant=self.public_tenant)
+        Access.objects.create(permission=perm, role=role, tenant=self.public_tenant)
+        seeded = SeededRoleV2.objects.create(
+            name=name,
+            tenant=self.public_tenant,
+            v1_source=role,
+        )
+        seeded.permissions.add(perm)
+        return seeded
+
+    def test_no_tuples_for_non_default_role(self):
+        """A role that is neither admin_default nor platform_default produces no tuples."""
+        seeded = self._create_system_role("Plain Role", admin_default=False, platform_default=False)
+        tuples = generate_seeded_role_hierarchy_tuples(seeded)
+        self.assertEqual(tuples, [])
+
+    def test_no_tuples_for_missing_v1_source(self):
+        """A seeded role with no v1_source produces no tuples."""
+        seeded = SeededRoleV2.objects.create(
+            name="Orphan Seeded Role",
+            tenant=self.public_tenant,
+            v1_source=None,
+        )
+        tuples = generate_seeded_role_hierarchy_tuples(seeded)
+        self.assertEqual(tuples, [])
+
+    @patch("management.inventory_checker.inventory_api_check.GlobalPolicyIdService.shared")
+    def test_admin_default_produces_one_tuple(self, mock_policy_service):
+        """An admin_default role produces one parent-child tuple."""
+        parent_uuid = uuid4()
+        mock_service = MagicMock()
+        mock_policy_service.return_value = mock_service
+        mock_service.admin_default_policy_uuid.return_value = parent_uuid
+
+        seeded = self._create_system_role("Admin Role", admin_default=True, platform_default=False)
+        tuples = generate_seeded_role_hierarchy_tuples(seeded)
+
+        self.assertEqual(len(tuples), 1)
+        self.assertEqual(tuples[0].resource.id, str(parent_uuid))
+        self.assertEqual(tuples[0].subject.subject.id, str(seeded.uuid))
+        self.assertEqual(tuples[0].relation, "child")
+
+    @patch("management.inventory_checker.inventory_api_check.GlobalPolicyIdService.shared")
+    def test_platform_default_produces_one_tuple(self, mock_policy_service):
+        """A platform_default role produces one parent-child tuple."""
+        parent_uuid = uuid4()
+        mock_service = MagicMock()
+        mock_policy_service.return_value = mock_service
+        mock_service.platform_default_policy_uuid.return_value = parent_uuid
+
+        seeded = self._create_system_role("Platform Role", admin_default=False, platform_default=True)
+        tuples = generate_seeded_role_hierarchy_tuples(seeded)
+
+        self.assertEqual(len(tuples), 1)
+        self.assertEqual(tuples[0].resource.id, str(parent_uuid))
+        self.assertEqual(tuples[0].subject.subject.id, str(seeded.uuid))
+        self.assertEqual(tuples[0].relation, "child")
+
+    @patch("management.inventory_checker.inventory_api_check.GlobalPolicyIdService.shared")
+    def test_both_defaults_produce_two_tuples(self, mock_policy_service):
+        """A role that is both admin_default and platform_default produces two tuples."""
+        admin_parent_uuid = uuid4()
+        platform_parent_uuid = uuid4()
+        mock_service = MagicMock()
+        mock_policy_service.return_value = mock_service
+        mock_service.admin_default_policy_uuid.return_value = admin_parent_uuid
+        mock_service.platform_default_policy_uuid.return_value = platform_parent_uuid
+
+        seeded = self._create_system_role("Both Default Role", admin_default=True, platform_default=True)
+        tuples = generate_seeded_role_hierarchy_tuples(seeded)
+
+        self.assertEqual(len(tuples), 2)
+        parent_ids = {t.resource.id for t in tuples}
+        self.assertEqual(parent_ids, {str(admin_parent_uuid), str(platform_parent_uuid)})
+        for t in tuples:
+            self.assertEqual(t.subject.subject.id, str(seeded.uuid))
+            self.assertEqual(t.relation, "child")
+
+    @patch("management.inventory_checker.inventory_api_check.GlobalPolicyIdService.shared")
+    def test_default_group_not_available_returns_partial(self, mock_policy_service):
+        """DefaultGroupNotAvailableError is caught and partial results are returned."""
+        platform_parent_uuid = uuid4()
+        mock_service = MagicMock()
+        mock_policy_service.return_value = mock_service
+        mock_service.admin_default_policy_uuid.side_effect = DefaultGroupNotAvailableError()
+        mock_service.platform_default_policy_uuid.return_value = platform_parent_uuid
+
+        seeded = self._create_system_role("Partial Default Role", admin_default=True, platform_default=True)
+        tuples = generate_seeded_role_hierarchy_tuples(seeded)
+
+        self.assertEqual(len(tuples), 1)
+        self.assertEqual(tuples[0].resource.id, str(platform_parent_uuid))
+        self.assertEqual(tuples[0].subject.subject.id, str(seeded.uuid))
+
+
+class SeededRoleHierarchyCheckerTest(IdentityRequest):
+    """Tests for the SeededRoleHierarchyChecker class."""
+
+    def setUp(self):
+        """Set up test data."""
+        super().setUp()
+        self.public_tenant, _ = Tenant.objects.get_or_create(tenant_name="public")
+        self.checker = SeededRoleHierarchyChecker()
+
+    def _create_seeded_role_with_tuples(self, name, admin_default=False, platform_default=False):
+        """Helper to create a seeded role and its expected hierarchy tuples."""
+        role = Role.objects.create(
+            name=name,
+            system=True,
+            admin_default=admin_default,
+            platform_default=platform_default,
+            tenant=self.public_tenant,
+        )
+        perm = Permission.objects.create(
+            permission=f"app:{name.lower().replace(' ', '_')}:read",
+            tenant=self.public_tenant,
+        )
+        Access.objects.create(permission=perm, role=role, tenant=self.public_tenant)
+        seeded = SeededRoleV2.objects.create(name=name, tenant=self.public_tenant, v1_source=role)
+        seeded.permissions.add(perm)
+        return seeded
+
+    def _setup_inventory_mocks(self, mock_create_channel, mock_stub_responses):
+        """Helper to set up inventory API mocks."""
+        mock_stub = MagicMock()
+        if isinstance(mock_stub_responses, list):
+            mock_stub.Check.side_effect = mock_stub_responses
+        else:
+            mock_stub.Check.return_value = mock_stub_responses
+
+        mock_channel = MagicMock()
+        mock_channel.__enter__.return_value = mock_channel
+        mock_channel.__exit__.return_value = None
+        mock_create_channel.return_value = mock_channel
+
+        return mock_stub
+
+    @patch("management.inventory_checker.inventory_api_check.create_client_channel_inventory")
+    @patch("management.inventory_checker.inventory_api_check.json_format.MessageToDict")
+    @patch("management.inventory_checker.inventory_api_check.GlobalPolicyIdService.shared")
+    def test_check_hierarchy_all_exist(self, mock_policy_service, mock_message_to_dict, mock_create_channel):
+        """Test that check returns True when all hierarchy relations exist in inventory."""
+        parent_uuid = uuid4()
+        mock_service = MagicMock()
+        mock_policy_service.return_value = mock_service
+        mock_service.admin_default_policy_uuid.return_value = parent_uuid
+
+        seeded = self._create_seeded_role_with_tuples("Admin Check Role", admin_default=True)
+        hierarchy_tuples = generate_seeded_role_hierarchy_tuples(seeded)
+
+        mock_response = MagicMock(spec=CheckResponse)
+        mock_stub = self._setup_inventory_mocks(mock_create_channel, mock_response)
+        mock_message_to_dict.return_value = {"allowed": "ALLOWED_TRUE"}
+
+        with patch(INVENTORY_STUB_PATH, return_value=mock_stub):
+            result = self.checker.check_seeded_role_hierarchy(hierarchy_tuples, str(seeded.uuid))
+            self.assertTrue(result)
+            self.assertEqual(mock_stub.Check.call_count, 1)
+
+    @patch("management.inventory_checker.inventory_api_check.create_client_channel_inventory")
+    @patch("management.inventory_checker.inventory_api_check.json_format.MessageToDict")
+    @patch("management.inventory_checker.inventory_api_check.GlobalPolicyIdService.shared")
+    def test_check_hierarchy_missing_relation(self, mock_policy_service, mock_message_to_dict, mock_create_channel):
+        """Test that check returns False when a hierarchy relation is missing in inventory."""
+        admin_parent = uuid4()
+        platform_parent = uuid4()
+        mock_service = MagicMock()
+        mock_policy_service.return_value = mock_service
+        mock_service.admin_default_policy_uuid.return_value = admin_parent
+        mock_service.platform_default_policy_uuid.return_value = platform_parent
+
+        seeded = self._create_seeded_role_with_tuples("Both Check Role", admin_default=True, platform_default=True)
+        hierarchy_tuples = generate_seeded_role_hierarchy_tuples(seeded)
+        self.assertEqual(len(hierarchy_tuples), 2)
+
+        mock_responses = [MagicMock(spec=CheckResponse), MagicMock(spec=CheckResponse)]
+        mock_stub = self._setup_inventory_mocks(mock_create_channel, mock_responses)
+        mock_message_to_dict.side_effect = [
+            {"allowed": "ALLOWED_TRUE"},
+            {"allowed": "ALLOWED_FALSE"},
+        ]
+
+        with patch(INVENTORY_STUB_PATH, return_value=mock_stub):
+            result = self.checker.check_seeded_role_hierarchy(hierarchy_tuples, str(seeded.uuid))
+            self.assertFalse(result)
+
+    def test_check_hierarchy_empty_tuples(self):
+        """Test that check returns True when there are no hierarchy tuples to verify."""
+        result = self.checker.check_seeded_role_hierarchy([], str(uuid4()))
+        self.assertTrue(result)
+
+    @patch("management.inventory_checker.inventory_api_check.create_client_channel_inventory")
+    @patch("management.inventory_checker.inventory_api_check.json_format.MessageToDict")
+    @patch("management.inventory_checker.inventory_api_check.GlobalPolicyIdService.shared")
+    def test_check_hierarchy_all_missing(self, mock_policy_service, mock_message_to_dict, mock_create_channel):
+        """Test that check returns False when all hierarchy relations are missing."""
+        parent_uuid = uuid4()
+        mock_service = MagicMock()
+        mock_policy_service.return_value = mock_service
+        mock_service.platform_default_policy_uuid.return_value = parent_uuid
+
+        seeded = self._create_seeded_role_with_tuples("Platform Missing Role", platform_default=True)
+        hierarchy_tuples = generate_seeded_role_hierarchy_tuples(seeded)
+
+        mock_responses = [MagicMock(spec=CheckResponse)]
+        mock_stub = self._setup_inventory_mocks(mock_create_channel, mock_responses)
+        mock_message_to_dict.side_effect = [{"allowed": "ALLOWED_FALSE"}]
+
+        with patch(INVENTORY_STUB_PATH, return_value=mock_stub):
+            result = self.checker.check_seeded_role_hierarchy(hierarchy_tuples, str(seeded.uuid))
+            self.assertFalse(result)


### PR DESCRIPTION
## Summary

- Add `SeededRoleHierarchyChecker` and `generate_seeded_role_hierarchy_tuples()` to verify platform/seeded role parent-child tuples (`rbac/role:<parent>#child@rbac/role:<child>`) exist in Kessel
- Integrate into `run_kessel_parity_checks_in_worker()` as a global check (seeded roles live in the public tenant, not per-org)
- Wrap seeded check in try/except so gRPC failures don't prevent per-tenant workspace and custom role checks from running

This is the third checker in the parity check epic (RHCLOUD-46767), after workspace parent hierarchy (RHCLOUD-46769) and custom role permissions (RHCLOUD-46770).

## How it works

The `generate_seeded_role_hierarchy_tuples()` function replicates the tuple generation logic from `SeedingRelationApiDualWriteHandler._check_create_admin_platform_relation()`:
- For `admin_default` V1 system roles: determines the admin platform parent role UUID based on scope (with ROOT override for Inventory admin roles)
- For `platform_default` V1 system roles: determines the user platform parent role UUID based on scope
- A role can be both, producing two tuples

The checker runs once before the per-tenant loop since seeded/platform roles are global (public tenant).

## Test plan

- [x] 10 unit tests covering tuple generation (admin_default, platform_default, both, neither, missing v1_source, DefaultGroupNotAvailableError handling)
- [x] 4 unit tests covering the checker class (all pass, missing relation, empty tuples, all missing)
- [x] All 17 existing parity task tests pass (backward compatible -- empty queryset when no seeded roles exist in test data)
- [x] Full test suite: 3345 tests pass, 0 failures
- [x] Linter clean (black + flake8)

## JIRA

https://issues.redhat.com/browse/RHCLOUD-46771

## Summary by Sourcery

Add a global parity check to verify seeded role parent-child hierarchies in Kessel inventory and report their results alongside existing workspace and custom role parity checks.

New Features:
- Introduce generation of expected parent-child relation tuples for seeded roles based on their V1 system-role defaults.
- Add a SeededRoleHierarchyChecker to validate seeded role hierarchy relations against the inventory API.
- Include seeded role hierarchy parity results and counts in the kessel parity worker task statistics and logging.

Tests:
- Add unit tests covering seeded role tuple generation for various admin/platform default combinations and error scenarios.
- Add unit tests for the SeededRoleHierarchyChecker to validate behavior when relations exist, are partially missing, entirely missing, or absent.