### PR TITLE
[RHCLOUD-47934] Reject empty ids list in V2 roles batchDelete

### DIFF
--- a/rbac/management/role/v2_serializer.py
+++ b/rbac/management/role/v2_serializer.py
@@ -313,4 +313,4 @@ class RoleV2RequestSerializer(serializers.ModelSerializer):
 class RoleV2BulkDeleteRequestSerializer(serializers.Serializer):
     """Serializer for requests to delete multiple roles."""
 
-    ids = serializers.ListField(child=UUIDStringField())
+    ids = serializers.ListField(child=UUIDStringField(), min_length=1)

--- a/tests/management/role/test_v2_view.py
+++ b/tests/management/role/test_v2_view.py
@@ -2044,9 +2044,11 @@ class RoleV2ViewSetTests(IdentityRequest):
         )
 
     def test_delete_empty(self):
-        """Test that deleting 0 roles is successful."""
+        """Test that deleting with an empty ids list returns 400."""
         response = self._request_delete({"ids": []})
-        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data["errors"][0]["field"], "ids")
+        self.assertEqual(response.data["errors"][0]["message"], "Ensure this field has at least 1 elements.")
 
     def test_delete_nonexistent_role(self):
         """Test that deleting a nonexistent role fails with status 404."""


### PR DESCRIPTION
## Link(s) to Jira
- [RHCLOUD-47934](https://issues.redhat.com/browse/RHCLOUD-47934)

## Description of Intent of Change(s)

The V2 roles `batchDelete` endpoint (`POST /api/v2/roles/:batchDelete`) accepted an empty `ids` list and returned `204 No Content` instead of rejecting the request with `400 Bad Request`.

The root cause is that `RoleV2BulkDeleteRequestSerializer.ids` was defined as `ListField(child=UUIDStringField())` without `min_length=1`, so DRF's default behavior allowed empty lists through validation.

This adds `min_length=1` to the `ids` field, consistent with the existing precedent in `BatchCreateRoleBindingRequestSerializer` which already enforces `min_length=1` on its list field.

## Local Testing

```bash
# Run the specific test
pipenv run tox -e py312-fast -- tests.management.role.test_v2_view.RoleV2ViewSetTests.test_delete_empty

# Run the full role V2 test module
pipenv run tox -e py312-fast -- tests.management.role.test_v2_view
```

## Checklist
- [x] if API spec changes are required, is the spec updated?
- [x] are there any pre/post merge actions required? if so, document here.
- [x] are theses changes covered by unit tests?
- [x] if warranted, are documentation changes accounted for?
- [x] does this require migration changes?
  - [x] N/A -- no model changes
- [x] is there known, direct impact to dependent teams/components?
  - [x] Callers sending empty `ids` lists will now receive 400 instead of 204. This is the correct behavior per the API contract.

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices

[RHCLOUD-47934]: https://redhat.atlassian.net/browse/RHCLOUD-47934?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Enforce validation on the V2 roles batch delete request to reject empty ID lists and document the expected error response.

Bug Fixes:
- Reject empty ID lists for the V2 roles batchDelete endpoint by requiring at least one ID in the request payload.

Tests:
- Update the V2 roles batch delete test to assert a 400 response and verify the returned validation error details when the IDs list is empty.