### PR TITLE
RHCLOUD-35482: Increase retry count during root workspace tenant replication

### DIFF
--- a/rbac/internal/migrations/replicate_root_workspace_tenants.py
+++ b/rbac/internal/migrations/replicate_root_workspace_tenants.py
@@ -19,7 +19,7 @@ from migration_tool.utils import create_relationship
 logger = logging.getLogger(__name__)
 
 
-@atomic_with_retry(retries=3)
+@atomic_with_retry(retries=10)
 def _do_replicate(replicator: RelationReplicator, raw_tenants: list[Tenant]) -> int:
     tenants = list(Tenant.objects.filter(pk__in=(t.pk for t in raw_tenants)).exclude(org_id=None))
     bootstrap_locks = {t: l for t, l in try_lock_tenants_for_bootstrap(tenants).items() if l is not None}


### PR DESCRIPTION
## Link(s) to Jira
[RHCLOUD-35482](https://redhat.atlassian.net/browse/RHCLOUD-35482)

## Description of Intent of Change(s)
This is failing in stage due to serialization errors. I don't see an obvious way to get around this (since we're locking 1000 workspaces), so let's just bump the retry count.

[RHCLOUD-35482]: https://redhat.atlassian.net/browse/RHCLOUD-35482?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Enhancements:
- Raise the atomic_with_retry attempt count for root workspace tenant replication from 3 to 10 to better tolerate serialization errors during migration.