### PR TITLE
fix(mcp): add hint to list_principals when username lookup returns no results

### DIFF
--- a/rbac/management/mcp_views.py
+++ b/rbac/management/mcp_views.py
@@ -473,7 +473,22 @@ def list_principals(
         query_params["match_criteria"] = match_criteria
 
     path = reverse("v1_management:principals")
-    return _call_view(request, _principal_view, path, query_params)
+    result = _call_view(request, _principal_view, path, query_params)
+
+    if usernames:
+        try:
+            parsed = json.loads(result)
+            if parsed.get("meta", {}).get("count", 1) == 0:
+                parsed["hint"] = (
+                    f"No users matched the username '{usernames}'. "
+                    f"If this is a display name (e.g. first/last name), "
+                    f"retry with list_principals(name='{usernames}') to search by display name."
+                )
+                return json.dumps(parsed, default=str)
+        except (json.JSONDecodeError, AttributeError):
+            pass
+
+    return result
 
 
 def _list_principals_by_name(

--- a/tests/management/test_mcp_views.py
+++ b/tests/management/test_mcp_views.py
@@ -602,6 +602,42 @@ class MCPViewTests(MCPToolTestMixin, IdentityRequest):
         tool_output = json.loads(data["result"]["content"][0]["text"])
         self.assertIn("errors", tool_output)
 
+    @patch("management.mcp_views._call_view")
+    def test_tools_call_list_principals_username_not_found_hint(self, mock_call_view):
+        """Positive: list_principals includes retry hint when usernames lookup returns zero results."""
+        mock_call_view.return_value = json.dumps({"meta": {"count": 0}, "data": [], "links": {}})
+        response = self._call_tool("list_principals", {"usernames": "Joe"})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        tool_output = self._get_tool_output(response)
+        self.assertEqual(tool_output["meta"]["count"], 0)
+        self.assertIn("hint", tool_output)
+        self.assertIn("Joe", tool_output["hint"])
+        self.assertIn("list_principals(name='Joe')", tool_output["hint"])
+
+    @patch("management.mcp_views._call_view")
+    def test_tools_call_list_principals_username_found_no_hint(self, mock_call_view):
+        """Positive: list_principals does NOT include hint when usernames lookup finds results."""
+        mock_call_view.return_value = json.dumps(
+            {"meta": {"count": 1}, "data": [{"username": "joe_user"}], "links": {}}
+        )
+        response = self._call_tool("list_principals", {"usernames": "joe_user"})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        tool_output = self._get_tool_output(response)
+        self.assertEqual(tool_output["meta"]["count"], 1)
+        self.assertNotIn("hint", tool_output)
+
+    @patch("management.mcp_views._call_view")
+    def test_tools_call_list_principals_no_hint_without_usernames(self, mock_call_view):
+        """Positive: list_principals does NOT include hint when no usernames filter is used."""
+        mock_call_view.return_value = json.dumps({"meta": {"count": 0}, "data": [], "links": {}})
+        response = self._call_tool("list_principals", {"limit": 10})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        tool_output = self._get_tool_output(response)
+        self.assertNotIn("hint", tool_output)
+
     def test_tools_call_unknown_tool_returns_error(self):
         """Negative: Calling an unknown tool returns error."""
         body = {


### PR DESCRIPTION
## Summary
- When `list_principals(usernames='Joe')` returns zero results, the LLM gives up and asks the user for the "exact username" instead of retrying with the `name` parameter for display name search
- Adds a `hint` field to the zero-result response guiding the LLM to call `list_principals(name='Joe')` instead
- Adds 3 tests covering: hint present on zero results, hint absent on successful lookup, hint absent when `usernames` not used

## Test plan
- [x] `test_tools_call_list_principals_username_not_found_hint` — verifies hint is added when usernames returns 0 results
- [x] `test_tools_call_list_principals_username_found_no_hint` — verifies no hint when results are found
- [x] `test_tools_call_list_principals_no_hint_without_usernames` — verifies no hint when usernames param is not used
- [ ] Manual verification in stage: call `list_principals(usernames='Joe')` and confirm LLM auto-retries with `name='Joe'`

## Summary by Sourcery

Add a hint to list_principals responses when username-based lookups return no results to guide callers toward display-name searches, and verify the behavior with targeted tests.

Bug Fixes:
- Ensure list_principals guides callers to retry with a display-name search when a username filter returns zero results instead of silently returning an empty response.

Tests:
- Add tests covering presence of the retry hint when username lookups return zero results, absence of the hint when results are found, and absence of the hint when the usernames filter is not used.