### PR TITLE
Update grafana dashboard with RBAC Consumer Queries PT 2

### DIFF
--- a/dashboards/grafana-dashboard-insights-rbac-operations.configmap.yaml
+++ b/dashboards/grafana-dashboard-insights-rbac-operations.configmap.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 data:
-  rbac-grafana-latest.json: |-
+  rbac-grafana.json: |-
     {
       "annotations": {
         "list": [

--- a/dashboards/grafana-dashboard-insights-rbac-operations.configmap.yaml
+++ b/dashboards/grafana-dashboard-insights-rbac-operations.configmap.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 data:
-  rbac-grafana-stage.json: |-
+  rbac-grafana-latest.json: |-
     {
       "annotations": {
         "list": [
@@ -27,7 +27,7 @@ data:
       "editable": true,
       "fiscalYearStartMonth": 0,
       "graphTooltip": 0,
-      "id": 1025919,
+      "id": 1102525,
       "links": [],
       "panels": [
         {
@@ -517,13 +517,13 @@ data:
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "histogram_quantile(0.95, rate(rbac_replication_event_latency_seconds_bucket[5m])) ",
+              "expr": "histogram_quantile(0.95, sum(rate(rbac_replication_event_latency_seconds_bucket[5m])) by (le,event_type))",
               "legendFormat": "__auto",
               "range": true,
               "refId": "A"
             }
           ],
-          "title": "95th Percentile Latency ",
+          "title": "95th Percentile Latency By Event Type",
           "type": "timeseries"
         },
         {
@@ -4535,7 +4535,7 @@ data:
       "timezone": "",
       "title": "Operations - Rbac w/CPU",
       "uid": "TjP_nMWMk",
-      "version": 14
+      "version": 15
     }
 kind: ConfigMap
 metadata:


### PR DESCRIPTION
Creating this PR based off of the comments made on this PR: https://github.com/RedHatInsights/insights-rbac/pull/2878#issuecomment-4449216975

Updating the query of a specific stage panel

## Summary by Sourcery

Update the RBAC operations Grafana dashboard config to point to the latest dashboard definition and refine a latency panel.

Enhancements:
- Rename the embedded RBAC Grafana dashboard JSON from the stage variant to the latest variant and update its ID and version metadata.
- Adjust the 95th percentile replication event latency panel to aggregate latency by event type and update its title to reflect the new breakdown.