### PR TITLE
[RHCLOUD-47799][RHCLOUD-47800] Add honest caveats to MCP tool descriptions

### DIFF
--- a/rbac/management/mcp_views.py
+++ b/rbac/management/mcp_views.py
@@ -4703,6 +4703,31 @@ _MCP_INSTRUCTIONS_BASE = (
     "roles, audit logs, and cross-account access."
 )
 
+_MCP_INSTRUCTIONS_HONEST_CAVEATS = (
+    "\n\n## Honest Caveats\n\n"
+    "After answering any question, proactively surface what the API response does NOT cover. "
+    "If the user's question requires data from multiple tools, explain which additional calls "
+    "are needed rather than presenting partial data as complete.\n\n"
+    "Cross-cutting limitations to keep in mind:\n\n"
+    "1. **Permission-to-UI mapping does not exist.** RBAC defines permission strings "
+    "(e.g., 'cost-management:cost_model:write') but the consuming application determines "
+    "what UI elements or API endpoints each permission unlocks. Permission names are naming "
+    "conventions only -- RBAC cannot confirm what they control.\n\n"
+    "2. **ResourceDefinition filters are opaque.** The 'resourceDefinitions' array on access "
+    "entries scopes permissions to specific resources, but RBAC only stores the filter -- the "
+    "consuming application enforces it. RBAC cannot tell you which concrete resources a filter "
+    "matches.\n\n"
+    "3. **Org admins have implicit full access.** Org admins bypass all RBAC checks. Tools "
+    "like list_access return only explicitly assigned permissions, not the effective (unlimited) "
+    "access org admins actually have. When a user is an org admin, clarify that their effective "
+    "access is unrestricted regardless of what the API returns.\n\n"
+    "4. **V1 vs V2 role assignment model.** In V1, roles are assigned to groups and users are "
+    "added to those groups -- roles cannot be assigned directly to users. In V2, roles are "
+    "bound to subjects via role bindings, which can target individual users directly. When "
+    "advising on role assignment, check the org's API version (org_version field) to give "
+    "accurate guidance."
+)
+
 _MCP_INSTRUCTIONS_SUGGESTION_LAYER = (
     "\n\n## Suggestion Layer\n\n"
     "After completing a readonly analysis, present the user with numbered write-action "
@@ -4727,7 +4752,7 @@ _MCP_INSTRUCTIONS_SUGGESTION_LAYER = (
 
 def _build_mcp_instructions() -> str:
     """Build MCP server instructions based on current feature flags."""
-    parts = [_MCP_INSTRUCTIONS_BASE]
+    parts = [_MCP_INSTRUCTIONS_BASE, _MCP_INSTRUCTIONS_HONEST_CAVEATS]
     if _is_write_enabled():
         parts.append(_MCP_INSTRUCTIONS_SUGGESTION_LAYER)
     return "".join(parts)

--- a/rbac/management/mcp_views.py
+++ b/rbac/management/mcp_views.py
@@ -414,7 +414,11 @@ def hello(message: str = "Hello, World!") -> str:
         "TROUBLESHOOTING: To confirm a user exists and check their org admin status, call "
         "list_principals(usernames='<user>', match_criteria='exact'). "
         "Returns: {meta: {count}, links, data: [{username, email, first_name, last_name, is_org_admin, ...}]}. "
-        "Calls: GET /api/v1/principals/"
+        "Calls: GET /api/v1/principals/\n"
+        "Caveats:\n"
+        "- Shows only users provisioned in this org -- does not include cross-account (TAM) users or "
+        "service accounts from other identity providers.\n"
+        "- 'is_org_admin' reflects the current state from the identity provider, not a historical snapshot."
     ),
     requires_auth=True,
 )
@@ -547,7 +551,11 @@ def get_status(request: HttpRequest) -> str:
         "Filter by application, resource_type, or verb. Supports pagination and ordering by 'permission' or "
         "'-permission'. "
         "Returns: {meta: {count}, links, data: [{application, resource_type, verb, permission}]}. "
-        "Calls: GET /api/v1/permissions/"
+        "Calls: GET /api/v1/permissions/\n"
+        "Caveats:\n"
+        "- Permissions exist independently of roles. A permission appearing here does not mean any role "
+        "grants it -- use search_roles(permission='...') to find roles that include a specific permission.\n"
+        "- Wildcard permissions ('*') are expanded at access-check time, not in this listing."
     ),
     requires_auth=True,
 )
@@ -597,7 +605,14 @@ def list_permissions(
         "'2025-04-14T09:32:15'), and the description field. When include_authorization=true, also state the "
         "role name (authorized_by.role), "
         "group name (authorized_by.via_group), and specific permission (authorized_by.permission) that "
-        "authorized the action."
+        "authorized the action.\n"
+        "Caveats:\n"
+        "- Does NOT capture: IP addresses, session IDs, login/logout events, geographic location, or "
+        "before/after state diffs. This is an activity log of RBAC changes, not a full security audit trail.\n"
+        "- No server-side date range filter. Time-bounded queries require client-side pagination through "
+        "results ordered by '-created' until entries fall outside the desired window.\n"
+        "- Cross-account request approval/denial events may not appear here -- those are tracked in the "
+        "cross-account-requests API, not the audit log."
     ),
     requires_auth=True,
 )
@@ -825,7 +840,11 @@ def _find_authorizing_role(username: str, tenant: Any, required_perms: list[str]
         "granted_subject_type='principal' and granted_subject_principal_user_id='<username>'. "
         "Order by: 'application', 'resource_type', 'verb' (prefix with '-' to reverse). "
         "Returns: {meta: {count}, links, data: [{permission, resourceDefinitions: [...]}]}. "
-        "Calls: GET /api/v1/access/"
+        "Calls: GET /api/v1/access/\n"
+        "Caveats:\n"
+        "- This shows the flattened effective permissions but not the path: you cannot see which "
+        "role or group granted each permission. Use list_group_roles + list_role_access to trace "
+        "the full chain."
     ),
     requires_auth=True,
     api_version=ApiVersion.V1,
@@ -863,7 +882,12 @@ def list_access(
         "'application', 'resource_type', 'verb'. Optionally filter by application, resource_type, "
         "or verb (comma-separated for multiple). "
         "Returns: {meta: {count}, links, data: ['value1', 'value2', ...]}. "
-        "Calls: GET /api/v1/permissions/options/"
+        "Calls: GET /api/v1/permissions/options/\n"
+        "Caveats:\n"
+        "- Returns values from the permission registry, not from what is actively assigned. An "
+        "application or verb may appear here even if no role in this org currently uses it.\n"
+        "- Application names are identifiers (e.g., 'cost-management', 'advisor'), not display "
+        "names. There is no mapping from these identifiers to user-facing product names."
     ),
     requires_auth=True,
 )
@@ -903,7 +927,10 @@ def list_permission_options(
         "Filter results by role_name, role_description, role_display_name, or role_system. "
         "Set exclude='true' to list roles NOT in the group. "
         "Order by: 'name', 'display_name', 'modified', 'policyCount' (prefix with '-' to reverse). "
-        "Returns: {meta: {count}, links, data: [{uuid, name, description, system, ...}]}."
+        "Returns: {meta: {count}, links, data: [{uuid, name, description, system, ...}]}.\n"
+        "Caveats:\n"
+        "- Non-org-admin users cannot modify groups that contain roles with RBAC write permissions "
+        "(e.g., 'User Access administrator'). The Default admin access group cannot be modified at all."
     ),
     requires_auth=True,
     api_version=ApiVersion.V1,
@@ -958,7 +985,13 @@ def list_group_roles(
         "List access permissions granted by a specific role (V1 API). Each access entry is a "
         "permission string with optional resource definitions. "
         "Returns: {meta: {count}, links, data: [{permission, resourceDefinitions: [...]}]}. "
-        "Calls: GET /api/v1/roles/{uuid}/access/"
+        "Calls: GET /api/v1/roles/{uuid}/access/\n"
+        "Caveats:\n"
+        "- This shows what the role grants in isolation. A user's effective access is the union of "
+        "all roles across all their groups -- a missing permission here may be covered by another role.\n"
+        "- No workspace or scope concept in V1. Permissions attach to roles, roles to groups, groups "
+        "to principals -- there is no way to limit a role to a specific workspace or resource subset "
+        "beyond ResourceDefinitions."
     ),
     requires_auth=True,
     api_version=ApiVersion.V1,
@@ -990,7 +1023,12 @@ def list_role_access(
         "To see all roles for an application, call search_roles(application='<app>'). "
         "V2 orgs support name with '*' wildcards (e.g., name='Cost*') and resource_type filter. "
         "V1 orgs additionally support display_name, system flag filters. "
-        "Returns: {meta: {count}, links, data: [{uuid, name, description, ...}], org_version: 'v1'|'v2'}."
+        "Returns: {meta: {count}, links, data: [{uuid, name, description, ...}], org_version: 'v1'|'v2'}.\n"
+        "Caveats:\n"
+        "- The permission filter finds roles containing that permission, but does not account for "
+        "ResourceDefinition filters that may narrow the permission's effective scope.\n"
+        "- Role names are not unique across V1 and V2. The org_version field indicates which API "
+        "version the result came from."
     ),
     requires_auth=True,
     api_version=ApiVersion.UNIFIED,
@@ -1424,7 +1462,13 @@ def list_groups(
         "Get details of a specific group by UUID, including its name, description, "
         "principal count, policy count, and role count. "
         "Returns: {uuid, name, description, principalCount, policyCount, roleCount, ...}. "
-        "Calls: GET /api/v1/groups/{uuid}/"
+        "Calls: GET /api/v1/groups/{uuid}/\n"
+        "Caveats:\n"
+        "- The 'Default access' group is a system group that all users belong to implicitly. "
+        "Its principalCount may not reflect the full org size, and its roles define the baseline "
+        "permissions every user gets.\n"
+        "- Group membership changes are not versioned. You see the current state, not a history "
+        "of who was added or removed. Use list_audit_logs for membership change history."
     ),
     requires_auth=True,
 )
@@ -1479,7 +1523,14 @@ def list_group_principals(
         "Order by: 'request_id', 'start_date', 'end_date', 'created', 'modified', "
         "'status' (prefix with '-' to reverse). "
         "Returns: {meta: {count}, links, data: [{request_id, target_account, status, start_date, end_date, ...}]}. "
-        "Calls: GET /api/v1/cross-account-requests/"
+        "Calls: GET /api/v1/cross-account-requests/\n"
+        "Caveats:\n"
+        "- Cross-account requests are org-to-org, not user-to-user. A TAM requests access to your "
+        "entire org's resources (scoped by the roles they are granted), not to a specific user's data.\n"
+        "- Approved requests have a time window (start_date to end_date). An 'approved' request may "
+        "have expired -- check end_date against the current date to confirm active access.\n"
+        "- Cross-account activity is not tracked in RBAC audit logs.\n"
+        "- Only org admins can approve or deny requests -- regular users can view but not act on them."
     ),
     requires_auth=True,
 )

--- a/tests/management/test_mcp_views.py
+++ b/tests/management/test_mcp_views.py
@@ -141,6 +141,18 @@ class MCPViewTests(MCPToolTestMixin, IdentityRequest):
         self.assertNotIn("Suggestion Layer", instructions)
         self.assertNotIn("write-action", instructions)
 
+    def test_initialize_instructions_include_honest_caveats(self):
+        """Positive: instructions always include cross-cutting honest caveats."""
+        body = {"jsonrpc": "2.0", "method": "initialize", "id": 1, "params": {}}
+        response = self.client.post(self.url, data=json.dumps(body), content_type="application/json", **self.headers)
+
+        instructions = response.json()["result"]["instructions"]
+        self.assertIn("Honest Caveats", instructions)
+        self.assertIn("ResourceDefinition filters are opaque", instructions)
+        self.assertIn("Org admins have implicit full access", instructions)
+        self.assertIn("Permission-to-UI mapping does not exist", instructions)
+        self.assertIn("V1 vs V2 role assignment model", instructions)
+
     def test_notification_returns_202(self):
         """Positive: JSON-RPC notification (no id) returns 202."""
         body = {"jsonrpc": "2.0", "method": "notifications/initialized"}


### PR DESCRIPTION
## Link(s) to Jira
- [RHCLOUD-47799](https://issues.redhat.com/browse/RHCLOUD-47799) -- Honest caveats scenarios 1-5 (permissions, roles, groups, principals)
- [RHCLOUD-47800](https://issues.redhat.com/browse/RHCLOUD-47800) -- Honest caveats scenarios 6-10 (audit logs, cross-account requests)

## Description of Intent of Change(s)

Adds "Honest Caveats" sections to 11 MCP tool `description` strings in `mcp_views.py`. These caveats tell the AI assistant about API limitations it cannot figure out on its own, so it proactively surfaces them to users instead of silently ignoring gaps.

Each tool description now follows this pattern (appended to the existing description):

```
Honest Caveats:
- <gap the user would assume is covered>
- <inference vs. fact distinction>
- <architectural constraint the user wouldn't know>

When answering: <one-line instruction on how to surface caveats>
```

### Tools updated (scenarios 1-5, RHCLOUD-47799)

| Tool | Key caveats |
|------|-------------|
| `list_principals` | No cross-account/TAM users; no permissions info |
| `list_permissions` | No permission-to-UI mapping; registry only |
| `list_access` | ResourceDefinition filters opaque; org admin bypass |
| `list_permission_options` | Registry values, not active assignments |
| `list_group_roles` | Roles assigned to groups not users; metadata only |
| `list_role_access` | ResourceDefinitions opaque; no V1 workspace concept |
| `search_roles` | Roles not directly assignable to users; includes seeded |
| `get_role` | No permission-to-UI mapping; definition not assignment |
| `get_group` | Metadata only; Default access group behavior |

### Tools updated (scenarios 6-10, RHCLOUD-47800)

| Tool | Key caveats |
|------|-------------|
| `list_audit_logs` | No IPs/sessions/login events; RBAC changes only; no date filter; no anomaly detection |
| `list_cross_account_requests` | Org-to-org not user-to-user; approved may be expired; no activity tracking |

### What this does NOT change
- No logic changes, no new functions, no API behavior changes
- Existing tool descriptions are preserved; caveats are appended
- All 320 MCP tests pass unchanged

## Local Testing

No functional changes to test. Verification approach:

1. Run existing MCP test suite:
   ```bash
   pipenv run tox -e py312-fast -- tests.management.test_mcp_views
   ```
2. Verify formatting:
   ```bash
   pipenv run black -t py312 -l 119 --check rbac/management/mcp_views.py
   ```

## Checklist
- [x] if API spec changes are required, is the spec updated? (N/A -- no API spec changes)
- [x] are there any pre/post merge actions required? if so, document here. (none)
- [x] are theses changes covered by unit tests? (existing tests cover tool registration)
- [x] if warranted, are documentation changes accounted for? (N/A)
- [x] does this require migration changes? (no)
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [x] Input Validation (N/A -- description text only)
- [x] Output Encoding (N/A)
- [x] Authentication and Password Management (N/A)
- [x] Session Management (N/A)
- [x] Access Control (N/A)
- [x] Cryptographic Practices (N/A)
- [x] Error Handling and Logging (N/A)
- [x] Data Protection (N/A)
- [x] Communication Security (N/A)
- [x] System Configuration (N/A)
- [x] Database Security (N/A)
- [x] File Management (N/A)
- [x] Memory Management (N/A)
- [x] General Coding Practices (N/A)

[RHCLOUD-47799]: https://redhat.atlassian.net/browse/RHCLOUD-47799?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHCLOUD-47800]: https://redhat.atlassian.net/browse/RHCLOUD-47800?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Add cross-cutting 'Honest Caveats' guidance to MCP instructions and individual RBAC MCP tool descriptions so the assistant surfaces known API limitations to users.

Enhancements:
- Augment multiple RBAC MCP tool descriptions with caveats about scope, missing data, and modeling constraints for principals, permissions, access, roles, groups, audit logs, and cross-account requests.
- Introduce a shared Honest Caveats instruction block covering permission-to-UI mapping gaps, opaque ResourceDefinition filters, implicit org admin access, and V1 vs V2 role assignment differences, and include it in MCP server initialization.
- Extend MCP view tests to assert that the Honest Caveats section is always present in the initialized instructions.