### PR TITLE
[RHCLOUD-47875] Add AFTER ANALYSIS hints to MCP tool descriptions

### DIFF
--- a/rbac/management/mcp_views.py
+++ b/rbac/management/mcp_views.py
@@ -1306,7 +1306,12 @@ def _get_role_v2(request: HttpRequest, role_uuid: str) -> str:
         "Set include_available_permissions=true to also list what permissions exist in each application "
         "that the role does NOT include. "
         "Returns: {role: {uuid, name, description, system/type}, permissions: {summary, by_application, "
-        "expanded_permissions, verbs_included, verbs_not_included}, coverage_analysis, recommendations, org_version}."
+        "expanded_permissions, verbs_included, verbs_not_included}, coverage_analysis, recommendations, org_version}. "
+        "AFTER ANALYSIS: Present numbered options: "
+        "(1) create a new group and attach the role, ready for user assignment, "
+        "(2) update the role's metadata (e.g. display_name) before assignment, "
+        "(3) add additional permissions to the role. "
+        "Format as 'Reply 1, 2, or 3 -- or no'. Do NOT execute write tools without explicit user selection."
     ),
     requires_auth=True,
     api_version=ApiVersion.UNIFIED,
@@ -1725,7 +1730,11 @@ def get_cross_account_request(
         "Set 'required_permission' to check if a specific permission is granted (e.g., "
         "'subscriptions:watch:read'). The tool will report whether that permission is present. "
         "Returns: {requests: [{request_id, status, end_date, days_remaining, requester_info, "
-        "roles: [{name, permissions: [...]}], permission_summary}], analysis}."
+        "roles: [{name, permissions: [...]}], permission_summary}], analysis}. "
+        "AFTER ANALYSIS: Present numbered options: "
+        "(1) update the cross-account request with an expanded roles list, "
+        "(2) deny the current request and ask the TAM to resubmit with the correct scope (cleaner audit trail). "
+        "Format as 'Reply 1 or 2 -- or no'. Do NOT execute write tools without explicit user selection."
     ),
     requires_auth=True,
     api_version=ApiVersion.COMMON,
@@ -1931,7 +1940,12 @@ def investigate_tam_access(
         "Set audit_days to control how far back to look in audit logs (default 30 days). "
         "Returns: {active_access: [{user_info, roles, permissions, expires, days_remaining, "
         "audit_activity: {total_actions, recent_actions, summary}}], summary: {total_users, "
-        "expiring_soon, unused_access}}."
+        "expiring_soon, unused_access}}. "
+        "AFTER ANALYSIS: Present numbered options: "
+        "(1) cancel unused cross-account access (requests with no audit log activity), "
+        "(2) format the full report for a CISO briefing, "
+        "(3) both. "
+        "Format as 'Reply 1, 2, or 3 -- or no'. Do NOT execute write tools without explicit user selection."
     ),
     requires_auth=True,
     api_version=ApiVersion.COMMON,
@@ -2146,7 +2160,12 @@ def audit_redhat_access(
         "roles: [{name, permissions}], analysis: {stranded_users, stranded_service_accounts, ...}}. "
         "STRANDED means the member is ONLY in this group plus platform_default — they'd be demoted "
         "to default access only. Service accounts with no other groups would start 403'ing. "
-        "Queries: Group, Principal, Policy, Role, Access models directly (no per-member API calls)"
+        "Queries: Group, Principal, Policy, Role, Access models directly (no per-member API calls). "
+        "AFTER ANALYSIS: Present numbered options: "
+        "(1) delete the group immediately (warn about stranded users/service accounts), "
+        "(2) create a transition group with the same roles, move stranded members, then delete the original, "
+        "(3) remove only covered users from the group, leave it intact for manual review. "
+        "Format as 'Reply 1, 2, or 3 -- or no'. Do NOT execute write tools without explicit user selection."
     ),
     requires_auth=True,
     api_version=ApiVersion.COMMON,
@@ -2997,7 +3016,9 @@ def _get_user_access_v1(request: HttpRequest, username: str) -> list[dict[str, A
         "RESPONSE FORMAT: Consolidate by actor. For each actor: '<actor>: <count> <action> actions on "
         "<resource_type> (<day of week>). <actor> holds <role name if known>.' "
         "Note patterns like 'Matches expected automation pattern' for service accounts. "
-        "Format dates as day of week (Monday, Tuesday, etc.), not ISO timestamps."
+        "Format dates as day of week (Monday, Tuesday, etc.), not ISO timestamps. "
+        "AFTER ANALYSIS: This is a review-only tool. Present the summary and let the user ask follow-up questions. "
+        "Do NOT offer write-action suggestions."
     ),
     requires_auth=True,
     required_relation="rbac_roles_read",
@@ -3383,7 +3404,12 @@ def _analyze_expected_permission(
         "RBAC is additive, so users get the most permissive access from all their memberships. "
         "Common causes: role doesn't contain the assumed permission, group doesn't have the expected role. "
         "V1 RETURNS: {user, org_version, groups: [{roles: [{permissions}]}], effective_access, analysis}. "
-        "V2 RETURNS: {user, org_version, groups, role_bindings: [{role: {permissions}}], effective_access, analysis}."
+        "V2 RETURNS: {user, org_version, groups, role_bindings: [{role: {permissions}}], effective_access, analysis}. "
+        "AFTER ANALYSIS: Present numbered remediation options: "
+        "(1) add a role containing the missing permission to the user's group, "
+        "(2) create a new custom role with the missing permission and add it to the group, "
+        "(3) do nothing -- audit the role definition first. "
+        "Format as 'Reply 1, 2, or 3 -- or no'. Do NOT execute write tools without explicit user selection."
     ),
     requires_auth=True,
     api_version=ApiVersion.COMMON,


### PR DESCRIPTION
## Link(s) to Jira
- [RHCLOUD-47875](https://issues.redhat.com/browse/RHCLOUD-47875)

## Description of Intent of Change(s)

**What:** Adds `AFTER ANALYSIS` blocks to the descriptions of 6 scenario-mapped read tools in the MCP server, coaching the AI assistant to present numbered write-action options after showing readonly results.

**Why:** The RBAC MCP server's tool descriptions are the primary guidance mechanism for the console.redhat.com AI assistant. While a general suggestion layer already exists in the MCP `instructions` field (added in RHCLOUD-47703/47704/47705), the assistant doesn't always offer scenario-specific suggestions after analysis. Per-tool hints reinforce the behavior with concrete options tailored to each use case.

**How:** Appended `AFTER ANALYSIS` coaching text to each tool's `description` string in the `@register_tool` decorator. No logic changes, no new functions, no test changes.

**Tools updated (6):**

| Tool | Scenario | Hint |
|------|----------|------|
| `investigate_user_access` | 1: conflicting access | 3 options: add role to group, create custom role, audit first |
| `check_role_permissions` | 2: pre-flight check | 3 options: create group+attach, update metadata, add permissions |
| `audit_group_for_dissolution` | 4: dissolve group | 3 options: delete immediately, transition group, partial cleanup |
| `investigate_tam_access` | 9: TAM access | 2 options: update request, deny+resubmit |
| `audit_redhat_access` | 10: Red Hat audit | 3 options: cancel unused, CISO briefing, both |
| `get_rbac_recent_changes` | 8: review-only | Explicit no-write hint |

Scenarios 3, 5, 6, 7 chain multiple generic tools -- adding scenario-specific hints to those tools would pollute their descriptions for non-scenario use. Those are handled by the server-level instructions field.

## Local Testing

Description-only change with no runtime logic impact. Verified via:
- `flake8` and `black --check` pass clean
- Full test suite (3545 tests) passes
- Tool descriptions can be inspected via `tools/list` MCP call in stage

## Checklist
- [x] if API spec changes are required, is the spec updated? (N/A -- no API changes)
- [x] are there any pre/post merge actions required? if so, document here. (none)
- [x] are theses changes covered by unit tests? (description-only, no logic to test)
- [x] if warranted, are documentation changes accounted for? (N/A)
- [x] does this require migration changes? (no)
- [ ] is there known, direct impact to dependent teams/components?
  - The console.redhat.com AI assistant will see updated tool descriptions and may change its suggestion behavior accordingly. This is the intended effect.

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [x] Input Validation (N/A -- no input changes)
- [x] Output Encoding (N/A -- no output changes)
- [x] Authentication and Password Management (N/A)
- [x] Session Management (N/A)
- [x] Access Control (N/A)
- [x] Cryptographic Practices (N/A)
- [x] Error Handling and Logging (N/A)
- [x] Data Protection (N/A)
- [x] Communication Security (N/A)
- [x] System Configuration (N/A)
- [x] Database Security (N/A)
- [x] File Management (N/A)
- [x] Memory Management (N/A)
- [x] General Coding Practices (N/A)

[RHCLOUD-47875]: https://redhat.atlassian.net/browse/RHCLOUD-47875?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Reinforce scenario-specific follow-up behavior for RBAC MCP read tools by extending their descriptions with explicit post-analysis guidance and guardrails around executing write actions.

Enhancements:
- Add AFTER ANALYSIS coaching text to several RBAC MCP read-tool descriptions to suggest numbered remediation or follow-up options tailored to each scenario.
- Clarify that certain audit and review tools are read-only and must not propose write actions, tightening guardrails on automated suggestions.