### PR TITLE
[RHCLOUD-46774] Integrate group-principal membership parity checker

### DIFF
--- a/rbac/management/inventory_checker/inventory_api_check.py
+++ b/rbac/management/inventory_checker/inventory_api_check.py
@@ -92,6 +92,12 @@ class InventoryApiBaseChecker:
             responses = [stub.Check(req) for req in checks]
             return all(self._is_allowed(res) for res in responses)
 
+    def _check_inventory_batch(self, checks: List[CheckRequest]) -> list[bool]:
+        """Check multiple relations via a single gRPC channel, returning per-request results."""
+        with create_client_channel_inventory(settings.INVENTORY_API_SERVER) as channel:
+            stub = inventory_service_pb2_grpc.KesselInventoryServiceStub(channel)
+            return [self._is_allowed(stub.Check(req)) for req in checks]
+
     def _is_allowed(self, response):
         response_dict = json_format.MessageToDict(response)
         return response_dict.get("allowed", "") != "ALLOWED_FALSE"
@@ -101,18 +107,23 @@ class GroupPrincipalInventoryChecker(InventoryApiBaseChecker):
     """Subclass to check group principal relations are correct on inventory api."""
 
     def check_relationships(self, relationships):
-        """Core logic to check group principal relations are correct."""
+        """Check group principal relations are correct. All relationships must belong to the same group."""
         inventory_relation_assignments = {"group_uuid": "", "principal_relations": []}
-        for r in relationships:
-            check_request = relation_tuple_to_check_request(r)
-            relation_exists = self.check_inventory_core(check_request)
+        if not relationships:
+            return inventory_relation_assignments
+
+        check_requests = [relation_tuple_to_check_request(r) for r in relationships]
+        results = self._check_inventory_batch(check_requests)
+
+        for r, relation_exists in zip(relationships, results):
             inventory_relation_assignments["group_uuid"] = r.resource.id
             inventory_relation_assignments["principal_relations"].append(
                 {"id": r.subject.subject.id, "relation_exists": relation_exists}
             )
             if not relation_exists:
                 logger.warning(
-                    f"Relation missing: User ID {r.subject.subject.id} is not associated with Group ID {r.resource.id}"
+                    f"Relation missing: User ID {r.subject.subject.id} "
+                    f"is not associated with Group ID {r.resource.id}"
                 )
         return inventory_relation_assignments
 

--- a/rbac/management/tasks.py
+++ b/rbac/management/tasks.py
@@ -35,10 +35,12 @@ from internal.utils import (
     remove_unassigned_system_binding_mappings,
     replicate_missing_binding_tuples,
 )
+from management.group.model import Group
 from management.health.healthcheck import redis_health
 from management.inventory_checker.inventory_api_check import (
     BootstrappedTenantInventoryChecker,
     CustomRolePermissionChecker,
+    GroupPrincipalInventoryChecker,
     SeededRoleHierarchyChecker,
     WorkspaceRelationInventoryChecker,
     generate_seeded_role_hierarchy_tuples,
@@ -260,6 +262,8 @@ def run_kessel_parity_checks_in_worker():
         "total_custom_roles_checked": 0,
         "total_seeded_roles_checked": 0,
         "total_bootstrap_checks": 0,
+        "total_groups_checked": 0,
+        "total_group_principal_relations_checked": 0,
         "passed_tenants": 0,
         "failed_tenants": 0,
         "tenants_not_found": 0,
@@ -272,6 +276,7 @@ def run_kessel_parity_checks_in_worker():
     role_permission_checker = CustomRolePermissionChecker()
     hierarchy_checker = SeededRoleHierarchyChecker()
     bootstrap_checker = BootstrappedTenantInventoryChecker()
+    group_principal_checker = GroupPrincipalInventoryChecker()
 
     # Seeded role hierarchy check (global, not per-tenant)
     seeded_start = time.monotonic()
@@ -351,6 +356,8 @@ def run_kessel_parity_checks_in_worker():
         custom_role_check_passed = True
         bootstrap_check_passed = False
         bootstrap_details: list[dict] = []
+        group_results = []
+        group_principal_check_passed = True
 
         try:
             tenant_start = time.monotonic()
@@ -420,7 +427,46 @@ def run_kessel_parity_checks_in_worker():
                 logger.warning(f"No tenant mapping for org_id: {org_id}, skipping bootstrap check")
                 bootstrap_check_passed = False
 
-            tenant_passed = workspace_check_passed and custom_role_check_passed and bootstrap_check_passed
+            groups = Group.objects.filter(tenant=tenant).prefetch_related("principals")
+            tenant_group_principal_relations = 0
+
+            for group in groups:
+                relationships = [group.relationship_to_principal(p) for p in group.principals.all()]
+                relationships = [r for r in relationships if r is not None]
+                principal_count = len(relationships)
+                tenant_group_principal_relations += principal_count
+
+                if relationships:
+                    result = group_principal_checker.check_relationships(relationships)
+                    all_exist = all(pr["relation_exists"] for pr in result["principal_relations"])
+                else:
+                    all_exist = True
+
+                group_results.append(
+                    {
+                        "group_uuid": str(group.uuid),
+                        "group_name": group.name,
+                        "principal_count": principal_count,
+                        "passed": all_exist,
+                    }
+                )
+                if not all_exist:
+                    group_principal_check_passed = False
+
+            stats["total_groups_checked"] += len(group_results)
+            stats["total_group_principal_relations_checked"] += tenant_group_principal_relations
+            if group_results:
+                logger.info(
+                    f"Checked {len(group_results)} group(s) with "
+                    f"{tenant_group_principal_relations} principal relation(s) for tenant {org_id}"
+                )
+
+            tenant_passed = (
+                workspace_check_passed
+                and custom_role_check_passed
+                and bootstrap_check_passed
+                and group_principal_check_passed
+            )
 
             if tenant_passed:
                 stats["passed_tenants"] += 1
@@ -444,6 +490,9 @@ def run_kessel_parity_checks_in_worker():
                     "bootstrap_check_passed": bootstrap_check_passed,
                     "bootstrap_details": bootstrap_details,
                     "role_results": role_results,
+                    "groups_checked": len(group_results),
+                    "group_principal_check_passed": group_principal_check_passed,
+                    "group_results": group_results,
                     "passed": tenant_passed,
                     "duration_seconds": round(tenant_elapsed, 3),
                 }
@@ -465,6 +514,9 @@ def run_kessel_parity_checks_in_worker():
                     "bootstrap_check_passed": bootstrap_check_passed,
                     "bootstrap_details": bootstrap_details,
                     "role_results": role_results,
+                    "groups_checked": len(group_results),
+                    "group_principal_check_passed": group_principal_check_passed,
+                    "group_results": group_results,
                     "passed": False,
                     "error": str(e),
                     "duration_seconds": round(tenant_elapsed, 3),
@@ -494,7 +546,9 @@ def run_kessel_parity_checks_in_worker():
         f"Total workspace pairs: {stats['total_workspace_pairs_checked']}, "
         f"Total custom roles: {stats['total_custom_roles_checked']}, "
         f"Total seeded roles: {stats['total_seeded_roles_checked']}, "
-        f"Total bootstrap checks: {stats['total_bootstrap_checks']}"
+        f"Total bootstrap checks: {stats['total_bootstrap_checks']}, "
+        f"Total groups: {stats['total_groups_checked']}, "
+        f"Total group-principal relations: {stats['total_group_principal_relations_checked']}"
     )
 
     stats["timing"] = timing_stats

--- a/tests/management/inventory_checker/test_group_principal_checker.py
+++ b/tests/management/inventory_checker/test_group_principal_checker.py
@@ -1,0 +1,180 @@
+#
+# Copyright 2026 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""Tests for GroupPrincipalInventoryChecker."""
+
+from unittest.mock import MagicMock, patch
+
+from kessel.inventory.v1beta2.check_response_pb2 import CheckResponse
+from management.group.model import Group
+from management.inventory_checker.inventory_api_check import GroupPrincipalInventoryChecker
+from management.principal.model import Principal
+from tests.identity_request import IdentityRequest
+
+INVENTORY_STUB_PATH = "management.inventory_checker.inventory_api_check.inventory_service_pb2_grpc.KesselInventoryServiceStub"  # noqa: E501
+
+
+class GroupPrincipalInventoryCheckerTest(IdentityRequest):
+    """Tests for the GroupPrincipalInventoryChecker class."""
+
+    def setUp(self):
+        """Set up test data."""
+        super().setUp()
+
+        self.group = Group.objects.create(
+            name="test-group",
+            tenant=self.tenant,
+        )
+
+        self.principal1 = Principal.objects.create(
+            username="user1",
+            tenant=self.tenant,
+            user_id="user1-id",
+        )
+        self.principal2 = Principal.objects.create(
+            username="user2",
+            tenant=self.tenant,
+            user_id="user2-id",
+        )
+        self.principal3 = Principal.objects.create(
+            username="user3",
+            tenant=self.tenant,
+            user_id="user3-id",
+        )
+
+        self.checker = GroupPrincipalInventoryChecker()
+
+    def _setup_inventory_mocks(self, mock_create_channel, mock_stub_responses):
+        """Helper to set up inventory API mocks."""
+        mock_stub = MagicMock()
+        if isinstance(mock_stub_responses, list):
+            mock_stub.Check.side_effect = mock_stub_responses
+        else:
+            mock_stub.Check.return_value = mock_stub_responses
+
+        mock_channel = MagicMock()
+        mock_channel.__enter__.return_value = mock_channel
+        mock_channel.__exit__.return_value = None
+        mock_create_channel.return_value = mock_channel
+
+        return mock_stub
+
+    @patch("management.inventory_checker.inventory_api_check.create_client_channel_inventory")
+    @patch("management.inventory_checker.inventory_api_check.json_format.MessageToDict")
+    def test_check_relationships_all_exist(self, mock_message_to_dict, mock_create_channel):
+        """Test that check returns all relation_exists=True when all relations exist."""
+        self.group.principals.add(self.principal1, self.principal2, self.principal3)
+
+        mock_response = MagicMock(spec=CheckResponse)
+        mock_stub = self._setup_inventory_mocks(mock_create_channel, mock_response)
+        mock_message_to_dict.return_value = {"allowed": "ALLOWED_TRUE"}
+
+        with patch(INVENTORY_STUB_PATH, return_value=mock_stub):
+            relationships = [self.group.relationship_to_principal(p) for p in self.group.principals.all()]
+            relationships = [r for r in relationships if r is not None]
+            result = self.checker.check_relationships(relationships)
+
+            self.assertEqual(result["group_uuid"], str(self.group.uuid))
+            self.assertEqual(len(result["principal_relations"]), 3)
+            self.assertTrue(all(pr["relation_exists"] for pr in result["principal_relations"]))
+            self.assertEqual(mock_stub.Check.call_count, 3)
+
+    @patch("management.inventory_checker.inventory_api_check.create_client_channel_inventory")
+    @patch("management.inventory_checker.inventory_api_check.json_format.MessageToDict")
+    def test_check_relationships_some_missing(self, mock_message_to_dict, mock_create_channel):
+        """Test that check returns correct relation_exists values when some are missing."""
+        self.group.principals.add(self.principal1, self.principal2, self.principal3)
+
+        mock_responses = [MagicMock(spec=CheckResponse) for _ in range(3)]
+        mock_stub = self._setup_inventory_mocks(mock_create_channel, mock_responses)
+        mock_message_to_dict.side_effect = [
+            {"allowed": "ALLOWED_TRUE"},
+            {"allowed": "ALLOWED_FALSE"},
+            {"allowed": "ALLOWED_TRUE"},
+        ]
+
+        with patch(INVENTORY_STUB_PATH, return_value=mock_stub):
+            relationships = [self.group.relationship_to_principal(p) for p in self.group.principals.all()]
+            relationships = [r for r in relationships if r is not None]
+            result = self.checker.check_relationships(relationships)
+
+            self.assertEqual(len(result["principal_relations"]), 3)
+            exists_values = [pr["relation_exists"] for pr in result["principal_relations"]]
+            self.assertIn(False, exists_values)
+            missing = [pr for pr in result["principal_relations"] if not pr["relation_exists"]]
+            self.assertEqual(len(missing), 1)
+
+    def test_check_relationships_empty_list(self):
+        """Test that check handles empty relationships list."""
+        result = self.checker.check_relationships([])
+        self.assertEqual(result["group_uuid"], "")
+        self.assertEqual(result["principal_relations"], [])
+
+    @patch("management.inventory_checker.inventory_api_check.create_client_channel_inventory")
+    @patch("management.inventory_checker.inventory_api_check.json_format.MessageToDict")
+    def test_check_relationships_all_missing(self, mock_message_to_dict, mock_create_channel):
+        """Test that check returns all relation_exists=False when all are missing."""
+        self.group.principals.add(self.principal1, self.principal2)
+
+        mock_responses = [MagicMock(spec=CheckResponse) for _ in range(2)]
+        mock_stub = self._setup_inventory_mocks(mock_create_channel, mock_responses)
+        mock_message_to_dict.side_effect = [
+            {"allowed": "ALLOWED_FALSE"},
+            {"allowed": "ALLOWED_FALSE"},
+        ]
+
+        with patch(INVENTORY_STUB_PATH, return_value=mock_stub):
+            relationships = [self.group.relationship_to_principal(p) for p in self.group.principals.all()]
+            relationships = [r for r in relationships if r is not None]
+            result = self.checker.check_relationships(relationships)
+
+            self.assertEqual(len(result["principal_relations"]), 2)
+            self.assertTrue(all(not pr["relation_exists"] for pr in result["principal_relations"]))
+
+    def test_principal_without_user_id_filtered_out(self):
+        """Test that principals without user_id produce None relationships that are filtered."""
+        principal_no_uid = Principal.objects.create(
+            username="no-uid-user",
+            tenant=self.tenant,
+            user_id=None,
+        )
+        self.group.principals.add(principal_no_uid)
+
+        relationships = [self.group.relationship_to_principal(p) for p in self.group.principals.all()]
+        non_none = [r for r in relationships if r is not None]
+
+        self.assertIn(None, relationships)
+        self.assertEqual(len(non_none), 0)
+
+    @patch("management.inventory_checker.inventory_api_check.create_client_channel_inventory")
+    @patch("management.inventory_checker.inventory_api_check.json_format.MessageToDict")
+    def test_check_relationships_single_principal(self, mock_message_to_dict, mock_create_channel):
+        """Test checking a group with a single principal."""
+        self.group.principals.add(self.principal1)
+
+        mock_response = MagicMock(spec=CheckResponse)
+        mock_stub = self._setup_inventory_mocks(mock_create_channel, mock_response)
+        mock_message_to_dict.return_value = {"allowed": "ALLOWED_TRUE"}
+
+        with patch(INVENTORY_STUB_PATH, return_value=mock_stub):
+            relationships = [self.group.relationship_to_principal(p) for p in self.group.principals.all()]
+            relationships = [r for r in relationships if r is not None]
+            result = self.checker.check_relationships(relationships)
+
+            self.assertEqual(result["group_uuid"], str(self.group.uuid))
+            self.assertEqual(len(result["principal_relations"]), 1)
+            self.assertTrue(result["principal_relations"][0]["relation_exists"])
+            self.assertEqual(mock_stub.Check.call_count, 1)

--- a/tests/management/inventory_checker/test_group_principal_checker.py
+++ b/tests/management/inventory_checker/test_group_principal_checker.py
@@ -82,7 +82,7 @@ class GroupPrincipalInventoryCheckerTest(IdentityRequest):
         mock_stub = self._setup_inventory_mocks(mock_create_channel, mock_response)
         mock_message_to_dict.return_value = {"allowed": "ALLOWED_TRUE"}
 
-        with patch(INVENTORY_STUB_PATH, return_value=mock_stub):
+        with patch(INVENTORY_STUB_PATH, return_value=mock_stub) as mock_stub_class:
             relationships = [self.group.relationship_to_principal(p) for p in self.group.principals.all()]
             relationships = [r for r in relationships if r is not None]
             result = self.checker.check_relationships(relationships)
@@ -91,6 +91,8 @@ class GroupPrincipalInventoryCheckerTest(IdentityRequest):
             self.assertEqual(len(result["principal_relations"]), 3)
             self.assertTrue(all(pr["relation_exists"] for pr in result["principal_relations"]))
             self.assertEqual(mock_stub.Check.call_count, 3)
+            mock_create_channel.assert_called_once()
+            mock_stub_class.assert_called_once()
 
     @patch("management.inventory_checker.inventory_api_check.create_client_channel_inventory")
     @patch("management.inventory_checker.inventory_api_check.json_format.MessageToDict")

--- a/tests/management/test_parity_tasks.py
+++ b/tests/management/test_parity_tasks.py
@@ -20,7 +20,9 @@ from unittest import mock
 from unittest.mock import patch
 
 from django.test import override_settings
+from management.group.model import Group
 from management.models import CustomRoleV2, Permission
+from management.principal.model import Principal
 from management.tasks import run_kessel_parity_checks_in_worker
 from management.tenant_mapping.model import TenantMapping
 from management.workspace.model import Workspace
@@ -481,15 +483,19 @@ class ParityCheckTasksTest(IdentityRequest):
         self.assertEqual(len(tenant_result["role_results"]), 0)
 
     @override_settings(PARITY_CHECK_ENABLED=False, PARITY_CHECK_ORG_IDS="test_org_id")
+    @mock.patch("management.tasks.GroupPrincipalInventoryChecker")
     @mock.patch("management.tasks.CustomRolePermissionChecker")
     @mock.patch("management.tasks.WorkspaceRelationInventoryChecker")
-    def test_parity_check_task_disabled(self, mock_workspace_checker_cls, mock_role_checker_cls):
+    def test_parity_check_task_disabled(
+        self, mock_workspace_checker_cls, mock_role_checker_cls, mock_group_checker_cls
+    ):
         """Test parity check task returns early when disabled."""
         result = run_kessel_parity_checks_in_worker()
 
         self.assertEqual(result, {"message": "Parity checks disabled"})
         mock_workspace_checker_cls.assert_not_called()
         mock_role_checker_cls.assert_not_called()
+        mock_group_checker_cls.assert_not_called()
 
     @override_settings(PARITY_CHECK_ENABLED=True, PARITY_CHECK_ORG_IDS="test_org_id")
     @patch(
@@ -683,3 +689,236 @@ class ParityCheckTasksTest(IdentityRequest):
         self.assertIn("gRPC unavailable", tenant_result["error"])
         self.assertEqual(tenant_result["bootstrap_checks"], 0)
         self.assertEqual(tenant_result["bootstrap_details"], [])
+
+    @override_settings(PARITY_CHECK_ENABLED=True, PARITY_CHECK_ORG_IDS="test_org_id")
+    @patch("management.inventory_checker.inventory_api_check.GroupPrincipalInventoryChecker.check_relationships")
+    @patch(
+        "management.inventory_checker.inventory_api_check.WorkspaceRelationInventoryChecker.check_workspace_descendants"
+    )
+    def test_parity_check_with_groups_all_pass(self, mock_check_workspace, mock_check_group):
+        """Test parity check when group-principal checks pass."""
+        self.tenant.org_id = "test_org_id"
+        self.tenant.save()
+
+        group1 = Group.objects.create(name="group1", tenant=self.tenant)
+        p1 = Principal.objects.create(username="user1", tenant=self.tenant, user_id="uid1")
+        p2 = Principal.objects.create(username="user2", tenant=self.tenant, user_id="uid2")
+        group1.principals.add(p1, p2)
+
+        mock_check_workspace.return_value = True
+        mock_check_group.return_value = {
+            "group_uuid": str(group1.uuid),
+            "principal_relations": [
+                {"id": "localhost/uid1", "relation_exists": True},
+                {"id": "localhost/uid2", "relation_exists": True},
+            ],
+        }
+
+        result = run_kessel_parity_checks_in_worker()
+
+        mock_check_group.assert_called_once()
+        self.assertEqual(result["total_groups_checked"], 1)
+        self.assertEqual(result["total_group_principal_relations_checked"], 2)
+        self.assertEqual(result["passed_tenants"], 1)
+        self.assertEqual(result["failed_tenants"], 0)
+
+        tenant_result = result["tenants_checked"][0]
+        self.assertTrue(tenant_result["group_principal_check_passed"])
+        self.assertEqual(tenant_result["groups_checked"], 1)
+        self.assertEqual(len(tenant_result["group_results"]), 1)
+        self.assertEqual(tenant_result["group_results"][0]["principal_count"], 2)
+        self.assertTrue(tenant_result["group_results"][0]["passed"])
+        self.assertTrue(tenant_result["passed"])
+
+    @override_settings(PARITY_CHECK_ENABLED=True, PARITY_CHECK_ORG_IDS="test_org_id")
+    @patch("management.inventory_checker.inventory_api_check.GroupPrincipalInventoryChecker.check_relationships")
+    @patch(
+        "management.inventory_checker.inventory_api_check.WorkspaceRelationInventoryChecker.check_workspace_descendants"
+    )
+    def test_parity_check_group_principal_fails(self, mock_check_workspace, mock_check_group):
+        """Test parity check fails when group-principal relation is missing."""
+        self.tenant.org_id = "test_org_id"
+        self.tenant.save()
+
+        group1 = Group.objects.create(name="group1", tenant=self.tenant)
+        p1 = Principal.objects.create(username="user1", tenant=self.tenant, user_id="uid1")
+        group1.principals.add(p1)
+
+        mock_check_workspace.return_value = True
+        mock_check_group.return_value = {
+            "group_uuid": str(group1.uuid),
+            "principal_relations": [
+                {"id": "localhost/uid1", "relation_exists": False},
+            ],
+        }
+
+        result = run_kessel_parity_checks_in_worker()
+
+        self.assertEqual(result["passed_tenants"], 0)
+        self.assertEqual(result["failed_tenants"], 1)
+
+        tenant_result = result["tenants_checked"][0]
+        self.assertFalse(tenant_result["group_principal_check_passed"])
+        self.assertFalse(tenant_result["group_results"][0]["passed"])
+        self.assertFalse(tenant_result["passed"])
+
+    @override_settings(PARITY_CHECK_ENABLED=True, PARITY_CHECK_ORG_IDS="test_org_id")
+    @patch("management.inventory_checker.inventory_api_check.GroupPrincipalInventoryChecker.check_relationships")
+    @patch(
+        "management.inventory_checker.inventory_api_check.WorkspaceRelationInventoryChecker.check_workspace_descendants"
+    )
+    def test_parity_check_group_no_principals(self, mock_check_workspace, mock_check_group):
+        """Test parity check passes for groups with no principals."""
+        self.tenant.org_id = "test_org_id"
+        self.tenant.save()
+
+        Group.objects.create(name="empty-group", tenant=self.tenant)
+
+        mock_check_workspace.return_value = True
+
+        result = run_kessel_parity_checks_in_worker()
+
+        mock_check_group.assert_not_called()
+
+        self.assertEqual(result["total_groups_checked"], 1)
+        self.assertEqual(result["total_group_principal_relations_checked"], 0)
+        self.assertEqual(result["passed_tenants"], 1)
+
+        tenant_result = result["tenants_checked"][0]
+        self.assertTrue(tenant_result["group_principal_check_passed"])
+        self.assertEqual(tenant_result["group_results"][0]["principal_count"], 0)
+        self.assertTrue(tenant_result["group_results"][0]["passed"])
+
+    @override_settings(PARITY_CHECK_ENABLED=True, PARITY_CHECK_ORG_IDS="test_org_id")
+    @patch("management.inventory_checker.inventory_api_check.GroupPrincipalInventoryChecker.check_relationships")
+    @patch(
+        "management.inventory_checker.inventory_api_check.WorkspaceRelationInventoryChecker.check_workspace_descendants"
+    )
+    def test_parity_check_principal_without_user_id(self, mock_check_workspace, mock_check_group):
+        """Test that principals without user_id are filtered out gracefully."""
+        self.tenant.org_id = "test_org_id"
+        self.tenant.save()
+
+        group1 = Group.objects.create(name="group1", tenant=self.tenant)
+        p_no_uid = Principal.objects.create(username="no-uid", tenant=self.tenant, user_id=None)
+        group1.principals.add(p_no_uid)
+
+        mock_check_workspace.return_value = True
+
+        result = run_kessel_parity_checks_in_worker()
+
+        mock_check_group.assert_not_called()
+
+        tenant_result = result["tenants_checked"][0]
+        self.assertTrue(tenant_result["group_principal_check_passed"])
+        self.assertEqual(tenant_result["group_results"][0]["principal_count"], 0)
+        self.assertTrue(tenant_result["group_results"][0]["passed"])
+        self.assertTrue(tenant_result["passed"])
+
+    @override_settings(PARITY_CHECK_ENABLED=True, PARITY_CHECK_ORG_IDS="test_org_id")
+    @patch("management.inventory_checker.inventory_api_check.GroupPrincipalInventoryChecker.check_relationships")
+    @patch(
+        "management.inventory_checker.inventory_api_check.WorkspaceRelationInventoryChecker.check_workspace_descendants"
+    )
+    def test_parity_check_multiple_groups(self, mock_check_workspace, mock_check_group):
+        """Test parity check with multiple groups per tenant."""
+        self.tenant.org_id = "test_org_id"
+        self.tenant.save()
+
+        group1 = Group.objects.create(name="group1", tenant=self.tenant)
+        group2 = Group.objects.create(name="group2", tenant=self.tenant)
+        p1 = Principal.objects.create(username="user1", tenant=self.tenant, user_id="uid1")
+        p2 = Principal.objects.create(username="user2", tenant=self.tenant, user_id="uid2")
+        group1.principals.add(p1)
+        group2.principals.add(p2)
+
+        mock_check_workspace.return_value = True
+        mock_check_group.side_effect = [
+            {
+                "group_uuid": str(group1.uuid),
+                "principal_relations": [{"id": "localhost/uid1", "relation_exists": True}],
+            },
+            {
+                "group_uuid": str(group2.uuid),
+                "principal_relations": [{"id": "localhost/uid2", "relation_exists": False}],
+            },
+        ]
+
+        result = run_kessel_parity_checks_in_worker()
+
+        self.assertEqual(mock_check_group.call_count, 2)
+        self.assertEqual(result["total_groups_checked"], 2)
+        self.assertEqual(result["total_group_principal_relations_checked"], 2)
+        self.assertEqual(result["failed_tenants"], 1)
+
+        tenant_result = result["tenants_checked"][0]
+        self.assertFalse(tenant_result["group_principal_check_passed"])
+        self.assertTrue(tenant_result["group_results"][0]["passed"])
+        self.assertFalse(tenant_result["group_results"][1]["passed"])
+        self.assertFalse(tenant_result["passed"])
+
+    @override_settings(PARITY_CHECK_ENABLED=True, PARITY_CHECK_ORG_IDS="test_org_id")
+    @patch("management.inventory_checker.inventory_api_check.GroupPrincipalInventoryChecker.check_relationships")
+    @patch(
+        "management.inventory_checker.inventory_api_check.CustomRolePermissionChecker.check_custom_role_permissions"
+    )
+    @patch(
+        "management.inventory_checker.inventory_api_check.WorkspaceRelationInventoryChecker.check_workspace_descendants"
+    )
+    def test_parity_check_group_fails_others_pass(self, mock_check_workspace, mock_check_role_perms, mock_check_group):
+        """Test that tenant fails when only group-principal check fails."""
+        self.tenant.org_id = "test_org_id"
+        self.tenant.save()
+
+        role1 = CustomRoleV2.objects.create(name="role1", tenant=self.tenant)
+        perm1 = Permission.objects.create(permission="inventory:hosts:read", tenant=self.tenant)
+        role1.permissions.add(perm1)
+
+        group1 = Group.objects.create(name="group1", tenant=self.tenant)
+        p1 = Principal.objects.create(username="user1", tenant=self.tenant, user_id="uid1")
+        group1.principals.add(p1)
+
+        mock_check_workspace.return_value = True
+        mock_check_role_perms.return_value = True
+        mock_check_group.return_value = {
+            "group_uuid": str(group1.uuid),
+            "principal_relations": [{"id": "localhost/uid1", "relation_exists": False}],
+        }
+
+        result = run_kessel_parity_checks_in_worker()
+
+        self.assertEqual(result["passed_tenants"], 0)
+        self.assertEqual(result["failed_tenants"], 1)
+
+        tenant_result = result["tenants_checked"][0]
+        self.assertTrue(tenant_result["workspace_check_passed"])
+        self.assertTrue(tenant_result["custom_role_check_passed"])
+        self.assertFalse(tenant_result["group_principal_check_passed"])
+        self.assertFalse(tenant_result["passed"])
+
+    @override_settings(PARITY_CHECK_ENABLED=True, PARITY_CHECK_ORG_IDS="test_org_id")
+    @patch("management.inventory_checker.inventory_api_check.GroupPrincipalInventoryChecker.check_relationships")
+    @patch(
+        "management.inventory_checker.inventory_api_check.WorkspaceRelationInventoryChecker.check_workspace_descendants"
+    )
+    def test_parity_check_group_checker_exception(self, mock_check_workspace, mock_check_group):
+        """Test that the task handles exceptions from the group-principal checker gracefully."""
+        self.tenant.org_id = "test_org_id"
+        self.tenant.save()
+
+        group1 = Group.objects.create(name="group1", tenant=self.tenant)
+        p1 = Principal.objects.create(username="user1", tenant=self.tenant, user_id="uid1")
+        group1.principals.add(p1)
+
+        mock_check_workspace.return_value = True
+        mock_check_group.side_effect = RuntimeError("gRPC connection timeout")
+
+        result = run_kessel_parity_checks_in_worker()
+
+        self.assertEqual(result["passed_tenants"], 0)
+        self.assertEqual(result["failed_tenants"], 1)
+
+        tenant_result = result["tenants_checked"][0]
+        self.assertFalse(tenant_result["passed"])
+        self.assertIn("error", tenant_result)
+        self.assertIn("gRPC connection timeout", tenant_result["error"])


### PR DESCRIPTION
## Summary

Integrates the existing `GroupPrincipalInventoryChecker` into the background Kessel parity check task (`run_kessel_parity_checks_in_worker`). This adds group-principal membership verification as the third parity check alongside workspace hierarchy and custom role permissions.

**JIRA**: [RHCLOUD-46774](https://issues.redhat.com/browse/RHCLOUD-46774)

## Changes

### Task integration (`tasks.py`)
- Queries all groups with prefetched principals for each tenant
- Builds relation tuples per group, filters out principals without `user_id`
- Calls `check_relationships()` and aggregates pass/fail per group
- New stats: `total_groups_checked`, `total_group_principal_relations_checked`
- Per-tenant output: `groups_checked`, `group_principal_check_passed`, `group_results`
- Tenant pass/fail now requires all three checks (workspace + custom role + group-principal)

### Checker optimization (`inventory_api_check.py`)
- Refactored `GroupPrincipalInventoryChecker.check_relationships()` to open a single gRPC channel for all principal checks instead of one channel per principal

### Tests
- 6 unit tests for `GroupPrincipalInventoryChecker` (all exist, some missing, all missing, empty, single, null user_id)
- 8 task integration tests (pass, fail, no principals, null user_id, multiple groups, combined failures, exception handling, disabled flag)

## Test plan

- [x] Unit tests for checker class cover all edge cases
- [x] Task integration tests verify stats aggregation and tenant pass/fail logic
- [x] Existing parity task tests still pass (24 tests)
- [x] Full test suite passes (3349 tests)
- [x] Linter and black formatting clean

[RHCLOUD-46774]: https://redhat.atlassian.net/browse/RHCLOUD-46774?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Integrate group–principal membership parity checking into the Kessel background parity task and extend reporting to include group-level results and statistics.

Enhancements:
- Extend the parity worker task to evaluate group–principal relationships per tenant alongside existing workspace and custom role checks, updating tenant pass/fail criteria and aggregated stats.
- Optimize GroupPrincipalInventoryChecker to reuse a single gRPC channel and stub for multiple relationship checks and handle empty relationship sets efficiently.

Tests:
- Add unit test suite for GroupPrincipalInventoryChecker covering empty, partial, and fully missing relationships, single principal, and principals without user IDs.
- Expand parity task tests to cover group–principal scenarios, including passing and failing tenants, groups without principals, principals lacking user IDs, multiple groups, checker exceptions, and ensuring the task short-circuits cleanly when disabled.