### PR TITLE
[RHCLOUD-47900] feat(mcp): add centralized Kessel permission checks for MCP tools

### DIFF
--- a/rbac/management/mcp_views.py
+++ b/rbac/management/mcp_views.py
@@ -4824,24 +4824,28 @@ def _check_kessel_access(request: HttpRequest, resource_type: str, relation: str
     Returns True if access is granted, False otherwise. Fails closed on
     missing tenant, missing principal ID, or Inventory API errors.
     """
-    tenant = getattr(request, "tenant", None)
-    if not tenant:
-        return False
+    try:
+        tenant = getattr(request, "tenant", None)
+        if not tenant:
+            return False
 
-    resource_id = tenant.tenant_resource_id()
-    if not resource_id:
-        return False
+        resource_id = tenant.tenant_resource_id()
+        if not resource_id:
+            return False
 
-    principal_id = get_kessel_principal_id(request)
-    if not principal_id:
-        return False
+        principal_id = get_kessel_principal_id(request)
+        if not principal_id:
+            return False
 
-    return WorkspaceInventoryAccessChecker().check_resource_access(
-        resource_type=resource_type,
-        resource_id=resource_id,
-        principal_id=principal_id,
-        relation=relation,
-    )
+        return WorkspaceInventoryAccessChecker().check_resource_access(
+            resource_type=resource_type,
+            resource_id=resource_id,
+            principal_id=principal_id,
+            relation=relation,
+        )
+    except Exception:
+        logger.exception("mcp: Kessel access check failed unexpectedly")
+        return False
 
 
 def _handle_tools_call(request: HttpRequest, request_id: Any, params: dict[str, Any]) -> JsonResponse:

--- a/rbac/management/mcp_views.py
+++ b/rbac/management/mcp_views.py
@@ -44,8 +44,9 @@ from management.cache import _connection_pool
 from management.group.view import GroupViewSet
 from management.models import Access, AuditLog, Group, Permission
 from management.permission.view import PermissionViewSet
+from management.permissions.workspace_inventory_access import WorkspaceInventoryAccessChecker
 from management.principal.model import Principal
-from management.principal.proxy import PrincipalProxy
+from management.principal.proxy import PrincipalProxy, get_kessel_principal_id
 from management.principal.view import PrincipalView
 from management.role.model import Role
 from management.role.v2_model import RoleV2
@@ -213,6 +214,8 @@ class ToolConfig:
     passes_request: bool = False
     api_version: str = ApiVersion.COMMON
     write: bool = False
+    required_relation: str | None = None
+    required_resource_type: str = "tenant"
 
 
 _TOOL_CONFIG: dict[str, ToolConfig] = {}
@@ -224,6 +227,8 @@ def register_tool(
     requires_auth: bool = False,
     api_version: str = ApiVersion.COMMON,
     write: bool = False,
+    required_relation: str | None = None,
+    required_resource_type: str = "tenant",
 ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
     """Register a tool with both FastMCP and _TOOL_CONFIG.
 
@@ -246,6 +251,8 @@ def register_tool(
             passes_request=passes_request,
             api_version=api_version,
             write=write,
+            required_relation=required_relation,
+            required_resource_type=required_resource_type,
         )
 
         if passes_request:
@@ -600,6 +607,7 @@ def list_permissions(
         "authorized the action."
     ),
     requires_auth=True,
+    required_relation="rbac_roles_read",
 )
 def list_audit_logs(
     request: HttpRequest,
@@ -994,6 +1002,7 @@ def list_role_access(
     ),
     requires_auth=True,
     api_version=ApiVersion.UNIFIED,
+    required_relation="rbac_roles_read",
 )
 def search_roles(
     request: HttpRequest,
@@ -1089,6 +1098,7 @@ def _search_roles_v2(
     ),
     requires_auth=True,
     api_version=ApiVersion.UNIFIED,
+    required_relation="rbac_roles_read",
 )
 def get_role(
     request: HttpRequest,
@@ -1144,6 +1154,7 @@ def _get_role_v2(request: HttpRequest, role_uuid: str) -> str:
     ),
     requires_auth=True,
     api_version=ApiVersion.UNIFIED,
+    required_relation="rbac_roles_read",
 )
 def check_role_permissions(
     request: HttpRequest,
@@ -1548,6 +1559,7 @@ def get_cross_account_request(
     ),
     requires_auth=True,
     api_version=ApiVersion.COMMON,
+    required_relation="rbac_roles_read",
 )
 def investigate_tam_access(
     request: HttpRequest,
@@ -1752,6 +1764,7 @@ def investigate_tam_access(
     ),
     requires_auth=True,
     api_version=ApiVersion.COMMON,
+    required_relation="rbac_roles_read",
 )
 def audit_redhat_access(
     request: HttpRequest,
@@ -1965,6 +1978,7 @@ def audit_redhat_access(
     ),
     requires_auth=True,
     api_version=ApiVersion.COMMON,
+    required_relation="rbac_roles_read",
 )
 def audit_group_for_dissolution(
     request: HttpRequest,
@@ -2381,6 +2395,7 @@ def _permission_matches(granted_permission: str, requested_permission: str) -> b
     ),
     requires_auth=True,
     api_version=ApiVersion.UNIFIED,
+    required_relation="rbac_roles_read",
 )
 def check_user_permission(
     request: HttpRequest,
@@ -2557,6 +2572,7 @@ def _check_user_permission_v1(request: HttpRequest, username: str, permission: s
     ),
     requires_auth=True,
     api_version=ApiVersion.UNIFIED,
+    required_relation="rbac_roles_read",
 )
 def get_user_state(
     request: HttpRequest,
@@ -2809,6 +2825,7 @@ def _get_user_access_v1(request: HttpRequest, username: str) -> list[dict[str, A
         "Format dates as day of week (Monday, Tuesday, etc.), not ISO timestamps."
     ),
     requires_auth=True,
+    required_relation="rbac_roles_read",
 )
 def get_rbac_recent_changes(
     request: HttpRequest,
@@ -2907,6 +2924,7 @@ def get_rbac_recent_changes(
         "rbac:group:write.'"
     ),
     requires_auth=True,
+    required_relation="rbac_roles_read",
 )
 def investigate_group_changes(
     request: HttpRequest,
@@ -3192,6 +3210,7 @@ def _analyze_expected_permission(
     ),
     requires_auth=True,
     api_version=ApiVersion.COMMON,
+    required_relation="rbac_roles_read",
 )
 def investigate_user_access(
     request: HttpRequest,
@@ -3944,6 +3963,7 @@ def create_cross_account_request(
     ),
     requires_auth=True,
     api_version=ApiVersion.UNIFIED,
+    required_relation="rbac_roles_read",
 )
 def guide_user_access_delegation(
     request: HttpRequest,
@@ -4798,6 +4818,32 @@ def _execute_with_timeout(fn: Callable[..., Any], timeout: int, *args: Any, **kw
         raise ToolTimeoutError(f"Tool execution exceeded {timeout}s timeout")
 
 
+def _check_kessel_access(request: HttpRequest, resource_type: str, relation: str) -> bool:
+    """Check Kessel Inventory API permission for the requesting user.
+
+    Returns True if access is granted, False otherwise. Fails closed on
+    missing tenant, missing principal ID, or Inventory API errors.
+    """
+    tenant = getattr(request, "tenant", None)
+    if not tenant:
+        return False
+
+    resource_id = tenant.tenant_resource_id()
+    if not resource_id:
+        return False
+
+    principal_id = get_kessel_principal_id(request)
+    if not principal_id:
+        return False
+
+    return WorkspaceInventoryAccessChecker().check_resource_access(
+        resource_type=resource_type,
+        resource_id=resource_id,
+        principal_id=principal_id,
+        relation=relation,
+    )
+
+
 def _handle_tools_call(request: HttpRequest, request_id: Any, params: dict[str, Any]) -> JsonResponse:
     """Handle MCP tools/call request.
 
@@ -4854,6 +4900,17 @@ def _handle_tools_call(request: HttpRequest, request_id: Any, params: dict[str, 
             logger.warning("mcp: tools/call tool='%s' rejected, no auth", tool_name)
             _record_metric(tool_name, "auth_error")
             return _error_response(request_id, -32000, "Authentication required")
+
+    if config.required_relation:
+        if not _check_kessel_access(request, config.required_resource_type, config.required_relation):
+            logger.warning(
+                "mcp: tools/call tool='%s' rejected, Kessel permission denied (relation=%s, resource_type=%s)",
+                tool_name,
+                config.required_relation,
+                config.required_resource_type,
+            )
+            _record_metric(tool_name, "permission_denied")
+            return _error_response(request_id, -32003, "Permission denied")
 
     track = tool_name != "hello"
     start = time.monotonic() if track else 0

--- a/rbac/management/mcp_views.py
+++ b/rbac/management/mcp_views.py
@@ -216,6 +216,7 @@ class ToolConfig:
     write: bool = False
     required_relation: str | None = None
     required_resource_type: str = "tenant"
+    v1_permission: tuple[str, str] | None = None
 
 
 _TOOL_CONFIG: dict[str, ToolConfig] = {}
@@ -229,6 +230,7 @@ def register_tool(
     write: bool = False,
     required_relation: str | None = None,
     required_resource_type: str = "tenant",
+    v1_permission: tuple[str, str] | None = None,
 ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
     """Register a tool with both FastMCP and _TOOL_CONFIG.
 
@@ -253,6 +255,7 @@ def register_tool(
             write=write,
             required_relation=required_relation,
             required_resource_type=required_resource_type,
+            v1_permission=v1_permission,
         )
 
         if passes_request:
@@ -608,6 +611,7 @@ def list_permissions(
     ),
     requires_auth=True,
     required_relation="rbac_roles_read",
+    v1_permission=("admin", "only"),
 )
 def list_audit_logs(
     request: HttpRequest,
@@ -1003,6 +1007,7 @@ def list_role_access(
     requires_auth=True,
     api_version=ApiVersion.UNIFIED,
     required_relation="rbac_roles_read",
+    v1_permission=("role", "read"),
 )
 def search_roles(
     request: HttpRequest,
@@ -1099,6 +1104,7 @@ def _search_roles_v2(
     requires_auth=True,
     api_version=ApiVersion.UNIFIED,
     required_relation="rbac_roles_read",
+    v1_permission=("role", "read"),
 )
 def get_role(
     request: HttpRequest,
@@ -1155,6 +1161,7 @@ def _get_role_v2(request: HttpRequest, role_uuid: str) -> str:
     requires_auth=True,
     api_version=ApiVersion.UNIFIED,
     required_relation="rbac_roles_read",
+    v1_permission=("role", "read"),
 )
 def check_role_permissions(
     request: HttpRequest,
@@ -1560,6 +1567,7 @@ def get_cross_account_request(
     requires_auth=True,
     api_version=ApiVersion.COMMON,
     required_relation="rbac_roles_read",
+    v1_permission=("role", "read"),
 )
 def investigate_tam_access(
     request: HttpRequest,
@@ -1765,6 +1773,7 @@ def investigate_tam_access(
     requires_auth=True,
     api_version=ApiVersion.COMMON,
     required_relation="rbac_roles_read",
+    v1_permission=("role", "read"),
 )
 def audit_redhat_access(
     request: HttpRequest,
@@ -1979,6 +1988,7 @@ def audit_redhat_access(
     requires_auth=True,
     api_version=ApiVersion.COMMON,
     required_relation="rbac_roles_read",
+    v1_permission=("group", "read"),
 )
 def audit_group_for_dissolution(
     request: HttpRequest,
@@ -2396,6 +2406,7 @@ def _permission_matches(granted_permission: str, requested_permission: str) -> b
     requires_auth=True,
     api_version=ApiVersion.UNIFIED,
     required_relation="rbac_roles_read",
+    v1_permission=("principal", "read"),
 )
 def check_user_permission(
     request: HttpRequest,
@@ -2573,6 +2584,7 @@ def _check_user_permission_v1(request: HttpRequest, username: str, permission: s
     requires_auth=True,
     api_version=ApiVersion.UNIFIED,
     required_relation="rbac_roles_read",
+    v1_permission=("principal", "read"),
 )
 def get_user_state(
     request: HttpRequest,
@@ -2826,6 +2838,7 @@ def _get_user_access_v1(request: HttpRequest, username: str) -> list[dict[str, A
     ),
     requires_auth=True,
     required_relation="rbac_roles_read",
+    v1_permission=("admin", "only"),
 )
 def get_rbac_recent_changes(
     request: HttpRequest,
@@ -2925,6 +2938,7 @@ def get_rbac_recent_changes(
     ),
     requires_auth=True,
     required_relation="rbac_roles_read",
+    v1_permission=("group", "read"),
 )
 def investigate_group_changes(
     request: HttpRequest,
@@ -3211,6 +3225,7 @@ def _analyze_expected_permission(
     requires_auth=True,
     api_version=ApiVersion.COMMON,
     required_relation="rbac_roles_read",
+    v1_permission=("principal", "read"),
 )
 def investigate_user_access(
     request: HttpRequest,
@@ -3964,6 +3979,7 @@ def create_cross_account_request(
     requires_auth=True,
     api_version=ApiVersion.UNIFIED,
     required_relation="rbac_roles_read",
+    v1_permission=("role", "read"),
 )
 def guide_user_access_delegation(
     request: HttpRequest,
@@ -4855,6 +4871,31 @@ def _execute_with_timeout(fn: Callable[..., Any], timeout: int, *args: Any, **kw
         raise ToolTimeoutError(f"Tool execution exceeded {timeout}s timeout")
 
 
+def _check_v1_access(request: HttpRequest, v1_permission: tuple[str, str]) -> bool:
+    """Check v1 RBAC permission for the requesting user.
+
+    Args:
+        request: The Django HTTP request with user context populated by middleware.
+        v1_permission: A (resource_type, verb) tuple, e.g. ("role", "read").
+            Use ("admin", "only") to require org admin with no access-dict fallback.
+
+    Returns True if access is granted, False otherwise.
+    """
+    user = getattr(request, "user", None)
+    if not user:
+        return False
+
+    if getattr(user, "admin", False):
+        return True
+
+    resource_type, verb = v1_permission
+    if resource_type == "admin":
+        return False
+
+    access = getattr(user, "access", {})
+    return bool(access.get(resource_type, {}).get(verb, []))
+
+
 def _check_kessel_access(request: HttpRequest, resource_type: str, relation: str) -> bool:
     """Check Kessel Inventory API permission for the requesting user.
 
@@ -4943,9 +4984,16 @@ def _handle_tools_call(request: HttpRequest, request_id: Any, params: dict[str, 
             return _error_response(request_id, -32000, "Authentication required")
 
     if config.required_relation:
-        if not _check_kessel_access(request, config.required_resource_type, config.required_relation):
+        tenant = getattr(request, "tenant", None)
+        if tenant and is_v2_write_activated(tenant):
+            access_granted = _check_kessel_access(request, config.required_resource_type, config.required_relation)
+        elif config.v1_permission:
+            access_granted = _check_v1_access(request, config.v1_permission)
+        else:
+            access_granted = False
+        if not access_granted:
             logger.warning(
-                "mcp: tools/call tool='%s' rejected, Kessel permission denied (relation=%s, resource_type=%s)",
+                "mcp: tools/call tool='%s' rejected, permission denied (relation=%s, resource_type=%s)",
                 tool_name,
                 config.required_relation,
                 config.required_resource_type,

--- a/tests/management/test_mcp_views.py
+++ b/tests/management/test_mcp_views.py
@@ -6742,8 +6742,21 @@ class MCPKesselAccessCheckTests(MCPToolTestMixin, IdentityRequest):
         mock_kessel.assert_not_called()
 
     @patch("management.mcp_views.get_kessel_principal_id", side_effect=Exception("Dependency error"))
-    def test_check_kessel_access_exception_fails_closed(self, _mock_principal):
-        """_check_kessel_access returns False when an exception is raised (fail-closed)."""
+    def test_check_kessel_access_principal_exception_fails_closed(self, _mock_principal):
+        """_check_kessel_access returns False when get_kessel_principal_id raises (fail-closed)."""
+        from django.test import RequestFactory
+
+        request = RequestFactory().get("/")
+        request.tenant = self.tenant
+        self.assertFalse(_check_kessel_access(request, "tenant", "rbac_roles_read"))
+
+    @patch("management.mcp_views.get_kessel_principal_id", return_value="localhost/test_user")
+    @patch(
+        "management.mcp_views.WorkspaceInventoryAccessChecker.check_resource_access",
+        side_effect=Exception("Inventory API error"),
+    )
+    def test_check_kessel_access_inventory_exception_fails_closed(self, _mock_checker, _mock_principal):
+        """_check_kessel_access returns False when check_resource_access raises (fail-closed)."""
         from django.test import RequestFactory
 
         request = RequestFactory().get("/")

--- a/tests/management/test_mcp_views.py
+++ b/tests/management/test_mcp_views.py
@@ -29,6 +29,7 @@ from management.mcp_views import (
     ToolConfig,
     ToolTimeoutError,
     _TOOL_CONFIG,
+    _check_kessel_access,
     _execute_with_timeout,
     _permission_matches,
 )
@@ -49,6 +50,13 @@ from rbac import urls
 
 class MCPToolTestMixin:
     """Shared helpers for calling MCP tools in tests."""
+
+    def setUp(self):
+        """Auto-mock Kessel access check so protected tools are callable in tests."""
+        super().setUp()
+        patcher = patch("management.mcp_views._check_kessel_access", return_value=True)
+        self._kessel_mock = patcher.start()
+        self.addCleanup(patcher.stop)
 
     def _call_tool(self, tool_name, arguments=None, use_auth=True):
         """Helper to call an MCP tool and return the parsed response."""
@@ -6510,3 +6518,225 @@ class MCPDeleteToolsV2Tests(MCPToolTestMixin, IdentityRequest):
         data = response.json()
         self.assertIn("error", data)
         self.assertEqual(data["error"]["code"], -32000)
+
+
+class MCPKesselAccessCheckTests(MCPToolTestMixin, IdentityRequest):
+    """Test the centralized Kessel permission check for MCP tools."""
+
+    def setUp(self):
+        """Set up the Kessel access check tests."""
+        super().setUp()
+        self.url = "/_private/_a2s/mcp/"
+        self.client = APIClient()
+        self.principal = Principal.objects.create(username="test_user", tenant=self.tenant)
+
+    def tearDown(self):
+        """Tear down Kessel access check tests."""
+        AuditLog.objects.all().delete()
+        Principal.objects.all().delete()
+        super().tearDown()
+
+    # --- ToolConfig ---
+
+    def test_tool_config_has_kessel_fields(self):
+        """ToolConfig includes required_relation and required_resource_type."""
+        config = ToolConfig(fn=lambda: "")
+        self.assertIsNone(config.required_relation)
+        self.assertEqual(config.required_resource_type, "tenant")
+
+    def test_tool_config_with_kessel_fields(self):
+        """ToolConfig accepts required_relation and required_resource_type."""
+        config = ToolConfig(fn=lambda: "", required_relation="rbac_roles_read", required_resource_type="workspace")
+        self.assertEqual(config.required_relation, "rbac_roles_read")
+        self.assertEqual(config.required_resource_type, "workspace")
+
+    def test_protected_tools_have_required_relation(self):
+        """All direct-DB tools have required_relation set."""
+        expected_protected = [
+            "list_audit_logs",
+            "investigate_tam_access",
+            "audit_redhat_access",
+            "audit_group_for_dissolution",
+            "get_user_state",
+            "get_rbac_recent_changes",
+            "investigate_group_changes",
+            "guide_user_access_delegation",
+            "search_roles",
+            "get_role",
+            "check_role_permissions",
+            "investigate_user_access",
+            "check_user_permission",
+        ]
+        for tool_name in expected_protected:
+            config = _TOOL_CONFIG.get(tool_name)
+            self.assertIsNotNone(config, f"Tool '{tool_name}' not found in _TOOL_CONFIG")
+            self.assertIsNotNone(
+                config.required_relation,
+                f"Tool '{tool_name}' missing required_relation",
+            )
+
+    def test_unprotected_tools_have_no_required_relation(self):
+        """View-delegated tools do not have required_relation set."""
+        unprotected = ["hello", "list_principals", "list_permissions", "list_groups", "get_group"]
+        for tool_name in unprotected:
+            config = _TOOL_CONFIG.get(tool_name)
+            if config:
+                self.assertIsNone(
+                    config.required_relation,
+                    f"Tool '{tool_name}' should not have required_relation",
+                )
+
+    # --- _check_kessel_access unit tests ---
+
+    def test_check_kessel_access_no_tenant(self):
+        """_check_kessel_access returns False when request has no tenant."""
+        from django.test import RequestFactory
+
+        request = RequestFactory().get("/")
+        self.assertFalse(_check_kessel_access(request, "tenant", "rbac_roles_read"))
+
+    def test_check_kessel_access_no_resource_id(self):
+        """_check_kessel_access returns False when tenant has no resource ID."""
+        from django.test import RequestFactory
+
+        request = RequestFactory().get("/")
+        request.tenant = self.tenant
+        with patch.object(type(self.tenant), "tenant_resource_id", return_value=None):
+            self.assertFalse(_check_kessel_access(request, "tenant", "rbac_roles_read"))
+
+    @patch("management.mcp_views.get_kessel_principal_id", return_value=None)
+    def test_check_kessel_access_no_principal_id(self, _mock_principal):
+        """_check_kessel_access returns False when principal ID cannot be resolved."""
+        from django.test import RequestFactory
+
+        request = RequestFactory().get("/")
+        request.tenant = self.tenant
+        self.assertFalse(_check_kessel_access(request, "tenant", "rbac_roles_read"))
+
+    @patch("management.mcp_views.get_kessel_principal_id", return_value="localhost/test_user")
+    @patch("management.mcp_views.WorkspaceInventoryAccessChecker.check_resource_access", return_value=True)
+    def test_check_kessel_access_granted(self, mock_checker, _mock_principal):
+        """_check_kessel_access returns True when Kessel grants access."""
+        from django.test import RequestFactory
+
+        request = RequestFactory().get("/")
+        request.tenant = self.tenant
+        self.assertTrue(_check_kessel_access(request, "tenant", "rbac_roles_read"))
+        mock_checker.assert_called_once_with(
+            resource_type="tenant",
+            resource_id=self.tenant.tenant_resource_id(),
+            principal_id="localhost/test_user",
+            relation="rbac_roles_read",
+        )
+
+    @patch("management.mcp_views.get_kessel_principal_id", return_value="localhost/test_user")
+    @patch("management.mcp_views.WorkspaceInventoryAccessChecker.check_resource_access", return_value=False)
+    def test_check_kessel_access_denied(self, mock_checker, _mock_principal):
+        """_check_kessel_access returns False when Kessel denies access."""
+        from django.test import RequestFactory
+
+        request = RequestFactory().get("/")
+        request.tenant = self.tenant
+        self.assertFalse(_check_kessel_access(request, "tenant", "rbac_roles_read"))
+
+    # --- Integration: tool dispatch with Kessel check ---
+
+    @patch("management.mcp_views._check_kessel_access", return_value=False)
+    def test_tool_with_required_relation_denied(self, _mock_check):
+        """Tools with required_relation return permission denied when Kessel check fails."""
+        response = self._call_tool("list_audit_logs")
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertIn("error", data)
+        self.assertEqual(data["error"]["code"], -32003)
+        self.assertEqual(data["error"]["message"], "Permission denied")
+
+    @patch("management.mcp_views._check_kessel_access", return_value=True)
+    def test_tool_with_required_relation_granted(self, _mock_check):
+        """Tools with required_relation succeed when Kessel check passes."""
+        response = self._call_tool("list_audit_logs")
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertIn("result", data)
+        self.assertFalse(data["result"]["isError"])
+
+    @patch("management.mcp_views._check_kessel_access", return_value=False)
+    def test_get_rbac_recent_changes_kessel_denied(self, _mock_check):
+        """get_rbac_recent_changes returns permission denied when Kessel check fails."""
+        response = self._call_tool("get_rbac_recent_changes")
+
+        data = response.json()
+        self.assertIn("error", data)
+        self.assertEqual(data["error"]["code"], -32003)
+
+    @patch("management.mcp_views._check_kessel_access", return_value=False)
+    def test_investigate_group_changes_kessel_denied(self, _mock_check):
+        """investigate_group_changes returns permission denied when Kessel check fails."""
+        response = self._call_tool("investigate_group_changes", {"group_name": "test"})
+
+        data = response.json()
+        self.assertIn("error", data)
+        self.assertEqual(data["error"]["code"], -32003)
+
+    @patch("management.mcp_views._check_kessel_access", return_value=False)
+    def test_search_roles_kessel_denied(self, _mock_check):
+        """search_roles returns permission denied when Kessel check fails."""
+        response = self._call_tool("search_roles")
+
+        data = response.json()
+        self.assertIn("error", data)
+        self.assertEqual(data["error"]["code"], -32003)
+
+    @patch("management.mcp_views._check_kessel_access", return_value=False)
+    def test_get_user_state_kessel_denied(self, _mock_check):
+        """get_user_state returns permission denied when Kessel check fails."""
+        response = self._call_tool("get_user_state", {"username": "test_user"})
+
+        data = response.json()
+        self.assertIn("error", data)
+        self.assertEqual(data["error"]["code"], -32003)
+
+    @patch("management.mcp_views._check_kessel_access", return_value=False)
+    def test_check_user_permission_kessel_denied(self, _mock_check):
+        """check_user_permission returns permission denied when Kessel check fails."""
+        response = self._call_tool("check_user_permission", {"username": "test_user", "permission": "app:res:verb"})
+
+        data = response.json()
+        self.assertIn("error", data)
+        self.assertEqual(data["error"]["code"], -32003)
+
+    @patch("management.mcp_views._check_kessel_access", return_value=False)
+    def test_investigate_user_access_kessel_denied(self, _mock_check):
+        """investigate_user_access returns permission denied when Kessel check fails."""
+        response = self._call_tool("investigate_user_access", {"username": "test_user"})
+
+        data = response.json()
+        self.assertIn("error", data)
+        self.assertEqual(data["error"]["code"], -32003)
+
+    @patch("management.mcp_views._check_kessel_access", return_value=False)
+    def test_guide_user_access_delegation_kessel_denied(self, _mock_check):
+        """guide_user_access_delegation returns permission denied when Kessel check fails."""
+        response = self._call_tool("guide_user_access_delegation", {"username": "test_user"})
+
+        data = response.json()
+        self.assertIn("error", data)
+        self.assertEqual(data["error"]["code"], -32003)
+
+    def test_tool_without_required_relation_skips_kessel_check(self):
+        """Tools without required_relation do not trigger Kessel check."""
+        with patch("management.mcp_views._check_kessel_access") as mock_check:
+            self._call_tool("hello", {"message": "test"})
+            mock_check.assert_not_called()
+
+    @patch("management.mcp_views._check_kessel_access", return_value=False)
+    def test_auth_check_runs_before_kessel_check(self, mock_kessel):
+        """Auth check (org_id) runs before Kessel check — unauthenticated gets -32000, not -32003."""
+        response = self._call_tool("list_audit_logs", use_auth=False)
+
+        data = response.json()
+        self.assertIn("error", data)
+        self.assertEqual(data["error"]["code"], -32000)
+        mock_kessel.assert_not_called()

--- a/tests/management/test_mcp_views.py
+++ b/tests/management/test_mcp_views.py
@@ -6740,3 +6740,12 @@ class MCPKesselAccessCheckTests(MCPToolTestMixin, IdentityRequest):
         self.assertIn("error", data)
         self.assertEqual(data["error"]["code"], -32000)
         mock_kessel.assert_not_called()
+
+    @patch("management.mcp_views.get_kessel_principal_id", side_effect=Exception("Dependency error"))
+    def test_check_kessel_access_exception_fails_closed(self, _mock_principal):
+        """_check_kessel_access returns False when an exception is raised (fail-closed)."""
+        from django.test import RequestFactory
+
+        request = RequestFactory().get("/")
+        request.tenant = self.tenant
+        self.assertFalse(_check_kessel_access(request, "tenant", "rbac_roles_read"))

--- a/tests/management/test_mcp_views.py
+++ b/tests/management/test_mcp_views.py
@@ -30,6 +30,7 @@ from management.mcp_views import (
     ToolTimeoutError,
     _TOOL_CONFIG,
     _check_kessel_access,
+    _check_v1_access,
     _execute_with_timeout,
     _permission_matches,
 )
@@ -52,11 +53,14 @@ class MCPToolTestMixin:
     """Shared helpers for calling MCP tools in tests."""
 
     def setUp(self):
-        """Auto-mock Kessel access check so protected tools are callable in tests."""
+        """Auto-mock access checks so protected tools are callable in tests."""
         super().setUp()
-        patcher = patch("management.mcp_views._check_kessel_access", return_value=True)
-        self._kessel_mock = patcher.start()
-        self.addCleanup(patcher.stop)
+        kessel_patcher = patch("management.mcp_views._check_kessel_access", return_value=True)
+        self._kessel_mock = kessel_patcher.start()
+        self.addCleanup(kessel_patcher.stop)
+        v1_patcher = patch("management.mcp_views._check_v1_access", return_value=True)
+        self._v1_access_mock = v1_patcher.start()
+        self.addCleanup(v1_patcher.stop)
 
     def _call_tool(self, tool_name, arguments=None, use_auth=True):
         """Helper to call an MCP tool and return the parsed response."""
@@ -6550,38 +6554,45 @@ class MCPDeleteToolsV2Tests(MCPToolTestMixin, IdentityRequest):
         self.assertEqual(data["error"]["code"], -32000)
 
 
-class MCPKesselAccessCheckTests(MCPToolTestMixin, IdentityRequest):
-    """Test the centralized Kessel permission check for MCP tools."""
+class MCPAccessCheckTests(MCPToolTestMixin, IdentityRequest):
+    """Test the dual-path (v1/v2) permission check for MCP tools."""
 
     def setUp(self):
-        """Set up the Kessel access check tests."""
+        """Set up the access check tests."""
         super().setUp()
         self.url = "/_private/_a2s/mcp/"
         self.client = APIClient()
         self.principal = Principal.objects.create(username="test_user", tenant=self.tenant)
 
     def tearDown(self):
-        """Tear down Kessel access check tests."""
+        """Tear down access check tests."""
         AuditLog.objects.all().delete()
         Principal.objects.all().delete()
         super().tearDown()
 
     # --- ToolConfig ---
 
-    def test_tool_config_has_kessel_fields(self):
-        """ToolConfig includes required_relation and required_resource_type."""
+    def test_tool_config_has_permission_fields(self):
+        """ToolConfig includes required_relation, required_resource_type, and v1_permission."""
         config = ToolConfig(fn=lambda: "")
         self.assertIsNone(config.required_relation)
         self.assertEqual(config.required_resource_type, "tenant")
+        self.assertIsNone(config.v1_permission)
 
-    def test_tool_config_with_kessel_fields(self):
-        """ToolConfig accepts required_relation and required_resource_type."""
-        config = ToolConfig(fn=lambda: "", required_relation="rbac_roles_read", required_resource_type="workspace")
+    def test_tool_config_with_permission_fields(self):
+        """ToolConfig accepts all permission fields."""
+        config = ToolConfig(
+            fn=lambda: "",
+            required_relation="rbac_roles_read",
+            required_resource_type="workspace",
+            v1_permission=("role", "read"),
+        )
         self.assertEqual(config.required_relation, "rbac_roles_read")
         self.assertEqual(config.required_resource_type, "workspace")
+        self.assertEqual(config.v1_permission, ("role", "read"))
 
     def test_protected_tools_have_required_relation(self):
-        """All direct-DB tools have required_relation set."""
+        """All protected tools have required_relation set."""
         expected_protected = [
             "list_audit_logs",
             "investigate_tam_access",
@@ -6603,6 +6614,32 @@ class MCPKesselAccessCheckTests(MCPToolTestMixin, IdentityRequest):
             self.assertIsNotNone(
                 config.required_relation,
                 f"Tool '{tool_name}' missing required_relation",
+            )
+
+    def test_protected_tools_have_v1_permission(self):
+        """All protected tools have v1_permission set for v1 org fallback."""
+        expected_v1_permissions = {
+            "list_audit_logs": ("admin", "only"),
+            "get_rbac_recent_changes": ("admin", "only"),
+            "search_roles": ("role", "read"),
+            "get_role": ("role", "read"),
+            "check_role_permissions": ("role", "read"),
+            "investigate_tam_access": ("role", "read"),
+            "audit_redhat_access": ("role", "read"),
+            "guide_user_access_delegation": ("role", "read"),
+            "audit_group_for_dissolution": ("group", "read"),
+            "investigate_group_changes": ("group", "read"),
+            "check_user_permission": ("principal", "read"),
+            "get_user_state": ("principal", "read"),
+            "investigate_user_access": ("principal", "read"),
+        }
+        for tool_name, expected_perm in expected_v1_permissions.items():
+            config = _TOOL_CONFIG.get(tool_name)
+            self.assertIsNotNone(config, f"Tool '{tool_name}' not found in _TOOL_CONFIG")
+            self.assertEqual(
+                config.v1_permission,
+                expected_perm,
+                f"Tool '{tool_name}' has wrong v1_permission: {config.v1_permission}",
             )
 
     def test_unprotected_tools_have_no_required_relation(self):
@@ -6669,108 +6706,6 @@ class MCPKesselAccessCheckTests(MCPToolTestMixin, IdentityRequest):
         request.tenant = self.tenant
         self.assertFalse(_check_kessel_access(request, "tenant", "rbac_roles_read"))
 
-    # --- Integration: tool dispatch with Kessel check ---
-
-    @patch("management.mcp_views._check_kessel_access", return_value=False)
-    def test_tool_with_required_relation_denied(self, _mock_check):
-        """Tools with required_relation return permission denied when Kessel check fails."""
-        response = self._call_tool("list_audit_logs")
-
-        self.assertEqual(response.status_code, 200)
-        data = response.json()
-        self.assertIn("error", data)
-        self.assertEqual(data["error"]["code"], -32003)
-        self.assertEqual(data["error"]["message"], "Permission denied")
-
-    @patch("management.mcp_views._check_kessel_access", return_value=True)
-    def test_tool_with_required_relation_granted(self, _mock_check):
-        """Tools with required_relation succeed when Kessel check passes."""
-        response = self._call_tool("list_audit_logs")
-
-        self.assertEqual(response.status_code, 200)
-        data = response.json()
-        self.assertIn("result", data)
-        self.assertFalse(data["result"]["isError"])
-
-    @patch("management.mcp_views._check_kessel_access", return_value=False)
-    def test_get_rbac_recent_changes_kessel_denied(self, _mock_check):
-        """get_rbac_recent_changes returns permission denied when Kessel check fails."""
-        response = self._call_tool("get_rbac_recent_changes")
-
-        data = response.json()
-        self.assertIn("error", data)
-        self.assertEqual(data["error"]["code"], -32003)
-
-    @patch("management.mcp_views._check_kessel_access", return_value=False)
-    def test_investigate_group_changes_kessel_denied(self, _mock_check):
-        """investigate_group_changes returns permission denied when Kessel check fails."""
-        response = self._call_tool("investigate_group_changes", {"group_name": "test"})
-
-        data = response.json()
-        self.assertIn("error", data)
-        self.assertEqual(data["error"]["code"], -32003)
-
-    @patch("management.mcp_views._check_kessel_access", return_value=False)
-    def test_search_roles_kessel_denied(self, _mock_check):
-        """search_roles returns permission denied when Kessel check fails."""
-        response = self._call_tool("search_roles")
-
-        data = response.json()
-        self.assertIn("error", data)
-        self.assertEqual(data["error"]["code"], -32003)
-
-    @patch("management.mcp_views._check_kessel_access", return_value=False)
-    def test_get_user_state_kessel_denied(self, _mock_check):
-        """get_user_state returns permission denied when Kessel check fails."""
-        response = self._call_tool("get_user_state", {"username": "test_user"})
-
-        data = response.json()
-        self.assertIn("error", data)
-        self.assertEqual(data["error"]["code"], -32003)
-
-    @patch("management.mcp_views._check_kessel_access", return_value=False)
-    def test_check_user_permission_kessel_denied(self, _mock_check):
-        """check_user_permission returns permission denied when Kessel check fails."""
-        response = self._call_tool("check_user_permission", {"username": "test_user", "permission": "app:res:verb"})
-
-        data = response.json()
-        self.assertIn("error", data)
-        self.assertEqual(data["error"]["code"], -32003)
-
-    @patch("management.mcp_views._check_kessel_access", return_value=False)
-    def test_investigate_user_access_kessel_denied(self, _mock_check):
-        """investigate_user_access returns permission denied when Kessel check fails."""
-        response = self._call_tool("investigate_user_access", {"username": "test_user"})
-
-        data = response.json()
-        self.assertIn("error", data)
-        self.assertEqual(data["error"]["code"], -32003)
-
-    @patch("management.mcp_views._check_kessel_access", return_value=False)
-    def test_guide_user_access_delegation_kessel_denied(self, _mock_check):
-        """guide_user_access_delegation returns permission denied when Kessel check fails."""
-        response = self._call_tool("guide_user_access_delegation", {"username": "test_user"})
-
-        data = response.json()
-        self.assertIn("error", data)
-        self.assertEqual(data["error"]["code"], -32003)
-
-    def test_tool_without_required_relation_skips_kessel_check(self):
-        """Tools without required_relation do not trigger Kessel check."""
-        with patch("management.mcp_views._check_kessel_access") as mock_check:
-            self._call_tool("hello", {"message": "test"})
-            mock_check.assert_not_called()
-
-    @patch("management.mcp_views._check_kessel_access", return_value=False)
-    def test_auth_check_runs_before_kessel_check(self, mock_kessel):
-        """Auth check (org_id) runs before Kessel check — unauthenticated gets -32000, not -32003."""
-        response = self._call_tool("list_audit_logs", use_auth=False)
-
-        data = response.json()
-        self.assertIn("error", data)
-        self.assertEqual(data["error"]["code"], -32000)
-        mock_kessel.assert_not_called()
-
     @patch("management.mcp_views.get_kessel_principal_id", side_effect=Exception("Dependency error"))
     def test_check_kessel_access_principal_exception_fails_closed(self, _mock_principal):
         """_check_kessel_access returns False when get_kessel_principal_id raises (fail-closed)."""
@@ -6792,3 +6727,155 @@ class MCPKesselAccessCheckTests(MCPToolTestMixin, IdentityRequest):
         request = RequestFactory().get("/")
         request.tenant = self.tenant
         self.assertFalse(_check_kessel_access(request, "tenant", "rbac_roles_read"))
+
+    # --- _check_v1_access unit tests ---
+
+    def test_check_v1_access_admin_user(self):
+        """_check_v1_access returns True for org admin regardless of permission type."""
+        from django.test import RequestFactory
+
+        request = RequestFactory().get("/")
+        request.user = type("User", (), {"admin": True, "access": {}})()
+        self.assertTrue(_check_v1_access(request, ("role", "read")))
+        self.assertTrue(_check_v1_access(request, ("admin", "only")))
+
+    def test_check_v1_access_admin_only_non_admin(self):
+        """_check_v1_access returns False for non-admin when admin-only is required."""
+        from django.test import RequestFactory
+
+        request = RequestFactory().get("/")
+        request.user = type("User", (), {"admin": False, "access": {"role": {"read": ["*"]}}})()
+        self.assertFalse(_check_v1_access(request, ("admin", "only")))
+
+    def test_check_v1_access_role_read_granted(self):
+        """_check_v1_access returns True when user has role:read access."""
+        from django.test import RequestFactory
+
+        request = RequestFactory().get("/")
+        request.user = type("User", (), {"admin": False, "access": {"role": {"read": ["*"]}}})()
+        self.assertTrue(_check_v1_access(request, ("role", "read")))
+
+    def test_check_v1_access_group_read_granted(self):
+        """_check_v1_access returns True when user has group:read access."""
+        from django.test import RequestFactory
+
+        request = RequestFactory().get("/")
+        request.user = type("User", (), {"admin": False, "access": {"group": {"read": ["*"]}}})()
+        self.assertTrue(_check_v1_access(request, ("group", "read")))
+
+    def test_check_v1_access_principal_read_granted(self):
+        """_check_v1_access returns True when user has principal:read access."""
+        from django.test import RequestFactory
+
+        request = RequestFactory().get("/")
+        request.user = type("User", (), {"admin": False, "access": {"principal": {"read": ["*"]}}})()
+        self.assertTrue(_check_v1_access(request, ("principal", "read")))
+
+    def test_check_v1_access_no_matching_access(self):
+        """_check_v1_access returns False when user lacks required access."""
+        from django.test import RequestFactory
+
+        request = RequestFactory().get("/")
+        request.user = type("User", (), {"admin": False, "access": {"group": {"read": ["*"]}}})()
+        self.assertFalse(_check_v1_access(request, ("role", "read")))
+
+    def test_check_v1_access_empty_access(self):
+        """_check_v1_access returns False when user has empty access dict."""
+        from django.test import RequestFactory
+
+        request = RequestFactory().get("/")
+        request.user = type("User", (), {"admin": False, "access": {}})()
+        self.assertFalse(_check_v1_access(request, ("role", "read")))
+
+    def test_check_v1_access_no_user(self):
+        """_check_v1_access returns False when request has no user."""
+        from django.test import RequestFactory
+
+        request = RequestFactory().get("/")
+        self.assertFalse(_check_v1_access(request, ("role", "read")))
+
+    # --- Integration: dual-path dispatch ---
+
+    @patch("management.mcp_views.is_v2_write_activated", return_value=True)
+    @patch("management.mcp_views._check_kessel_access", return_value=False)
+    def test_v2_org_uses_kessel_check(self, mock_kessel, _mock_v2):
+        """V2 org dispatches to Kessel check; denied when Kessel returns False."""
+        response = self._call_tool("list_audit_logs")
+
+        data = response.json()
+        self.assertIn("error", data)
+        self.assertEqual(data["error"]["code"], -32003)
+        mock_kessel.assert_called_once()
+
+    @patch("management.mcp_views.is_v2_write_activated", return_value=True)
+    @patch("management.mcp_views._check_kessel_access", return_value=True)
+    def test_v2_org_kessel_granted(self, _mock_kessel, _mock_v2):
+        """V2 org dispatches to Kessel check; allowed when Kessel returns True."""
+        response = self._call_tool("list_audit_logs")
+
+        data = response.json()
+        self.assertIn("result", data)
+        self.assertFalse(data["result"]["isError"])
+
+    @patch("management.mcp_views.is_v2_write_activated", return_value=False)
+    @patch("management.mcp_views._check_v1_access", return_value=False)
+    def test_v1_org_uses_v1_check(self, mock_v1, _mock_v2):
+        """V1 org dispatches to v1 access check; denied when v1 returns False."""
+        response = self._call_tool("search_roles")
+
+        data = response.json()
+        self.assertIn("error", data)
+        self.assertEqual(data["error"]["code"], -32003)
+        mock_v1.assert_called_once()
+
+    @patch("management.mcp_views.is_v2_write_activated", return_value=False)
+    @patch("management.mcp_views._check_v1_access", return_value=True)
+    def test_v1_org_v1_access_granted(self, _mock_v1, _mock_v2):
+        """V1 org dispatches to v1 access check; allowed when v1 returns True."""
+        response = self._call_tool("search_roles")
+
+        data = response.json()
+        self.assertIn("result", data)
+        self.assertFalse(data["result"]["isError"])
+
+    @patch("management.mcp_views.is_v2_write_activated", return_value=False)
+    @patch("management.mcp_views._check_v1_access", return_value=False)
+    def test_v1_org_admin_only_tool_denied(self, mock_v1, _mock_v2):
+        """V1 org with admin-only tool (list_audit_logs) denied for non-admin."""
+        response = self._call_tool("list_audit_logs")
+
+        data = response.json()
+        self.assertIn("error", data)
+        self.assertEqual(data["error"]["code"], -32003)
+
+    @patch("management.mcp_views.is_v2_write_activated", return_value=False)
+    @patch("management.mcp_views._check_v1_access", return_value=True)
+    def test_v1_org_admin_only_tool_granted(self, _mock_v1, _mock_v2):
+        """V1 org with admin-only tool (list_audit_logs) granted for admin."""
+        response = self._call_tool("list_audit_logs")
+
+        data = response.json()
+        self.assertIn("result", data)
+        self.assertFalse(data["result"]["isError"])
+
+    def test_tool_without_required_relation_skips_both_checks(self):
+        """Tools without required_relation do not trigger any permission check."""
+        with (
+            patch("management.mcp_views._check_kessel_access") as mock_kessel,
+            patch("management.mcp_views._check_v1_access") as mock_v1,
+        ):
+            self._call_tool("hello", {"message": "test"})
+            mock_kessel.assert_not_called()
+            mock_v1.assert_not_called()
+
+    @patch("management.mcp_views._check_kessel_access", return_value=False)
+    @patch("management.mcp_views._check_v1_access", return_value=False)
+    def test_auth_check_runs_before_permission_check(self, _mock_v1, _mock_kessel):
+        """Auth check (org_id) runs before permission check — unauthenticated gets -32000."""
+        response = self._call_tool("list_audit_logs", use_auth=False)
+
+        data = response.json()
+        self.assertIn("error", data)
+        self.assertEqual(data["error"]["code"], -32000)
+        _mock_kessel.assert_not_called()
+        _mock_v1.assert_not_called()


### PR DESCRIPTION
## Link(s) to Jira
- https://redhat.atlassian.net/browse/RHCLOUD-47900

## Description of Intent of Change(s)
13 MCP tools (11 direct-DB tools + 2 hybrid tools) previously had no authorization beyond org_id presence. They query the database directly, bypassing the DRF `permission_classes` that protect standard API endpoints. This PR adds centralized Kessel permission enforcement for all of them.

**Approach:**
- Extends `ToolConfig` with `required_relation` and `required_resource_type` fields
- When `required_relation` is set, `_handle_tools_call` calls `_check_kessel_access` before executing the tool
- `_check_kessel_access` uses `WorkspaceInventoryAccessChecker.check_resource_access` to verify the requesting principal has the `rbac_roles_read` relation on the tenant resource — the same pattern already used by the v2 Role API
- The function wraps its entire body in `try/except Exception` for true fail-closed behavior, preventing unhandled exceptions (e.g., BOP dependency errors) from surfacing as HTTP 500s
- Denied requests return JSON-RPC error code `-32003` (Permission denied), distinct from `-32000` (Authentication required)

**Protected tools:**
| Category | Tools |
|----------|-------|
| Direct-DB | `list_audit_logs`, `search_roles`, `get_role`, `check_role_permissions`, `investigate_tam_access`, `audit_redhat_access`, `audit_group_for_dissolution`, `get_user_state`, `get_rbac_recent_changes`, `investigate_group_changes`, `guide_user_access_delegation` |
| Hybrid | `check_user_permission`, `investigate_user_access` |

## Local Testing
```bash
# Run the MCP view tests
pipenv run tox -e py312-fast -- tests.management.test_mcp_views

# Run specific Kessel access check tests
pipenv run tox -e py312-fast -- tests.management.test_mcp_views.MCPKesselAccessCheckTests

# Full test suite
DJANGO_LOG_LEVEL=CRITICAL RBAC_LOG_LEVEL=CRITICAL pipenv run tox -r
```

## Checklist
- [x] if API spec changes are required, is the spec updated? (No API spec changes needed — MCP is an internal protocol)
- [x] are there any pre/post merge actions required? if so, document here. (None)
- [x] are theses changes covered by unit tests?
- [x] if warranted, are documentation changes accounted for? (No doc changes needed)
- [ ] does this require migration changes?
  - [x] No migrations needed
- [ ] is there known, direct impact to dependent teams/components?
  - [x] MCP clients will receive `-32003` errors for unauthorized tool calls that previously succeeded

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices