### PR TITLE
[RHCLOUD-45039] Unify empty filter param handling across V2 list endpoints

### DIFF
--- a/rbac/management/role_binding/serializer.py
+++ b/rbac/management/role_binding/serializer.py
@@ -21,6 +21,7 @@ This module contains:
 - Output serializers: For serializing response data
 """
 
+import uuid
 from typing import Optional
 
 from management.models import Group
@@ -64,6 +65,24 @@ class RoleBindingBySubjectFieldSelection(FieldSelection):
     }
 
 
+def _normalize_blank_or_none(value: str | None) -> str | None:
+    """Return None for empty/blank values, pass through otherwise."""
+    return value or None
+
+
+def _normalize_uuid_or_none(value: str | None) -> uuid.UUID | None:
+    """Return None for empty/blank values, validate and return UUID otherwise.
+
+    Raises serializers.ValidationError for non-empty, non-UUID strings.
+    """
+    if not value or not value.strip():
+        return None
+    try:
+        return uuid.UUID(value.strip())
+    except ValueError as e:
+        raise serializers.ValidationError("Enter a valid UUID.") from e
+
+
 def _validate_resource_identifiers(attrs: dict) -> None:
     """Validate resource.tenant.org_id vs resource_id/resource_type mutual exclusivity.
 
@@ -86,17 +105,9 @@ def _validate_resource_identifiers(attrs: dict) -> None:
             raise serializers.ValidationError(
                 {"resource_id": "resource_id is required (or use resource.tenant.org_id)."}
             )
-        if not resource_id.strip():
-            raise serializers.ValidationError(
-                {"resource_id": "resource_id is required to identify the resource for role bindings."}
-            )
         if not resource_type:
             raise serializers.ValidationError(
                 {"resource_type": "resource_type is required (or use resource.tenant.org_id)."}
-            )
-        if not resource_type.strip():
-            raise serializers.ValidationError(
-                {"resource_type": "resource_type is required to specify the type of resource (e.g., 'workspace')."}
             )
 
 
@@ -157,36 +168,63 @@ class RoleBindingListInputSerializer(RoleBindingInputSerializerMixin, serializer
         "granted_subject.principal.user_id": "granted_subject_principal_user_id",
     }
 
-    role_id = serializers.UUIDField(required=False, help_text="Filter by role ID")
-    resource_id = serializers.CharField(required=False, max_length=256, help_text="Filter by resource ID")
-    resource_type = serializers.CharField(required=False, help_text="Filter by resource type")
+    role_id = serializers.CharField(required=False, allow_blank=True, help_text="Filter by role ID")
+    resource_id = serializers.CharField(
+        required=False, allow_blank=True, max_length=256, help_text="Filter by resource ID"
+    )
+    resource_type = serializers.CharField(required=False, allow_blank=True, help_text="Filter by resource type")
     resource_tenant_org_id = serializers.CharField(
         required=False,
+        allow_blank=True,
         help_text="Org ID of the tenant resource to filter by",
     )
-    subject_type = serializers.CharField(required=False, help_text="Filter by subject type")
-    subject_id = serializers.UUIDField(required=False, help_text="Filter by subject ID")
+    subject_type = serializers.CharField(required=False, allow_blank=True, help_text="Filter by subject type")
+    subject_id = serializers.CharField(required=False, allow_blank=True, help_text="Filter by subject ID")
     granted_subject_type = serializers.CharField(
         required=False,
+        allow_blank=True,
         help_text="Filter by the type of subject effectively granted access ('user', 'group', or 'principal')",
     )
     granted_subject_id = serializers.CharField(
         required=False,
+        allow_blank=True,
         help_text=("ID effectively granted access: for 'user', principal UUID or user_id; for 'group', group UUID"),
     )
     granted_subject_principal_user_id = serializers.CharField(
         required=False,
+        allow_blank=True,
         help_text="External user ID of the principal effectively granted access",
     )
-    fields = serializers.CharField(required=False, help_text="Control which fields are included")
-    order_by = serializers.CharField(required=False, help_text="Sort by specified field(s)")
+    fields = serializers.CharField(required=False, allow_blank=True, help_text="Control which fields are included")
+    order_by = serializers.CharField(required=False, allow_blank=True, help_text="Sort by specified field(s)")
     exclude_sources = serializers.ChoiceField(
         choices=ExcludeSources.values,
         required=False,
+        allow_blank=True,
         default=ExcludeSources.NONE,
         help_text="Exclude bindings: 'none' (default) shows all, 'indirect' hides inherited, 'direct' hides direct. "
         "Requires both resource_id and resource_type to be specified for inherited binding lookups.",
     )
+
+    def validate_role_id(self, value: str | None) -> uuid.UUID | None:
+        """Return None for empty values, validate UUID format otherwise."""
+        return _normalize_uuid_or_none(value)
+
+    def validate_subject_id(self, value: str | None) -> uuid.UUID | None:
+        """Return None for empty values, validate UUID format otherwise."""
+        return _normalize_uuid_or_none(value)
+
+    validate_resource_id = staticmethod(_normalize_blank_or_none)
+    validate_resource_type = staticmethod(_normalize_blank_or_none)
+    validate_resource_tenant_org_id = staticmethod(_normalize_blank_or_none)
+    validate_subject_type = staticmethod(_normalize_blank_or_none)
+    validate_granted_subject_type = staticmethod(_normalize_blank_or_none)
+    validate_granted_subject_id = staticmethod(_normalize_blank_or_none)
+    validate_granted_subject_principal_user_id = staticmethod(_normalize_blank_or_none)
+
+    def validate_exclude_sources(self, value):
+        """Map empty string to the default (none = show all)."""
+        return ExcludeSources.NONE if not value else value
 
     def validate(self, attrs):
         """Cross-field validation for exclude_sources, granted_subject, resource, and subject params."""
@@ -277,10 +315,11 @@ class RoleBindingInputSerializer(RoleBindingInputSerializerMixin, serializers.Se
         "resource.tenant.org_id": "resource_tenant_org_id",
     }
 
-    resource_id = serializers.CharField(required=False, help_text="Filter by resource ID")
-    resource_type = serializers.CharField(required=False, help_text="Filter by resource type")
+    resource_id = serializers.CharField(required=False, allow_blank=True, help_text="Filter by resource ID")
+    resource_type = serializers.CharField(required=False, allow_blank=True, help_text="Filter by resource type")
     resource_tenant_org_id = serializers.CharField(
         required=False,
+        allow_blank=True,
         help_text="Org ID of the tenant resource to filter by",
     )
     subject_type = serializers.CharField(required=False, allow_blank=True, help_text="Filter by subject type")
@@ -294,19 +333,17 @@ class RoleBindingInputSerializer(RoleBindingInputSerializerMixin, serializers.Se
         help_text="Exclude bindings: 'none' (default) shows all, 'indirect' hides inherited, 'direct' hides direct",
     )
 
+    validate_resource_id = staticmethod(_normalize_blank_or_none)
+    validate_resource_type = staticmethod(_normalize_blank_or_none)
+    validate_resource_tenant_org_id = staticmethod(_normalize_blank_or_none)
+    validate_subject_type = staticmethod(_normalize_blank_or_none)
+    validate_subject_id = staticmethod(_normalize_blank_or_none)
+
     def validate(self, attrs):
         """Cross-field validation for resource params."""
         attrs = super().validate(attrs)
         _validate_resource_identifiers(attrs)
         return attrs
-
-    def validate_subject_type(self, value):
-        """Return None for empty values."""
-        return value or None
-
-    def validate_subject_id(self, value):
-        """Return None for empty values."""
-        return value or None
 
     def validate_fields(self, value):
         """Parse and validate fields parameter using by-subject selection."""
@@ -1073,10 +1110,15 @@ class UpdateRoleBindingRequestSerializer(RoleBindingInputSerializerMixin, serial
     DEFAULT_FIELDS = "resource(id),subject(id,type),roles(id)"
 
     # Query parameters
-    resource_id = serializers.CharField(required=False, help_text="Resource ID to update bindings for")
-    resource_type = serializers.CharField(required=False, help_text="Resource type (e.g., 'workspace')")
+    resource_id = serializers.CharField(
+        required=False, allow_blank=True, help_text="Resource ID to update bindings for"
+    )
+    resource_type = serializers.CharField(
+        required=False, allow_blank=True, help_text="Resource type (e.g., 'workspace')"
+    )
     resource_tenant_org_id = serializers.CharField(
         required=False,
+        allow_blank=True,
         help_text="Org ID of the tenant resource to update bindings for",
     )
     subject_id = serializers.CharField(required=True, help_text="Subject ID (UUID)")
@@ -1087,6 +1129,10 @@ class UpdateRoleBindingRequestSerializer(RoleBindingInputSerializerMixin, serial
 
     # Request body
     roles = RoleIdSerializer(many=True, required=True, help_text="Roles to assign")
+
+    validate_resource_id = staticmethod(_normalize_blank_or_none)
+    validate_resource_type = staticmethod(_normalize_blank_or_none)
+    validate_resource_tenant_org_id = staticmethod(_normalize_blank_or_none)
 
     def validate_fields(self, value):
         """Parse and validate fields parameter using by-subject selection."""

--- a/rbac/management/workspace/serializer.py
+++ b/rbac/management/workspace/serializer.py
@@ -18,6 +18,7 @@
 """Serializer for workspace management."""
 
 import re
+import uuid
 
 from management.workspace.service import WorkspaceService
 from rest_framework import serializers
@@ -25,6 +26,79 @@ from rest_framework import serializers
 from .model import Workspace
 
 WORKSPACE_NAME_REGEX = re.compile(r"^[\w\s-]+$")
+
+_ALL_TYPE = "all"
+_VALID_TYPES = [v.lower() for v in Workspace.Types.values] + [_ALL_TYPE]
+
+
+class WorkspaceListInputSerializer(serializers.Serializer):
+    """Input serializer for workspace list query parameters.
+
+    GET /v2/workspaces/
+    """
+
+    type = serializers.CharField(required=False, allow_blank=True, help_text="Filter by workspace type")
+    name = serializers.CharField(required=False, allow_blank=True, help_text="Filter by workspace name")
+    parent_id = serializers.CharField(required=False, allow_blank=True, help_text="Filter by parent workspace ID")
+    ids = serializers.CharField(required=False, allow_blank=True, help_text="Filter by comma-separated workspace IDs")
+
+    def to_internal_value(self, data):
+        """Reject NUL bytes in query parameters."""
+        for key, value in data.items():
+            if isinstance(value, str) and "\x00" in value:
+                raise serializers.ValidationError({key: f"The '{key}' query parameter contains invalid characters."})
+        return super().to_internal_value(data)
+
+    def validate_type(self, value: str | None) -> list[str] | None:
+        """Normalize empty to None, split comma-separated values, validate against allowed types."""
+        if not value or not value.strip():
+            return None
+        fields = [v.strip().lower() for v in value.split(",") if v.strip()]
+        if not fields:
+            return None
+        for val in fields:
+            if val not in _VALID_TYPES:
+                raise serializers.ValidationError(
+                    f"type query parameter value '{val}' is invalid. "
+                    f"Allowed values are {[str(v) for v in _VALID_TYPES]}."
+                )
+        if _ALL_TYPE in fields:
+            return None
+        return fields
+
+    def validate_name(self, value: str | None) -> str | None:
+        """Return None for empty values."""
+        if not value or not value.strip():
+            return None
+        return value
+
+    def validate_parent_id(self, value: str | None) -> str | None:
+        """Return None for empty values, validate UUID format otherwise."""
+        if not value or not value.strip():
+            return None
+        try:
+            uuid.UUID(value.strip())
+        except ValueError as e:
+            raise serializers.ValidationError(f"{value} is not a valid UUID.") from e
+        return value.strip()
+
+    def validate_ids(self, value: str | None) -> list[str] | None:
+        """Return None for empty values, split and validate UUIDs otherwise."""
+        if not value or not value.strip():
+            return None
+        ids = list(dict.fromkeys(stripped for id_val in value.split(",") if (stripped := id_val.strip().lower())))
+        for workspace_id in ids:
+            try:
+                uuid.UUID(workspace_id)
+            except ValueError as e:
+                raise serializers.ValidationError(f"{workspace_id} is not a valid UUID.") from e
+        return ids
+
+    def validate(self, data):
+        """Cross-field validation: ids without explicit type defaults to standard."""
+        if data.get("ids") is not None and "type" not in self.initial_data:
+            data["type"] = [Workspace.Types.STANDARD]
+        return data
 
 
 class WorkspaceSerializer(serializers.ModelSerializer):

--- a/rbac/management/workspace/service.py
+++ b/rbac/management/workspace/service.py
@@ -353,6 +353,23 @@ class WorkspaceService:
 
         self._replicator = replicator
 
+    def list(self, queryset, params: dict):
+        """Apply parameter-based filters to a pre-filtered workspace queryset."""
+        ids = params.get("ids")
+        type_filter = params.get("type")
+        name = params.get("name")
+        parent_id = params.get("parent_id")
+
+        if ids:
+            queryset = queryset.filter(id__in=ids)
+        if type_filter:
+            queryset = queryset.filter(type__in=type_filter)
+        if name:
+            queryset = queryset.filter(name__icontains=name)
+        if parent_id:
+            queryset = queryset.filter(parent_id=parent_id)
+        return queryset
+
     def _dual_write_handler(
         self, workspace: Workspace, event_type: ReplicationEventType
     ) -> RelationApiDualWriteWorkspaceHandler:

--- a/rbac/management/workspace/view.py
+++ b/rbac/management/workspace/view.py
@@ -28,7 +28,7 @@ from management.audit_log.model import AuditLog
 from management.base_viewsets import BaseV2ViewSet
 from management.filters import ValidatedOrderingFilter
 from management.permissions.workspace_access import WorkspaceAccessPermission
-from management.utils import clean_query_param, validate_and_get_key, validate_and_get_key_multi
+from management.utils import validate_and_get_key
 from management.workspace.filters import WorkspaceAccessFilterBackend, WorkspaceObjectAccessMixin
 from management.workspace.service import WorkspaceService
 from psycopg2.errors import DeadlockDetected, SerializationFailure
@@ -40,7 +40,7 @@ from rest_framework.response import Response
 
 from api.common.pagination import V2ResultsSetPagination
 from .model import Workspace
-from .serializer import WorkspaceSerializer, WorkspaceWithAncestrySerializer
+from .serializer import WorkspaceListInputSerializer, WorkspaceSerializer, WorkspaceWithAncestrySerializer
 from ..utils import flatten_validation_error, validate_uuid
 
 INCLUDE_ANCESTRY_KEY = "include_ancestry"
@@ -180,59 +180,15 @@ class WorkspaceViewSet(WorkspaceObjectAccessMixin, BaseV2ViewSet):
 
         Access filtering is handled by WorkspaceAccessFilterBackend.
         Ordering is handled by OrderingFilter (supports ?order_by=name or ?order_by=-name).
-        This method only handles additional query parameter filtering.
-
-        The ``type`` query parameter supports comma-separated values so that
-        callers can request multiple workspace types in a single request, e.g.
-        ``?type=standard,ungrouped-hosts``.
+        Domain filters (type, name, parent_id, ids) are validated by
+        WorkspaceListInputSerializer and applied by WorkspaceService.list().
         """
-        all_types = "all"
-        valid_types = [v.lower() for v in Workspace.Types.values] + [all_types]
-        # Use filter_queryset to apply all filter backends (including access filtering and ordering)
+        input_serializer = WorkspaceListInputSerializer(data=request.query_params)
+        input_serializer.is_valid(raise_exception=True)
+        validated_params = input_serializer.validated_data
+
         queryset = self.filter_queryset(self.get_queryset())
-
-        # Sanitize the raw type parameter for NUL bytes (consistent with name/parent_id/ids)
-        type_raw = clean_query_param(request.query_params.get("type"), "type")
-
-        # Support comma-separated type values (e.g. "standard,ungrouped-hosts")
-        type_fields = validate_and_get_key_multi(
-            {"type": type_raw} if type_raw is not None else {},
-            "type",
-            valid_types,
-            default_value=all_types,
-        )
-        # Collapse: if "all" is among the values, treat as unfiltered
-        if all_types in type_fields:
-            type_fields = [all_types]
-
-        name = clean_query_param(request.query_params.get("name"), "name")
-        parent_id = clean_query_param(request.query_params.get("parent_id"), "parent_id")
-        id_filter = clean_query_param(request.query_params.get("ids"), "ids")
-
-        # Validate parent_id is a valid UUID
-        if parent_id is not None:
-            validate_uuid(parent_id, "parent_id")
-
-        # Validate and filter by ids parameter (comma-separated list of UUIDs)
-        if id_filter is not None:
-            ids = list(
-                dict.fromkeys(stripped for id_val in id_filter.split(",") if (stripped := id_val.strip().lower()))
-            )
-
-            for workspace_id in ids:
-                validate_uuid(workspace_id, "workspace id filter")
-            queryset = queryset.filter(id__in=ids)
-
-            # When filtering by ids, default to standard type unless type is explicitly specified
-            if "type" not in request.query_params:
-                type_fields = [Workspace.Types.STANDARD]
-
-        if type_fields != [all_types]:
-            queryset = queryset.filter(type__in=type_fields)
-        if name:
-            queryset = queryset.filter(name__icontains=name)
-        if parent_id:
-            queryset = queryset.filter(parent_id=parent_id)
+        queryset = self._service.list(queryset, validated_params)
 
         page = self.paginate_queryset(queryset)
         serializer = self.get_serializer(page, many=True)

--- a/tests/management/role_binding/test_serializer.py
+++ b/tests/management/role_binding/test_serializer.py
@@ -30,13 +30,14 @@ from management.role_binding.serializer import (
     RoleBindingByGroupSerializer,
     RoleBindingBySubjectFieldSelection,
     RoleBindingFieldSelection,
+    RoleBindingInputSerializer,
     RoleBindingListInputSerializer,
     RoleBindingListOutputSerializer,
     RoleBindingOutputSerializer,
     UpdateRoleBindingRequestSerializer,
     UpdateRoleBindingResponseSerializer,
 )
-from management.role_binding.service import UpdateRoleBindingResult
+from management.role_binding.service import ExcludeSources, UpdateRoleBindingResult
 from management.subject.model import SubjectType
 from management.utils import FieldSelection
 from tests.identity_request import IdentityRequest
@@ -777,14 +778,20 @@ class RoleBindingListInputSerializerTest(TestCase):
         invalid_values = [
             ("not-a-uuid", "not-a-uuid"),
             ("integer", "12345"),
-            ("empty", ""),
-            ("spaces", "   "),
         ]
         for label, value in invalid_values:
             with self.subTest(label=label):
                 s = RoleBindingListInputSerializer(data={"role_id": value})
                 self.assertFalse(s.is_valid())
                 self.assertIn("role_id", s.errors)
+
+    def test_role_id_empty_returns_none(self):
+        """Test that empty string for role_id is treated as unset."""
+        for label, value in [("empty", ""), ("spaces", "   ")]:
+            with self.subTest(label=label):
+                s = RoleBindingListInputSerializer(data={"role_id": value})
+                self.assertTrue(s.is_valid(), s.errors)
+                self.assertIsNone(s.validated_data["role_id"])
 
     def test_role_id_omitted_is_valid(self):
         """Test that omitting role_id is valid (required=False)."""
@@ -867,11 +874,11 @@ class RoleBindingListInputSerializerTest(TestCase):
                 self.assertTrue(s.is_valid(), s.errors)
                 self.assertEqual(s.validated_data["resource_id"], value)
 
-    def test_resource_id_rejects_empty(self):
-        """Test that empty string is rejected for resource_id."""
+    def test_resource_id_empty_returns_none(self):
+        """Test that empty string for resource_id is treated as unset."""
         s = RoleBindingListInputSerializer(data={"resource_id": ""})
-        self.assertFalse(s.is_valid())
-        self.assertIn("resource_id", s.errors)
+        self.assertTrue(s.is_valid(), s.errors)
+        self.assertIsNone(s.validated_data["resource_id"])
 
     def test_resource_id_omitted_is_valid(self):
         """Test that omitting resource_id is valid (required=False)."""
@@ -955,14 +962,20 @@ class RoleBindingListInputSerializerTest(TestCase):
         invalid_values = [
             ("not-a-uuid", "not-a-uuid"),
             ("integer", "12345"),
-            ("empty", ""),
-            ("spaces", "   "),
         ]
         for label, value in invalid_values:
             with self.subTest(label=label):
                 s = RoleBindingListInputSerializer(data={"subject_id": value})
                 self.assertFalse(s.is_valid())
                 self.assertIn("subject_id", s.errors)
+
+    def test_subject_id_empty_returns_none(self):
+        """Test that empty string for subject_id is treated as unset."""
+        for label, value in [("empty", ""), ("spaces", "   ")]:
+            with self.subTest(label=label):
+                s = RoleBindingListInputSerializer(data={"subject_id": value})
+                self.assertTrue(s.is_valid(), s.errors)
+                self.assertIsNone(s.validated_data["subject_id"])
 
     def test_subject_id_omitted_is_valid(self):
         """Test that omitting subject_id is valid (required=False)."""
@@ -1004,6 +1017,65 @@ class RoleBindingListInputSerializerTest(TestCase):
         valid_uuid = "550e8400-e29b-41d4-a716-446655440000"
         s = RoleBindingListInputSerializer(data={"subject_id": f"\x00{valid_uuid}\x00"})
         self.assertTrue(s.is_valid(), s.errors)
+
+    # --- empty string normalization (all optional filter params) ---
+
+    def test_all_empty_filter_params_valid(self):
+        """Test that all filter params as empty strings produce valid result with None values."""
+        s = RoleBindingListInputSerializer(
+            data={
+                "role_id": "",
+                "resource_id": "",
+                "resource_type": "",
+                "subject_type": "",
+                "subject_id": "",
+                "granted_subject_type": "",
+                "granted_subject_id": "",
+                "fields": "",
+                "order_by": "",
+                "exclude_sources": "",
+            }
+        )
+        self.assertTrue(s.is_valid(), s.errors)
+        for field in [
+            "role_id",
+            "resource_id",
+            "resource_type",
+            "subject_type",
+            "subject_id",
+            "granted_subject_type",
+            "granted_subject_id",
+            "fields",
+            "order_by",
+        ]:
+            self.assertIsNone(s.validated_data[field], f"{field} should be None for empty string")
+        self.assertEqual(
+            s.validated_data["exclude_sources"], ExcludeSources.NONE, "exclude_sources should default to 'none'"
+        )
+
+    def test_resource_type_empty_returns_none(self):
+        """Test that empty string for resource_type is treated as unset."""
+        s = RoleBindingListInputSerializer(data={"resource_type": ""})
+        self.assertTrue(s.is_valid(), s.errors)
+        self.assertIsNone(s.validated_data["resource_type"])
+
+    def test_subject_type_empty_returns_none(self):
+        """Test that empty string for subject_type is treated as unset."""
+        s = RoleBindingListInputSerializer(data={"subject_type": ""})
+        self.assertTrue(s.is_valid(), s.errors)
+        self.assertIsNone(s.validated_data["subject_type"])
+
+    def test_granted_subject_type_empty_returns_none(self):
+        """Test that empty string for granted_subject_type is treated as unset."""
+        s = RoleBindingListInputSerializer(data={"granted_subject_type": ""})
+        self.assertTrue(s.is_valid(), s.errors)
+        self.assertIsNone(s.validated_data["granted_subject_type"])
+
+    def test_granted_subject_id_empty_returns_none(self):
+        """Test that empty string for granted_subject_id is treated as unset."""
+        s = RoleBindingListInputSerializer(data={"granted_subject_id": ""})
+        self.assertTrue(s.is_valid(), s.errors)
+        self.assertIsNone(s.validated_data["granted_subject_id"])
 
     # --- granted_subject_type ---
 
@@ -1239,6 +1311,49 @@ class RoleBindingListInputSerializerTest(TestCase):
         self.assertIn("granted_subject_type", s.validated_data)
         self.assertIn("granted_subject_id", s.validated_data)
         self.assertIn("role_id", s.validated_data)
+
+
+class RoleBindingInputSerializerTest(TestCase):
+    """Test the RoleBindingInputSerializer (by-subject endpoint).
+
+    Validates empty-as-unset normalization for query parameters
+    on GET /role-bindings/by-subject/.
+    """
+
+    def test_resource_id_empty_triggers_cross_field_error(self):
+        """Test that empty resource_id is normalized to None, triggering cross-field validation."""
+        s = RoleBindingInputSerializer(data={"resource_id": "", "resource_type": "workspace"})
+        self.assertFalse(s.is_valid())
+        self.assertIn("resource_id", s.errors)
+
+    def test_resource_type_empty_triggers_cross_field_error(self):
+        """Test that empty resource_type is normalized to None, triggering cross-field validation."""
+        s = RoleBindingInputSerializer(data={"resource_id": "test-id", "resource_type": ""})
+        self.assertFalse(s.is_valid())
+        self.assertIn("resource_type", s.errors)
+
+    def test_resource_tenant_org_id_empty_returns_none(self):
+        """Test that empty resource.tenant.org_id is normalized to None (falls through to resource_id check)."""
+        s = RoleBindingInputSerializer(
+            data={"resource.tenant.org_id": "", "resource_id": "test-id", "resource_type": "workspace"}
+        )
+        self.assertTrue(s.is_valid(), s.errors)
+        self.assertIsNone(s.validated_data.get("resource_tenant_org_id"))
+
+    def test_subject_type_empty_returns_none(self):
+        """Test that empty subject_type is normalized to None."""
+        s = RoleBindingInputSerializer(
+            data={"resource_id": "test-id", "resource_type": "workspace", "subject_type": ""}
+        )
+        self.assertTrue(s.is_valid(), s.errors)
+        self.assertIsNone(s.validated_data.get("subject_type"))
+
+    def test_valid_resource_params_pass_through(self):
+        """Test that valid resource params are not modified."""
+        s = RoleBindingInputSerializer(data={"resource_id": "test-id", "resource_type": "workspace"})
+        self.assertTrue(s.is_valid(), s.errors)
+        self.assertEqual(s.validated_data["resource_id"], "test-id")
+        self.assertEqual(s.validated_data["resource_type"], "workspace")
 
 
 class RoleBindingListOutputSerializerTest(IdentityRequest):
@@ -1938,6 +2053,30 @@ class UpdateRoleBindingRequestSerializerTests(IdentityRequest):
         self.assertFalse(s.is_valid())
         self.assertIn("resource_type must be 'tenant'", str(s.errors))
 
+    # ── Empty resource_* normalization ────────────────────────────────
+
+    def test_resource_id_empty_triggers_cross_field_error(self):
+        """Test that empty resource_id is normalized to None, triggering cross-field validation."""
+        data = self._make_valid_data(resource_id="")
+        s = UpdateRoleBindingRequestSerializer(data=data)
+        self.assertFalse(s.is_valid())
+        self.assertIn("resource_id", s.errors)
+
+    def test_resource_type_empty_triggers_cross_field_error(self):
+        """Test that empty resource_type is normalized to None, triggering cross-field validation."""
+        data = self._make_valid_data(resource_type="")
+        s = UpdateRoleBindingRequestSerializer(data=data)
+        self.assertFalse(s.is_valid())
+        self.assertIn("resource_type", s.errors)
+
+    def test_resource_tenant_org_id_empty_returns_none(self):
+        """Test that empty resource.tenant.org_id is normalized to None."""
+        data = self._make_valid_data()
+        data["resource.tenant.org_id"] = ""
+        s = UpdateRoleBindingRequestSerializer(data=data)
+        self.assertTrue(s.is_valid(), s.errors)
+        self.assertIsNone(s.validated_data.get("resource_tenant_org_id"))
+
     # ── Missing required fields (parameterized) ──────────────────────
 
     def test_missing_required_field_returns_error(self):
@@ -2006,6 +2145,30 @@ class UpdateRoleBindingRequestSerializerTests(IdentityRequest):
                 if expected_msg:
                     error_messages = str(serializer.errors[error_field])
                     self.assertIn(expected_msg, error_messages, f"Expected message for: {description}")
+
+    # ── Empty string normalization ─────────────────────────────────
+
+    def test_empty_resource_id_treated_as_unset(self):
+        """Test that empty resource_id is normalized to None, triggering cross-field error."""
+        data = self._make_valid_data(resource_id="")
+        serializer = UpdateRoleBindingRequestSerializer(data=data)
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("resource_id", serializer.errors)
+
+    def test_empty_resource_type_treated_as_unset(self):
+        """Test that empty resource_type is normalized to None, triggering cross-field error."""
+        data = self._make_valid_data(resource_type="")
+        serializer = UpdateRoleBindingRequestSerializer(data=data)
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("resource_type", serializer.errors)
+
+    def test_empty_resource_tenant_org_id_treated_as_unset(self):
+        """Test that empty resource.tenant.org_id is normalized to None."""
+        data = self._make_valid_data()
+        data["resource.tenant.org_id"] = ""
+        serializer = UpdateRoleBindingRequestSerializer(data=data)
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        self.assertIsNone(serializer.validated_data.get("resource_tenant_org_id"))
 
     # ── NUL byte sanitization (parameterized) ────────────────────────
 

--- a/tests/management/workspace/test_serializer.py
+++ b/tests/management/workspace/test_serializer.py
@@ -14,6 +14,8 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
+import uuid
+
 from django.test import TestCase
 from unittest.mock import Mock
 from api.models import Tenant
@@ -21,6 +23,7 @@ from management.models import Workspace
 from rest_framework import serializers
 from management.workspace.serializer import (
     WorkspaceAncestrySerializer,
+    WorkspaceListInputSerializer,
     WorkspaceSerializer,
     WorkspaceWithAncestrySerializer,
 )
@@ -125,3 +128,201 @@ class WorkspaceSerializerTest(TestCase):
         self.child.name = "legacy@name"
         result = serializer.validate_name("legacy@name")
         self.assertEqual(result, "legacy@name")
+
+
+class WorkspaceListInputSerializerTest(TestCase):
+    """Test the WorkspaceListInputSerializer.
+
+    Validates query parameter parsing and normalization for
+    GET /v2/workspaces/.
+    """
+
+    # --- type ---
+
+    def test_type_empty_returns_none(self):
+        """Test that empty type is treated as unset (returns all)."""
+        s = WorkspaceListInputSerializer(data={"type": ""})
+        self.assertTrue(s.is_valid(), s.errors)
+        self.assertIsNone(s.validated_data.get("type"))
+
+    def test_type_omitted_returns_none(self):
+        """Test that omitting type is valid."""
+        s = WorkspaceListInputSerializer(data={})
+        self.assertTrue(s.is_valid(), s.errors)
+        self.assertIsNone(s.validated_data.get("type"))
+
+    def test_type_valid_single_value(self):
+        """Test that a valid single type value is accepted."""
+        s = WorkspaceListInputSerializer(data={"type": "standard"})
+        self.assertTrue(s.is_valid(), s.errors)
+        self.assertEqual(s.validated_data["type"], ["standard"])
+
+    def test_type_valid_comma_separated(self):
+        """Test that comma-separated type values are split and validated."""
+        s = WorkspaceListInputSerializer(data={"type": "standard,ungrouped-hosts"})
+        self.assertTrue(s.is_valid(), s.errors)
+        self.assertEqual(s.validated_data["type"], ["standard", "ungrouped-hosts"])
+
+    def test_type_case_insensitive(self):
+        """Test that type values are lowercased."""
+        s = WorkspaceListInputSerializer(data={"type": "STANDARD"})
+        self.assertTrue(s.is_valid(), s.errors)
+        self.assertEqual(s.validated_data["type"], ["standard"])
+
+    def test_type_all_returns_none(self):
+        """Test that type=all means unfiltered (None)."""
+        s = WorkspaceListInputSerializer(data={"type": "all"})
+        self.assertTrue(s.is_valid(), s.errors)
+        self.assertIsNone(s.validated_data.get("type"))
+
+    def test_type_all_in_comma_list_returns_none(self):
+        """Test that 'all' in a comma-separated list collapses to unfiltered."""
+        s = WorkspaceListInputSerializer(data={"type": "standard,all"})
+        self.assertTrue(s.is_valid(), s.errors)
+        self.assertIsNone(s.validated_data.get("type"))
+
+    def test_type_invalid_value(self):
+        """Test that an invalid type value is rejected."""
+        s = WorkspaceListInputSerializer(data={"type": "invalid"})
+        self.assertFalse(s.is_valid())
+        self.assertIn("type", s.errors)
+        message = str(s.errors["type"])
+        self.assertIn("invalid", message)
+        self.assertIn("allowed", message.lower())
+
+    def test_type_whitespace_only_returns_none(self):
+        """Test that whitespace-only type is treated as unset."""
+        s = WorkspaceListInputSerializer(data={"type": "   "})
+        self.assertTrue(s.is_valid(), s.errors)
+        self.assertIsNone(s.validated_data.get("type"))
+
+    # --- name ---
+
+    def test_name_empty_returns_none(self):
+        """Test that empty name is treated as unset."""
+        s = WorkspaceListInputSerializer(data={"name": ""})
+        self.assertTrue(s.is_valid(), s.errors)
+        self.assertIsNone(s.validated_data.get("name"))
+
+    def test_name_whitespace_returns_none(self):
+        """Test that whitespace-only name is treated as unset."""
+        s = WorkspaceListInputSerializer(data={"name": "   "})
+        self.assertTrue(s.is_valid(), s.errors)
+        self.assertIsNone(s.validated_data.get("name"))
+
+    def test_name_valid_passes_through(self):
+        """Test that a valid name passes through unchanged."""
+        s = WorkspaceListInputSerializer(data={"name": "test workspace"})
+        self.assertTrue(s.is_valid(), s.errors)
+        self.assertEqual(s.validated_data["name"], "test workspace")
+
+    # --- parent_id ---
+
+    def test_parent_id_empty_returns_none(self):
+        """Test that empty parent_id is treated as unset."""
+        s = WorkspaceListInputSerializer(data={"parent_id": ""})
+        self.assertTrue(s.is_valid(), s.errors)
+        self.assertIsNone(s.validated_data.get("parent_id"))
+
+    def test_parent_id_whitespace_returns_none(self):
+        """Test that whitespace-only parent_id is treated as unset."""
+        s = WorkspaceListInputSerializer(data={"parent_id": "   "})
+        self.assertTrue(s.is_valid(), s.errors)
+        self.assertIsNone(s.validated_data.get("parent_id"))
+
+    def test_parent_id_valid_uuid(self):
+        """Test that a valid UUID parent_id passes validation."""
+        test_uuid = str(uuid.uuid4())
+        s = WorkspaceListInputSerializer(data={"parent_id": test_uuid})
+        self.assertTrue(s.is_valid(), s.errors)
+        self.assertEqual(s.validated_data["parent_id"], test_uuid)
+
+    def test_parent_id_invalid_uuid(self):
+        """Test that an invalid UUID parent_id is rejected."""
+        s = WorkspaceListInputSerializer(data={"parent_id": "not-a-uuid"})
+        self.assertFalse(s.is_valid())
+        self.assertIn("parent_id", s.errors)
+
+    # --- ids ---
+
+    def test_ids_empty_returns_none(self):
+        """Test that empty ids is treated as unset."""
+        s = WorkspaceListInputSerializer(data={"ids": ""})
+        self.assertTrue(s.is_valid(), s.errors)
+        self.assertIsNone(s.validated_data.get("ids"))
+
+    def test_ids_whitespace_returns_none(self):
+        """Test that whitespace-only ids is treated as unset."""
+        s = WorkspaceListInputSerializer(data={"ids": "   "})
+        self.assertTrue(s.is_valid(), s.errors)
+        self.assertIsNone(s.validated_data.get("ids"))
+
+    def test_ids_single_valid_uuid(self):
+        """Test that a single valid UUID is accepted."""
+        test_uuid = str(uuid.uuid4())
+        s = WorkspaceListInputSerializer(data={"ids": test_uuid})
+        self.assertTrue(s.is_valid(), s.errors)
+        self.assertEqual(s.validated_data["ids"], [test_uuid])
+
+    def test_ids_comma_separated_valid(self):
+        """Test that comma-separated UUIDs are accepted and deduplicated."""
+        u1 = str(uuid.uuid4())
+        u2 = str(uuid.uuid4())
+        s = WorkspaceListInputSerializer(data={"ids": f"{u1},{u2},{u1}"})
+        self.assertTrue(s.is_valid(), s.errors)
+        self.assertEqual(len(s.validated_data["ids"]), 2)
+
+    def test_ids_invalid_uuid(self):
+        """Test that invalid UUIDs in ids are rejected."""
+        s = WorkspaceListInputSerializer(data={"ids": "not-a-uuid"})
+        self.assertFalse(s.is_valid())
+        self.assertIn("ids", s.errors)
+
+    # --- cross-field: ids + type ---
+
+    def test_ids_without_type_defaults_to_standard(self):
+        """Test that providing ids without type defaults type to standard."""
+        test_uuid = str(uuid.uuid4())
+        s = WorkspaceListInputSerializer(data={"ids": test_uuid})
+        self.assertTrue(s.is_valid(), s.errors)
+        self.assertEqual(s.validated_data["type"], [Workspace.Types.STANDARD])
+
+    def test_ids_with_explicit_type_keeps_type(self):
+        """Test that providing ids with explicit type preserves the type."""
+        test_uuid = str(uuid.uuid4())
+        s = WorkspaceListInputSerializer(data={"ids": test_uuid, "type": "root"})
+        self.assertTrue(s.is_valid(), s.errors)
+        self.assertEqual(s.validated_data["type"], ["root"])
+
+    def test_ids_with_type_all_keeps_none(self):
+        """Test that providing ids with type=all returns unfiltered."""
+        test_uuid = str(uuid.uuid4())
+        s = WorkspaceListInputSerializer(data={"ids": test_uuid, "type": "all"})
+        self.assertTrue(s.is_valid(), s.errors)
+        self.assertIsNone(s.validated_data.get("type"))
+
+    # --- NUL byte rejection ---
+
+    def test_nul_byte_in_type_returns_400(self):
+        """Test that NUL bytes in type are rejected."""
+        s = WorkspaceListInputSerializer(data={"type": "standard\x00evil"})
+        self.assertFalse(s.is_valid())
+        self.assertIn("type", s.errors)
+
+    def test_nul_byte_in_name_returns_400(self):
+        """Test that NUL bytes in name are rejected."""
+        s = WorkspaceListInputSerializer(data={"name": "test\x00evil"})
+        self.assertFalse(s.is_valid())
+        self.assertIn("name", s.errors)
+
+    def test_nul_byte_in_parent_id_returns_400(self):
+        """Test that NUL bytes in parent_id are rejected."""
+        s = WorkspaceListInputSerializer(data={"parent_id": "abc\x00def"})
+        self.assertFalse(s.is_valid())
+        self.assertIn("parent_id", s.errors)
+
+    def test_nul_byte_in_ids_returns_400(self):
+        """Test that NUL bytes in ids are rejected."""
+        s = WorkspaceListInputSerializer(data={"ids": "abc\x00def"})
+        self.assertFalse(s.is_valid())
+        self.assertIn("ids", s.errors)


### PR DESCRIPTION
## Link(s) to Jira
- [RHCLOUD-45039](https://issues.redhat.com/browse/RHCLOUD-45039)

## Description of Intent of Change(s)

**Problem:** V2 list endpoints handle empty query parameters (`?name=`, `?resource_type=`) inconsistently:
- Roles V2 list: treats empty as unset (skip filter) -- this is the reference pattern
- RoleBinding list: returns 400 on empty string
- RoleBinding by-subject: mixed behavior (some fields allow blank, others don't)
- Workspace list: correct behavior but uses raw view-level parsing instead of the serializer+service pattern

**Decision (confirmed with Sneha and Jay):** Empty string at field level = treat as unset (skip the filter) for all optional filter params. Conditionally required params continue to enforce requirements in cross-field `validate()`.

### What changed

**Role binding serializers:**
- Added `allow_blank=True` + `validate_<field>` normalizers to all optional filter fields in `RoleBindingListInputSerializer`, `RoleBindingInputSerializer` (by-subject), and `UpdateRoleBindingRequestSerializer`
- Converted `role_id` and `subject_id` from `UUIDField` to `CharField` with manual UUID validation (consistent with `RoleV2ListSerializer.validate_resource_id` pattern)
- Removed redundant `.strip()` checks in `_validate_resource_identifiers` that would crash on `None` after normalization

**Workspace list refactor:**
- Created `WorkspaceListInputSerializer` with empty-string normalization, NUL byte rejection, comma-separated type parsing, UUID validation for `parent_id`/`ids`, and cross-field defaulting (ids without explicit type defaults to standard)
- Added `WorkspaceService.list()` method for domain filtering
- Simplified `WorkspaceViewSet.list()` from ~60 lines of inline parsing to a clean serializer+service call

### Breaking change

RoleBinding list (`GET /api/rbac/v2/role_bindings/`) will stop returning 400 for empty filter params like `?role_id=` or `?resource_type=`. Empty params are now treated as unset (no filter applied), matching the Roles V2 behavior.

## Local Testing

```bash
# Run targeted tests
pipenv run tox -e py312-fast -- tests.management.role_binding.test_serializer tests.management.workspace.test_serializer tests.management.workspace.test_view

# Run full suite
DJANGO_LOG_LEVEL=CRITICAL RBAC_LOG_LEVEL=CRITICAL pipenv run tox -e py312-fast
```

All 3491 tests pass, lint passes.

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [x] are there any pre/post merge actions required?
- [x] are these changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [x] does this require migration changes? No
- [ ] is there known, direct impact to dependent teams/components?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices

[RHCLOUD-45039]: https://redhat.atlassian.net/browse/RHCLOUD-45039?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Unify handling of empty string query parameters for V2 role binding and workspace list endpoints so that empty optional filters are treated as unset, and refactor workspace list filtering into a dedicated serializer and service layer.

New Features:
- Introduce WorkspaceListInputSerializer to validate and normalize workspace list query parameters, including type, name, parent_id, and ids.
- Add WorkspaceService.list() to encapsulate domain-level filtering for workspace queries.

Enhancements:
- Normalize optional role binding filter parameters across list, by-subject, and update serializers so empty strings are treated as unset while preserving cross-field validation rules.
- Refactor the workspace list view to delegate query parameter parsing and filtering to the new serializer and WorkspaceService method, simplifying the view logic.

Tests:
- Add comprehensive serializer tests for WorkspaceListInputSerializer covering type parsing, UUID validation, cross-field defaults, and NUL-byte rejection.
- Extend role binding serializer tests to cover empty-as-unset normalization and related cross-field validation behavior across list, by-subject, and update serializers.