### PR TITLE
fix(role-binding): include resource.type in batch create default response

### DIFF
--- a/docs/source/specs/typespec/main.tsp
+++ b/docs/source/specs/typespec/main.tsp
@@ -1068,7 +1068,7 @@ namespace RoleBindings {
         }
     })
     @post op batchCreate(
-        @query fields?: FieldMask = "resource(id),role(id),subject(id,type)";
+        @query fields?: FieldMask = "resource(id,type),role(id),subject(id,type)";
         @body body: BatchCreateRoleBindingsRequest;
     ): BatchCreateRoleBindingsResponse | Problems.CommonProblems | Problems.Problem400;
 

--- a/docs/source/specs/v2/openapi.json
+++ b/docs/source/specs/v2/openapi.json
@@ -870,7 +870,7 @@
                   "$ref": "#/components/schemas/FieldMask"
                 }
               ],
-              "default": "resource(id),role(id),subject(id,type)"
+              "default": "resource(id,type),role(id),subject(id,type)"
             },
             "explode": false
           }

--- a/docs/source/specs/v2/openapi.yaml
+++ b/docs/source/specs/v2/openapi.yaml
@@ -555,7 +555,7 @@ paths:
           schema:
             allOf:
               - $ref: '#/components/schemas/FieldMask'
-            default: resource(id),role(id),subject(id,type)
+            default: resource(id,type),role(id),subject(id,type)
           explode: false
       responses:
         '201':

--- a/rbac/management/role_binding/serializer.py
+++ b/rbac/management/role_binding/serializer.py
@@ -876,7 +876,7 @@ class BatchCreateRoleBindingRequestSerializer(serializers.Serializer):
 
     service_class = RoleBindingService
 
-    DEFAULT_FIELDS = "resource(id),role(id),subject(id,type)"
+    DEFAULT_FIELDS = "resource(id,type),role(id),subject(id,type)"
 
     requests = CreateRoleBindingItemSerializer(many=True, min_length=1, max_length=100)
     fields = serializers.CharField(

--- a/tests/management/role_binding/test_view.py
+++ b/tests/management/role_binding/test_view.py
@@ -3552,6 +3552,8 @@ class BatchCreateViewTests(IdentityRequest):
 
         self.assertIn("id", item["resource"])
         self.assertEqual(item["resource"]["id"], str(self.workspace.id))
+        self.assertIn("type", item["resource"])
+        self.assertEqual(item["resource"]["type"], "workspace")
 
     @patch(
         "management.permissions.role_binding_access.RoleBindingKesselAccessPermission.has_permission",


### PR DESCRIPTION
## Description of Intent of Change(s)
The V2 RoleBindings POST endpoint was missing the resource.type field in the default response. The OpenAPI spec example showed resource.type but the default field mask only included resource(id), causing the field masking logic to strip it from the response.

Updated DEFAULT_FIELDS from "resource(id),role(id),subject(id,type)" to "resource(id,type),role(id),subject(id,type)" in:
- BatchCreateRoleBindingRequestSerializer
- OpenAPI spec (v2/openapi.yaml)
- TypeSpec source (typespec/main.tsp)

## Link(s) to Jira
- [RHCLOUD-47532](https://redhat.atlassian.net/browse/RHCLOUD-47532)

## Local Testing
Added test assertion to verify resource.type is included in the response.

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices


[RHCLOUD-47532]: https://redhat.atlassian.net/browse/RHCLOUD-47532?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Ensure batch role binding creation responses include the resource type in both implementation and API definitions.

Bug Fixes:
- Include resource.type in the default field mask for the batchCreate RoleBindings V2 endpoint so it is returned in responses.

Enhancements:
- Align TypeSpec and OpenAPI v2 definitions with the updated default field mask for batchCreate RoleBindings.

Tests:
- Extend batchCreate role binding response tests to assert that resource.type is present and correctly set.