### PR TITLE
[RHCLOUD-46190] Unify name filtering across V2 endpoints

### DIFF
--- a/docs/source/specs/typespec/main.tsp
+++ b/docs/source/specs/typespec/main.tsp
@@ -519,7 +519,7 @@ namespace Workspaces {
 
         @doc("Filter by workspace type. Supports comma-separated values (e.g. type=standard,ungrouped-hosts). Defaults to all when not supplied. Case-insensitive.")
         @query type?: string = "all";
-        @doc("Case sensitive exact match of workspace by name.")
+        @doc("Filter by workspace name. Case-insensitive exact match by default; use * as a wildcard for partial matching (e.g. foo*).")
         @query name?: string;
         @doc("Filter workspaces by parent workspace UUID. Returns only direct children of the specified workspace. Useful for lazy-loading a nested tree structure.")
         @query parent_id?: UUID;

--- a/docs/source/specs/v2/openapi.json
+++ b/docs/source/specs/v2/openapi.json
@@ -1960,7 +1960,7 @@
             "name": "name",
             "in": "query",
             "required": false,
-            "description": "Case sensitive exact match of workspace by name.",
+            "description": "Filter by workspace name. Case-insensitive exact match by default; use * as a wildcard for partial matching (e.g. foo*).",
             "schema": {
               "type": "string"
             },
@@ -2281,6 +2281,32 @@
                       "$ref": "#/components/schemas/Workspaces.ReadWorkspaceWithAncestryResponse"
                     }
                   ]
+                },
+                "examples": {
+                  "example0": {
+                    "value": {
+                      "_": 200,
+                      "id": "e4277742-b91c-43f1-a185-b827e8574345",
+                      "parent_id": "c1f729e2-3e2b-4f9e-b247-a4b568393e11",
+                      "type": "standard",
+                      "name": "Alpha Workspace",
+                      "description": "Create a standard workspace.",
+                      "created": "2024-08-04T12:00:00Z",
+                      "modified": "2024-08-04T12:00:00Z"
+                    }
+                  },
+                  "example1": {
+                    "value": {
+                      "_": 200,
+                      "id": "e4277742-b91c-43f1-a185-b827e8574345",
+                      "parent_id": "c1f729e2-3e2b-4f9e-b247-a4b568393e11",
+                      "type": "standard",
+                      "name": "Alpha Workspace",
+                      "description": "Create a standard workspace.",
+                      "created": "2024-08-04T12:00:00Z",
+                      "modified": "2024-08-04T12:00:00Z"
+                    }
+                  }
                 }
               }
             }
@@ -3384,7 +3410,8 @@
         "discriminator": {
           "propertyName": "type",
           "mapping": {
-            "group": "#/components/schemas/RoleBindings.GroupSubject"
+            "group": "#/components/schemas/RoleBindings.GroupSubject",
+            "user": "#/components/schemas/RoleBindings.UserSubject"
           }
         }
       },

--- a/docs/source/specs/v2/openapi.yaml
+++ b/docs/source/specs/v2/openapi.yaml
@@ -1252,7 +1252,7 @@ paths:
         - name: name
           in: query
           required: false
-          description: Case sensitive exact match of workspace by name.
+          description: Filter by workspace name. Case-insensitive exact match by default; use * as a wildcard for partial matching (e.g. foo*).
           schema:
             type: string
           explode: false
@@ -1465,6 +1465,27 @@ paths:
                 anyOf:
                   - $ref: '#/components/schemas/Workspaces.ReadWorkspaceResponse'
                   - $ref: '#/components/schemas/Workspaces.ReadWorkspaceWithAncestryResponse'
+              examples:
+                example0:
+                  value:
+                    _: 200
+                    id: e4277742-b91c-43f1-a185-b827e8574345
+                    parent_id: c1f729e2-3e2b-4f9e-b247-a4b568393e11
+                    type: standard
+                    name: Alpha Workspace
+                    description: Create a standard workspace.
+                    created: '2024-08-04T12:00:00Z'
+                    modified: '2024-08-04T12:00:00Z'
+                example1:
+                  value:
+                    _: 200
+                    id: e4277742-b91c-43f1-a185-b827e8574345
+                    parent_id: c1f729e2-3e2b-4f9e-b247-a4b568393e11
+                    type: standard
+                    name: Alpha Workspace
+                    description: Create a standard workspace.
+                    created: '2024-08-04T12:00:00Z'
+                    modified: '2024-08-04T12:00:00Z'
         '401':
           description: Access is unauthorized.
           content:
@@ -2216,6 +2237,7 @@ components:
         propertyName: type
         mapping:
           group: '#/components/schemas/RoleBindings.GroupSubject'
+          user: '#/components/schemas/RoleBindings.UserSubject'
     RoleBindings.BatchCreateRoleBindingsRequest:
       type: object
       required:

--- a/rbac/management/role/queryset.py
+++ b/rbac/management/role/queryset.py
@@ -16,17 +16,10 @@
 #
 """QuerySet for RoleV2 lookups."""
 
-import re
-
 from django.db import models
 from django.db.models import Count, Exists, IntegerField, OuterRef, Q, Subquery, Value
 from django.db.models.functions import Coalesce
-
-
-def _glob_to_regex(pattern: str) -> str:
-    """Convert a glob pattern with '*' wildcards to a regex."""
-    parts = pattern.split("*", maxsplit=10)
-    return "^" + ".*".join(re.escape(p) for p in parts) + "$"
+from management.v2_filters import v2_name_filter
 
 
 class RoleV2QuerySet(models.QuerySet):
@@ -80,13 +73,9 @@ class RoleV2QuerySet(models.QuerySet):
             qs = qs.prefetch_related("permissions")
         return qs
 
-    def named(self, name):
+    def named(self, name: str) -> "RoleV2QuerySet":
         """Filter to roles matching a name, with '*' glob support."""
-        if name == "*":
-            return self  # match all — no filter needed
-        if "*" in name:
-            return self.filter(name__iregex=_glob_to_regex(name))
-        return self.filter(name__iexact=name)
+        return v2_name_filter(self, name)
 
     def excluding_out_of_scope_v2_roles(self):
         """Exclude roles that include any permission from a migration-excluded application.

--- a/rbac/management/role_binding/serializer.py
+++ b/rbac/management/role_binding/serializer.py
@@ -67,7 +67,7 @@ class RoleBindingBySubjectFieldSelection(FieldSelection):
 
 def _normalize_blank_or_none(value: str | None) -> str | None:
     """Return None for empty/blank values, pass through otherwise."""
-    return value or None
+    return (value and value.strip()) or None
 
 
 def _normalize_uuid_or_none(value: str | None) -> uuid.UUID | None:

--- a/rbac/management/v2_filters.py
+++ b/rbac/management/v2_filters.py
@@ -1,0 +1,41 @@
+#
+# Copyright 2026 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""Shared V2 query filter utilities."""
+
+import re
+
+from django.db.models import QuerySet
+
+
+def _glob_to_regex(pattern: str) -> str:
+    """Convert a glob pattern with '*' wildcards to a regex."""
+    parts = pattern.split("*", maxsplit=10)
+    return "^" + ".*".join(re.escape(p) for p in parts) + "$"
+
+
+def v2_name_filter(queryset: QuerySet, name: str, field: str = "name") -> QuerySet:
+    """Filter a queryset by name with '*' glob support.
+
+    Without wildcards, performs case-insensitive exact match.
+    With '*' wildcards, converts to regex for pattern matching.
+    A bare '*' matches everything (no filter applied).
+    """
+    if name == "*":
+        return queryset
+    if "*" in name:
+        return queryset.filter(**{f"{field}__iregex": _glob_to_regex(name)})
+    return queryset.filter(**{f"{field}__iexact": name})

--- a/rbac/management/workspace/serializer.py
+++ b/rbac/management/workspace/serializer.py
@@ -71,20 +71,26 @@ class WorkspaceListInputSerializer(serializers.Serializer):
         return fields
 
     def validate_name(self, value: str | None) -> str | None:
-        """Return None for empty values."""
-        if not value or not value.strip():
+        """Return None for empty values, strip surrounding whitespace."""
+        if value is None:
             return None
-        return value
+        cleaned = value.strip()
+        if not cleaned:
+            return None
+        return cleaned
 
     def validate_parent_id(self, value: str | None) -> str | None:
         """Return None for empty values, validate UUID format otherwise."""
-        if not value or not value.strip():
+        if not value:
+            return None
+        cleaned = value.strip()
+        if not cleaned:
             return None
         try:
-            uuid.UUID(value.strip())
+            uuid.UUID(cleaned)
         except ValueError as e:
-            raise serializers.ValidationError(f"{value} is not a valid UUID.") from e
-        return value.strip()
+            raise serializers.ValidationError(f"{cleaned} is not a valid UUID.") from e
+        return cleaned
 
     def validate_ids(self, value: str | None) -> list[str] | None:
         """Return None for empty values, split and validate UUIDs otherwise."""

--- a/rbac/management/workspace/serializer.py
+++ b/rbac/management/workspace/serializer.py
@@ -38,7 +38,11 @@ class WorkspaceListInputSerializer(serializers.Serializer):
     """
 
     type = serializers.CharField(required=False, allow_blank=True, help_text="Filter by workspace type")
-    name = serializers.CharField(required=False, allow_blank=True, help_text="Filter by workspace name")
+    name = serializers.CharField(
+        required=False,
+        allow_blank=True,
+        help_text="Filter by workspace name. Use * as wildcard for partial matching.",
+    )
     parent_id = serializers.CharField(required=False, allow_blank=True, help_text="Filter by parent workspace ID")
     ids = serializers.CharField(required=False, allow_blank=True, help_text="Filter by comma-separated workspace IDs")
 

--- a/rbac/management/workspace/service.py
+++ b/rbac/management/workspace/service.py
@@ -42,6 +42,7 @@ from management.role.model import BindingMapping
 from management.role.relation_api_dual_write_handler import RelationApiDualWriteHandler
 from management.role_binding.model import RoleBinding
 from management.tenant_mapping.v2_activation import TenantVersion, lock_tenant_version
+from management.v2_filters import v2_name_filter
 from management.workspace.relation_api_dual_write_workspace_handler import RelationApiDualWriteWorkspaceHandler
 from migration_tool.sharedSystemRolesReplicatedRoleBindings import attribute_key_to_v2_related_resource_type
 from prometheus_client import Counter, Histogram
@@ -365,7 +366,7 @@ class WorkspaceService:
         if type_filter:
             queryset = queryset.filter(type__in=type_filter)
         if name:
-            queryset = queryset.filter(name__icontains=name)
+            queryset = v2_name_filter(queryset, name)
         if parent_id:
             queryset = queryset.filter(parent_id=parent_id)
         return queryset

--- a/tests/management/role_binding/test_serializer.py
+++ b/tests/management/role_binding/test_serializer.py
@@ -2146,30 +2146,6 @@ class UpdateRoleBindingRequestSerializerTests(IdentityRequest):
                     error_messages = str(serializer.errors[error_field])
                     self.assertIn(expected_msg, error_messages, f"Expected message for: {description}")
 
-    # ── Empty string normalization ─────────────────────────────────
-
-    def test_empty_resource_id_treated_as_unset(self):
-        """Test that empty resource_id is normalized to None, triggering cross-field error."""
-        data = self._make_valid_data(resource_id="")
-        serializer = UpdateRoleBindingRequestSerializer(data=data)
-        self.assertFalse(serializer.is_valid())
-        self.assertIn("resource_id", serializer.errors)
-
-    def test_empty_resource_type_treated_as_unset(self):
-        """Test that empty resource_type is normalized to None, triggering cross-field error."""
-        data = self._make_valid_data(resource_type="")
-        serializer = UpdateRoleBindingRequestSerializer(data=data)
-        self.assertFalse(serializer.is_valid())
-        self.assertIn("resource_type", serializer.errors)
-
-    def test_empty_resource_tenant_org_id_treated_as_unset(self):
-        """Test that empty resource.tenant.org_id is normalized to None."""
-        data = self._make_valid_data()
-        data["resource.tenant.org_id"] = ""
-        serializer = UpdateRoleBindingRequestSerializer(data=data)
-        self.assertTrue(serializer.is_valid(), serializer.errors)
-        self.assertIsNone(serializer.validated_data.get("resource_tenant_org_id"))
-
     # ── NUL byte sanitization (parameterized) ────────────────────────
 
     def test_nul_bytes_sanitized_from_string_fields(self):

--- a/tests/management/test_v2_name_filter.py
+++ b/tests/management/test_v2_name_filter.py
@@ -1,0 +1,105 @@
+#
+# Copyright 2026 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""Test the shared v2_name_filter utility."""
+
+from django.test import TestCase
+from management.v2_filters import v2_name_filter
+from management.workspace.model import Workspace
+
+from api.models import Tenant
+
+
+class V2NameFilterTest(TestCase):
+    """Test v2_name_filter with real ORM queries."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.tenant, _ = Tenant.objects.get_or_create(
+            tenant_name="acct_filter_test",
+            defaults={"account_id": "filter_test", "org_id": "filter_org", "ready": True},
+        )
+
+    def setUp(self):
+        super().setUp()
+        self.root = Workspace.objects.create(name="Root", tenant=self.tenant, type=Workspace.Types.ROOT)
+        self.ws1 = Workspace.objects.create(
+            name="Sales Team Alpha", tenant=self.tenant, type="standard", parent=self.root
+        )
+        self.ws2 = Workspace.objects.create(
+            name="Sales Team Beta", tenant=self.tenant, type="standard", parent=self.root
+        )
+        self.ws3 = Workspace.objects.create(
+            name="Engineering Squad", tenant=self.tenant, type="standard", parent=self.root
+        )
+        self.qs = Workspace.objects.filter(tenant=self.tenant, type="standard")
+
+    def test_exact_match(self):
+        """Without wildcards, name filter does case-insensitive exact match."""
+        result = v2_name_filter(self.qs, "Sales Team Alpha")
+        self.assertEqual(list(result.values_list("name", flat=True)), ["Sales Team Alpha"])
+
+    def test_exact_match_no_substring(self):
+        """Without wildcards, partial strings do not match."""
+        result = v2_name_filter(self.qs, "Sales")
+        self.assertEqual(result.count(), 0)
+
+    def test_exact_match_case_insensitive(self):
+        """Exact match is case-insensitive."""
+        result = v2_name_filter(self.qs, "sales team alpha")
+        self.assertEqual(result.count(), 1)
+        self.assertEqual(result.first().name, "Sales Team Alpha")
+
+    def test_wildcard_prefix(self):
+        """Prefix pattern matches names starting with the given string."""
+        result = v2_name_filter(self.qs, "Sales*")
+        self.assertCountEqual(list(result.values_list("name", flat=True)), ["Sales Team Alpha", "Sales Team Beta"])
+
+    def test_wildcard_suffix(self):
+        """Suffix pattern matches names ending with the given string."""
+        result = v2_name_filter(self.qs, "*Alpha")
+        self.assertEqual(list(result.values_list("name", flat=True)), ["Sales Team Alpha"])
+
+    def test_wildcard_substring(self):
+        """Substring pattern *term* matches names containing the term."""
+        result = v2_name_filter(self.qs, "*Team*")
+        self.assertCountEqual(list(result.values_list("name", flat=True)), ["Sales Team Alpha", "Sales Team Beta"])
+
+    def test_wildcard_complex_pattern(self):
+        """Complex pattern with multiple wildcards."""
+        result = v2_name_filter(self.qs, "Sales*Alpha")
+        self.assertEqual(list(result.values_list("name", flat=True)), ["Sales Team Alpha"])
+
+    def test_wildcard_star_returns_all(self):
+        """Bare * returns all records (no filter applied)."""
+        result = v2_name_filter(self.qs, "*")
+        self.assertEqual(result.count(), 3)
+
+    def test_wildcard_no_match(self):
+        """Wildcard pattern matching nothing returns empty queryset."""
+        result = v2_name_filter(self.qs, "zzz*")
+        self.assertEqual(result.count(), 0)
+
+    def test_wildcard_case_insensitive(self):
+        """Wildcard matching is case-insensitive."""
+        result = v2_name_filter(self.qs, "*sales*")
+        self.assertCountEqual(list(result.values_list("name", flat=True)), ["Sales Team Alpha", "Sales Team Beta"])
+
+    def test_custom_field(self):
+        """Filter works with a custom field name."""
+        result = v2_name_filter(self.qs, "standard", field="type")
+        self.assertEqual(result.count(), 3)

--- a/tests/management/workspace/test_view.py
+++ b/tests/management/workspace/test_view.py
@@ -2975,8 +2975,8 @@ class WorkspaceTestsList(WorkspaceViewTests):
         self.assertEqual(payload.get("data")[0]["id"], str(self.root_workspace.id))
         self.assertType(payload, "root")
 
-    def test_workspace_list_filter_by_name(self):
-        """List workspaces filtered by name using case-insensitive substring matching."""
+    def test_workspace_list_filter_by_name_exact(self):
+        """Test that name filter without wildcards does case-insensitive exact match."""
         ws_name_1 = "Sales Team Alpha"
         ws_name_2 = "Sales Team Beta"
         ws_name_3 = "Engineering Squad"
@@ -3006,34 +3006,111 @@ class WorkspaceTestsList(WorkspaceViewTests):
         url = reverse("v2_management:workspace-list")
         client = APIClient()
 
-        # Substring "Sales" matches Sales Team Alpha and Sales Team Beta
-        response = client.get(f"{url}?name=Sales", None, format="json", **self.headers)
-        payload = response.data
-        self.assertSuccessfulList(response, payload)
-        self.assertEqual(payload.get("meta").get("count"), 2)
-
-        # Substring "Alpha" matches only Sales Team Alpha
-        response = client.get(f"{url}?name=Alpha", None, format="json", **self.headers)
+        # Exact match "Sales Team Alpha" returns only that workspace
+        response = client.get(f"{url}?name=Sales Team Alpha", None, format="json", **self.headers)
         payload = response.data
         self.assertSuccessfulList(response, payload)
         self.assertEqual(payload.get("meta").get("count"), 1)
         self.assertEqual(payload.get("data")[0]["name"], ws_name_1)
 
-        # Substring "Squad" matches only Engineering Squad
-        response = client.get(f"{url}?name=Squad", None, format="json", **self.headers)
+        # Partial string "Sales" without wildcard does NOT match (exact match semantics)
+        response = client.get(f"{url}?name=Sales", None, format="json", **self.headers)
+        payload = response.data
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(payload.get("meta").get("count"), 0)
+
+        # Exact match for "Engineering Squad"
+        response = client.get(f"{url}?name=Engineering Squad", None, format="json", **self.headers)
         payload = response.data
         self.assertSuccessfulList(response, payload)
         self.assertEqual(payload.get("meta").get("count"), 1)
         self.assertEqual(payload.get("data")[0]["name"], ws_name_3)
 
-        # Middle substring "Team" matches both Sales Team workspaces
-        response = client.get(f"{url}?name=Team", None, format="json", **self.headers)
+    def test_workspace_list_filter_by_name_wildcard(self):
+        """Test that name filter with * wildcards does glob pattern matching."""
+        ws_name_1 = "Sales Team Alpha"
+        ws_name_2 = "Sales Team Beta"
+        ws_name_3 = "Engineering Squad"
+        Workspace.objects.bulk_create(
+            [
+                Workspace(
+                    name=ws_name_1,
+                    tenant=self.tenant,
+                    type="standard",
+                    parent_id=self.default_workspace.id,
+                ),
+                Workspace(
+                    name=ws_name_2,
+                    tenant=self.tenant,
+                    type="standard",
+                    parent_id=self.default_workspace.id,
+                ),
+                Workspace(
+                    name=ws_name_3,
+                    tenant=self.tenant,
+                    type="standard",
+                    parent_id=self.default_workspace.id,
+                ),
+            ]
+        )
+
+        url = reverse("v2_management:workspace-list")
+        client = APIClient()
+
+        # Substring wildcard *Sales* matches both Sales Team workspaces
+        response = client.get(f"{url}?name=*Sales*", None, format="json", **self.headers)
         payload = response.data
         self.assertSuccessfulList(response, payload)
         self.assertEqual(payload.get("meta").get("count"), 2)
 
+        # Prefix wildcard Sales* matches both Sales Team workspaces
+        response = client.get(f"{url}?name=Sales*", None, format="json", **self.headers)
+        payload = response.data
+        self.assertSuccessfulList(response, payload)
+        self.assertEqual(payload.get("meta").get("count"), 2)
+
+        # Suffix wildcard *Alpha matches only Sales Team Alpha
+        response = client.get(f"{url}?name=*Alpha", None, format="json", **self.headers)
+        payload = response.data
+        self.assertSuccessfulList(response, payload)
+        self.assertEqual(payload.get("meta").get("count"), 1)
+        self.assertEqual(payload.get("data")[0]["name"], ws_name_1)
+
+        # Substring wildcard *Team* matches both Sales Team workspaces
+        response = client.get(f"{url}?name=*Team*", None, format="json", **self.headers)
+        payload = response.data
+        self.assertSuccessfulList(response, payload)
+        self.assertEqual(payload.get("meta").get("count"), 2)
+
+        # Complex pattern Sales*Alpha matches only Sales Team Alpha
+        response = client.get(f"{url}?name=Sales*Alpha", None, format="json", **self.headers)
+        payload = response.data
+        self.assertSuccessfulList(response, payload)
+        self.assertEqual(payload.get("meta").get("count"), 1)
+        self.assertEqual(payload.get("data")[0]["name"], ws_name_1)
+
+    def test_workspace_list_filter_by_name_wildcard_no_match(self):
+        """Test that a wildcard pattern matching nothing returns empty list."""
+        url = reverse("v2_management:workspace-list")
+        client = APIClient()
+        response = client.get(f"{url}?name=zzz*", None, format="json", **self.headers)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["data"], [])
+
+    def test_workspace_list_filter_by_name_wildcard_star_returns_all(self):
+        """Test that name=* returns all workspaces (no filter applied)."""
+        url = reverse("v2_management:workspace-list")
+        client = APIClient()
+        total_count = Workspace.objects.count()
+
+        response = client.get(f"{url}?name=*", None, format="json", **self.headers)
+        payload = response.data
+        self.assertSuccessfulList(response, payload)
+        self.assertEqual(payload.get("meta").get("count"), total_count)
+
     def test_workspace_list_filter_by_name_is_case_insensitive(self):
-        """Test that name filter is case-insensitive substring matching."""
+        """Test that name filter is case-insensitive for both exact and wildcard matching."""
         Workspace.objects.create(
             name="Sales Team Alpha",
             tenant=self.tenant,
@@ -3044,15 +3121,22 @@ class WorkspaceTestsList(WorkspaceViewTests):
         url = reverse("v2_management:workspace-list")
         client = APIClient()
 
-        # Lowercase substring should match "Sales Team Alpha"
-        response = client.get(f"{url}?name=sales", None, format="json", **self.headers)
+        # Lowercase exact match
+        response = client.get(f"{url}?name=sales team alpha", None, format="json", **self.headers)
         payload = response.data
         self.assertSuccessfulList(response, payload)
         self.assertEqual(payload.get("meta").get("count"), 1)
         self.assertEqual(payload.get("data")[0]["name"], "Sales Team Alpha")
 
-        # Uppercase substring should also match
-        response = client.get(f"{url}?name=SALES", None, format="json", **self.headers)
+        # Uppercase exact match
+        response = client.get(f"{url}?name=SALES TEAM ALPHA", None, format="json", **self.headers)
+        payload = response.data
+        self.assertSuccessfulList(response, payload)
+        self.assertEqual(payload.get("meta").get("count"), 1)
+        self.assertEqual(payload.get("data")[0]["name"], "Sales Team Alpha")
+
+        # Case-insensitive wildcard
+        response = client.get(f"{url}?name=*sales*", None, format="json", **self.headers)
         payload = response.data
         self.assertSuccessfulList(response, payload)
         self.assertEqual(payload.get("meta").get("count"), 1)


### PR DESCRIPTION
## Link(s) to Jira
- [RHCLOUD-46190](https://issues.redhat.com/browse/RHCLOUD-46190)

## Description of Intent of Change(s)

V2 list endpoints used different name filtering semantics:

- **Roles** (`?name=`): Case-insensitive exact match by default, glob pattern matching with `*` wildcards
- **Workspaces** (`?name=`): Always case-insensitive substring match (`icontains`), no wildcard support

This inconsistency confused API consumers who expected the same filtering syntax across V2 endpoints.

**Changes:**

1. Extract the glob-based name filtering logic from `RoleV2QuerySet.named()` into a shared `v2_name_filter()` utility in `management/v2_filters.py`
2. Update `WorkspaceService.list()` to use `v2_name_filter()` instead of `icontains`
3. Both endpoints now use identical filtering semantics:
   - `name=foo` -- case-insensitive exact match
   - `name=foo*` -- prefix match
   - `name=*foo*` -- substring match
   - `name=*` -- match all (no filter applied)

The shared module is kept dependency-free (only `django.db.models`) to avoid circular imports through `management.models`.

**Behavior changes for API consumers:**
- **Workspace name filtering**: `?name=foo` now does case-insensitive exact match instead of substring match. To get the old substring behavior, use `?name=*foo*`.
- **Role-binding empty params**: Empty query parameters (e.g. `?role_id=`) now return 200 (treated as unset) instead of 400. This matches the Roles V2 convention where empty = no filter.

~~**Prerequisite:** PR #2907 must be merged first (workspace list filtering refactor).~~ Merged and rebased.

## Local Testing

```bash
# Unit tests for the shared utility
pipenv run tox -e py312-fast -- tests.management.test_v2_name_filter

# Workspace name filter tests
pipenv run tox -e py312-fast -- tests.management.workspace.test_view.WorkspaceTestsList.test_workspace_list_filter_by_name_exact
pipenv run tox -e py312-fast -- tests.management.workspace.test_view.WorkspaceTestsList.test_workspace_list_filter_by_name_wildcard

# Role name filter tests (unchanged behavior)
pipenv run tox -e py312-fast -- tests.management.role.test_v2_view.RoleV2ViewSetTests.test_list_roles_with_name_filter
pipenv run tox -e py312-fast -- tests.management.role.test_v2_view.RoleV2ViewSetTests.test_list_roles_with_wildcard_name_filter

# Full suite (3506 tests pass)
pipenv run tox -e py312-fast
```

## Checklist
- [x] if API spec changes are required, is the spec updated?
- [x] are there any pre/post merge actions required? ~~PR #2907 must merge first~~ Done
- [x] are these changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes? No
- [ ] is there known, direct impact to dependent teams/components?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices

[RHCLOUD-46190]: https://redhat.atlassian.net/browse/RHCLOUD-46190?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Unify V2 workspace and role name filtering semantics and harden query parameter validation for workspace and role-binding endpoints.

New Features:
- Introduce a shared v2_name_filter utility to provide consistent glob-based, case-insensitive name filtering across V2 endpoints.
- Add a WorkspaceListInputSerializer to normalize and validate workspace list query parameters, including type, name, parent_id, and ids.

Enhancements:
- Refactor workspace list view to delegate domain filtering to WorkspaceService.list using validated parameters from the new input serializer.
- Extend workspace listing to support wildcard name filtering with exact, prefix, substring, and match-all patterns aligned with role listing behavior.
- Improve role-binding input serializers to treat empty strings as unset for optional filters and centralize blank/UUID normalization helpers.

Tests:
- Add comprehensive tests for WorkspaceListInputSerializer covering type parsing, UUID validation, cross-field defaults, and NUL-byte rejection.
- Expand workspace list view tests to cover exact and wildcard name filtering behaviors and case-insensitivity.
- Add tests for the shared v2_name_filter utility using real ORM queries and for updated role-binding serializers’ empty-string normalization and cross-field validation behavior.