### PR TITLE
feat(consumer): add per-event-type processing duration metric and timing to logs

### DIFF
--- a/rbac/core/kafka_consumer.py
+++ b/rbac/core/kafka_consumer.py
@@ -71,6 +71,13 @@ message_processing_duration = Histogram(
     ["message_type", "event_type"],
 )
 
+kessel_write_duration = Histogram(
+    "rbac_kessel_write_duration_seconds",
+    "Time spent on Kessel Relations API write and delete calls",
+    ["operation", "event_type"],
+    buckets=(0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0),
+)
+
 validation_errors_total = Counter(
     "rbac_kafka_consumer_validation_errors_total",
     "Total number of validation errors",
@@ -1308,14 +1315,18 @@ class RBACKafkaConsumer:
                     raise RuntimeError(error_msg)
 
             # Do tuple deletes for relationships with fencing check
+            delete_start = time.time()
             replication_delete_response = relations_api_replication.delete_relationships(
                 relationships=relations_to_remove_pb, fencing_check=fencing_check
             )
+            delete_duration = time.time() - delete_start
 
             # Do tuple writes for relationships with fencing check
+            add_start = time.time()
             replication_add_response = relations_api_replication.write_relationships(
                 relationships=relations_to_add_pb, fencing_check=fencing_check
             )
+            add_duration = time.time() - add_start
 
             # Extract consistency token from responses
             token = getattr(replication_add_response.consistency_token, "token", None) or getattr(
@@ -1368,6 +1379,10 @@ class RBACKafkaConsumer:
             processing_duration_seconds = time.time() - processing_start
             latency_event_type = event_type or "unknown"
 
+            # Record Kessel write duration metrics
+            kessel_write_duration.labels(operation="delete", event_type=latency_event_type).observe(delete_duration)
+            kessel_write_duration.labels(operation="add", event_type=latency_event_type).observe(add_duration)
+
             # Record processing duration metric with event_type label
             message_processing_duration.labels(message_type="debezium", event_type=latency_event_type).observe(
                 processing_duration_seconds
@@ -1390,6 +1405,8 @@ class RBACKafkaConsumer:
                 f"Message processed successfully "
                 f"(partition: {message_partition}, offset: {message_offset}, "
                 f"event_type: {latency_event_type}, "
+                f"kessel_delete_duration: {delete_duration:.3f}s, "
+                f"kessel_add_duration: {add_duration:.3f}s, "
                 f"processing_duration: {processing_duration_seconds:.3f}s, "
                 f"replication_event_latency: {f'{latency_seconds:.3f}s' if latency_seconds is not None else 'N/A'})"
             )

--- a/rbac/core/kafka_consumer.py
+++ b/rbac/core/kafka_consumer.py
@@ -68,7 +68,7 @@ messages_processed_total = Counter(
 message_processing_duration = Histogram(
     "rbac_kafka_consumer_message_processing_duration_seconds",
     "Time spent processing messages",
-    ["message_type"],
+    ["message_type", "event_type"],
 )
 
 validation_errors_total = Counter(
@@ -1008,7 +1008,7 @@ class RBACKafkaConsumer:
         parsed_message = self._parse_debezium_message(message_value)
 
         # Process the message (may raise ValidationError or other exceptions)
-        return self._process_debezium_message(parsed_message)
+        return self._process_debezium_message(parsed_message, message_partition, message_offset)
 
     def _parse_debezium_message(self, message_value: Dict[str, Any]) -> Dict[str, Any]:
         """Parse standard Debezium message format with schema/payload wrapper.
@@ -1155,7 +1155,6 @@ class RBACKafkaConsumer:
             # IMPORTANT: We do NOT commit offsets during retries
             # Offsets are only committed after successful processing
             retry_helper.run(process_wrapper)
-            logger.info(f"Message processed successfully (partition: {message_partition}, offset: {message_offset})")
             return True
 
         except InterruptedError:
@@ -1200,35 +1199,43 @@ class RBACKafkaConsumer:
             messages_processed_total.labels(message_type="unknown", status="error_handler_skip").inc()
             raise
 
-    def _process_debezium_message(self, message_value: Dict[str, Any]) -> bool:
+    def _process_debezium_message(
+        self, message_value: Dict[str, Any], message_partition: int, message_offset: int
+    ) -> bool:
         """Process a Debezium message."""
-        with message_processing_duration.labels(message_type="debezium").time():
-            try:
-                # Create structured message
-                # Note: message structure is already validated by _parse_debezium_message
-                debezium_msg = DebeziumMessage.from_kafka_message(message_value)
+        try:
+            # Create structured message
+            # Note: message structure is already validated by _parse_debezium_message
+            debezium_msg = DebeziumMessage.from_kafka_message(message_value)
 
-                # Process all messages with relations - no strict aggregate type checking
-                return self._process_relations_message(debezium_msg)
+            # Process all messages with relations - no strict aggregate type checking
+            return self._process_relations_message(debezium_msg, message_partition, message_offset)
 
-            except ValidationError:
-                # Re-raise ValidationError - will NOT be retried (non-retryable)
-                raise
-            except Exception as e:
-                logger.error(f"Error processing Debezium message: {e}")
-                messages_processed_total.labels(message_type="debezium", status="error").inc()
-                # Re-raise to allow retry logic to handle
-                raise
+        except ValidationError:
+            # Re-raise ValidationError - will NOT be retried (non-retryable)
+            raise
+        except Exception as e:
+            logger.error(
+                f"Error processing Debezium message (partition: {message_partition}, offset: {message_offset}): {e}"
+            )
+            messages_processed_total.labels(message_type="debezium", status="error").inc()
+            # Re-raise to allow retry logic to handle
+            raise
 
-    def _process_relations_message(self, debezium_msg: DebeziumMessage) -> bool:
+    def _process_relations_message(
+        self, debezium_msg: DebeziumMessage, message_partition: int, message_offset: int
+    ) -> bool:
         """Process a relations Debezium message."""
+        processing_start = time.time()
         try:
             # Validate replication payload
             if not self.validator.validate_replication_message(debezium_msg.payload):
-                logger.error(f"Replication message validation failed. Payload content: {debezium_msg.payload}")
+                logger.error(
+                    f"Replication message validation failed "
+                    f"(partition: {message_partition}, offset: {message_offset}). "
+                    f"Payload content: {debezium_msg.payload}"
+                )
                 messages_processed_total.labels(message_type="relations", status="validation_failed").inc()
-                # Raise ValidationError instead of returning False
-                # This signals a permanent validation failure that shouldn't be retried
                 raise ValidationError(
                     f"Replication message validation failed for aggregateid: {debezium_msg.aggregateid}"
                 )
@@ -1248,7 +1255,8 @@ class RBACKafkaConsumer:
             else:
                 logger.debug(
                     f"No resource_context found, skipping org_id and event_type extraction. "
-                    f"aggregateid: {debezium_msg.aggregateid}"
+                    f"aggregateid: {debezium_msg.aggregateid}, "
+                    f"partition: {message_partition}, offset: {message_offset}"
                 )
 
             # Create structured replication message
@@ -1258,7 +1266,8 @@ class RBACKafkaConsumer:
                 f"Processing relations message - org_id: {org_id}, "
                 f"event_type: {event_type}, "
                 f"relations_to_add: {len(replication_msg.relations_to_add)}, "
-                f"relations_to_remove: {len(replication_msg.relations_to_remove)}"
+                f"relations_to_remove: {len(replication_msg.relations_to_remove)}, "
+                f"partition: {message_partition}, offset: {message_offset}"
             )
 
             # Convert JSON dictionaries to protobuf objects
@@ -1355,28 +1364,35 @@ class RBACKafkaConsumer:
                         f"Failed to send NOTIFY for workspace_id '{resource_id}' on channel '{notify_channel}': {e}"
                     )
 
+            # Calculate processing duration and replication latency
+            processing_duration_seconds = time.time() - processing_start
+            latency_event_type = event_type or "unknown"
+
+            # Record processing duration metric with event_type label
+            message_processing_duration.labels(message_type="debezium", event_type=latency_event_type).observe(
+                processing_duration_seconds
+            )
+
             # Calculate and emit replication latency metric
+            latency_seconds = None
             if created_at is not None:
                 try:
                     latency_seconds = time.time() - float(created_at)
-                    latency_event_type = event_type or "unknown"
                     replication_event_latency.labels(event_type=latency_event_type).observe(latency_seconds)
-                    # Log per-event latency at DEBUG level to avoid excessive log volume at scale
-                    logger.debug(
-                        "Replication event latency: %.3fs for event_type=%s, aggregateid=%s",
-                        latency_seconds,
-                        latency_event_type,
-                        debezium_msg.aggregateid,
-                    )
                 except (ValueError, TypeError) as e:
                     logger.warning(
-                        f"Could not calculate replication latency: invalid created_at value '{created_at}': {e}"
+                        f"Could not calculate replication latency: invalid created_at value "
+                        f"'{created_at}': {e} "
+                        f"(partition: {message_partition}, offset: {message_offset})"
                     )
-            else:
-                logger.debug(
-                    f"No created_at timestamp in resource_context, skipping latency metric. "
-                    f"aggregateid: {debezium_msg.aggregateid}"
-                )
+
+            logger.info(
+                f"Message processed successfully "
+                f"(partition: {message_partition}, offset: {message_offset}, "
+                f"event_type: {latency_event_type}, "
+                f"processing_duration: {processing_duration_seconds:.3f}s, "
+                f"replication_event_latency: {f'{latency_seconds:.3f}s' if latency_seconds is not None else 'N/A'})"
+            )
 
             messages_processed_total.labels(message_type="relations", status="success").inc()
             return True
@@ -1387,24 +1403,27 @@ class RBACKafkaConsumer:
         except grpc.RpcError as e:
             # Handle gRPC errors specially to check for invalid fencing tokens
             if e.code() == grpc.StatusCode.FAILED_PRECONDITION:
-                # Invalid fencing token - partition was reassigned to another consumer
                 error_msg = (
                     f"Fencing token validation failed - partition reassigned. "
                     f"Lock ID: {self.lock_id}, Token: {self.lock_token}. "
-                    f"Consumer will stop processing to prevent stale updates."
+                    f"Consumer will stop processing to prevent stale updates. "
+                    f"(partition: {message_partition}, offset: {message_offset})"
                 )
                 logger.error(error_msg)
                 messages_processed_total.labels(message_type="relations", status="fencing_failed").inc()
-                # Raise a RuntimeError to stop the consumer - this is a fatal error
-                # The partition has been reassigned, so we should not continue processing
                 raise RuntimeError(error_msg) from e
             else:
-                # Other gRPC errors - log and re-raise to trigger retry
-                logger.error(f"gRPC error processing relations message: {e.code()}: {e.details()}")
+                logger.error(
+                    f"gRPC error processing relations message: {e.code()}: {e.details()} "
+                    f"(partition: {message_partition}, offset: {message_offset})"
+                )
                 messages_processed_total.labels(message_type="relations", status="grpc_error").inc()
                 raise
         except Exception as e:
-            logger.error(f"Error processing relations message: {e}")
+            logger.error(
+                f"Error processing relations message: {e} "
+                f"(partition: {message_partition}, offset: {message_offset})"
+            )
             messages_processed_total.labels(message_type="relations", status="error").inc()
             # Re-raise to trigger retry logic
             raise

--- a/tests/core/test_kafka_consumer.py
+++ b/tests/core/test_kafka_consumer.py
@@ -596,7 +596,7 @@ class RBACKafkaConsumerTests(TestCase):
         }
 
         with patch.object(consumer, "_process_relations_message", return_value=True) as mock_process:
-            result = consumer._process_debezium_message(message_value)
+            result = consumer._process_debezium_message(message_value, 0, 0)
 
             self.assertTrue(result)
             mock_process.assert_called_once()
@@ -619,7 +619,7 @@ class RBACKafkaConsumerTests(TestCase):
 
         # Should raise ValidationError because payload doesn't have relations_to_add or relations_to_remove
         with self.assertRaises(ValidationError):
-            consumer._process_debezium_message(message_value)
+            consumer._process_debezium_message(message_value, 0, 0)
 
     def test_process_debezium_message_invalid(self):
         """Test processing invalid message."""
@@ -634,7 +634,7 @@ class RBACKafkaConsumerTests(TestCase):
 
         # Should raise ValidationError for invalid message
         with self.assertRaises(ValidationError):
-            consumer._process_debezium_message(message_value)
+            consumer._process_debezium_message(message_value, 0, 0)
 
     @patch("core.kafka_consumer.json_format.ParseDict")
     @patch("core.kafka_consumer.relations_api_replication.write_relationships")
@@ -688,7 +688,7 @@ class RBACKafkaConsumerTests(TestCase):
             },
         )
 
-        result = consumer._process_relations_message(debezium_msg)
+        result = consumer._process_relations_message(debezium_msg, 0, 0)
 
         self.assertTrue(result)
         mock_tenant_get.assert_called_once_with(org_id="12345")
@@ -732,7 +732,7 @@ class RBACKafkaConsumerTests(TestCase):
 
         # Should raise ValidationError for empty relations
         with self.assertRaises(ValidationError):
-            consumer._process_relations_message(debezium_msg)
+            consumer._process_relations_message(debezium_msg, 0, 0)
 
     @override_settings(
         KAFKA_ENABLED=True,
@@ -1607,7 +1607,7 @@ class FencingTokenProcessingTests(TestCase):
             payload=self.payload,
         )
 
-        result = self.consumer._process_relations_message(debezium_msg)
+        result = self.consumer._process_relations_message(debezium_msg, 0, 0)
 
         self.assertTrue(result)
 
@@ -1639,7 +1639,7 @@ class FencingTokenProcessingTests(TestCase):
 
         # Verify that processing raises RuntimeError when no lock token is available
         with self.assertRaises(RuntimeError) as ctx:
-            self.consumer._process_relations_message(debezium_msg)
+            self.consumer._process_relations_message(debezium_msg, 0, 0)
 
         # Verify error message
         self.assertIn("Lock token not available", str(ctx.exception))
@@ -1857,7 +1857,7 @@ class FencingTokenErrorHandlingTests(TestCase):
         )
 
         with self.assertRaises(RuntimeError) as ctx:
-            self.consumer._process_relations_message(debezium_msg)
+            self.consumer._process_relations_message(debezium_msg, 0, 0)
 
         self.assertIn("Fencing token validation failed", str(ctx.exception))
 
@@ -1885,4 +1885,4 @@ class FencingTokenErrorHandlingTests(TestCase):
 
         # Should re-raise the gRPC error (not RuntimeError)
         with self.assertRaises(grpc.RpcError):
-            self.consumer._process_relations_message(debezium_msg)
+            self.consumer._process_relations_message(debezium_msg, 0, 0)


### PR DESCRIPTION
## Summary
- Add `event_type` label to `message_processing_duration` histogram so consumer processing time can be queried per event type in Prometheus (e.g. `migrate_tenant_groups` vs `assign_role`)
- Include `processing_duration` and `replication_event_latency` in the "Message processed successfully" log line for Kibana visibility
- Add `partition` and `offset` to all log messages in the processing path for event correlation

## Test plan
- [ ] Verify existing consumer tests pass with updated method signatures
- [ ] Confirm Prometheus metric `rbac_kafka_consumer_message_processing_duration_seconds` now exposes `event_type` label
- [ ] Search Kibana for `"Message processed successfully"` and verify `processing_duration`, `replication_event_latency`, `event_type`, `partition`, `offset` are present
- [ ] Query Prometheus: `histogram_quantile(0.95, sum(rate(rbac_kafka_consumer_message_processing_duration_seconds_bucket{event_type="migrate_tenant_groups"}[5m])) by (le))`

## Summary by Sourcery

Add per-event-type processing duration metrics and enriched logging for Kafka consumer message processing, including partition and offset context.

New Features:
- Expose message processing duration histogram labeled by both message_type and event_type for Debezium relations messages.

Enhancements:
- Log successful relations message processing with event type, processing duration, replication latency, partition, and offset for easier observability and correlation across systems.
- Include partition and offset details in validation, latency-calculation, and error logs for Debezium and relations message processing paths.

Tests:
- Update Kafka consumer tests to accommodate new method signatures requiring partition and offset parameters when processing Debezium and relations messages.