### PR TITLE
feat(mcp): append honest caveats to tool results

### DIFF
--- a/rbac/management/mcp_views.py
+++ b/rbac/management/mcp_views.py
@@ -217,6 +217,7 @@ class ToolConfig:
     required_relation: str | None = None
     required_resource_type: str = "tenant"
     v1_permission: tuple[str, str] | None = None
+    caveats: str = ""
 
 
 _TOOL_CONFIG: dict[str, ToolConfig] = {}
@@ -231,6 +232,7 @@ def register_tool(
     required_relation: str | None = None,
     required_resource_type: str = "tenant",
     v1_permission: tuple[str, str] | None = None,
+    caveats: str = "",
 ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
     """Register a tool with both FastMCP and _TOOL_CONFIG.
 
@@ -256,6 +258,7 @@ def register_tool(
             required_relation=required_relation,
             required_resource_type=required_resource_type,
             v1_permission=v1_permission,
+            caveats=caveats,
         )
 
         if passes_request:
@@ -435,6 +438,13 @@ def hello(message: str = "Hello, World!") -> str:
         "- 'is_org_admin' reflects the current state from the identity provider, not a historical snapshot."
     ),
     requires_auth=True,
+    caveats=(
+        "- Shows only users provisioned in this org -- does not include cross-account (TAM) users or "
+        "service accounts from other identity providers.\n"
+        "- 'is_org_admin' reflects the current state from the identity provider, not a historical snapshot.\n"
+        "- Org admins have implicit full access that bypasses all RBAC checks; "
+        "this is not reflected in the returned data."
+    ),
 )
 def list_principals(
     request: HttpRequest,
@@ -680,6 +690,13 @@ def get_status(request: HttpRequest) -> str:
         "- Wildcard permissions ('*') are expanded at access-check time, not in this listing."
     ),
     requires_auth=True,
+    caveats=(
+        "- Permissions exist independently of roles. A permission appearing here does not mean any role "
+        "grants it -- use search_roles(permission='...') to find roles that include a specific permission.\n"
+        "- Wildcard permissions ('*') are expanded at access-check time, not in this listing.\n"
+        "- Permission names are naming conventions only -- RBAC cannot confirm what UI elements "
+        "or API endpoints they control."
+    ),
 )
 def list_permissions(
     request: HttpRequest,
@@ -739,6 +756,14 @@ def list_permissions(
     requires_auth=True,
     required_relation="rbac_roles_read",
     v1_permission=("admin", "only"),
+    caveats=(
+        "- Does NOT capture: IP addresses, session IDs, login/logout events, geographic location, or "
+        "before/after state diffs. This is an activity log of RBAC changes, not a full security audit trail.\n"
+        "- No server-side date range filter. Time-bounded queries require client-side pagination through "
+        "results ordered by '-created' until entries fall outside the desired window.\n"
+        "- Cross-account request approval/denial events may not appear here -- those are tracked in the "
+        "cross-account-requests API, not the audit log."
+    ),
 )
 def list_audit_logs(
     request: HttpRequest,
@@ -972,6 +997,14 @@ def _find_authorizing_role(username: str, tenant: Any, required_perms: list[str]
     ),
     requires_auth=True,
     api_version=ApiVersion.V1,
+    caveats=(
+        "- This shows the flattened effective permissions but not the path: you cannot see which "
+        "role or group granted each permission. Use list_group_roles + list_role_access to trace "
+        "the full chain.\n"
+        "- Org admins bypass all RBAC checks; this tool returns only explicitly assigned permissions, "
+        "not their effective unlimited access.\n"
+        "- ResourceDefinition filters are stored but enforced by the consuming application, not RBAC."
+    ),
 )
 def list_access(
     request: HttpRequest,
@@ -1014,6 +1047,12 @@ def list_access(
         "names. There is no mapping from these identifiers to user-facing product names."
     ),
     requires_auth=True,
+    caveats=(
+        "- Returns values from the permission registry, not from what is actively assigned. An "
+        "application or verb may appear here even if no role in this org currently uses it.\n"
+        "- Application names are identifiers (e.g., 'cost-management', 'advisor'), not display "
+        "names. There is no mapping from these identifiers to user-facing product names."
+    ),
 )
 def list_permission_options(
     request: HttpRequest,
@@ -1058,6 +1097,12 @@ def list_permission_options(
     ),
     requires_auth=True,
     api_version=ApiVersion.V1,
+    caveats=(
+        "- Non-org-admin users cannot modify groups that contain roles with RBAC write permissions "
+        "(e.g., 'User Access administrator'). The Default admin access group cannot be modified at all.\n"
+        "- In V1, roles are assigned to groups and users are added to groups -- "
+        "roles cannot be assigned directly to users."
+    ),
 )
 def list_group_roles(
     request: HttpRequest,
@@ -1119,6 +1164,13 @@ def list_group_roles(
     ),
     requires_auth=True,
     api_version=ApiVersion.V1,
+    caveats=(
+        "- This shows what the role grants in isolation. A user's effective access is the union of "
+        "all roles across all their groups -- a missing permission here may be covered by another role.\n"
+        "- ResourceDefinition filters are stored but enforced by the consuming application, not RBAC.\n"
+        "- Permission names are naming conventions only -- RBAC cannot confirm what UI elements "
+        "or API endpoints they control."
+    ),
 )
 def list_role_access(
     request: HttpRequest,
@@ -1158,6 +1210,12 @@ def list_role_access(
     api_version=ApiVersion.UNIFIED,
     required_relation="rbac_roles_read",
     v1_permission=("role", "read"),
+    caveats=(
+        "- The permission filter finds roles containing that permission, but does not account for "
+        "ResourceDefinition filters that may narrow the permission's effective scope.\n"
+        "- Role names are not unique across V1 and V2. The org_version field indicates which API "
+        "version the result came from."
+    ),
 )
 def search_roles(
     request: HttpRequest,
@@ -1317,6 +1375,11 @@ def _get_role_v2(request: HttpRequest, role_uuid: str) -> str:
     api_version=ApiVersion.UNIFIED,
     required_relation="rbac_roles_read",
     v1_permission=("role", "read"),
+    caveats=(
+        "- Permission names are naming conventions only -- RBAC cannot confirm what UI elements "
+        "or API endpoints they control.\n"
+        "- ResourceDefinition filters are stored but enforced by the consuming application, not RBAC."
+    ),
 )
 def check_role_permissions(
     request: HttpRequest,
@@ -1606,6 +1669,13 @@ def list_groups(
         "of who was added or removed. Use list_audit_logs for membership change history."
     ),
     requires_auth=True,
+    caveats=(
+        "- The 'Default access' group is a system group that all users belong to implicitly. "
+        "Its principalCount may not reflect the full org size, and its roles define the baseline "
+        "permissions every user gets.\n"
+        "- Group membership changes are not versioned. You see the current state, not a history "
+        "of who was added or removed. Use list_audit_logs for membership change history."
+    ),
 )
 def get_group(
     request: HttpRequest,
@@ -1668,6 +1738,14 @@ def list_group_principals(
         "- Only org admins can approve or deny requests -- regular users can view but not act on them."
     ),
     requires_auth=True,
+    caveats=(
+        "- Cross-account requests are org-to-org, not user-to-user. A TAM requests access to your "
+        "entire org's resources (scoped by the roles they are granted), not to a specific user's data.\n"
+        "- Approved requests have a time window (start_date to end_date). An 'approved' request may "
+        "have expired -- check end_date against the current date to confirm active access.\n"
+        "- Cross-account activity is not tracked in RBAC audit logs.\n"
+        "- Only org admins can approve or deny requests -- regular users can view but not act on them."
+    ),
 )
 def list_cross_account_requests(
     request: HttpRequest,
@@ -2589,6 +2667,13 @@ def _permission_matches(granted_permission: str, requested_permission: str) -> b
     api_version=ApiVersion.UNIFIED,
     required_relation="rbac_roles_read",
     v1_permission=("principal", "read"),
+    caveats=(
+        "- Org admins bypass all RBAC checks; this tool returns only explicitly assigned permissions, "
+        "not their effective unlimited access.\n"
+        "- ResourceDefinition filters are stored but enforced by the consuming application, not RBAC.\n"
+        "- Permission names are naming conventions only -- RBAC cannot confirm what UI elements "
+        "or API endpoints they control."
+    ),
 )
 def check_user_permission(
     request: HttpRequest,
@@ -2767,6 +2852,12 @@ def _check_user_permission_v1(request: HttpRequest, username: str, permission: s
     api_version=ApiVersion.UNIFIED,
     required_relation="rbac_roles_read",
     v1_permission=("principal", "read"),
+    caveats=(
+        "- Org admins have implicit full access that bypasses all RBAC checks; "
+        "this is not reflected in the returned data.\n"
+        "- Permission names are naming conventions only -- RBAC cannot confirm what UI elements "
+        "or API endpoints they control."
+    ),
 )
 def get_user_state(
     request: HttpRequest,
@@ -3415,6 +3506,14 @@ def _analyze_expected_permission(
     api_version=ApiVersion.COMMON,
     required_relation="rbac_roles_read",
     v1_permission=("principal", "read"),
+    caveats=(
+        "- Org admins bypass all RBAC checks; this tool returns only explicitly assigned permissions, "
+        "not their effective unlimited access.\n"
+        "- In V1, roles are assigned to groups -- roles cannot be assigned directly to users. "
+        "In V2, roles are bound to subjects via role bindings, which can target individual users.\n"
+        "- Permission names are naming conventions only -- RBAC cannot confirm what UI elements "
+        "or API endpoints they control."
+    ),
 )
 def investigate_user_access(
     request: HttpRequest,
@@ -5243,7 +5342,13 @@ def _handle_tools_call(request: HttpRequest, request_id: Any, params: dict[str, 
             _record_metric(tool_name, "success", duration)
             logger.info("mcp: tools/call tool='%s' completed in %.3fs", tool_name, duration)
 
-        content = [{"type": "text", "text": _normalize_tool_result(result)}]
+        result_text = _normalize_tool_result(result)
+        content = [{"type": "text", "text": result_text}]
+        if config.caveats:
+            content.append(
+                {"type": "text", "text": f"IMPORTANT — INCLUDE THESE CAVEATS IN YOUR ANSWER:\n{config.caveats}"}
+            )
+
         return _success_response(request_id, {"content": content, "isError": False})
     except ToolTimeoutError:
         duration = time.monotonic() - start if track else timeout

--- a/rbac/management/mcp_views.py
+++ b/rbac/management/mcp_views.py
@@ -249,6 +249,10 @@ def register_tool(
         first_param = next(iter(sig.parameters), None)
         passes_request = first_param == "request"
 
+        resolved_caveats = caveats
+        if not resolved_caveats and "Caveats:\n" in description:
+            resolved_caveats = description.split("Caveats:\n", 1)[1].strip()
+
         _TOOL_CONFIG[tool_name] = ToolConfig(
             fn=fn,
             requires_auth=requires_auth,
@@ -258,7 +262,7 @@ def register_tool(
             required_relation=required_relation,
             required_resource_type=required_resource_type,
             v1_permission=v1_permission,
-            caveats=caveats,
+            caveats=resolved_caveats,
         )
 
         if passes_request:
@@ -438,13 +442,6 @@ def hello(message: str = "Hello, World!") -> str:
         "- 'is_org_admin' reflects the current state from the identity provider, not a historical snapshot."
     ),
     requires_auth=True,
-    caveats=(
-        "- Shows only users provisioned in this org -- does not include cross-account (TAM) users or "
-        "service accounts from other identity providers.\n"
-        "- 'is_org_admin' reflects the current state from the identity provider, not a historical snapshot.\n"
-        "- Org admins have implicit full access that bypasses all RBAC checks; "
-        "this is not reflected in the returned data."
-    ),
 )
 def list_principals(
     request: HttpRequest,
@@ -690,13 +687,6 @@ def get_status(request: HttpRequest) -> str:
         "- Wildcard permissions ('*') are expanded at access-check time, not in this listing."
     ),
     requires_auth=True,
-    caveats=(
-        "- Permissions exist independently of roles. A permission appearing here does not mean any role "
-        "grants it -- use search_roles(permission='...') to find roles that include a specific permission.\n"
-        "- Wildcard permissions ('*') are expanded at access-check time, not in this listing.\n"
-        "- Permission names are naming conventions only -- RBAC cannot confirm what UI elements "
-        "or API endpoints they control."
-    ),
 )
 def list_permissions(
     request: HttpRequest,
@@ -756,14 +746,6 @@ def list_permissions(
     requires_auth=True,
     required_relation="rbac_roles_read",
     v1_permission=("admin", "only"),
-    caveats=(
-        "- Does NOT capture: IP addresses, session IDs, login/logout events, geographic location, or "
-        "before/after state diffs. This is an activity log of RBAC changes, not a full security audit trail.\n"
-        "- No server-side date range filter. Time-bounded queries require client-side pagination through "
-        "results ordered by '-created' until entries fall outside the desired window.\n"
-        "- Cross-account request approval/denial events may not appear here -- those are tracked in the "
-        "cross-account-requests API, not the audit log."
-    ),
 )
 def list_audit_logs(
     request: HttpRequest,
@@ -997,14 +979,6 @@ def _find_authorizing_role(username: str, tenant: Any, required_perms: list[str]
     ),
     requires_auth=True,
     api_version=ApiVersion.V1,
-    caveats=(
-        "- This shows the flattened effective permissions but not the path: you cannot see which "
-        "role or group granted each permission. Use list_group_roles + list_role_access to trace "
-        "the full chain.\n"
-        "- Org admins bypass all RBAC checks; this tool returns only explicitly assigned permissions, "
-        "not their effective unlimited access.\n"
-        "- ResourceDefinition filters are stored but enforced by the consuming application, not RBAC."
-    ),
 )
 def list_access(
     request: HttpRequest,
@@ -1047,12 +1021,6 @@ def list_access(
         "names. There is no mapping from these identifiers to user-facing product names."
     ),
     requires_auth=True,
-    caveats=(
-        "- Returns values from the permission registry, not from what is actively assigned. An "
-        "application or verb may appear here even if no role in this org currently uses it.\n"
-        "- Application names are identifiers (e.g., 'cost-management', 'advisor'), not display "
-        "names. There is no mapping from these identifiers to user-facing product names."
-    ),
 )
 def list_permission_options(
     request: HttpRequest,
@@ -1097,12 +1065,6 @@ def list_permission_options(
     ),
     requires_auth=True,
     api_version=ApiVersion.V1,
-    caveats=(
-        "- Non-org-admin users cannot modify groups that contain roles with RBAC write permissions "
-        "(e.g., 'User Access administrator'). The Default admin access group cannot be modified at all.\n"
-        "- In V1, roles are assigned to groups and users are added to groups -- "
-        "roles cannot be assigned directly to users."
-    ),
 )
 def list_group_roles(
     request: HttpRequest,
@@ -1164,13 +1126,6 @@ def list_group_roles(
     ),
     requires_auth=True,
     api_version=ApiVersion.V1,
-    caveats=(
-        "- This shows what the role grants in isolation. A user's effective access is the union of "
-        "all roles across all their groups -- a missing permission here may be covered by another role.\n"
-        "- ResourceDefinition filters are stored but enforced by the consuming application, not RBAC.\n"
-        "- Permission names are naming conventions only -- RBAC cannot confirm what UI elements "
-        "or API endpoints they control."
-    ),
 )
 def list_role_access(
     request: HttpRequest,
@@ -1210,12 +1165,6 @@ def list_role_access(
     api_version=ApiVersion.UNIFIED,
     required_relation="rbac_roles_read",
     v1_permission=("role", "read"),
-    caveats=(
-        "- The permission filter finds roles containing that permission, but does not account for "
-        "ResourceDefinition filters that may narrow the permission's effective scope.\n"
-        "- Role names are not unique across V1 and V2. The org_version field indicates which API "
-        "version the result came from."
-    ),
 )
 def search_roles(
     request: HttpRequest,
@@ -1369,17 +1318,16 @@ def _get_role_v2(request: HttpRequest, role_uuid: str) -> str:
         "(1) create a new group and attach the role, ready for user assignment, "
         "(2) update the role's metadata (e.g. display_name) before assignment, "
         "(3) add additional permissions to the role. "
-        "Format as 'Reply 1, 2, or 3 -- or no'. Do NOT execute write tools without explicit user selection."
+        "Format as 'Reply 1, 2, or 3 -- or no'. Do NOT execute write tools without explicit user selection.\n"
+        "Caveats:\n"
+        "- Permission names are naming conventions only -- RBAC cannot confirm what UI elements "
+        "or API endpoints they control.\n"
+        "- ResourceDefinition filters are stored but enforced by the consuming application, not RBAC."
     ),
     requires_auth=True,
     api_version=ApiVersion.UNIFIED,
     required_relation="rbac_roles_read",
     v1_permission=("role", "read"),
-    caveats=(
-        "- Permission names are naming conventions only -- RBAC cannot confirm what UI elements "
-        "or API endpoints they control.\n"
-        "- ResourceDefinition filters are stored but enforced by the consuming application, not RBAC."
-    ),
 )
 def check_role_permissions(
     request: HttpRequest,
@@ -1669,13 +1617,6 @@ def list_groups(
         "of who was added or removed. Use list_audit_logs for membership change history."
     ),
     requires_auth=True,
-    caveats=(
-        "- The 'Default access' group is a system group that all users belong to implicitly. "
-        "Its principalCount may not reflect the full org size, and its roles define the baseline "
-        "permissions every user gets.\n"
-        "- Group membership changes are not versioned. You see the current state, not a history "
-        "of who was added or removed. Use list_audit_logs for membership change history."
-    ),
 )
 def get_group(
     request: HttpRequest,
@@ -1738,14 +1679,6 @@ def list_group_principals(
         "- Only org admins can approve or deny requests -- regular users can view but not act on them."
     ),
     requires_auth=True,
-    caveats=(
-        "- Cross-account requests are org-to-org, not user-to-user. A TAM requests access to your "
-        "entire org's resources (scoped by the roles they are granted), not to a specific user's data.\n"
-        "- Approved requests have a time window (start_date to end_date). An 'approved' request may "
-        "have expired -- check end_date against the current date to confirm active access.\n"
-        "- Cross-account activity is not tracked in RBAC audit logs.\n"
-        "- Only org admins can approve or deny requests -- regular users can view but not act on them."
-    ),
 )
 def list_cross_account_requests(
     request: HttpRequest,
@@ -2661,19 +2594,18 @@ def _permission_matches(granted_permission: str, requested_permission: str) -> b
         "Returns: {allowed: bool, username, permission, matched_permission, ...} "
         "or {allowed: false, hint: str}. "
         "V1 calls: GET /api/v1/access/?username=X&application=Y (internally). "
-        "V2 resolves: role bindings → roles → permissions (internally)."
-    ),
-    requires_auth=True,
-    api_version=ApiVersion.UNIFIED,
-    required_relation="rbac_roles_read",
-    v1_permission=("principal", "read"),
-    caveats=(
+        "V2 resolves: role bindings → roles → permissions (internally).\n"
+        "Caveats:\n"
         "- Org admins bypass all RBAC checks; this tool returns only explicitly assigned permissions, "
         "not their effective unlimited access.\n"
         "- ResourceDefinition filters are stored but enforced by the consuming application, not RBAC.\n"
         "- Permission names are naming conventions only -- RBAC cannot confirm what UI elements "
         "or API endpoints they control."
     ),
+    requires_auth=True,
+    api_version=ApiVersion.UNIFIED,
+    required_relation="rbac_roles_read",
+    v1_permission=("principal", "read"),
 )
 def check_user_permission(
     request: HttpRequest,
@@ -2846,18 +2778,17 @@ def _check_user_permission_v1(request: HttpRequest, username: str, permission: s
         "Audit log: <N> actions performed by user on <groups> (action types).'. "
         "Returns: {username, org_version, groups: [{name, roles, recent_activity}], "
         "access: [{permission, role_name, ...}], user_actions: {total_count, by_group, by_type, recent}, "
-        "summary: {group_count, permission_count, actions_by_user, recent_actions_on_groups}}."
-    ),
-    requires_auth=True,
-    api_version=ApiVersion.UNIFIED,
-    required_relation="rbac_roles_read",
-    v1_permission=("principal", "read"),
-    caveats=(
+        "summary: {group_count, permission_count, actions_by_user, recent_actions_on_groups}}.\n"
+        "Caveats:\n"
         "- Org admins have implicit full access that bypasses all RBAC checks; "
         "this is not reflected in the returned data.\n"
         "- Permission names are naming conventions only -- RBAC cannot confirm what UI elements "
         "or API endpoints they control."
     ),
+    requires_auth=True,
+    api_version=ApiVersion.UNIFIED,
+    required_relation="rbac_roles_read",
+    v1_permission=("principal", "read"),
 )
 def get_user_state(
     request: HttpRequest,
@@ -3500,13 +3431,8 @@ def _analyze_expected_permission(
         "(1) add a role containing the missing permission to the user's group, "
         "(2) create a new custom role with the missing permission and add it to the group, "
         "(3) do nothing -- audit the role definition first. "
-        "Format as 'Reply 1, 2, or 3 -- or no'. Do NOT execute write tools without explicit user selection."
-    ),
-    requires_auth=True,
-    api_version=ApiVersion.COMMON,
-    required_relation="rbac_roles_read",
-    v1_permission=("principal", "read"),
-    caveats=(
+        "Format as 'Reply 1, 2, or 3 -- or no'. Do NOT execute write tools without explicit user selection.\n"
+        "Caveats:\n"
         "- Org admins bypass all RBAC checks; this tool returns only explicitly assigned permissions, "
         "not their effective unlimited access.\n"
         "- In V1, roles are assigned to groups -- roles cannot be assigned directly to users. "
@@ -3514,6 +3440,10 @@ def _analyze_expected_permission(
         "- Permission names are naming conventions only -- RBAC cannot confirm what UI elements "
         "or API endpoints they control."
     ),
+    requires_auth=True,
+    api_version=ApiVersion.COMMON,
+    required_relation="rbac_roles_read",
+    v1_permission=("principal", "read"),
 )
 def investigate_user_access(
     request: HttpRequest,

--- a/tests/management/test_mcp_views.py
+++ b/tests/management/test_mcp_views.py
@@ -377,7 +377,6 @@ class MCPViewTests(MCPToolTestMixin, IdentityRequest):
         self.assertEqual(data["id"], 5)
         result = data["result"]
         self.assertFalse(result["isError"])
-        self.assertGreaterEqual(len(result["content"]), 1)
         self.assertEqual(result["content"][0]["type"], "text")
 
         tool_output = json.loads(result["content"][0]["text"])

--- a/tests/management/test_mcp_views.py
+++ b/tests/management/test_mcp_views.py
@@ -174,6 +174,44 @@ class MCPViewTests(MCPToolTestMixin, IdentityRequest):
         self.assertIn("Permission-to-UI mapping does not exist", instructions)
         self.assertIn("V1 vs V2 role assignment model", instructions)
 
+    @patch(
+        "management.principal.proxy.PrincipalProxy.request_principals",
+        return_value={
+            "status_code": 200,
+            "data": [{"username": "caveat_user", "email": "c@example.com"}],
+            "userCount": 1,
+        },
+    )
+    def test_tool_result_includes_caveats_in_separate_content_block(self, mock_request):
+        """Positive: tools with caveats append a second content block with caveat text."""
+        response = self._call_tool("list_principals", {"limit": 1})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        result = response.json()["result"]
+        self.assertFalse(result["isError"])
+        self.assertEqual(len(result["content"]), 2)
+
+        json.loads(result["content"][0]["text"])
+
+        caveat_block = result["content"][1]
+        self.assertEqual(caveat_block["type"], "text")
+        self.assertIn("IMPORTANT", caveat_block["text"])
+        self.assertIn("CAVEATS", caveat_block["text"])
+        self.assertIn("is_org_admin", caveat_block["text"])
+
+    def test_tool_result_without_caveats_has_single_content_block(self):
+        """Positive: tools without caveats return only one content block."""
+        response = self._call_tool("hello", {"message": "test"}, use_auth=False)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        result = response.json()["result"]
+        self.assertFalse(result["isError"])
+        self.assertEqual(len(result["content"]), 1)
+        self.assertEqual(result["content"][0]["type"], "text")
+
+        tool_output = json.loads(result["content"][0]["text"])
+        self.assertIn("response", tool_output)
+
     def test_notification_returns_202(self):
         """Positive: JSON-RPC notification (no id) returns 202."""
         body = {"jsonrpc": "2.0", "method": "notifications/initialized"}
@@ -339,7 +377,7 @@ class MCPViewTests(MCPToolTestMixin, IdentityRequest):
         self.assertEqual(data["id"], 5)
         result = data["result"]
         self.assertFalse(result["isError"])
-        self.assertEqual(len(result["content"]), 1)
+        self.assertGreaterEqual(len(result["content"]), 1)
         self.assertEqual(result["content"][0]["type"], "text")
 
         tool_output = json.loads(result["content"][0]["text"])
@@ -347,6 +385,10 @@ class MCPViewTests(MCPToolTestMixin, IdentityRequest):
         self.assertIn("links", tool_output)
         self.assertEqual(len(tool_output["data"]), 1)
         self.assertEqual(tool_output["data"][0]["username"], "test_user")
+
+        self.assertEqual(len(result["content"]), 2)
+        self.assertIn("IMPORTANT", result["content"][1]["text"])
+        self.assertIn("CAVEATS", result["content"][1]["text"])
 
     @patch("management.mcp_views._principal_view")
     def test_tools_call_list_principals_non_drf_response(self, mock_principal_view):


### PR DESCRIPTION
## Summary

- Llama Stack's MCP provider discards the `initialize` response, so caveats in `instructions` never reach the LLM
- Adds a `caveats` field to `ToolConfig` and `register_tool()` to carry per-tool caveat text
- When a tool has caveats, `_handle_tools_call` appends them as a **separate MCP content block** (`content[1]`), preserving JSON parseability in `content[0]`
- 14 tools now carry result-time caveats covering the 4 global honest caveats (permission-to-UI mapping, ResourceDefinition opacity, org admin implicit access, V1/V2 model) plus per-tool specifics

## Root Cause

Traced through the full chain: RBAC MCP server → Llama Stack `remote::model-context-protocol` provider → Lightspeed Stack → LLM. Llama Stack calls `session.initialize()` but discards the return value ([`mcp.py:182`](https://github.com/meta-llama/llama-stack/blob/main/llama_stack/providers/utils/tools/mcp.py#L182), [`mcp.py:324`](https://github.com/meta-llama/llama-stack/blob/main/llama_stack/providers/utils/tools/mcp.py#L324)). The `instructions` field — where honest caveats lived — is never forwarded to the LLM.

## Solution

The only data paths reliably reaching the LLM are **tool descriptions** (`tools/list`) and **tool results** (`tools/call`). Descriptions already contain `Caveats:` blocks for tool selection guidance. This PR adds the same caveats to tool results so they're in the LLM's immediate context when formulating its answer.

## Test plan

- [x] `test_tool_result_includes_caveats_in_separate_content_block` — verifies tools with caveats produce 2 content blocks, with caveat text in `content[1]`
- [x] `test_tool_result_without_caveats_has_single_content_block` — verifies tools without caveats (e.g., `hello`) produce only 1 content block
- [x] Updated `test_tools_call_list_principals_success` to validate caveat content block
- [x] All 362 MCP tests pass
- [x] Lint and black pass

RHCLOUD-47930

## Summary by Sourcery

Add per-tool caveats to MCP tool configuration and include them alongside tool results so the LLM receives honest usage limitations with each call.

New Features:
- Introduce a caveats field on MCP ToolConfig and register_tool to carry per-tool caveat text that is returned with tool outputs.

Enhancements:
- Append caveat text as a separate MCP content block in tools/call responses while preserving JSON-only output in the primary content block.
- Annotate multiple RBAC MCP tools with detailed, tool-specific caveats about permissions, org admin behavior, resource definitions, and model versions.

Tests:
- Add tests verifying that tools with caveats return an additional caveat content block and tools without caveats return a single content block, and update existing list_principals tools/call test to assert the new behavior.