### PR TITLE
[RHCLOUD-48138] Add listen and notify for migration

### DIFF
--- a/rbac/core/kafka_consumer.py
+++ b/rbac/core/kafka_consumer.py
@@ -30,11 +30,13 @@ import grpc
 from django.conf import settings
 from django.db import connection
 from google.protobuf import json_format
+from internal.pg_notify_wait import REMOVE_LEGACY_ROOT_WORKSPACE_PARENT_NOTIFY_CHANNEL
 from kafka import KafkaConsumer, TopicPartition
 from kafka.consumer.subscription_state import ConsumerRebalanceListener
 from kafka.errors import KafkaError
 from kafka.structs import OffsetAndMetadata
 from kessel.relations.v1beta1 import common_pb2
+from management.relation_replicator.relation_replicator import ReplicationEventType
 from management.relation_replicator.relations_api_replicator import (
     RelationsApiReplicator,
 )
@@ -714,6 +716,19 @@ class RebalanceListener(ConsumerRebalanceListener):
             logger.warning("on_partitions_assigned called with empty partition list")
 
 
+def _send_pg_notify_best_effort(channel: str, payload: str, description: str) -> None:
+    """Send PostgreSQL NOTIFY after successful side effects. Errors are logged only; they do not fail replication."""
+    try:
+        notify_sql = sql.SQL("NOTIFY {}, %s").format(sql.Identifier(channel))
+        with connection.cursor() as cursor:
+            # nosemgrep: python.sqlalchemy.security.sqlalchemy-execute-raw-query
+            # Safe: psycopg2.sql.SQL with Identifier(channel); payload is parameterized.
+            cursor.execute(notify_sql, [payload])
+        logger.info("Sent NOTIFY on channel '%s' (%s)", channel, description)
+    except Exception as e:
+        logger.error("Failed NOTIFY on channel '%s' (%s): %s", channel, description, e)
+
+
 class RBACKafkaConsumer:
     """RBAC Kafka consumer for processing Debezium and replication messages."""
 
@@ -1357,23 +1372,21 @@ class RBACKafkaConsumer:
                     resource_id,
                     token,
                 )
-                try:
-                    notify_channel = settings.READ_YOUR_WRITES_CHANNEL
-                    notify_sql = sql.SQL("NOTIFY {}, %s").format(sql.Identifier(notify_channel))
-                    with connection.cursor() as cursor:
-                        # nosemgrep: python.sqlalchemy.security.sqlalchemy-execute-raw-query
-                        # Safe: Using psycopg2.sql.SQL with sql.Identifier for channel name
-                        # and parameterized query (%s) for resource_id
-                        cursor.execute(notify_sql, [resource_id])
-                    logger.info(
-                        f"Sent NOTIFY on channel '{notify_channel}' for workspace_id '{resource_id}' "
-                        f"after successful replication"
-                    )
-                except Exception as e:
-                    # Log error but don't fail the processing - NOTIFY is best-effort
-                    logger.error(
-                        f"Failed to send NOTIFY for workspace_id '{resource_id}' on channel '{notify_channel}': {e}"
-                    )
+                _send_pg_notify_best_effort(
+                    settings.READ_YOUR_WRITES_CHANNEL,
+                    resource_id,
+                    f"read-your-writes after workspace create (workspace_id={resource_id})",
+                )
+
+            # remove_legacy_root_workspace_tenant_parent_relations job LISTENs for batch completion
+            batch_notify_token = resource_context.get("notify_token") if resource_context else None
+            if event_type == ReplicationEventType.REMOVE_ROOT_PARENT_TENANT_RELATIONSHIPS.value and batch_notify_token:
+                payload = str(batch_notify_token).strip()
+                _send_pg_notify_best_effort(
+                    REMOVE_LEGACY_ROOT_WORKSPACE_PARENT_NOTIFY_CHANNEL,
+                    payload,
+                    f"remove_root_parent_tenant_relationships batch (token={payload})",
+                )
 
             # Calculate processing duration and replication latency
             processing_duration_seconds = time.time() - processing_start

--- a/rbac/core/kafka_consumer.py
+++ b/rbac/core/kafka_consumer.py
@@ -41,7 +41,6 @@ from management.relation_replicator.relations_api_replicator import (
     RelationsApiReplicator,
 )
 from prometheus_client import Counter, Gauge, Histogram
-from psycopg2 import sql
 
 from api.models import Tenant
 
@@ -719,11 +718,8 @@ class RebalanceListener(ConsumerRebalanceListener):
 def _send_pg_notify_best_effort(channel: str, payload: str, description: str) -> None:
     """Send PostgreSQL NOTIFY after successful side effects. Errors are logged only; they do not fail replication."""
     try:
-        notify_sql = sql.SQL("NOTIFY {}, %s").format(sql.Identifier(channel))
         with connection.cursor() as cursor:
-            # nosemgrep: python.sqlalchemy.security.sqlalchemy-execute-raw-query
-            # Safe: psycopg2.sql.SQL with Identifier(channel); payload is parameterized.
-            cursor.execute(notify_sql, [payload])
+            cursor.execute("SELECT pg_notify(%s, %s)", [channel, payload])
         logger.info("Sent NOTIFY on channel '%s' (%s)", channel, description)
     except Exception as e:
         logger.error("Failed NOTIFY on channel '%s' (%s): %s", channel, description, e)

--- a/rbac/internal/pg_notify_wait.py
+++ b/rbac/internal/pg_notify_wait.py
@@ -77,6 +77,7 @@ def wait_for_pg_notify(
         conn = connection.connection
 
         with connection.cursor() as cursor:
+            # nosemgrep: python.sqlalchemy.security.sqlalchemy-execute-raw-query
             cursor.execute(listen_sql)
 
         logger.info(
@@ -153,6 +154,7 @@ def wait_for_pg_notify(
     finally:
         try:
             with connection.cursor() as cursor:
+                # nosemgrep: python.sqlalchemy.security.sqlalchemy-execute-raw-query
                 cursor.execute(unlisten_sql)
         except Exception:
             pass

--- a/rbac/internal/pg_notify_wait.py
+++ b/rbac/internal/pg_notify_wait.py
@@ -1,0 +1,158 @@
+#
+# Copyright 2026 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+"""Helpers to wait on PostgreSQL NOTIFY (coordination with the RBAC Kafka consumer)."""
+
+import logging
+import select
+import time
+from collections import deque
+from collections.abc import Callable
+
+from django.db import connection
+from psycopg2 import sql
+
+logger = logging.getLogger(__name__)
+
+# Coordinates ``remove_legacy_root_workspace_tenant_parent_relations`` with the RBAC Kafka consumer.
+REMOVE_LEGACY_ROOT_WORKSPACE_PARENT_NOTIFY_CHANNEL = "remove_legacy_root_workspace_parent_batch"
+REMOVE_LEGACY_ROOT_WORKSPACE_PARENT_NOTIFY_TIMEOUT_SECONDS = 600
+
+
+def wait_for_pg_notify(
+    *,
+    channel: str,
+    expected_payload: str,
+    timeout_seconds: float,
+    log_label: str,
+    on_success: Callable[[float], None] | None = None,
+    on_timeout: Callable[[float], None] | None = None,
+    timeout_error_message: str | None = None,
+) -> None:
+    """
+    LISTEN on ``channel`` until a NOTIFY is received with payload matching ``expected_payload``.
+
+    Shared by read-your-writes (workspace create) and migration jobs that coordinate with the
+    RBAC Kafka consumer.
+
+    Args:
+        channel: PostgreSQL NOTIFY channel name (must be a valid unquoted identifier).
+        expected_payload: Payload string to match (stripped of whitespace).
+        timeout_seconds: Max seconds to wait; use ``<= 0`` to skip waiting (e.g. tests).
+        log_label: Prefix for log messages (e.g. ``"[Service] RYW"``).
+        on_success: Optional callback with elapsed seconds when a matching NOTIFY is received.
+        on_timeout: Optional callback with elapsed seconds before :class:`TimeoutError` is raised.
+        timeout_error_message: If set, used as the :class:`TimeoutError` message instead of a generic one.
+
+    Raises:
+        TimeoutError: If no matching NOTIFY arrives in time (only when timeout is positive).
+    """
+    if timeout_seconds is None or timeout_seconds <= 0:
+        logger.debug(
+            "%s skipped waiting for NOTIFY (non-positive timeout) channel=%s payload=%s",
+            log_label,
+            channel,
+            expected_payload,
+        )
+        return
+
+    listen_sql = sql.SQL("LISTEN {};").format(sql.Identifier(channel))
+    unlisten_sql = sql.SQL("UNLISTEN {};").format(sql.Identifier(channel))
+    try:
+        connection.ensure_connection()
+        conn = connection.connection
+
+        with connection.cursor() as cursor:
+            cursor.execute(listen_sql)
+
+        logger.info(
+            "%s waiting for NOTIFY channel=%s payload=%s timeout=%ss",
+            log_label,
+            channel,
+            expected_payload,
+            timeout_seconds,
+        )
+
+        started = time.monotonic()
+        deadline = started + float(timeout_seconds)
+        expected_payload_str = str(expected_payload).strip()
+
+        try:
+            conn.poll()
+            if getattr(conn, "notifies", None):
+                conn.notifies.clear()
+        except Exception:
+            logger.debug("%s: failed to clear stale notifications before LISTEN, continuing anyway", log_label)
+
+        fd = conn.fileno() if hasattr(conn, "fileno") else conn
+
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+
+            readable, _, _ = select.select([fd], [], [], min(1.0, remaining))
+            if not readable:
+                continue
+
+            conn.poll()
+            notifies = getattr(conn, "notifies", None)
+            if notifies:
+                q = deque(notifies)
+                notifies.clear()
+                while q:
+                    n = q.popleft()
+                    payload = (getattr(n, "payload", "") or "").strip()
+                    if n.channel == channel and payload == expected_payload_str:
+                        duration = time.monotonic() - started
+                        logger.info(
+                            "%s received NOTIFY channel=%s payload=%s after %.3fs",
+                            log_label,
+                            channel,
+                            payload,
+                            duration,
+                        )
+                        if on_success is not None:
+                            on_success(duration)
+                        return
+
+        duration = time.monotonic() - started
+        logger.error(
+            "%s timed out waiting for NOTIFY channel=%s payload=%s after %ss",
+            log_label,
+            channel,
+            expected_payload_str,
+            timeout_seconds,
+        )
+        if on_timeout is not None:
+            on_timeout(duration)
+        raise TimeoutError(
+            timeout_error_message
+            if timeout_error_message is not None
+            else f"{log_label}: timed out after {timeout_seconds}s waiting for NOTIFY on {channel}"
+        )
+    except TimeoutError:
+        raise
+    except Exception:
+        logger.exception("%s: error while waiting for NOTIFY", log_label)
+        raise
+    finally:
+        try:
+            with connection.cursor() as cursor:
+                cursor.execute(unlisten_sql)
+        except Exception:
+            pass

--- a/rbac/internal/utils.py
+++ b/rbac/internal/utils.py
@@ -31,6 +31,11 @@ from django.conf import settings
 from django.db import transaction
 from django.db.models import Q
 from django.urls import resolve
+from internal.pg_notify_wait import (
+    REMOVE_LEGACY_ROOT_WORKSPACE_PARENT_NOTIFY_CHANNEL,
+    REMOVE_LEGACY_ROOT_WORKSPACE_PARENT_NOTIFY_TIMEOUT_SECONDS,
+    wait_for_pg_notify,
+)
 from internal.schemas import INVENTORY_INPUT_SCHEMAS, RELATION_INPUT_SCHEMAS
 from jsonschema import validate
 from management.atomic_transactions import atomic, atomic_block, atomic_with_retry
@@ -462,10 +467,14 @@ def remove_legacy_root_workspace_tenant_parent_relations() -> dict:
     def flush_batch() -> None:
         if not batch:
             return
+        notify_token = str(uuid.uuid4())
         replicator.replicate(
             ReplicationEvent(
-                event_type=ReplicationEventType.MIGRATE_TENANT_GROUPS,
-                info={"action": "remove_root_workspace_tenant_parent", "batch_size": len(batch)},
+                event_type=ReplicationEventType.REMOVE_ROOT_PARENT_TENANT_RELATIONSHIPS,
+                info={
+                    "batch_size": len(batch),
+                    "notify_token": notify_token,
+                },
                 partition_key=PartitionKey.byEnvironment(),
                 add=[],
                 remove=batch,
@@ -473,6 +482,12 @@ def remove_legacy_root_workspace_tenant_parent_relations() -> dict:
         )
         batch.clear()
         logger.info(f"Processed {tenants_processed} of {tenants_total} tenants")
+        wait_for_pg_notify(
+            channel=REMOVE_LEGACY_ROOT_WORKSPACE_PARENT_NOTIFY_CHANNEL,
+            expected_payload=notify_token,
+            timeout_seconds=float(REMOVE_LEGACY_ROOT_WORKSPACE_PARENT_NOTIFY_TIMEOUT_SECONDS),
+            log_label="remove_legacy_root_workspace_tenant_parent",
+        )
 
     for tenant in qs.iterator(chunk_size=500):
         tenants_processed += 1

--- a/rbac/management/relation_replicator/relation_replicator.py
+++ b/rbac/management/relation_replicator/relation_replicator.py
@@ -85,6 +85,7 @@ class ReplicationEventType(str, Enum):
     UPDATE_ROLE_BINDINGS_FOR_SUBJECT = "update_role_bindings_for_subject"
     REMOVE_DELETED_WORKSPACE_BINDINGS = "remove_deleted_workspace_bindings"
     UPDATE_ROOT_WORKSPACE_TENANTS = "update_root_workspace_tenants"
+    REMOVE_ROOT_PARENT_TENANT_RELATIONSHIPS = "remove_root_parent_tenant_relationships"
 
 
 class ReplicationEvent:
@@ -113,6 +114,22 @@ class ReplicationEvent:
 
     def resource_context(self) -> Dict[str, object] | None:
         """Build context for all replication events that have identifiable resources."""
+        if self.event_type == ReplicationEventType.REMOVE_ROOT_PARENT_TENANT_RELATIONSHIPS:
+            token = self.event_info.get("notify_token")
+            if not token:
+                logger.warning(
+                    "remove_root_parent_tenant_relationships batch missing notify_token in event_info=%s",
+                    self.event_info,
+                )
+                return None
+            context = ReplicationEventResourceContext(
+                org_id="",
+                event_type=self.event_type.value,
+            )
+            result = context.to_json()
+            result["notify_token"] = str(token)
+            return result
+
         # Validate org_id exists for all events
         org_id = str(self.event_info.get("org_id", ""))
         if not org_id:

--- a/rbac/management/workspace/service.py
+++ b/rbac/management/workspace/service.py
@@ -18,18 +18,16 @@
 
 import itertools
 import logging
-import select
-import time
 import uuid
-from collections import deque
 from itertools import groupby
 from typing import Optional
 
 from django.conf import settings
 from django.core.exceptions import ValidationError
-from django.db import connection, transaction
+from django.db import transaction
 from django.db.models import Q
 from feature_flags import FEATURE_FLAGS
+from internal.pg_notify_wait import wait_for_pg_notify
 from internal.utils import get_workspace_ids_from_resource_definition
 from management.atomic_transactions import atomic
 from management.models import ResourceDefinition, Role, Workspace
@@ -47,7 +45,6 @@ from management.tenant_mapping.v2_activation import TenantVersion, lock_tenant_v
 from management.workspace.relation_api_dual_write_workspace_handler import RelationApiDualWriteWorkspaceHandler
 from migration_tool.sharedSystemRolesReplicatedRoleBindings import attribute_key_to_v2_related_resource_type
 from prometheus_client import Counter, Histogram
-from psycopg2 import sql
 from rest_framework import serializers
 
 from api.models import Tenant
@@ -89,10 +86,6 @@ def _record_ryw_metrics(duration: float, result: str) -> None:
     """
     ryw_wait_duration_seconds.labels(result=result).observe(duration)
     ryw_wait_total.labels(result=result).inc()
-
-
-LISTEN_SQL = sql.SQL("LISTEN {};").format(sql.Identifier(READ_YOUR_WRITES_CHANNEL))
-UNLISTEN_SQL = sql.SQL("UNLISTEN {};").format(sql.Identifier(READ_YOUR_WRITES_CHANNEL))
 
 
 def _update_custom_roles_for_removed_workspace(workspace_id: uuid.UUID, replicator: RelationReplicator) -> int:
@@ -542,91 +535,29 @@ class WorkspaceService:
 
         Intended for use as a transaction.on_commit callback.
         """
+        timeout_seconds = settings.READ_YOUR_WRITES_TIMEOUT_SECONDS
+
+        if timeout_seconds is None or timeout_seconds <= 0:
+            logger.debug(
+                "[Service] RYW skipped waiting due to non-positive timeout for channel='%s' workspace_id='%s'",
+                READ_YOUR_WRITES_CHANNEL,
+                str(workspace_id),
+            )
+            return
+
         try:
-            connection.ensure_connection()
-            conn = connection.connection
-            timeout_seconds = settings.READ_YOUR_WRITES_TIMEOUT_SECONDS
-
-            # Early exit if misconfigured
-            if timeout_seconds is None or timeout_seconds <= 0:
-                logger.debug(
-                    "[Service] RYW skipped waiting due to non-positive timeout for channel='%s' workspace_id='%s'",
-                    READ_YOUR_WRITES_CHANNEL,
-                    str(workspace_id),
-                )
-                return
-
-            with connection.cursor() as cursor:
-                cursor.execute(LISTEN_SQL)
-
-            logger.info(
-                "[Service] RYW waiting for NOTIFY channel='%s' workspace_id='%s' timeout=%ss",
-                READ_YOUR_WRITES_CHANNEL,
-                str(workspace_id),
-                timeout_seconds,
-            )
-
-            # Use monotonic clock and a strict deadline to avoid overshooting
-            started = time.monotonic()
-            deadline = started + float(timeout_seconds)
-            workspace_id_str = str(workspace_id)
-
-            # Clear any stale notifications from before LISTEN was issued
-            try:
-                conn.poll()  # bring any pending into conn.notifies
-                if getattr(conn, "notifies", None):
-                    conn.notifies.clear()
-            except Exception:
-                logger.debug("Failed to clear stale notifications before LISTEN, continuing anyway")
-
-            fd = conn.fileno() if hasattr(conn, "fileno") else conn
-
-            while True:
-                remaining = deadline - time.monotonic()
-                if remaining <= 0:
-                    break
-
-                readable, _, _ = select.select([fd], [], [], min(1.0, remaining))
-                if not readable:
-                    continue
-
-                conn.poll()
-                notifies = getattr(conn, "notifies", None)
-                if notifies:
-                    q = deque(notifies)
-                    notifies.clear()
-                    while q:
-                        n = q.popleft()
-                        payload = (getattr(n, "payload", "") or "").strip()
-                        if n.channel == READ_YOUR_WRITES_CHANNEL and payload == workspace_id_str:
-                            duration = time.monotonic() - started
-                            logger.info(
-                                "[Service] RYW received NOTIFY channel='%s' workspace_id='%s' after %.3fs",
-                                n.channel,
-                                payload,
-                                duration,
-                            )
-                            _record_ryw_metrics(duration, "success")
-                            return
-
-            duration = time.monotonic() - started
-            logger.error(
-                "[Service] RYW timed out waiting for NOTIFY channel='%s' workspace_id='%s' after %ss",
-                READ_YOUR_WRITES_CHANNEL,
-                str(workspace_id),
-                timeout_seconds,
-            )
-            _record_ryw_metrics(duration, "timeout")
-            raise TimeoutError(
-                f"Read-your-writes consistency check timed out after {timeout_seconds}s for workspace {workspace_id}"
+            wait_for_pg_notify(
+                channel=READ_YOUR_WRITES_CHANNEL,
+                expected_payload=str(workspace_id),
+                timeout_seconds=float(timeout_seconds),
+                log_label="[Service] RYW",
+                on_success=lambda d: _record_ryw_metrics(d, "success"),
+                on_timeout=lambda d: _record_ryw_metrics(d, "timeout"),
+                timeout_error_message=(
+                    f"Read-your-writes consistency check timed out after {timeout_seconds}s "
+                    f"for workspace {workspace_id}"
+                ),
             )
         except Exception:
             logger.exception("Error while waiting for NOTIFY after workspace create")
             raise
-        finally:
-            try:
-                with connection.cursor() as cursor:
-                    cursor.execute(UNLISTEN_SQL)
-            except Exception:
-                # Best-effort cleanup
-                pass

--- a/rbac/management/workspace/service.py
+++ b/rbac/management/workspace/service.py
@@ -558,6 +558,8 @@ class WorkspaceService:
                     f"for workspace {workspace_id}"
                 ),
             )
+        except TimeoutError:
+            raise
         except Exception:
             logger.exception("Error while waiting for NOTIFY after workspace create")
             raise

--- a/tests/core/test_kafka_consumer.py
+++ b/tests/core/test_kafka_consumer.py
@@ -717,7 +717,7 @@ class RBACKafkaConsumerTests(TestCase):
     @patch("core.kafka_consumer.relations_api_replication.delete_relationships")
     @patch("core.kafka_consumer.Tenant.objects.get")
     def test_process_relations_message_remove_legacy_root_parent_sends_notify(
-        self, mock_tenant_get, mock_delete, mock_write, mock_parse_dict, mock_conn_cursor, _mock_batch_channel
+        self, mock_tenant_get, mock_delete, mock_write, mock_parse_dict, mock_conn_cursor
     ):
         """Consumer NOTIFYs after remove_root_parent_tenant_relationships batch replication."""
         from management.relation_replicator.relation_replicator import ReplicationEventType
@@ -758,11 +758,11 @@ class RBACKafkaConsumerTests(TestCase):
             },
         )
 
-        self.assertTrue(consumer._process_relations_message(debezium_msg))
+        self.assertTrue(consumer._process_relations_message(debezium_msg, 0, 0))
 
-        notify_sql_calls = [c for c in mock_cursor.execute.call_args_list if "NOTIFY" in str(c[0][0]).upper()]
+        notify_sql_calls = [c for c in mock_cursor.execute.call_args_list if "PG_NOTIFY" in str(c[0][0]).upper()]
         self.assertEqual(len(notify_sql_calls), 1)
-        self.assertEqual(notify_sql_calls[0][0][1], ["batch-ack-token"])
+        self.assertEqual(notify_sql_calls[0][0][1], ["test_legacy_ch", "batch-ack-token"])
 
     def test_process_relations_message_invalid_payload(self):
         """Test relations message processing with invalid payload raises ValidationError."""

--- a/tests/core/test_kafka_consumer.py
+++ b/tests/core/test_kafka_consumer.py
@@ -710,6 +710,60 @@ class RBACKafkaConsumerTests(TestCase):
         self.assertEqual(delete_fencing_check.lock_id, "test-group/0")
         self.assertEqual(delete_fencing_check.lock_token, "test-lock-token")
 
+    @patch("core.kafka_consumer.REMOVE_LEGACY_ROOT_WORKSPACE_PARENT_NOTIFY_CHANNEL", "test_legacy_ch")
+    @patch("core.kafka_consumer.connection.cursor")
+    @patch("core.kafka_consumer.json_format.ParseDict")
+    @patch("core.kafka_consumer.relations_api_replication.write_relationships")
+    @patch("core.kafka_consumer.relations_api_replication.delete_relationships")
+    @patch("core.kafka_consumer.Tenant.objects.get")
+    def test_process_relations_message_remove_legacy_root_parent_sends_notify(
+        self, mock_tenant_get, mock_delete, mock_write, mock_parse_dict, mock_conn_cursor, _mock_batch_channel
+    ):
+        """Consumer NOTIFYs after remove_root_parent_tenant_relationships batch replication."""
+        from management.relation_replicator.relation_replicator import ReplicationEventType
+
+        mock_tenant_get.return_value = Mock(org_id="12345")
+        mock_parse_dict.return_value = Mock()
+        mock_write.return_value = Mock(consistency_token=Mock(token="tok"))
+        mock_delete.return_value = Mock(consistency_token=Mock(token=None))
+
+        mock_cursor = Mock()
+        mock_cm = Mock()
+        mock_cm.__enter__ = Mock(return_value=mock_cursor)
+        mock_cm.__exit__ = Mock(return_value=False)
+        mock_conn_cursor.return_value = mock_cm
+
+        consumer = RBACKafkaConsumer()
+        consumer.lock_id = "test-group/0"
+        consumer.lock_token = "test-lock-token"
+
+        debezium_msg = DebeziumMessage(
+            aggregatetype="relations",
+            aggregateid="test-id",
+            event_type=ReplicationEventType.REMOVE_ROOT_PARENT_TENANT_RELATIONSHIPS.value,
+            payload={
+                "relations_to_add": [],
+                "relations_to_remove": [
+                    {
+                        "resource": {"type": "rbac", "id": "ws1"},
+                        "subject": {"type": "rbac", "id": "t1"},
+                        "relation": "parent",
+                    }
+                ],
+                "resource_context": {
+                    "org_id": "",
+                    "event_type": ReplicationEventType.REMOVE_ROOT_PARENT_TENANT_RELATIONSHIPS.value,
+                    "notify_token": "batch-ack-token",
+                },
+            },
+        )
+
+        self.assertTrue(consumer._process_relations_message(debezium_msg))
+
+        notify_sql_calls = [c for c in mock_cursor.execute.call_args_list if "NOTIFY" in str(c[0][0]).upper()]
+        self.assertEqual(len(notify_sql_calls), 1)
+        self.assertEqual(notify_sql_calls[0][0][1], ["batch-ack-token"])
+
     def test_process_relations_message_invalid_payload(self):
         """Test relations message processing with invalid payload raises ValidationError."""
         from core.kafka_consumer import ValidationError

--- a/tests/internal/test_utils.py
+++ b/tests/internal/test_utils.py
@@ -1105,6 +1105,9 @@ class RemoveLegacyRootWorkspaceTenantParentRelationsTest(TestCase):
     """Tests for remove_legacy_root_workspace_tenant_parent_relations."""
 
     def setUp(self):
+        timeout_patcher = patch("internal.utils.REMOVE_LEGACY_ROOT_WORKSPACE_PARENT_NOTIFY_TIMEOUT_SECONDS", 0)
+        timeout_patcher.start()
+        self.addCleanup(timeout_patcher.stop)
         self.tenant = Tenant.objects.create(tenant_name="legacy_root_cleanup", org_id="9918877")
         self.tuples = InMemoryTuples()
         bootstrap_tenant_for_v2_test(self.tenant, tuples=self.tuples)

--- a/tests/management/workspace/test_service.py
+++ b/tests/management/workspace/test_service.py
@@ -59,8 +59,8 @@ class FakeNotify:
 class WorkspaceServiceTest(TestCase):
     """Tests for WorkspaceService._wait_for_notify_post_commit."""
 
-    @patch("management.workspace.service.select.select")
-    @patch("management.workspace.service.connection")
+    @patch("internal.pg_notify_wait.select.select")
+    @patch("internal.pg_notify_wait.connection")
     def test_wait_for_notify_post_commit_listen_unlisten(self, mock_connection, mock_select):
         # Arrange
         mock_conn = Mock()
@@ -91,8 +91,8 @@ class WorkspaceServiceTest(TestCase):
         self.assertTrue(any("LISTEN" in str(c) for c in executed_sql_calls))
         self.assertTrue(any("UNLISTEN" in str(c) for c in executed_sql_calls))
 
-    @patch("management.workspace.service.select.select")
-    @patch("management.workspace.service.connection")
+    @patch("internal.pg_notify_wait.select.select")
+    @patch("internal.pg_notify_wait.connection")
     def test_wait_for_notify_post_commit_payload_trimmed(self, mock_connection, mock_select):
         # Arrange: notification payload contains extra spaces; should still match
         mock_conn = Mock()
@@ -121,8 +121,8 @@ class WorkspaceServiceTest(TestCase):
         self.assertTrue(any("LISTEN" in str(c) for c in executed_sql_calls))
         self.assertTrue(any("UNLISTEN" in str(c) for c in executed_sql_calls))
 
-    @patch("management.workspace.service.select.select")
-    @patch("management.workspace.service.connection")
+    @patch("internal.pg_notify_wait.select.select")
+    @patch("internal.pg_notify_wait.connection")
     def test_wait_for_notify_post_commit_timeout(self, mock_connection, mock_select):
         # Arrange: no readability, so we loop until timeout and then exit
         mock_conn = Mock()


### PR DESCRIPTION
## Link(s) to Jira
- https://redhat.atlassian.net/browse/RHCLOUD-48138

## Description of Intent of Change(s)
The migration job produced a ton of events into kafka queue and blocks the regular event processing

## Local Testing
Unit test

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Introduce shared PostgreSQL LISTEN/NOTIFY coordination utilities and use them to synchronize workspace creation and legacy root workspace migration with the RBAC Kafka consumer while keeping NOTIFY best-effort and non-blocking.

Enhancements:
- Refactor read-your-writes workspace notification waiting into a reusable PostgreSQL NOTIFY helper shared across services and jobs.
- Add best-effort PostgreSQL NOTIFY sending utility in the Kafka consumer to emit signals after successful workspace replication and legacy root parent tenant relationship cleanup batches.
- Extend replication events and migration utilities to support batched removal of legacy root workspace tenant parent relationships coordinated via NOTIFY tokens.

Tests:
- Add unit tests verifying Kafka consumer sends NOTIFY for legacy root parent tenant relationship removal batches.
- Adjust workspace service tests to use the new shared PostgreSQL NOTIFY waiting helper module.
- Update migration cleanup tests to account for the new NOTIFY-based batch coordination timeout configuration.