### PR TITLE
RHCLOUD-35482: Replicate tenant relation for root workspaces

### DIFF
--- a/deploy/rbac-clowdapp.yml
+++ b/deploy/rbac-clowdapp.yml
@@ -1293,6 +1293,21 @@ objects:
               cpu: 50m
               memory: 512Mi
           env: *common_env_vars
+      - name: replicate-root-workspace-tenants
+        podSpec:
+          image: ${IMAGE}:${IMAGE_TAG}
+          command:
+            - /opt/rbac/rbac/manage.py
+            - replicate_root_workspace_tenants
+            - "--all"
+          resources:
+            limits:
+              cpu: 300m
+              memory: 1Gi
+            requests:
+              cpu: 50m
+              memory: 512Mi
+          env: *common_env_vars
 - apiVersion: v1
   kind: ConfigMap
   metadata:

--- a/deploy/rbac-clowdapp.yml
+++ b/deploy/rbac-clowdapp.yml
@@ -1300,6 +1300,7 @@ objects:
             - /opt/rbac/rbac/manage.py
             - replicate_root_workspace_tenants
             - "--all"
+            - "--sleep-sec=0.5"
           resources:
             limits:
               cpu: 300m

--- a/deploy/replicate_root_workspace_tenants.yml
+++ b/deploy/replicate_root_workspace_tenants.yml
@@ -1,0 +1,19 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: replicate-root-workspace-tenants
+objects:
+  - apiVersion: cloud.redhat.com/v1alpha1
+    kind: ClowdJobInvocation
+    metadata:
+      labels:
+        app: rbac
+      name: replicate-root-workspace-tenants-${RUN_NUMBER}
+    spec:
+      appName: rbac
+      jobs:
+        - replicate-root-workspace-tenants
+parameters:
+  - name: RUN_NUMBER
+    description: Used to track and re-run the job
+    value: '1'

--- a/rbac/internal/migrations/replicate_root_workspace_tenants.py
+++ b/rbac/internal/migrations/replicate_root_workspace_tenants.py
@@ -3,7 +3,7 @@ import logging
 from typing import Optional
 
 from api.models import Tenant
-from management.atomic_transactions import atomic
+from management.atomic_transactions import atomic_with_retry
 from management.relation_replicator.outbox_replicator import OutboxReplicator
 from management.relation_replicator.relation_replicator import (
     RelationReplicator,
@@ -18,7 +18,7 @@ from migration_tool.utils import create_relationship
 logger = logging.getLogger(__name__)
 
 
-@atomic
+@atomic_with_retry(retries=3)
 def _do_replicate(replicator: RelationReplicator, raw_tenants: list[Tenant]) -> int:
     tenants = list(Tenant.objects.filter(pk__in=(t.pk for t in raw_tenants)).exclude(org_id=None))
     bootstrap_locks = try_lock_tenants_for_bootstrap(tenants)

--- a/rbac/internal/migrations/replicate_root_workspace_tenants.py
+++ b/rbac/internal/migrations/replicate_root_workspace_tenants.py
@@ -1,5 +1,6 @@
 import itertools
 import logging
+import time
 from typing import Optional
 
 from api.models import Tenant
@@ -66,7 +67,16 @@ def _do_replicate(replicator: RelationReplicator, raw_tenants: list[Tenant]) -> 
     return len(tenants)
 
 
-def replicate_root_workspace_tenants(replicator: Optional[RelationReplicator] = None):
+def replicate_root_workspace_tenants(
+    replicator: Optional[RelationReplicator] = None, *, batch_sleep_seconds: int | float = 0
+):
+    """
+    Replicate the tenant relation for all existing root workspaces.
+
+    Args:
+        replicator: the replicator to use (defaulting to OutboxReplicator)
+        batch_sleep_seconds: if positive, how many seconds to sleep between each "batch" (defaulting to 0)
+    """
     if replicator is None:
         replicator = OutboxReplicator()
 
@@ -80,5 +90,8 @@ def replicate_root_workspace_tenants(replicator: Optional[RelationReplicator] = 
     for raw_tenant_batch in itertools.batched(query.iterator(), 1000):
         replicated_count += _do_replicate(replicator, list(raw_tenant_batch))
         logger.info(f"Replicated {replicated_count}/~{tenant_count} root workspace tenants.")
+
+        if batch_sleep_seconds > 0:
+            time.sleep(batch_sleep_seconds)
 
     logger.info(f"Finished replicating a total of {replicated_count} root workspace tenants.")

--- a/rbac/internal/migrations/replicate_root_workspace_tenants.py
+++ b/rbac/internal/migrations/replicate_root_workspace_tenants.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 @atomic_with_retry(retries=3)
 def _do_replicate(replicator: RelationReplicator, raw_tenants: list[Tenant]) -> int:
     tenants = list(Tenant.objects.filter(pk__in=(t.pk for t in raw_tenants)).exclude(org_id=None))
-    bootstrap_locks = try_lock_tenants_for_bootstrap(tenants)
+    bootstrap_locks = {t: l for t, l in try_lock_tenants_for_bootstrap(tenants).items() if l is not None}
 
     if len(tenants) != len(bootstrap_locks):
         expected_pks = set(t.pk for t in tenants)

--- a/rbac/internal/migrations/replicate_root_workspace_tenants.py
+++ b/rbac/internal/migrations/replicate_root_workspace_tenants.py
@@ -1,0 +1,84 @@
+import itertools
+import logging
+from typing import Optional
+
+from api.models import Tenant
+from management.atomic_transactions import atomic
+from management.relation_replicator.outbox_replicator import OutboxReplicator
+from management.relation_replicator.relation_replicator import (
+    RelationReplicator,
+    ReplicationEvent,
+    ReplicationEventType,
+    PartitionKey,
+)
+from management.tenant_service.v2 import try_lock_tenants_for_bootstrap
+from management.workspace.model import Workspace
+from migration_tool.utils import create_relationship
+
+logger = logging.getLogger(__name__)
+
+
+@atomic
+def _do_replicate(replicator: RelationReplicator, raw_tenants: list[Tenant]) -> int:
+    tenants = list(Tenant.objects.filter(pk__in=(t.pk for t in raw_tenants)).exclude(org_id=None))
+    bootstrap_locks = try_lock_tenants_for_bootstrap(tenants)
+
+    if len(tenants) != len(bootstrap_locks):
+        expected_pks = set(t.pk for t in tenants)
+        actual_pks = set(t.pk for t in bootstrap_locks.keys())
+
+        raise RuntimeError(f"Failed to lock some tenants for bootstrap: pks={expected_pks - actual_pks}")
+
+    tenants_by_id = {t.id: t for t in tenants}
+
+    if len(tenants_by_id) != len(tenants):
+        raise AssertionError("Found tenants with duplicate IDs")
+
+    root_workspaces = list(
+        Workspace.objects.filter(type=Workspace.Types.ROOT).filter(tenant__in=tenants).select_for_update()
+    )
+
+    if len(root_workspaces) != len(tenants):
+        raise AssertionError("Found tenant without a root workspace")
+
+    tuples = []
+
+    for root_workspace in root_workspaces:
+        tuples.append(
+            create_relationship(
+                resource_name=("rbac", "workspace"),
+                resource_id=str(root_workspace.id),
+                subject_name=("rbac", "tenant"),
+                subject_id=tenants_by_id[root_workspace.tenant_id].tenant_resource_id(),
+                relation="tenant",
+            )
+        )
+
+    for tuples_batch in itertools.batched(tuples, 1000):
+        replicator.replicate(
+            ReplicationEvent(
+                event_type=ReplicationEventType.UPDATE_ROOT_WORKSPACE_TENANTS,
+                partition_key=PartitionKey.byEnvironment(),
+                add=list(tuples_batch),
+            )
+        )
+
+    return len(tenants)
+
+
+def replicate_root_workspace_tenants(replicator: Optional[RelationReplicator] = None):
+    if replicator is None:
+        replicator = OutboxReplicator()
+
+    query = Tenant.objects.exclude(org_id=None)
+    tenant_count = query.count()
+
+    logger.info(f"About to replicate root workspace -> tenant relations for ~{tenant_count} tenants.")
+
+    replicated_count = 0
+
+    for raw_tenant_batch in itertools.batched(query.iterator(), 1000):
+        replicated_count += _do_replicate(replicator, list(raw_tenant_batch))
+        logger.info(f"Replicated {replicated_count}/~{tenant_count} root workspace tenants.")
+
+    logger.info(f"Finished replicating a total of {replicated_count} root workspace tenants.")

--- a/rbac/management/inventory_checker/inventory_api_check.py
+++ b/rbac/management/inventory_checker/inventory_api_check.py
@@ -169,7 +169,7 @@ class BootstrappedTenantInventoryChecker(InventoryApiBaseChecker):
                     root_workspace_id,
                     ("rbac", "tenant"),
                     Tenant.org_id_to_tenant_resource_id(org_id=org_id),
-                    "parent",
+                    "tenant",
                 ),
             )
         )

--- a/rbac/management/inventory_checker/inventory_api_check.py
+++ b/rbac/management/inventory_checker/inventory_api_check.py
@@ -41,6 +41,8 @@ from management.tenant_mapping.model import DefaultAccessType, TenantMapping
 from management.utils import create_client_channel_inventory
 from migration_tool.utils import create_relationship
 
+from api.models import Tenant
+
 jwt_cache = JWTCache()
 jwt_provider = JWTProvider()
 jwt_manager = JWTManager(jwt_provider, jwt_cache)
@@ -139,6 +141,7 @@ class BootstrappedTenantInventoryChecker(InventoryApiBaseChecker):
 
     def _build_named_tuples(
         self,
+        org_id: str,
         tenant_mapping: TenantMapping,
         root_workspace_id: str,
         default_workspace_id: str,
@@ -155,6 +158,18 @@ class BootstrappedTenantInventoryChecker(InventoryApiBaseChecker):
                 "default_workspace_parent",
                 create_relationship(
                     ("rbac", "workspace"), default_workspace_id, ("rbac", "workspace"), root_workspace_id, "parent"
+                ),
+            )
+        )
+        named_tuples.append(
+            (
+                "root_workspace_tenant",
+                create_relationship(
+                    ("rbac", "workspace"),
+                    root_workspace_id,
+                    ("rbac", "tenant"),
+                    Tenant.org_id_to_tenant_resource_id(org_id=org_id),
+                    "parent",
                 ),
             )
         )
@@ -251,6 +266,7 @@ class BootstrappedTenantInventoryChecker(InventoryApiBaseChecker):
         }
 
         named_tuples = self._build_named_tuples(
+            org_id=org_id,
             tenant_mapping=tenant_mapping,
             root_workspace_id=root_workspace_id,
             default_workspace_id=default_workspace_id,

--- a/rbac/management/management/commands/replicate_root_workspace_tenants.py
+++ b/rbac/management/management/commands/replicate_root_workspace_tenants.py
@@ -17,9 +17,19 @@ class Command(BaseCommand):
             help="whether to replicate tenants for all root workspaces (required for forwards compatibility)",
         )
 
+        parser.add_argument(
+            "--sleep-sec",
+            type=float,
+            default=0.0,
+            help=(
+                "if positive, the number of seconds to sleep in between each replication batch "
+                "(defaults to 0, no sleeping)"
+            ),
+        )
+
     def handle(self, **options):
         """Run the command."""
         if not options["all"]:
             raise CommandError("Must pass --all to request replicating tenants for all root workspaces", returncode=1)
 
-        replicate_root_workspace_tenants()
+        replicate_root_workspace_tenants(batch_sleep_seconds=options["sleep_sec"])

--- a/rbac/management/management/commands/replicate_root_workspace_tenants.py
+++ b/rbac/management/management/commands/replicate_root_workspace_tenants.py
@@ -1,0 +1,25 @@
+"""Command to replicate tenants for existing root workspaces."""
+
+from django.core.management import BaseCommand, CommandError
+from internal.migrations.replicate_root_workspace_tenants import replicate_root_workspace_tenants
+
+
+class Command(BaseCommand):
+    """Command for replicating tenant relations for root workspaces."""
+
+    help = "Replicate existing default workspaces."
+
+    def add_arguments(self, parser):
+        """Parse command arguments."""
+        parser.add_argument(
+            "--all",
+            action="store_true",
+            help="whether to replicate tenants for all root workspaces (required for forwards compatibility)",
+        )
+
+    def handle(self, **options):
+        """Run the command."""
+        if not options["all"]:
+            raise CommandError("Must pass --all to request replicating tenants for all root workspaces", returncode=1)
+
+        replicate_root_workspace_tenants()

--- a/rbac/management/relation_replicator/relation_replicator.py
+++ b/rbac/management/relation_replicator/relation_replicator.py
@@ -84,6 +84,7 @@ class ReplicationEventType(str, Enum):
     BATCH_CREATE_ROLE_BINDING = "batch_create_role_binding"
     UPDATE_ROLE_BINDINGS_FOR_SUBJECT = "update_role_bindings_for_subject"
     REMOVE_DELETED_WORKSPACE_BINDINGS = "remove_deleted_workspace_bindings"
+    UPDATE_ROOT_WORKSPACE_TENANTS = "update_root_workspace_tenants"
 
 
 class ReplicationEvent:

--- a/rbac/management/tenant_service/v2.py
+++ b/rbac/management/tenant_service/v2.py
@@ -172,7 +172,6 @@ class V2TenantBootstrapService:
     """Service for bootstrapping tenants with built-in relationships."""
 
     _replicator: RelationReplicator
-    _user_domain = settings.PRINCIPAL_USER_DOMAIN
     _public_tenant: Optional[Tenant]
     _policy_service: GlobalPolicyIdService
 
@@ -821,7 +820,7 @@ class V2TenantBootstrapService:
 
     def _built_in_hierarchy_tuples(self, default_workspace_id, root_workspace_id, org_id) -> List[RelationTuple]:
         """Create tuples for default->root workspace parents and tenant->platform."""
-        tenant_id = f"{self._user_domain}/{org_id}"
+        tenant_id = Tenant.org_id_to_tenant_resource_id(org_id=org_id)
 
         return [
             create_relationship(
@@ -831,8 +830,20 @@ class V2TenantBootstrapService:
                 str(root_workspace_id),
                 "parent",
             ),
-            # Include platform for tenant
-            create_relationship(("rbac", "tenant"), tenant_id, ("rbac", "platform"), settings.ENV_NAME, "platform"),
+            create_relationship(
+                ("rbac", "workspace"),
+                str(root_workspace_id),
+                ("rbac", "tenant"),
+                tenant_id,
+                "tenant",
+            ),
+            create_relationship(
+                ("rbac", "tenant"),
+                tenant_id,
+                ("rbac", "platform"),
+                settings.ENV_NAME,
+                "platform",
+            ),
         ]
 
     def _bootstrap_default_access(

--- a/tests/internal/migrations/test_replicate_root_workspace_tenants.py
+++ b/tests/internal/migrations/test_replicate_root_workspace_tenants.py
@@ -1,0 +1,56 @@
+from django.test import TestCase, override_settings
+
+from api.models import Tenant
+from internal.migrations.replicate_root_workspace_tenants import replicate_root_workspace_tenants
+from management.relation_replicator.noop_replicator import NoopReplicator
+from management.tenant_service import V2TenantBootstrapService
+from management.models import Workspace
+from migration_tool.in_memory_tuples import (
+    InMemoryTuples,
+    InMemoryRelationReplicator,
+    resource,
+    relation,
+    subject,
+    all_of,
+)
+
+
+@override_settings(ATOMIC_RETRY_DISABLED=True)
+class ReplicateRootWorkspacesTest(TestCase):
+    def setUp(self):
+        self.tuples = InMemoryTuples()
+
+        # We will need to know exactly what tenants exist, so delete all non-public tenants.
+        Tenant.objects.exclude(tenant_name="public").delete()
+
+    def test_replicate_root_workspace_tenants(self):
+        bootstrap_service = V2TenantBootstrapService(replicator=NoopReplicator())
+
+        tenant_a = bootstrap_service.new_bootstrapped_tenant(org_id="a").tenant
+        tenant_b = bootstrap_service.new_bootstrapped_tenant(org_id="b").tenant
+
+        replicate_root_workspace_tenants(replicator=InMemoryRelationReplicator(self.tuples))
+
+        self.assertEqual(len(self.tuples), 2)
+
+        self.assertEqual(
+            1,
+            self.tuples.count_tuples(
+                all_of(
+                    resource("rbac", "workspace", str(Workspace.objects.root(tenant_a).id)),
+                    relation("tenant"),
+                    subject("rbac", "tenant", tenant_a.tenant_resource_id()),
+                )
+            ),
+        )
+
+        self.assertEqual(
+            1,
+            self.tuples.count_tuples(
+                all_of(
+                    resource("rbac", "workspace", str(Workspace.objects.root(tenant_b).id)),
+                    relation("tenant"),
+                    subject("rbac", "tenant", tenant_b.tenant_resource_id()),
+                )
+            ),
+        )

--- a/tests/internal/migrations/test_replicate_root_workspace_tenants.py
+++ b/tests/internal/migrations/test_replicate_root_workspace_tenants.py
@@ -54,3 +54,11 @@ class ReplicateRootWorkspacesTest(TestCase):
                 )
             ),
         )
+
+    def test_replicate_unbootstrapped(self):
+        Tenant.objects.create(tenant_name="unbootstrapped tenant", org_id="unbootstrapped")
+
+        with self.assertRaises(RuntimeError) as ctx:
+            replicate_root_workspace_tenants(NoopReplicator())
+
+        self.assertIn("bootstrap", str(ctx.exception))

--- a/tests/internal/test_views.py
+++ b/tests/internal/test_views.py
@@ -1176,7 +1176,7 @@ class InternalViewsetTests(BaseInternalViewsetTests):
         self.assertIsNotNone(Workspace.objects.root(tenant=tenant))
         self.assertIsNotNone(Workspace.objects.default(tenant=tenant))
         self.assertTrue(getattr(tenant, "tenant_mapping"))
-        self.assertEqual(len(tuples), 20)
+        self.assertEqual(len(tuples), 21)
 
     @patch("management.relation_replicator.outbox_replicator.OutboxReplicator.replicate")
     def test_bootstrapping_multiple_tenants(self, replicate):
@@ -1215,8 +1215,8 @@ class InternalViewsetTests(BaseInternalViewsetTests):
             self.assertTrue(getattr(tenant, "tenant_mapping"))
         self.assertEqual(
             len(tuples),
-            20 + 20 + 20,
-        )  # orgs: per tenant, workspace hierarchy + default access (root no longer has workspace#parent@tenant)
+            21 + 21 + 21,
+        )  # orgs: 3 for workspaces, (3 for default and 3 for admin default access) for each of 3 scopes
 
     @patch("management.relation_replicator.outbox_replicator.OutboxReplicator.replicate")
     def test_bootstrapping_existing_tenant_without_force_does_nothing(self, replicate):
@@ -1271,7 +1271,7 @@ class InternalViewsetTests(BaseInternalViewsetTests):
         )
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(len(tuples), 20)
+        self.assertEqual(len(tuples), 21)
 
     @override_settings(REPLICATION_TO_RELATION_ENABLED=True)
     def test_cannot_force_bootstrapping_while_replication_enabled(self):

--- a/tests/management/inventory_checker/test_bootstrapped_tenant_checker.py
+++ b/tests/management/inventory_checker/test_bootstrapped_tenant_checker.py
@@ -29,9 +29,9 @@ from tests.identity_request import IdentityRequest
 INVENTORY_STUB_PATH = "management.inventory_checker.inventory_api_check.inventory_service_pb2_grpc.KesselInventoryServiceStub"  # noqa: E501
 PLATFORM_ROLE_UUID_PATH = "management.inventory_checker.inventory_api_check.platform_v2_role_uuid_for"
 
-# 2 hierarchy + 6 binding combos x 3 tuples each = 20 base checks
-EXPECTED_BASE_CHECK_COUNT = 20
-EXPECTED_WITH_UNGROUPED = 21
+# 3 hierarchy + 6 binding combos x 3 tuples each = 21 base checks
+EXPECTED_BASE_CHECK_COUNT = 21
+EXPECTED_WITH_UNGROUPED = 22
 
 
 class BootstrappedTenantCheckerTest(IdentityRequest):
@@ -160,7 +160,7 @@ class BootstrappedTenantCheckerTest(IdentityRequest):
         mock_stub = self._setup_inventory_mocks(mock_create_channel, responses)
         allowed_results = [{"allowed": "ALLOWED_TRUE"}] * EXPECTED_BASE_CHECK_COUNT
         # user_root_binding: 2 hierarchy + 3 user_default = index 5
-        allowed_results[5] = {"allowed": "ALLOWED_FALSE"}
+        allowed_results[6] = {"allowed": "ALLOWED_FALSE"}
         mock_message_to_dict.side_effect = allowed_results
 
         with patch(INVENTORY_STUB_PATH, return_value=mock_stub):
@@ -188,7 +188,7 @@ class BootstrappedTenantCheckerTest(IdentityRequest):
         mock_stub = self._setup_inventory_mocks(mock_create_channel, responses)
         allowed_results = [{"allowed": "ALLOWED_TRUE"}] * EXPECTED_BASE_CHECK_COUNT
         # admin_tenant_subject: 2 hierarchy + 15 (user 9 + admin default 3 + admin root 3) + 2 = index 19
-        allowed_results[19] = {"allowed": "ALLOWED_FALSE"}
+        allowed_results[20] = {"allowed": "ALLOWED_FALSE"}
         mock_message_to_dict.side_effect = allowed_results
 
         with patch(INVENTORY_STUB_PATH, return_value=mock_stub):
@@ -278,7 +278,7 @@ class BootstrappedTenantCheckerTest(IdentityRequest):
             )
 
         check_names = {c["name"] for c in checks}
-        expected_names = {"default_workspace_parent", "tenant_platform"}
+        expected_names = {"default_workspace_parent", "root_workspace_tenant", "tenant_platform"}
         for access_type in DefaultAccessType:
             for scope in Scope:
                 prefix = f"{access_type.value}_{scope.name.lower()}"

--- a/tests/management/tenant/test_model.py
+++ b/tests/management/tenant/test_model.py
@@ -305,9 +305,9 @@ class V2TenantBootstrapServiceTest(TestCase):
         # Admins get 2, otherwise 1
         num_group_membership_tuples = 2 + 1 + 2 + 1 + 1 + 1
         # o1 is already bootstrapped, should get 0
-        # existing unbootstrapped custom group tenants get 11 (one fewer hierarchy tuple vs full bootstrap)
-        # new or otherwise unbootstrapped tenants get 20 (root workspace no longer gets workspace#parent@tenant)
-        num_tenant_bootstrapping_tuples = 0 + 20 + 11 + 20
+        # existing unbootstrapped custom group tenants get 12
+        # new or otherwise unbootstrapped tenants get 21
+        num_tenant_bootstrapping_tuples = 0 + 21 + 12 + 21
 
         self.assertEqual(num_group_membership_tuples + num_tenant_bootstrapping_tuples, self.tuples.count_tuples())
 
@@ -645,15 +645,15 @@ class V2TenantBootstrapServiceTest(TestCase):
             f"Expected default workspace to be child of root workspace for tenant {org_id}",
         )
         self.assertEqual(
-            0,
+            1,
             self.tuples.count_tuples(
                 all_of(
                     resource("rbac", "workspace", root.id),
-                    relation("parent"),
+                    relation("tenant"),
                     subject("rbac", "tenant", f"localhost/{org_id}"),
                 )
             ),
-            f"Expected root workspace not to replicate workspace#parent@tenant for tenant {org_id}",
+            f"Expected root workspace to have workspace#tenant@tenant for tenant {org_id}",
         )
         self.assertEqual(
             1,


### PR DESCRIPTION
## Link(s) to Jira
[RHCLOUD-35482](https://redhat.atlassian.net/browse/RHCLOUD-35482)

## Description of Intent of Change(s)
Per the changes in https://github.com/RedHatInsights/rbac-config/pull/773, replicate `tenant` relation of root workspaces. (This will determining the tenant that a resource in a workspace belongs to.)

[RHCLOUD-35482]: https://redhat.atlassian.net/browse/RHCLOUD-35482?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Replicate tenant relationships for root workspaces and backfill existing data to align workspace–tenant–platform hierarchy with updated model.

New Features:
- Add a management command and internal migration to replicate tenant relations for all existing root workspaces.
- Introduce a new replication event type to propagate updated root workspace–tenant relations.

Bug Fixes:
- Ensure root workspaces explicitly store their tenant relation instead of relying solely on tenant–platform links.

Enhancements:
- Adjust tenant bootstrap hierarchy to create workspace–tenant and tenant–platform relations using the canonical tenant resource identifier.
- Extend inventory bootstrap checks to validate root workspace–tenant relations and update associated tests and tuple count expectations.

Tests:
- Add tests for the root workspace tenant replication migration and update existing bootstrap and inventory checker tests for the new hierarchy tuples.