### PR TITLE
[RHCLOUD-46773] extend bootstrap parity checker to cover all bootstrap relations

### DIFF
--- a/rbac/internal/views.py
+++ b/rbac/internal/views.py
@@ -1954,7 +1954,6 @@ def check_bootstrapped_tenants(request, org_id):
                 "bootstrapped_correct": bootstrap_tenants_correct,
                 "relations_checked": checks,
             },
-            safe=False,
         )
     except RpcError as e:
         return JsonResponse(

--- a/rbac/internal/views.py
+++ b/rbac/internal/views.py
@@ -1934,38 +1934,38 @@ def check_inventory(request):
 def check_bootstrapped_tenants(request, org_id):
     """POST to check if bootstrapped tenant is correct on inventory api."""
     tenant = get_object_or_404(Tenant, org_id=org_id)
-    if tenant and tenant.tenant_mapping:
-        default_workspace = Workspace.objects.default(tenant=tenant)
-        root_workspace = Workspace.objects.root(tenant=tenant)
-        mapping = {
-            "org_id": tenant.org_id,
-            "root_workspace": str(root_workspace.id),
-            "default_workspace": str(default_workspace.id),
-            "tenant_mapping": {
-                "default_group_uuid": str(tenant.tenant_mapping.default_group_uuid),
-                "default_admin_group_uuid": str(tenant.tenant_mapping.default_admin_group_uuid),
-                "default_role_binding_uuid": str(tenant.tenant_mapping.default_role_binding_uuid),
-                "default_admin_role_binding_uuid": str(tenant.tenant_mapping.default_admin_role_binding_uuid),
-            },
-        }
-        try:
-            bootstrap_tenants_correct, checks = BootstrappedTenantChecker.check_bootstrapped_tenants(mapping)
-            bootstrapped_tenant_response = {
+    if not hasattr(tenant, "tenant_mapping"):
+        return JsonResponse({"detail": f"No tenant mapping for org_id: {org_id}"}, status=404)
+
+    default_workspace = Workspace.objects.default(tenant=tenant)
+    root_workspace = Workspace.objects.root(tenant=tenant)
+    ungrouped = Workspace.objects.filter(tenant=tenant, type=Workspace.Types.UNGROUPED_HOSTS).first()
+    try:
+        bootstrap_tenants_correct, checks = BootstrappedTenantChecker.check_bootstrapped_tenant(
+            org_id=tenant.org_id,
+            tenant_mapping=tenant.tenant_mapping,
+            root_workspace_id=str(root_workspace.id),
+            default_workspace_id=str(default_workspace.id),
+            ungrouped_workspace_id=str(ungrouped.id) if ungrouped else None,
+        )
+        return JsonResponse(
+            {
                 "org_id": tenant.org_id,
                 "bootstrapped_correct": bootstrap_tenants_correct,
                 "relations_checked": checks,
-            }
-        except RpcError as e:
-            return JsonResponse(
-                {"detail": "gRPC error occurred during inventory bootstrapped tenant check", "error": str(e)},
-                status=400,
-            )
-        except Exception as e:
-            return JsonResponse(
-                {"detail": "Unexpected error during inventory bootstrapped tenant check", "error": str(e)},
-                status=500,
-            )
-    return JsonResponse(bootstrapped_tenant_response, safe=False)
+            },
+            safe=False,
+        )
+    except RpcError as e:
+        return JsonResponse(
+            {"detail": "gRPC error occurred during inventory bootstrapped tenant check", "error": str(e)},
+            status=400,
+        )
+    except Exception as e:
+        return JsonResponse(
+            {"detail": "Unexpected error during inventory bootstrapped tenant check", "error": str(e)},
+            status=500,
+        )
 
 
 def check_workspace_relation(request, workspace_uuid):

--- a/rbac/management/inventory_checker/inventory_api_check.py
+++ b/rbac/management/inventory_checker/inventory_api_check.py
@@ -19,7 +19,7 @@
 
 import logging
 from collections.abc import Sequence
-from typing import List, Union
+from typing import List, Optional, Union
 
 from django.conf import settings
 from google.protobuf import json_format
@@ -33,12 +33,13 @@ from kessel.inventory.v1beta2 import (
 from kessel.inventory.v1beta2.check_request_pb2 import CheckRequest
 from management.cache import JWTCache
 from management.group.platform import DefaultGroupNotAvailableError, GlobalPolicyIdService
-from management.permission.scope_service import ImplicitResourceService
+from management.permission.scope_service import ImplicitResourceService, Scope
 from management.relation_replicator.types import RelationTuple
 from management.role.platform import admin_platform_parent_scope_for_seeded_system_role, platform_v2_role_uuid_for
 from management.role.relations import role_child_relationship
-from management.tenant_mapping.model import DefaultAccessType
+from management.tenant_mapping.model import DefaultAccessType, TenantMapping
 from management.utils import create_client_channel_inventory
+from migration_tool.utils import create_relationship
 
 jwt_cache = JWTCache()
 jwt_provider = JWTProvider()
@@ -119,138 +120,175 @@ class GroupPrincipalInventoryChecker(InventoryApiBaseChecker):
 class BootstrappedTenantInventoryChecker(InventoryApiBaseChecker):
     """Subclass to check bootstrapped tenants are correct on inventory api."""
 
-    def check_bootstrapped_tenants(self, mapping):
-        """Core logic to check bootstrapped tenants are correct."""
-        if mapping:
-            # If mapping provided create the correct check requests for check_relation_core
-            # Each tuple contains (name, check_request) for labeling purposes
-            checks_with_names = [
-                # Check default workspace has root workspace as parent
-                (
-                    "workspace_parent",
-                    CheckRequest(
-                        object=resource_reference_pb2.ResourceReference(
-                            resource_id=mapping["default_workspace"],
-                            resource_type="workspace",
-                            reporter=reporter_reference_pb2.ReporterReference(type="rbac"),
-                        ),
-                        relation="parent",
-                        subject=subject_reference_pb2.SubjectReference(
-                            resource=resource_reference_pb2.ResourceReference(
-                                resource_id=mapping["root_workspace"],
-                                resource_type="workspace",
-                                reporter=reporter_reference_pb2.ReporterReference(type="rbac"),
-                            )
-                        ),
-                    ),
-                ),
-                # Check default workspace has correct default role binding
-                (
-                    "default_access_binding",
-                    CheckRequest(
-                        object=resource_reference_pb2.ResourceReference(
-                            resource_id=mapping["default_workspace"],
-                            resource_type="workspace",
-                            reporter=reporter_reference_pb2.ReporterReference(type="rbac"),
-                        ),
-                        relation="binding",
-                        subject=subject_reference_pb2.SubjectReference(
-                            resource=resource_reference_pb2.ResourceReference(
-                                resource_id=mapping["tenant_mapping"]["default_role_binding_uuid"],
-                                resource_type="role_binding",
-                                reporter=reporter_reference_pb2.ReporterReference(type="rbac"),
-                            )
-                        ),
-                    ),
-                ),
-                # Check default workspace has correct default admin role binding
-                (
-                    "admin_default_access_binding",
-                    CheckRequest(
-                        object=resource_reference_pb2.ResourceReference(
-                            resource_id=mapping["default_workspace"],
-                            resource_type="workspace",
-                            reporter=reporter_reference_pb2.ReporterReference(type="rbac"),
-                        ),
-                        relation="binding",
-                        subject=subject_reference_pb2.SubjectReference(
-                            resource=resource_reference_pb2.ResourceReference(
-                                resource_id=mapping["tenant_mapping"]["default_admin_role_binding_uuid"],
-                                resource_type="role_binding",
-                                reporter=reporter_reference_pb2.ReporterReference(type="rbac"),
-                            )
-                        ),
-                    ),
-                ),
-                # Check default role binding is assigned to correct group
-                (
-                    "default_access_subject",
-                    CheckRequest(
-                        object=resource_reference_pb2.ResourceReference(
-                            resource_id=mapping["tenant_mapping"]["default_role_binding_uuid"],
-                            resource_type="role_binding",
-                            reporter=reporter_reference_pb2.ReporterReference(type="rbac"),
-                        ),
-                        relation="subject",
-                        subject=subject_reference_pb2.SubjectReference(
-                            resource=resource_reference_pb2.ResourceReference(
-                                resource_id=mapping["tenant_mapping"]["default_group_uuid"],
-                                resource_type="group",
-                                reporter=reporter_reference_pb2.ReporterReference(type="rbac"),
-                            ),
-                            relation="member",
-                        ),
-                    ),
-                ),
-                # Check default admin role binding is assigned to correct group
-                (
-                    "admin_default_access_subject",
-                    CheckRequest(
-                        object=resource_reference_pb2.ResourceReference(
-                            resource_id=mapping["tenant_mapping"]["default_admin_role_binding_uuid"],
-                            resource_type="role_binding",
-                            reporter=reporter_reference_pb2.ReporterReference(type="rbac"),
-                        ),
-                        relation="subject",
-                        subject=subject_reference_pb2.SubjectReference(
-                            resource=resource_reference_pb2.ResourceReference(
-                                resource_id=mapping["tenant_mapping"]["default_admin_group_uuid"],
-                                resource_type="group",
-                                reporter=reporter_reference_pb2.ReporterReference(type="rbac"),
-                            ),
-                            relation="member",
-                        ),
-                    ),
-                ),
-            ]
-            checks = [check for _, check in checks_with_names]
-            bootstrapped_tenant_correct = self.check_inventory_core(checks)
-            if not bootstrapped_tenant_correct:
-                logger.warning(f'{mapping["org_id"]} does not have the expected hierarchy for bootstrapped tenant.')
-            else:
-                logger.info(f'{mapping["org_id"]} is correctly bootstrapped.')
+    _SCOPE_RESOURCE_TYPE: dict[Scope, str] = {
+        Scope.DEFAULT: "workspace",
+        Scope.ROOT: "workspace",
+        Scope.TENANT: "tenant",
+    }
 
-            # Convert checks to readable format for logging in response
-            check_list = []
-            for name, check in checks_with_names:
-                check_dict = json_format.MessageToDict(check)
-                obj = check_dict.get("object", {})
-                subject = check_dict.get("subject", {})
-                subject_resource = subject.get("resource", {})
-                relation = check_dict.get("relation", "")
-                subject_relation = subject.get("relation", "")
-                obj_reporter = obj.get("reporter", {}).get("type", "")
-                subject_reporter = subject_resource.get("reporter", {}).get("type", "")
+    _SCOPE_LABEL: dict[Scope, str] = {
+        Scope.DEFAULT: "default",
+        Scope.ROOT: "root",
+        Scope.TENANT: "tenant",
+    }
 
-                subject_relation_suffix = f"#{subject_relation}" if subject_relation else ""
-                check_str = (
-                    f"{obj_reporter}/{obj.get('resourceType', '')}:{obj.get('resourceId', '')}/"
-                    f"{relation}#{subject_reporter}/{subject_resource.get('resourceType', '')}:"
-                    f"{subject_resource.get('resourceId', '')}{subject_relation_suffix}"
+    _ACCESS_LABEL: dict[DefaultAccessType, str] = {
+        DefaultAccessType.USER: "user",
+        DefaultAccessType.ADMIN: "admin",
+    }
+
+    def _build_named_tuples(
+        self,
+        tenant_mapping: TenantMapping,
+        root_workspace_id: str,
+        default_workspace_id: str,
+        ungrouped_workspace_id: Optional[str],
+        scope_resource_ids: dict[Scope, str],
+        policy_service: GlobalPolicyIdService,
+    ) -> list[tuple[str, RelationTuple]]:
+        """Build all expected bootstrap tuples with descriptive names."""
+        named_tuples: list[tuple[str, RelationTuple]] = []
+        tenant_id = scope_resource_ids[Scope.TENANT]
+
+        named_tuples.append(
+            (
+                "default_workspace_parent",
+                create_relationship(
+                    ("rbac", "workspace"), default_workspace_id, ("rbac", "workspace"), root_workspace_id, "parent"
+                ),
+            )
+        )
+        named_tuples.append(
+            (
+                "root_workspace_parent",
+                create_relationship(("rbac", "workspace"), root_workspace_id, ("rbac", "tenant"), tenant_id, "parent"),
+            )
+        )
+        named_tuples.append(
+            (
+                "tenant_platform",
+                create_relationship(
+                    ("rbac", "tenant"), tenant_id, ("rbac", "platform"), settings.ENV_NAME, "platform"
+                ),
+            )
+        )
+
+        for access_type in DefaultAccessType:
+            group_uuid = str(tenant_mapping.group_uuid_for(access_type))
+            access_label = self._ACCESS_LABEL[access_type]
+
+            for scope in Scope:
+                scope_label = self._SCOPE_LABEL[scope]
+                rb_uuid = str(tenant_mapping.default_role_binding_uuid_for(access_type, scope))
+                resource_type = self._SCOPE_RESOURCE_TYPE[scope]
+                resource_id = scope_resource_ids[scope]
+                role_uuid = str(platform_v2_role_uuid_for(access_type, scope, policy_service))
+
+                named_tuples.append(
+                    (
+                        f"{access_label}_{scope_label}_binding",
+                        create_relationship(
+                            ("rbac", resource_type), resource_id, ("rbac", "role_binding"), rb_uuid, "binding"
+                        ),
+                    )
                 )
-                check_exists = self.check_inventory_core(check)
-                check_list.append({"name": name, "check": check_str, "exists": check_exists})
-        return bootstrapped_tenant_correct, check_list
+                named_tuples.append(
+                    (
+                        f"{access_label}_{scope_label}_role",
+                        create_relationship(("rbac", "role_binding"), rb_uuid, ("rbac", "role"), role_uuid, "role"),
+                    )
+                )
+                named_tuples.append(
+                    (
+                        f"{access_label}_{scope_label}_subject",
+                        create_relationship(
+                            ("rbac", "role_binding"), rb_uuid, ("rbac", "group"), group_uuid, "subject", "member"
+                        ),
+                    )
+                )
+
+        if ungrouped_workspace_id:
+            named_tuples.append(
+                (
+                    "ungrouped_workspace_parent",
+                    create_relationship(
+                        ("rbac", "workspace"),
+                        ungrouped_workspace_id,
+                        ("rbac", "workspace"),
+                        default_workspace_id,
+                        "parent",
+                    ),
+                )
+            )
+
+        return named_tuples
+
+    @staticmethod
+    def _tuple_to_readable(t: RelationTuple) -> str:
+        """Format a RelationTuple as a human-readable string."""
+        subject_suffix = f"#{t.subject.relation}" if t.subject.relation else ""
+        return (
+            f"{t.resource.type.namespace}/{t.resource.type.name}:{t.resource.id}"
+            f"#{t.relation}"
+            f"@{t.subject.subject.type.namespace}/{t.subject.subject.type.name}:{t.subject.subject.id}"
+            f"{subject_suffix}"
+        )
+
+    def check_bootstrapped_tenant(
+        self,
+        org_id: str,
+        tenant_mapping: TenantMapping,
+        root_workspace_id: str,
+        default_workspace_id: str,
+        ungrouped_workspace_id: Optional[str] = None,
+    ) -> tuple[bool, list[dict]]:
+        """Check all bootstrap relations for a tenant against inventory.
+
+        Returns:
+            Tuple of (all_passed, list of per-check result dicts).
+        """
+        policy_service = GlobalPolicyIdService.shared()
+        tenant_id = f"{settings.PRINCIPAL_USER_DOMAIN}/{org_id}"
+
+        scope_resource_ids: dict[Scope, str] = {
+            Scope.DEFAULT: default_workspace_id,
+            Scope.ROOT: root_workspace_id,
+            Scope.TENANT: tenant_id,
+        }
+
+        named_tuples = self._build_named_tuples(
+            tenant_mapping=tenant_mapping,
+            root_workspace_id=root_workspace_id,
+            default_workspace_id=default_workspace_id,
+            ungrouped_workspace_id=ungrouped_workspace_id,
+            scope_resource_ids=scope_resource_ids,
+            policy_service=policy_service,
+        )
+
+        check_list: list[dict] = []
+        all_passed = True
+
+        for name, rel_tuple in named_tuples:
+            check_request = relation_tuple_to_check_request(rel_tuple)
+            exists = self.check_inventory_core(check_request)
+            check_list.append(
+                {
+                    "name": name,
+                    "check": self._tuple_to_readable(rel_tuple),
+                    "exists": exists,
+                }
+            )
+            if not exists:
+                all_passed = False
+                logger.warning(f"Bootstrap check failed for {org_id}: {name} missing")
+
+        if all_passed:
+            logger.info(f"{org_id} is correctly bootstrapped ({len(check_list)} checks passed).")
+        else:
+            failed = [c["name"] for c in check_list if not c["exists"]]
+            logger.warning(f"{org_id} bootstrap check FAILED. Missing: {failed}")
+
+        return all_passed, check_list
 
 
 class WorkspaceRelationInventoryChecker(InventoryApiBaseChecker):

--- a/rbac/management/inventory_checker/inventory_api_check.py
+++ b/rbac/management/inventory_checker/inventory_api_check.py
@@ -126,17 +126,6 @@ class BootstrappedTenantInventoryChecker(InventoryApiBaseChecker):
         Scope.TENANT: "tenant",
     }
 
-    _SCOPE_LABEL: dict[Scope, str] = {
-        Scope.DEFAULT: "default",
-        Scope.ROOT: "root",
-        Scope.TENANT: "tenant",
-    }
-
-    _ACCESS_LABEL: dict[DefaultAccessType, str] = {
-        DefaultAccessType.USER: "user",
-        DefaultAccessType.ADMIN: "admin",
-    }
-
     def _build_named_tuples(
         self,
         tenant_mapping: TenantMapping,
@@ -160,12 +149,6 @@ class BootstrappedTenantInventoryChecker(InventoryApiBaseChecker):
         )
         named_tuples.append(
             (
-                "root_workspace_parent",
-                create_relationship(("rbac", "workspace"), root_workspace_id, ("rbac", "tenant"), tenant_id, "parent"),
-            )
-        )
-        named_tuples.append(
-            (
                 "tenant_platform",
                 create_relationship(
                     ("rbac", "tenant"), tenant_id, ("rbac", "platform"), settings.ENV_NAME, "platform"
@@ -175,10 +158,10 @@ class BootstrappedTenantInventoryChecker(InventoryApiBaseChecker):
 
         for access_type in DefaultAccessType:
             group_uuid = str(tenant_mapping.group_uuid_for(access_type))
-            access_label = self._ACCESS_LABEL[access_type]
+            access_label = access_type.value
 
             for scope in Scope:
-                scope_label = self._SCOPE_LABEL[scope]
+                scope_label = scope.name.lower()
                 rb_uuid = str(tenant_mapping.default_role_binding_uuid_for(access_type, scope))
                 resource_type = self._SCOPE_RESOURCE_TYPE[scope]
                 resource_id = scope_resource_ids[scope]

--- a/rbac/management/tasks.py
+++ b/rbac/management/tasks.py
@@ -43,8 +43,8 @@ from management.inventory_checker.inventory_api_check import (
     WorkspaceRelationInventoryChecker,
     generate_seeded_role_hierarchy_tuples,
 )
-from management.permission.scope_service import ImplicitResourceService
 from management.parity_check import run_parity_checks
+from management.permission.scope_service import ImplicitResourceService
 from management.principal.cleaner import (
     clean_tenants_principals,
     process_principal_events_from_umb,
@@ -332,6 +332,12 @@ def run_kessel_parity_checks_in_worker():
     # Bulk fetch tenant mappings
     tenant_mappings = {tm.tenant_id: tm for tm in TenantMapping.objects.filter(tenant__in=tenants.values())}
 
+    # Bulk fetch workspaces for bootstrap checks to avoid N+1 queries
+    relevant_workspace_types = (Workspace.Types.ROOT, Workspace.Types.DEFAULT, Workspace.Types.UNGROUPED_HOSTS)
+    workspace_index: dict[tuple[int, str], Workspace] = {}
+    for ws in Workspace.objects.filter(tenant__in=tenants.values(), type__in=relevant_workspace_types):
+        workspace_index[(ws.tenant_id, ws.type)] = ws
+
     for org_id in org_ids:
         tenant = tenants.get(org_id)
         if not tenant:
@@ -394,9 +400,9 @@ def run_kessel_parity_checks_in_worker():
             # Bootstrap completeness check
             mapping = tenant_mappings.get(tenant.id)
             if mapping:
-                root_ws = Workspace.objects.filter(tenant=tenant, type=Workspace.Types.ROOT).first()
-                default_ws = Workspace.objects.filter(tenant=tenant, type=Workspace.Types.DEFAULT).first()
-                ungrouped_ws = Workspace.objects.filter(tenant=tenant, type=Workspace.Types.UNGROUPED_HOSTS).first()
+                root_ws = workspace_index.get((tenant.id, Workspace.Types.ROOT))
+                default_ws = workspace_index.get((tenant.id, Workspace.Types.DEFAULT))
+                ungrouped_ws = workspace_index.get((tenant.id, Workspace.Types.UNGROUPED_HOSTS))
 
                 if root_ws and default_ws:
                     bootstrap_check_passed, bootstrap_details = bootstrap_checker.check_bootstrapped_tenant(

--- a/rbac/management/tasks.py
+++ b/rbac/management/tasks.py
@@ -37,6 +37,7 @@ from internal.utils import (
 )
 from management.health.healthcheck import redis_health
 from management.inventory_checker.inventory_api_check import (
+    BootstrappedTenantInventoryChecker,
     CustomRolePermissionChecker,
     SeededRoleHierarchyChecker,
     WorkspaceRelationInventoryChecker,
@@ -49,6 +50,7 @@ from management.principal.cleaner import (
     process_principal_events_from_umb,
 )
 from management.role.v2_model import CustomRoleV2, SeededRoleV2
+from management.tenant_mapping.model import TenantMapping
 from management.workspace.model import Workspace
 from migration_tool.migrate import migrate_data
 from migration_tool.migrate_binding_scope import migrate_all_role_bindings
@@ -257,6 +259,7 @@ def run_kessel_parity_checks_in_worker():
         "total_workspace_pairs_checked": 0,
         "total_custom_roles_checked": 0,
         "total_seeded_roles_checked": 0,
+        "total_bootstrap_checks": 0,
         "passed_tenants": 0,
         "failed_tenants": 0,
         "tenants_not_found": 0,
@@ -268,6 +271,7 @@ def run_kessel_parity_checks_in_worker():
     workspace_checker = WorkspaceRelationInventoryChecker()
     role_permission_checker = CustomRolePermissionChecker()
     hierarchy_checker = SeededRoleHierarchyChecker()
+    bootstrap_checker = BootstrappedTenantInventoryChecker()
 
     # Seeded role hierarchy check (global, not per-tenant)
     seeded_start = time.monotonic()
@@ -325,6 +329,8 @@ def run_kessel_parity_checks_in_worker():
 
     # Bulk fetch all tenants to avoid N+1 queries
     tenants = {t.org_id: t for t in Tenant.objects.filter(org_id__in=org_ids)}
+    # Bulk fetch tenant mappings
+    tenant_mappings = {tm.tenant_id: tm for tm in TenantMapping.objects.filter(tenant__in=tenants.values())}
 
     for org_id in org_ids:
         tenant = tenants.get(org_id)
@@ -337,6 +343,8 @@ def run_kessel_parity_checks_in_worker():
         workspace_check_passed = False
         role_results = []
         custom_role_check_passed = True
+        bootstrap_check_passed = False
+        bootstrap_details: list[dict] = []
 
         try:
             tenant_start = time.monotonic()
@@ -356,7 +364,6 @@ def run_kessel_parity_checks_in_worker():
                 logger.info(f"Checking {pairs_count} workspace parent relations for tenant {org_id}")
                 workspace_check_passed = workspace_checker.check_workspace_descendants(workspace_pairs)
             else:
-                # No pairs means no default workspace with a parent — this is unexpected and should be flagged
                 logger.warning(f"No workspace pairs to check for tenant {org_id} — missing default workspace?")
                 workspace_check_passed = False
 
@@ -384,8 +391,30 @@ def run_kessel_parity_checks_in_worker():
             if role_results:
                 logger.info(f"Checked {len(role_results)} custom role(s) for tenant {org_id}")
 
-            # Tenant passes only if BOTH workspace and custom role checks pass
-            tenant_passed = workspace_check_passed and custom_role_check_passed
+            # Bootstrap completeness check
+            mapping = tenant_mappings.get(tenant.id)
+            if mapping:
+                root_ws = Workspace.objects.filter(tenant=tenant, type=Workspace.Types.ROOT).first()
+                default_ws = Workspace.objects.filter(tenant=tenant, type=Workspace.Types.DEFAULT).first()
+                ungrouped_ws = Workspace.objects.filter(tenant=tenant, type=Workspace.Types.UNGROUPED_HOSTS).first()
+
+                if root_ws and default_ws:
+                    bootstrap_check_passed, bootstrap_details = bootstrap_checker.check_bootstrapped_tenant(
+                        org_id=org_id,
+                        tenant_mapping=mapping,
+                        root_workspace_id=str(root_ws.id),
+                        default_workspace_id=str(default_ws.id),
+                        ungrouped_workspace_id=str(ungrouped_ws.id) if ungrouped_ws else None,
+                    )
+                    stats["total_bootstrap_checks"] += len(bootstrap_details)
+                else:
+                    logger.warning(f"Missing root/default workspace for tenant {org_id}, skipping bootstrap check")
+                    bootstrap_check_passed = False
+            else:
+                logger.warning(f"No tenant mapping for org_id: {org_id}, skipping bootstrap check")
+                bootstrap_check_passed = False
+
+            tenant_passed = workspace_check_passed and custom_role_check_passed and bootstrap_check_passed
 
             if tenant_passed:
                 stats["passed_tenants"] += 1
@@ -405,6 +434,9 @@ def run_kessel_parity_checks_in_worker():
                     "workspace_check_passed": workspace_check_passed,
                     "custom_roles_checked": len(role_results),
                     "custom_role_check_passed": custom_role_check_passed,
+                    "bootstrap_checks": len(bootstrap_details),
+                    "bootstrap_check_passed": bootstrap_check_passed,
+                    "bootstrap_details": bootstrap_details,
                     "role_results": role_results,
                     "passed": tenant_passed,
                     "duration_seconds": round(tenant_elapsed, 3),
@@ -414,7 +446,7 @@ def run_kessel_parity_checks_in_worker():
         except Exception as e:
             tenant_elapsed = time.monotonic() - tenant_start
             tenant_durations.append(tenant_elapsed)
-            logger.error(f"Error checking parity for tenant {org_id}: {e}", exc_info=True)
+            logger.exception(f"Error checking parity for tenant {org_id}: {e}")
             stats["failed_tenants"] += 1
             stats["tenants_checked"].append(
                 {
@@ -423,6 +455,9 @@ def run_kessel_parity_checks_in_worker():
                     "workspace_check_passed": workspace_check_passed,
                     "custom_roles_checked": len(role_results),
                     "custom_role_check_passed": custom_role_check_passed,
+                    "bootstrap_checks": len(bootstrap_details),
+                    "bootstrap_check_passed": bootstrap_check_passed,
+                    "bootstrap_details": bootstrap_details,
                     "role_results": role_results,
                     "passed": False,
                     "error": str(e),
@@ -452,7 +487,8 @@ def run_kessel_parity_checks_in_worker():
         f"Not Found: {stats['tenants_not_found']}, "
         f"Total workspace pairs: {stats['total_workspace_pairs_checked']}, "
         f"Total custom roles: {stats['total_custom_roles_checked']}, "
-        f"Total seeded roles: {stats['total_seeded_roles_checked']}"
+        f"Total seeded roles: {stats['total_seeded_roles_checked']}, "
+        f"Total bootstrap checks: {stats['total_bootstrap_checks']}"
     )
 
     stats["timing"] = timing_stats

--- a/tests/internal/test_views.py
+++ b/tests/internal/test_views.py
@@ -4672,18 +4672,24 @@ class InternalInventoryViewsetTests(BaseInternalViewsetTests):
     @patch("internal.jwt_utils.JWTProvider.get_jwt_token", return_value={"access_token": "mocked_valid_token"})
     @patch("management.utils.create_client_channel")
     @patch(
-        "management.inventory_checker.inventory_api_check.BootstrappedTenantInventoryChecker.check_bootstrapped_tenants"
+        "management.inventory_checker.inventory_api_check.BootstrappedTenantInventoryChecker.check_bootstrapped_tenant"
     )
-    def test_inventory_bootstrapped_tenants(
-        self, mock_check_bootstrapped_tenants, mock_create_channel, mock_get_token
-    ):
+    def test_inventory_bootstrapped_tenants(self, mock_check_bootstrapped_tenant, mock_create_channel, mock_get_token):
         """Test a request to check bootstrapped tenants on inventory returns correct response."""
-        # Mock returns tuple of (bool, list of check strings)
+        # Mock returns tuple of (bool, list of check dicts)
         mock_relations_checked = [
-            "rbac/workspace:ws-123/parent#rbac/workspace:ws-456",
-            "rbac/workspace:ws-456/binding#rbac/role_binding:rb-789",
+            {
+                "name": "default_workspace_parent",
+                "check": "rbac/workspace:ws-123#parent@rbac/workspace:ws-456",
+                "exists": True,
+            },
+            {
+                "name": "root_workspace_parent",
+                "check": "rbac/workspace:ws-456#parent@rbac/tenant:localhost/org",
+                "exists": True,
+            },
         ]
-        mock_check_bootstrapped_tenants.return_value = (True, mock_relations_checked)
+        mock_check_bootstrapped_tenant.return_value = (True, mock_relations_checked)
 
         response = self.client.get(
             f"/_private/api/inventory/bootstrap_tenants/{self.tenant.org_id}/",
@@ -4700,7 +4706,7 @@ class InternalInventoryViewsetTests(BaseInternalViewsetTests):
         self.assertEqual(response_body["relations_checked"], mock_relations_checked)
 
     @patch(
-        "management.inventory_checker.inventory_api_check.BootstrappedTenantInventoryChecker.check_bootstrapped_tenants",
+        "management.inventory_checker.inventory_api_check.BootstrappedTenantInventoryChecker.check_bootstrapped_tenant",
         side_effect=RpcError("Simulated GRPC error"),
     )
     def test_inventory_bootstrapped_tenants_grpc_error(self, mock_check_relationships):
@@ -4721,7 +4727,7 @@ class InternalInventoryViewsetTests(BaseInternalViewsetTests):
         self.assertEqual(response_body["error"], "Simulated GRPC error")
 
     @patch(
-        "management.inventory_checker.inventory_api_check.BootstrappedTenantInventoryChecker.check_bootstrapped_tenants",
+        "management.inventory_checker.inventory_api_check.BootstrappedTenantInventoryChecker.check_bootstrapped_tenant",
         side_effect=Exception("Simulated internal error"),
     )
     def test_inventory_bootstrapped_tenants_error(self, mock_check_relationships):

--- a/tests/management/inventory_checker/test_bootstrapped_tenant_checker.py
+++ b/tests/management/inventory_checker/test_bootstrapped_tenant_checker.py
@@ -1,0 +1,430 @@
+#
+# Copyright 2026 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""Tests for BootstrappedTenantInventoryChecker."""
+
+import uuid
+from unittest.mock import MagicMock, patch
+
+from django.test import override_settings
+from kessel.inventory.v1beta2.check_response_pb2 import CheckResponse
+from management.inventory_checker.inventory_api_check import BootstrappedTenantInventoryChecker
+from management.permission.scope_service import Scope
+from management.tenant_mapping.model import DefaultAccessType, TenantMapping
+from tests.identity_request import IdentityRequest
+
+INVENTORY_STUB_PATH = "management.inventory_checker.inventory_api_check.inventory_service_pb2_grpc.KesselInventoryServiceStub"  # noqa: E501
+PLATFORM_ROLE_UUID_PATH = "management.inventory_checker.inventory_api_check.platform_v2_role_uuid_for"
+
+# 3 hierarchy + 6 binding combos x 3 tuples each = 21 base checks
+EXPECTED_BASE_CHECK_COUNT = 21
+EXPECTED_WITH_UNGROUPED = 22
+
+
+class BootstrappedTenantCheckerTest(IdentityRequest):
+    """Tests for BootstrappedTenantInventoryChecker.check_bootstrapped_tenant."""
+
+    def setUp(self):
+        """Set up test data."""
+        super().setUp()
+
+        self.tenant_mapping = TenantMapping.objects.create(tenant=self.tenant)
+        self.root_workspace_id = str(uuid.uuid4())
+        self.default_workspace_id = str(uuid.uuid4())
+        self.ungrouped_workspace_id = str(uuid.uuid4())
+
+        self.role_uuids: dict[tuple[DefaultAccessType, Scope], uuid.UUID] = {}
+        for access_type in DefaultAccessType:
+            for scope in Scope:
+                self.role_uuids[(access_type, scope)] = uuid.uuid4()
+
+        self.checker = BootstrappedTenantInventoryChecker()
+
+    def _mock_platform_role_uuid(self, mock_fn: MagicMock) -> None:
+        mock_fn.side_effect = lambda access_type, scope, policy_service: self.role_uuids[(access_type, scope)]
+
+    def _setup_inventory_mocks(
+        self, mock_create_channel: MagicMock, mock_stub_responses: MagicMock | list[MagicMock]
+    ) -> MagicMock:
+        mock_stub = MagicMock()
+        if isinstance(mock_stub_responses, list):
+            mock_stub.Check.side_effect = mock_stub_responses
+        else:
+            mock_stub.Check.return_value = mock_stub_responses
+
+        mock_channel = MagicMock()
+        mock_channel.__enter__.return_value = mock_channel
+        mock_channel.__exit__.return_value = None
+        mock_create_channel.return_value = mock_channel
+
+        return mock_stub
+
+    @patch(PLATFORM_ROLE_UUID_PATH)
+    @patch("management.inventory_checker.inventory_api_check.create_client_channel_inventory")
+    @patch("management.inventory_checker.inventory_api_check.json_format.MessageToDict")
+    @override_settings(ENV_NAME="stage", PRINCIPAL_USER_DOMAIN="localhost")
+    def test_all_checks_pass(self, mock_message_to_dict, mock_create_channel, mock_role_uuid):
+        """All bootstrap relations exist in inventory."""
+        self._mock_platform_role_uuid(mock_role_uuid)
+
+        mock_response = MagicMock(spec=CheckResponse)
+        mock_stub = self._setup_inventory_mocks(mock_create_channel, mock_response)
+        mock_message_to_dict.return_value = {"allowed": "ALLOWED_TRUE"}
+
+        with patch(INVENTORY_STUB_PATH, return_value=mock_stub):
+            passed, checks = self.checker.check_bootstrapped_tenant(
+                org_id=self.tenant.org_id,
+                tenant_mapping=self.tenant_mapping,
+                root_workspace_id=self.root_workspace_id,
+                default_workspace_id=self.default_workspace_id,
+            )
+
+        self.assertTrue(passed)
+        self.assertEqual(len(checks), EXPECTED_BASE_CHECK_COUNT)
+        self.assertTrue(all(c["exists"] for c in checks))
+
+    @patch(PLATFORM_ROLE_UUID_PATH)
+    @patch("management.inventory_checker.inventory_api_check.create_client_channel_inventory")
+    @patch("management.inventory_checker.inventory_api_check.json_format.MessageToDict")
+    @override_settings(ENV_NAME="stage", PRINCIPAL_USER_DOMAIN="localhost")
+    def test_all_checks_pass_with_ungrouped(self, mock_message_to_dict, mock_create_channel, mock_role_uuid):
+        """All bootstrap relations including ungrouped workspace exist."""
+        self._mock_platform_role_uuid(mock_role_uuid)
+
+        mock_response = MagicMock(spec=CheckResponse)
+        mock_stub = self._setup_inventory_mocks(mock_create_channel, mock_response)
+        mock_message_to_dict.return_value = {"allowed": "ALLOWED_TRUE"}
+
+        with patch(INVENTORY_STUB_PATH, return_value=mock_stub):
+            passed, checks = self.checker.check_bootstrapped_tenant(
+                org_id=self.tenant.org_id,
+                tenant_mapping=self.tenant_mapping,
+                root_workspace_id=self.root_workspace_id,
+                default_workspace_id=self.default_workspace_id,
+                ungrouped_workspace_id=self.ungrouped_workspace_id,
+            )
+
+        self.assertTrue(passed)
+        self.assertEqual(len(checks), EXPECTED_WITH_UNGROUPED)
+
+    @patch(PLATFORM_ROLE_UUID_PATH)
+    @patch("management.inventory_checker.inventory_api_check.create_client_channel_inventory")
+    @patch("management.inventory_checker.inventory_api_check.json_format.MessageToDict")
+    @override_settings(ENV_NAME="stage", PRINCIPAL_USER_DOMAIN="localhost")
+    def test_missing_hierarchy_tuple(self, mock_message_to_dict, mock_create_channel, mock_role_uuid):
+        """Fails when the root_workspace_parent hierarchy tuple is missing."""
+        self._mock_platform_role_uuid(mock_role_uuid)
+
+        responses = [MagicMock(spec=CheckResponse) for _ in range(EXPECTED_BASE_CHECK_COUNT)]
+        mock_stub = self._setup_inventory_mocks(mock_create_channel, responses)
+        allowed_results = [{"allowed": "ALLOWED_TRUE"}] * EXPECTED_BASE_CHECK_COUNT
+        # root_workspace_parent is index 1
+        allowed_results[1] = {"allowed": "ALLOWED_FALSE"}
+        mock_message_to_dict.side_effect = allowed_results
+
+        with patch(INVENTORY_STUB_PATH, return_value=mock_stub):
+            passed, checks = self.checker.check_bootstrapped_tenant(
+                org_id=self.tenant.org_id,
+                tenant_mapping=self.tenant_mapping,
+                root_workspace_id=self.root_workspace_id,
+                default_workspace_id=self.default_workspace_id,
+            )
+
+        self.assertFalse(passed)
+        failed = [c for c in checks if not c["exists"]]
+        self.assertEqual(len(failed), 1)
+        self.assertEqual(failed[0]["name"], "root_workspace_parent")
+
+    @patch(PLATFORM_ROLE_UUID_PATH)
+    @patch("management.inventory_checker.inventory_api_check.create_client_channel_inventory")
+    @patch("management.inventory_checker.inventory_api_check.json_format.MessageToDict")
+    @override_settings(ENV_NAME="stage", PRINCIPAL_USER_DOMAIN="localhost")
+    def test_missing_root_scope_binding(self, mock_message_to_dict, mock_create_channel, mock_role_uuid):
+        """Fails when a root-scope binding tuple is missing."""
+        self._mock_platform_role_uuid(mock_role_uuid)
+
+        responses = [MagicMock(spec=CheckResponse) for _ in range(EXPECTED_BASE_CHECK_COUNT)]
+        mock_stub = self._setup_inventory_mocks(mock_create_channel, responses)
+        allowed_results = [{"allowed": "ALLOWED_TRUE"}] * EXPECTED_BASE_CHECK_COUNT
+        # user_root_binding: 3 hierarchy + 3 user_default = index 6
+        allowed_results[6] = {"allowed": "ALLOWED_FALSE"}
+        mock_message_to_dict.side_effect = allowed_results
+
+        with patch(INVENTORY_STUB_PATH, return_value=mock_stub):
+            passed, checks = self.checker.check_bootstrapped_tenant(
+                org_id=self.tenant.org_id,
+                tenant_mapping=self.tenant_mapping,
+                root_workspace_id=self.root_workspace_id,
+                default_workspace_id=self.default_workspace_id,
+            )
+
+        self.assertFalse(passed)
+        failed = [c for c in checks if not c["exists"]]
+        self.assertEqual(len(failed), 1)
+        self.assertEqual(failed[0]["name"], "user_root_binding")
+
+    @patch(PLATFORM_ROLE_UUID_PATH)
+    @patch("management.inventory_checker.inventory_api_check.create_client_channel_inventory")
+    @patch("management.inventory_checker.inventory_api_check.json_format.MessageToDict")
+    @override_settings(ENV_NAME="stage", PRINCIPAL_USER_DOMAIN="localhost")
+    def test_missing_tenant_scope_subject(self, mock_message_to_dict, mock_create_channel, mock_role_uuid):
+        """Fails when the admin tenant-scope subject is missing."""
+        self._mock_platform_role_uuid(mock_role_uuid)
+
+        responses = [MagicMock(spec=CheckResponse) for _ in range(EXPECTED_BASE_CHECK_COUNT)]
+        mock_stub = self._setup_inventory_mocks(mock_create_channel, responses)
+        allowed_results = [{"allowed": "ALLOWED_TRUE"}] * EXPECTED_BASE_CHECK_COUNT
+        # admin_tenant_subject: 3 hierarchy + 15 (user 9 + admin default 3 + admin root 3) + 2 = index 20
+        allowed_results[20] = {"allowed": "ALLOWED_FALSE"}
+        mock_message_to_dict.side_effect = allowed_results
+
+        with patch(INVENTORY_STUB_PATH, return_value=mock_stub):
+            passed, checks = self.checker.check_bootstrapped_tenant(
+                org_id=self.tenant.org_id,
+                tenant_mapping=self.tenant_mapping,
+                root_workspace_id=self.root_workspace_id,
+                default_workspace_id=self.default_workspace_id,
+            )
+
+        self.assertFalse(passed)
+        failed = [c for c in checks if not c["exists"]]
+        self.assertEqual(len(failed), 1)
+        self.assertEqual(failed[0]["name"], "admin_tenant_subject")
+
+    @patch(PLATFORM_ROLE_UUID_PATH)
+    @patch("management.inventory_checker.inventory_api_check.create_client_channel_inventory")
+    @patch("management.inventory_checker.inventory_api_check.json_format.MessageToDict")
+    @override_settings(ENV_NAME="stage", PRINCIPAL_USER_DOMAIN="localhost")
+    def test_missing_ungrouped_workspace(self, mock_message_to_dict, mock_create_channel, mock_role_uuid):
+        """Fails when the ungrouped workspace parent relation is missing."""
+        self._mock_platform_role_uuid(mock_role_uuid)
+
+        responses = [MagicMock(spec=CheckResponse) for _ in range(EXPECTED_WITH_UNGROUPED)]
+        mock_stub = self._setup_inventory_mocks(mock_create_channel, responses)
+        allowed_results = [{"allowed": "ALLOWED_TRUE"}] * EXPECTED_WITH_UNGROUPED
+        # ungrouped is at the end (index 21)
+        allowed_results[-1] = {"allowed": "ALLOWED_FALSE"}
+        mock_message_to_dict.side_effect = allowed_results
+
+        with patch(INVENTORY_STUB_PATH, return_value=mock_stub):
+            passed, checks = self.checker.check_bootstrapped_tenant(
+                org_id=self.tenant.org_id,
+                tenant_mapping=self.tenant_mapping,
+                root_workspace_id=self.root_workspace_id,
+                default_workspace_id=self.default_workspace_id,
+                ungrouped_workspace_id=self.ungrouped_workspace_id,
+            )
+
+        self.assertFalse(passed)
+        failed = [c for c in checks if not c["exists"]]
+        self.assertEqual(len(failed), 1)
+        self.assertEqual(failed[0]["name"], "ungrouped_workspace_parent")
+
+    @patch(PLATFORM_ROLE_UUID_PATH)
+    @patch("management.inventory_checker.inventory_api_check.create_client_channel_inventory")
+    @patch("management.inventory_checker.inventory_api_check.json_format.MessageToDict")
+    @override_settings(ENV_NAME="stage", PRINCIPAL_USER_DOMAIN="localhost")
+    def test_multiple_failures(self, mock_message_to_dict, mock_create_channel, mock_role_uuid):
+        """Reports all failures when multiple checks fail."""
+        self._mock_platform_role_uuid(mock_role_uuid)
+
+        responses = [MagicMock(spec=CheckResponse) for _ in range(EXPECTED_BASE_CHECK_COUNT)]
+        mock_stub = self._setup_inventory_mocks(mock_create_channel, responses)
+        mock_message_to_dict.side_effect = [{"allowed": "ALLOWED_FALSE"}] * EXPECTED_BASE_CHECK_COUNT
+
+        with patch(INVENTORY_STUB_PATH, return_value=mock_stub):
+            passed, checks = self.checker.check_bootstrapped_tenant(
+                org_id=self.tenant.org_id,
+                tenant_mapping=self.tenant_mapping,
+                root_workspace_id=self.root_workspace_id,
+                default_workspace_id=self.default_workspace_id,
+            )
+
+        self.assertFalse(passed)
+        failed = [c for c in checks if not c["exists"]]
+        self.assertEqual(len(failed), EXPECTED_BASE_CHECK_COUNT)
+
+    @patch(PLATFORM_ROLE_UUID_PATH)
+    @patch("management.inventory_checker.inventory_api_check.create_client_channel_inventory")
+    @patch("management.inventory_checker.inventory_api_check.json_format.MessageToDict")
+    @override_settings(ENV_NAME="stage", PRINCIPAL_USER_DOMAIN="localhost")
+    def test_check_names_cover_all_scopes(self, mock_message_to_dict, mock_create_channel, mock_role_uuid):
+        """Verify check names cover all expected access_type/scope combinations."""
+        self._mock_platform_role_uuid(mock_role_uuid)
+
+        mock_response = MagicMock(spec=CheckResponse)
+        mock_stub = self._setup_inventory_mocks(mock_create_channel, mock_response)
+        mock_message_to_dict.return_value = {"allowed": "ALLOWED_TRUE"}
+
+        with patch(INVENTORY_STUB_PATH, return_value=mock_stub):
+            _, checks = self.checker.check_bootstrapped_tenant(
+                org_id=self.tenant.org_id,
+                tenant_mapping=self.tenant_mapping,
+                root_workspace_id=self.root_workspace_id,
+                default_workspace_id=self.default_workspace_id,
+            )
+
+        check_names = {c["name"] for c in checks}
+        expected_names = {"default_workspace_parent", "root_workspace_parent", "tenant_platform"}
+        for access_type in DefaultAccessType:
+            for scope in Scope:
+                prefix = f"{access_type.value}_{scope.name.lower()}"
+                expected_names.update({f"{prefix}_binding", f"{prefix}_role", f"{prefix}_subject"})
+
+        self.assertEqual(check_names, expected_names)
+
+    @patch(PLATFORM_ROLE_UUID_PATH)
+    @patch("management.inventory_checker.inventory_api_check.create_client_channel_inventory")
+    @patch("management.inventory_checker.inventory_api_check.json_format.MessageToDict")
+    @override_settings(ENV_NAME="stage", PRINCIPAL_USER_DOMAIN="localhost")
+    def test_uses_correct_tenant_resource_id(self, mock_message_to_dict, mock_create_channel, mock_role_uuid):
+        """Verify the tenant resource ID uses PRINCIPAL_USER_DOMAIN/org_id format."""
+        self._mock_platform_role_uuid(mock_role_uuid)
+
+        mock_response = MagicMock(spec=CheckResponse)
+        mock_stub = self._setup_inventory_mocks(mock_create_channel, mock_response)
+        mock_message_to_dict.return_value = {"allowed": "ALLOWED_TRUE"}
+
+        with patch(INVENTORY_STUB_PATH, return_value=mock_stub):
+            passed, _ = self.checker.check_bootstrapped_tenant(
+                org_id=self.tenant.org_id,
+                tenant_mapping=self.tenant_mapping,
+                root_workspace_id=self.root_workspace_id,
+                default_workspace_id=self.default_workspace_id,
+            )
+
+        self.assertTrue(passed)
+        # tenant_platform check is at index 2
+        calls = mock_stub.Check.call_args_list
+        check_request = calls[2][0][0]
+        self.assertEqual(check_request.object.resource_id, f"localhost/{self.tenant.org_id}")
+        self.assertEqual(check_request.object.resource_type, "tenant")
+        self.assertEqual(check_request.subject.resource.resource_id, "stage")
+        self.assertEqual(check_request.subject.resource.resource_type, "platform")
+
+    @patch(PLATFORM_ROLE_UUID_PATH)
+    @patch("management.inventory_checker.inventory_api_check.create_client_channel_inventory")
+    @patch("management.inventory_checker.inventory_api_check.json_format.MessageToDict")
+    @override_settings(ENV_NAME="stage", PRINCIPAL_USER_DOMAIN="localhost")
+    def test_binding_uses_correct_role_binding_uuid(self, mock_message_to_dict, mock_create_channel, mock_role_uuid):
+        """Verify binding checks use the correct UUIDs from TenantMapping."""
+        self._mock_platform_role_uuid(mock_role_uuid)
+
+        mock_response = MagicMock(spec=CheckResponse)
+        mock_stub = self._setup_inventory_mocks(mock_create_channel, mock_response)
+        mock_message_to_dict.return_value = {"allowed": "ALLOWED_TRUE"}
+
+        with patch(INVENTORY_STUB_PATH, return_value=mock_stub):
+            passed, _ = self.checker.check_bootstrapped_tenant(
+                org_id=self.tenant.org_id,
+                tenant_mapping=self.tenant_mapping,
+                root_workspace_id=self.root_workspace_id,
+                default_workspace_id=self.default_workspace_id,
+            )
+
+        self.assertTrue(passed)
+        # user_default_binding is at index 3 (after 3 hierarchy checks)
+        calls = mock_stub.Check.call_args_list
+        check_request = calls[3][0][0]
+        expected_rb_uuid = str(self.tenant_mapping.default_role_binding_uuid)
+        self.assertEqual(check_request.subject.resource.resource_id, expected_rb_uuid)
+        self.assertEqual(check_request.subject.resource.resource_type, "role_binding")
+
+    @patch(PLATFORM_ROLE_UUID_PATH)
+    @patch("management.inventory_checker.inventory_api_check.create_client_channel_inventory")
+    @patch("management.inventory_checker.inventory_api_check.json_format.MessageToDict")
+    @override_settings(ENV_NAME="stage", PRINCIPAL_USER_DOMAIN="localhost")
+    def test_role_check_uses_platform_role_uuid(self, mock_message_to_dict, mock_create_channel, mock_role_uuid):
+        """Verify role checks use the UUID from platform_v2_role_uuid_for."""
+        self._mock_platform_role_uuid(mock_role_uuid)
+
+        mock_response = MagicMock(spec=CheckResponse)
+        mock_stub = self._setup_inventory_mocks(mock_create_channel, mock_response)
+        mock_message_to_dict.return_value = {"allowed": "ALLOWED_TRUE"}
+
+        with patch(INVENTORY_STUB_PATH, return_value=mock_stub):
+            passed, _ = self.checker.check_bootstrapped_tenant(
+                org_id=self.tenant.org_id,
+                tenant_mapping=self.tenant_mapping,
+                root_workspace_id=self.root_workspace_id,
+                default_workspace_id=self.default_workspace_id,
+            )
+
+        self.assertTrue(passed)
+        # user_default_role is at index 4 (3 hierarchy + 1 binding)
+        calls = mock_stub.Check.call_args_list
+        check_request = calls[4][0][0]
+        expected_role_uuid = str(self.role_uuids[(DefaultAccessType.USER, Scope.DEFAULT)])
+        self.assertEqual(check_request.subject.resource.resource_id, expected_role_uuid)
+        self.assertEqual(check_request.subject.resource.resource_type, "role")
+
+    @patch(PLATFORM_ROLE_UUID_PATH)
+    @patch("management.inventory_checker.inventory_api_check.create_client_channel_inventory")
+    @patch("management.inventory_checker.inventory_api_check.json_format.MessageToDict")
+    @override_settings(ENV_NAME="stage", PRINCIPAL_USER_DOMAIN="localhost")
+    def test_subject_check_uses_group_uuid(self, mock_message_to_dict, mock_create_channel, mock_role_uuid):
+        """Verify subject checks use the correct group UUID from TenantMapping."""
+        self._mock_platform_role_uuid(mock_role_uuid)
+
+        mock_response = MagicMock(spec=CheckResponse)
+        mock_stub = self._setup_inventory_mocks(mock_create_channel, mock_response)
+        mock_message_to_dict.return_value = {"allowed": "ALLOWED_TRUE"}
+
+        with patch(INVENTORY_STUB_PATH, return_value=mock_stub):
+            passed, _ = self.checker.check_bootstrapped_tenant(
+                org_id=self.tenant.org_id,
+                tenant_mapping=self.tenant_mapping,
+                root_workspace_id=self.root_workspace_id,
+                default_workspace_id=self.default_workspace_id,
+            )
+
+        self.assertTrue(passed)
+        # user_default_subject is at index 5 (3 hierarchy + 2)
+        calls = mock_stub.Check.call_args_list
+        check_request = calls[5][0][0]
+        expected_group_uuid = str(self.tenant_mapping.default_group_uuid)
+        self.assertEqual(check_request.subject.resource.resource_id, expected_group_uuid)
+        self.assertEqual(check_request.subject.resource.resource_type, "group")
+        self.assertEqual(check_request.subject.relation, "member")
+
+    @patch(PLATFORM_ROLE_UUID_PATH)
+    @patch("management.inventory_checker.inventory_api_check.create_client_channel_inventory")
+    @patch("management.inventory_checker.inventory_api_check.json_format.MessageToDict")
+    @override_settings(ENV_NAME="stage", PRINCIPAL_USER_DOMAIN="localhost")
+    def test_readable_check_string_format(self, mock_message_to_dict, mock_create_channel, mock_role_uuid):
+        """Verify the check string uses namespace/type:id#relation@namespace/type:id format."""
+        self._mock_platform_role_uuid(mock_role_uuid)
+
+        mock_response = MagicMock(spec=CheckResponse)
+        mock_stub = self._setup_inventory_mocks(mock_create_channel, mock_response)
+        mock_message_to_dict.return_value = {"allowed": "ALLOWED_TRUE"}
+
+        with patch(INVENTORY_STUB_PATH, return_value=mock_stub):
+            _, checks = self.checker.check_bootstrapped_tenant(
+                org_id=self.tenant.org_id,
+                tenant_mapping=self.tenant_mapping,
+                root_workspace_id=self.root_workspace_id,
+                default_workspace_id=self.default_workspace_id,
+            )
+
+        # default_workspace_parent check string
+        ws_parent = next(c for c in checks if c["name"] == "default_workspace_parent")
+        expected = f"rbac/workspace:{self.default_workspace_id}" f"#parent" f"@rbac/workspace:{self.root_workspace_id}"
+        self.assertEqual(ws_parent["check"], expected)
+
+        # subject check includes #member suffix
+        subject = next(c for c in checks if c["name"] == "user_default_subject")
+        self.assertIn("#member", subject["check"])

--- a/tests/management/inventory_checker/test_bootstrapped_tenant_checker.py
+++ b/tests/management/inventory_checker/test_bootstrapped_tenant_checker.py
@@ -29,9 +29,9 @@ from tests.identity_request import IdentityRequest
 INVENTORY_STUB_PATH = "management.inventory_checker.inventory_api_check.inventory_service_pb2_grpc.KesselInventoryServiceStub"  # noqa: E501
 PLATFORM_ROLE_UUID_PATH = "management.inventory_checker.inventory_api_check.platform_v2_role_uuid_for"
 
-# 3 hierarchy + 6 binding combos x 3 tuples each = 21 base checks
-EXPECTED_BASE_CHECK_COUNT = 21
-EXPECTED_WITH_UNGROUPED = 22
+# 2 hierarchy + 6 binding combos x 3 tuples each = 20 base checks
+EXPECTED_BASE_CHECK_COUNT = 20
+EXPECTED_WITH_UNGROUPED = 21
 
 
 class BootstrappedTenantCheckerTest(IdentityRequest):
@@ -125,14 +125,14 @@ class BootstrappedTenantCheckerTest(IdentityRequest):
     @patch("management.inventory_checker.inventory_api_check.json_format.MessageToDict")
     @override_settings(ENV_NAME="stage", PRINCIPAL_USER_DOMAIN="localhost")
     def test_missing_hierarchy_tuple(self, mock_message_to_dict, mock_create_channel, mock_role_uuid):
-        """Fails when the root_workspace_parent hierarchy tuple is missing."""
+        """Fails when the default_workspace_parent hierarchy tuple is missing."""
         self._mock_platform_role_uuid(mock_role_uuid)
 
         responses = [MagicMock(spec=CheckResponse) for _ in range(EXPECTED_BASE_CHECK_COUNT)]
         mock_stub = self._setup_inventory_mocks(mock_create_channel, responses)
         allowed_results = [{"allowed": "ALLOWED_TRUE"}] * EXPECTED_BASE_CHECK_COUNT
-        # root_workspace_parent is index 1
-        allowed_results[1] = {"allowed": "ALLOWED_FALSE"}
+        # default_workspace_parent is index 0
+        allowed_results[0] = {"allowed": "ALLOWED_FALSE"}
         mock_message_to_dict.side_effect = allowed_results
 
         with patch(INVENTORY_STUB_PATH, return_value=mock_stub):
@@ -146,7 +146,7 @@ class BootstrappedTenantCheckerTest(IdentityRequest):
         self.assertFalse(passed)
         failed = [c for c in checks if not c["exists"]]
         self.assertEqual(len(failed), 1)
-        self.assertEqual(failed[0]["name"], "root_workspace_parent")
+        self.assertEqual(failed[0]["name"], "default_workspace_parent")
 
     @patch(PLATFORM_ROLE_UUID_PATH)
     @patch("management.inventory_checker.inventory_api_check.create_client_channel_inventory")
@@ -159,8 +159,8 @@ class BootstrappedTenantCheckerTest(IdentityRequest):
         responses = [MagicMock(spec=CheckResponse) for _ in range(EXPECTED_BASE_CHECK_COUNT)]
         mock_stub = self._setup_inventory_mocks(mock_create_channel, responses)
         allowed_results = [{"allowed": "ALLOWED_TRUE"}] * EXPECTED_BASE_CHECK_COUNT
-        # user_root_binding: 3 hierarchy + 3 user_default = index 6
-        allowed_results[6] = {"allowed": "ALLOWED_FALSE"}
+        # user_root_binding: 2 hierarchy + 3 user_default = index 5
+        allowed_results[5] = {"allowed": "ALLOWED_FALSE"}
         mock_message_to_dict.side_effect = allowed_results
 
         with patch(INVENTORY_STUB_PATH, return_value=mock_stub):
@@ -187,8 +187,8 @@ class BootstrappedTenantCheckerTest(IdentityRequest):
         responses = [MagicMock(spec=CheckResponse) for _ in range(EXPECTED_BASE_CHECK_COUNT)]
         mock_stub = self._setup_inventory_mocks(mock_create_channel, responses)
         allowed_results = [{"allowed": "ALLOWED_TRUE"}] * EXPECTED_BASE_CHECK_COUNT
-        # admin_tenant_subject: 3 hierarchy + 15 (user 9 + admin default 3 + admin root 3) + 2 = index 20
-        allowed_results[20] = {"allowed": "ALLOWED_FALSE"}
+        # admin_tenant_subject: 2 hierarchy + 15 (user 9 + admin default 3 + admin root 3) + 2 = index 19
+        allowed_results[19] = {"allowed": "ALLOWED_FALSE"}
         mock_message_to_dict.side_effect = allowed_results
 
         with patch(INVENTORY_STUB_PATH, return_value=mock_stub):
@@ -278,7 +278,7 @@ class BootstrappedTenantCheckerTest(IdentityRequest):
             )
 
         check_names = {c["name"] for c in checks}
-        expected_names = {"default_workspace_parent", "root_workspace_parent", "tenant_platform"}
+        expected_names = {"default_workspace_parent", "tenant_platform"}
         for access_type in DefaultAccessType:
             for scope in Scope:
                 prefix = f"{access_type.value}_{scope.name.lower()}"
@@ -307,10 +307,15 @@ class BootstrappedTenantCheckerTest(IdentityRequest):
             )
 
         self.assertTrue(passed)
-        # tenant_platform check is at index 2
         calls = mock_stub.Check.call_args_list
-        check_request = calls[2][0][0]
-        self.assertEqual(check_request.object.resource_id, f"localhost/{self.tenant.org_id}")
+        tenant_calls = [
+            c[0][0]
+            for c in calls
+            if getattr(getattr(c[0][0], "object", None), "resource_type", None) == "tenant"
+            and c[0][0].object.resource_id == f"localhost/{self.tenant.org_id}"
+        ]
+        self.assertTrue(len(tenant_calls) > 0, "Expected a Check call for the tenant resource")
+        check_request = tenant_calls[0]
         self.assertEqual(check_request.object.resource_type, "tenant")
         self.assertEqual(check_request.subject.resource.resource_id, "stage")
         self.assertEqual(check_request.subject.resource.resource_type, "platform")
@@ -336,12 +341,15 @@ class BootstrappedTenantCheckerTest(IdentityRequest):
             )
 
         self.assertTrue(passed)
-        # user_default_binding is at index 3 (after 3 hierarchy checks)
         calls = mock_stub.Check.call_args_list
-        check_request = calls[3][0][0]
         expected_rb_uuid = str(self.tenant_mapping.default_role_binding_uuid)
-        self.assertEqual(check_request.subject.resource.resource_id, expected_rb_uuid)
-        self.assertEqual(check_request.subject.resource.resource_type, "role_binding")
+        rb_calls = [
+            c[0][0]
+            for c in calls
+            if getattr(getattr(c[0][0].subject, "resource", None), "resource_type", None) == "role_binding"
+            and c[0][0].subject.resource.resource_id == expected_rb_uuid
+        ]
+        self.assertTrue(len(rb_calls) > 0, "Expected a Check call for the user's default role binding UUID")
 
     @patch(PLATFORM_ROLE_UUID_PATH)
     @patch("management.inventory_checker.inventory_api_check.create_client_channel_inventory")
@@ -364,12 +372,15 @@ class BootstrappedTenantCheckerTest(IdentityRequest):
             )
 
         self.assertTrue(passed)
-        # user_default_role is at index 4 (3 hierarchy + 1 binding)
         calls = mock_stub.Check.call_args_list
-        check_request = calls[4][0][0]
         expected_role_uuid = str(self.role_uuids[(DefaultAccessType.USER, Scope.DEFAULT)])
-        self.assertEqual(check_request.subject.resource.resource_id, expected_role_uuid)
-        self.assertEqual(check_request.subject.resource.resource_type, "role")
+        role_calls = [
+            c[0][0]
+            for c in calls
+            if getattr(getattr(c[0][0].subject, "resource", None), "resource_type", None) == "role"
+            and c[0][0].subject.resource.resource_id == expected_role_uuid
+        ]
+        self.assertTrue(len(role_calls) > 0, "Expected a Check call for the platform role UUID")
 
     @patch(PLATFORM_ROLE_UUID_PATH)
     @patch("management.inventory_checker.inventory_api_check.create_client_channel_inventory")
@@ -392,13 +403,16 @@ class BootstrappedTenantCheckerTest(IdentityRequest):
             )
 
         self.assertTrue(passed)
-        # user_default_subject is at index 5 (3 hierarchy + 2)
         calls = mock_stub.Check.call_args_list
-        check_request = calls[5][0][0]
         expected_group_uuid = str(self.tenant_mapping.default_group_uuid)
-        self.assertEqual(check_request.subject.resource.resource_id, expected_group_uuid)
-        self.assertEqual(check_request.subject.resource.resource_type, "group")
-        self.assertEqual(check_request.subject.relation, "member")
+        group_calls = [
+            c[0][0]
+            for c in calls
+            if getattr(getattr(c[0][0].subject, "resource", None), "resource_type", None) == "group"
+            and c[0][0].subject.resource.resource_id == expected_group_uuid
+            and c[0][0].subject.relation == "member"
+        ]
+        self.assertTrue(len(group_calls) > 0, "Expected a Check call for the group UUID with member relation")
 
     @patch(PLATFORM_ROLE_UUID_PATH)
     @patch("management.inventory_checker.inventory_api_check.create_client_channel_inventory")

--- a/tests/management/test_parity_tasks.py
+++ b/tests/management/test_parity_tasks.py
@@ -561,3 +561,125 @@ class ParityCheckTasksTest(IdentityRequest):
         self.assertTrue(tenant_result["passed"])
         self.assertEqual(tenant_result["custom_roles_checked"], 1)
         self.assertEqual(tenant_result["role_results"][0]["permission_count"], 0)
+
+    @override_settings(PARITY_CHECK_ENABLED=True, PARITY_CHECK_ORG_IDS="test_org_id")
+    @patch(
+        "management.inventory_checker.inventory_api_check.WorkspaceRelationInventoryChecker.check_workspace_descendants"
+    )
+    def test_bootstrap_parity_success_updates_stats(self, mock_check_workspace):
+        """Bootstrap parity success should increment counters and mark tenant as passed."""
+        self.tenant.org_id = "test_org_id"
+        self.tenant.save()
+        mock_check_workspace.return_value = True
+
+        bootstrap_details = [
+            {"name": "default_workspace_parent", "exists": True},
+            {"name": "root_workspace_parent", "exists": True},
+        ]
+        self.mock_bootstrap_checker.return_value = (True, bootstrap_details)
+
+        result = run_kessel_parity_checks_in_worker()
+
+        self.assertEqual(result["total_bootstrap_checks"], 2)
+        self.assertEqual(result["passed_tenants"], 1)
+
+        tenant_result = result["tenants_checked"][0]
+        self.assertEqual(tenant_result["bootstrap_checks"], 2)
+        self.assertTrue(tenant_result["bootstrap_check_passed"])
+        self.assertEqual(tenant_result["bootstrap_details"], bootstrap_details)
+        self.assertTrue(tenant_result["passed"])
+
+    @override_settings(PARITY_CHECK_ENABLED=True, PARITY_CHECK_ORG_IDS="test_org_id")
+    @patch(
+        "management.inventory_checker.inventory_api_check.WorkspaceRelationInventoryChecker.check_workspace_descendants"
+    )
+    def test_bootstrap_parity_failure_marks_tenant_failed(self, mock_check_workspace):
+        """Bootstrap parity failure should mark tenant as failed even when other checks pass."""
+        self.tenant.org_id = "test_org_id"
+        self.tenant.save()
+        mock_check_workspace.return_value = True
+
+        bootstrap_details = [
+            {"name": "default_workspace_parent", "exists": True},
+            {"name": "root_workspace_parent", "exists": False},
+        ]
+        self.mock_bootstrap_checker.return_value = (False, bootstrap_details)
+
+        result = run_kessel_parity_checks_in_worker()
+
+        self.assertEqual(result["total_bootstrap_checks"], 2)
+        self.assertEqual(result["passed_tenants"], 0)
+        self.assertEqual(result["failed_tenants"], 1)
+
+        tenant_result = result["tenants_checked"][0]
+        self.assertEqual(tenant_result["bootstrap_checks"], 2)
+        self.assertFalse(tenant_result["bootstrap_check_passed"])
+        self.assertFalse(tenant_result["passed"])
+
+    @override_settings(PARITY_CHECK_ENABLED=True, PARITY_CHECK_ORG_IDS="test_org_id")
+    @patch(
+        "management.inventory_checker.inventory_api_check.WorkspaceRelationInventoryChecker.check_workspace_descendants"
+    )
+    def test_bootstrap_parity_no_tenant_mapping(self, mock_check_workspace):
+        """Missing TenantMapping should skip bootstrap check and fail the tenant."""
+        self.tenant.org_id = "test_org_id"
+        self.tenant.save()
+        mock_check_workspace.return_value = True
+        self.tenant_mapping.delete()
+
+        result = run_kessel_parity_checks_in_worker()
+
+        self.mock_bootstrap_checker.assert_not_called()
+        self.assertEqual(result["total_bootstrap_checks"], 0)
+        self.assertEqual(result["passed_tenants"], 0)
+        self.assertEqual(result["failed_tenants"], 1)
+
+        tenant_result = result["tenants_checked"][0]
+        self.assertFalse(tenant_result["bootstrap_check_passed"])
+        self.assertFalse(tenant_result["passed"])
+
+    @override_settings(PARITY_CHECK_ENABLED=True, PARITY_CHECK_ORG_IDS="test_org_id")
+    @patch(
+        "management.inventory_checker.inventory_api_check.WorkspaceRelationInventoryChecker.check_workspace_descendants"
+    )
+    def test_bootstrap_parity_missing_root_workspace(self, mock_check_workspace):
+        """Missing root workspace should skip bootstrap check and fail the tenant."""
+        self.tenant.org_id = "test_org_id"
+        self.tenant.save()
+        mock_check_workspace.return_value = True
+
+        self.child_workspace.delete()
+        self.default_workspace.delete()
+        self.root_workspace.delete()
+
+        result = run_kessel_parity_checks_in_worker()
+
+        self.mock_bootstrap_checker.assert_not_called()
+        self.assertEqual(result["total_bootstrap_checks"], 0)
+
+        tenant_result = result["tenants_checked"][0]
+        self.assertFalse(tenant_result["bootstrap_check_passed"])
+        self.assertFalse(tenant_result["passed"])
+
+    @override_settings(PARITY_CHECK_ENABLED=True, PARITY_CHECK_ORG_IDS="test_org_id")
+    @patch(
+        "management.inventory_checker.inventory_api_check.WorkspaceRelationInventoryChecker.check_workspace_descendants"
+    )
+    def test_bootstrap_parity_exception_still_counts_tenant(self, mock_check_workspace):
+        """When the bootstrap checker raises, the tenant is still counted and marked failed."""
+        self.tenant.org_id = "test_org_id"
+        self.tenant.save()
+        mock_check_workspace.return_value = True
+        self.mock_bootstrap_checker.side_effect = Exception("gRPC unavailable")
+
+        result = run_kessel_parity_checks_in_worker()
+
+        self.assertEqual(result["total_tenants"], 1)
+        self.assertEqual(result["failed_tenants"], 1)
+
+        tenant_result = result["tenants_checked"][0]
+        self.assertFalse(tenant_result["passed"])
+        self.assertIn("error", tenant_result)
+        self.assertIn("gRPC unavailable", tenant_result["error"])
+        self.assertEqual(tenant_result["bootstrap_checks"], 0)
+        self.assertEqual(tenant_result["bootstrap_details"], [])

--- a/tests/management/test_parity_tasks.py
+++ b/tests/management/test_parity_tasks.py
@@ -22,8 +22,13 @@ from unittest.mock import patch
 from django.test import override_settings
 from management.models import CustomRoleV2, Permission
 from management.tasks import run_kessel_parity_checks_in_worker
+from management.tenant_mapping.model import TenantMapping
 from management.workspace.model import Workspace
 from tests.identity_request import IdentityRequest
+
+BOOTSTRAP_CHECKER_PATH = (
+    "management.inventory_checker.inventory_api_check.BootstrappedTenantInventoryChecker.check_bootstrapped_tenant"
+)
 
 
 class ParityCheckTasksTest(IdentityRequest):
@@ -52,6 +57,18 @@ class ParityCheckTasksTest(IdentityRequest):
             tenant=self.tenant,
             parent=self.default_workspace,
         )
+
+        # Create tenant mapping so bootstrap checker path is reachable
+        self.tenant_mapping = TenantMapping.objects.create(tenant=self.tenant)
+
+        # Mock bootstrap checker by default so existing tests aren't affected
+        self._bootstrap_patcher = patch(BOOTSTRAP_CHECKER_PATH, return_value=(True, []))
+        self.mock_bootstrap_checker = self._bootstrap_patcher.start()
+
+    def tearDown(self):
+        """Clean up mocks."""
+        self._bootstrap_patcher.stop()
+        super().tearDown()
 
     @override_settings(PARITY_CHECK_ENABLED=True, PARITY_CHECK_ORG_IDS="")
     def test_parity_check_task_no_org_ids_configured(self):


### PR DESCRIPTION
## Link(s) to Jira
- [RHCLOUD-46773](https://issues.redhat.com/browse/RHCLOUD-46773)

## Description of Intent of Change(s)

**WHAT**: Rewrites `BootstrappedTenantInventoryChecker` to verify all 21-22 relations created during tenant bootstrap, up from 5. Integrates the checker into the `run_kessel_parity_checks_in_worker` Celery task and updates the internal view.

**WHY**: The previous implementation only verified 5 of 22 bootstrap relations (default workspace parent + 4 binding checks), leaving gaps in parity coverage. This change ensures all hierarchy tuples, scope bindings, role assignments, and group subjects are verified.

**HOW**:
- Refactored checker to use `RelationTuple` + `create_relationship()` instead of manual `CheckRequest` construction, staying in sync with the actual bootstrap code
- 3 hierarchy checks: default->root workspace, root->tenant, tenant->platform
- 18 binding checks: 6 scope/access-type combos (USER+ADMIN x DEFAULT/ROOT/TENANT), each with 3 sub-checks (binding, role, subject)
- 1 optional check: ungrouped workspace parent (when present)
- Each check gets a descriptive name for clear pass/fail reporting
- Task now fetches `TenantMapping` and workspaces per tenant, calls bootstrap checker, tracks stats
- Internal view updated to pass model objects and handle missing `TenantMapping` gracefully (404 instead of crash)

## Local Testing

```bash
# Unit tests for the checker (13 tests)
pipenv run tox -e py312-fast -- tests.management.inventory_checker.test_bootstrapped_tenant_checker

# Parity task integration tests (17 tests)
pipenv run tox -e py312-fast -- tests.management.test_parity_tasks

# Full test suite
pipenv run tox -e py312-fast
```

All 2175+ tests pass. Two pre-existing failures on master (unrelated integration tests with PSK auth issues) are not affected by this change.

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required?
- [x] are these changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices

[RHCLOUD-46773]: https://redhat.atlassian.net/browse/RHCLOUD-46773?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Extend the inventory bootstrap parity checker to validate all tenant bootstrap relations and integrate its results into both the internal inventory check endpoint and the Kessel parity worker task.

New Features:
- Add comprehensive bootstrap relation validation for tenants, covering hierarchy, bindings, roles, and group subjects, with human-readable per-check results.
- Expose detailed bootstrap validation results and status via the internal inventory bootstrap_tenants API endpoint.
- Incorporate bootstrap parity into the Kessel parity worker, tracking per-tenant bootstrap results and aggregate statistics.

Enhancements:
- Refactor the bootstrapped tenant inventory checker to operate on RelationTuple-based relationships aligned with the bootstrap logic and to produce descriptive check names.
- Improve error handling and logging in parity tasks by using exception logging and including bootstrap metrics in summary logs.

Tests:
- Add a dedicated test suite for the bootstrapped tenant inventory checker to cover success, failure modes, naming, and tuple formatting.
- Extend parity task and internal view tests to cover bootstrap parity success/failure, missing mappings/workspaces, and updated API response shapes.