### PR TITLE
[RHCLOUD-47926] V2 system role update/delete returns 400 instead of 404

### DIFF
--- a/rbac/management/role/v2_view.py
+++ b/rbac/management/role/v2_view.py
@@ -64,7 +64,7 @@ class RoleV2ViewSet(AtomicOperationsMixin, BaseV2ViewSet):
     DEFAULT_CREATE_UPDATE_FIELDS = {"id", "name", "description", "permissions", "last_modified"}
 
     def get_queryset(self):
-        """Return assignable roles for the requesting tenant. Restricts writes to custom roles."""
+        """Return assignable roles for the requesting tenant. Restricts creates to custom roles."""
         if self.action == "retrieve":
             fields = RoleV2Service.DEFAULT_RETRIEVE_FIELDS
         else:
@@ -73,6 +73,8 @@ class RoleV2ViewSet(AtomicOperationsMixin, BaseV2ViewSet):
 
         if self.action in ("list", "retrieve"):
             return base_qs.excluding_out_of_scope_v2_roles()
+        if self.action in ("update", "bulk_destroy"):
+            return base_qs
         return base_qs.filter(type=RoleV2.Types.CUSTOM)
 
     def get_serializer_context(self):
@@ -156,6 +158,9 @@ class RoleV2ViewSet(AtomicOperationsMixin, BaseV2ViewSet):
         with atomic_block():
             instance = self.get_object()
 
+            if instance.type != RoleV2.Types.CUSTOM:
+                raise ValidationError({"uuid": "System roles may not be updated."})
+
             audit_log = AuditLog()
             audit_log.log_edit(request=request, resource=AuditLog.ROLE_V2, object=instance)
 
@@ -193,6 +198,27 @@ class RoleV2ViewSet(AtomicOperationsMixin, BaseV2ViewSet):
 
         ids = set(serializer.validated_data["ids"])
 
+        if ids:
+            non_custom = (
+                RoleV2.objects.for_tenant(request.tenant)
+                .assignable()
+                .filter(uuid__in=ids)
+                .exclude(type=RoleV2.Types.CUSTOM)
+            )
+            if non_custom.exists():
+                return Response(
+                    v2response_error_from_errors(
+                        errors=[
+                            {
+                                "detail": "System roles may not be deleted.",
+                                "status": status.HTTP_400_BAD_REQUEST,
+                                "source": "ids",
+                            }
+                        ],
+                    ),
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+
         try:
             removed_roles = service.bulk_delete(ids, from_tenant=self.request.tenant)
 
@@ -207,12 +233,18 @@ class RoleV2ViewSet(AtomicOperationsMixin, BaseV2ViewSet):
                 status=status.HTTP_404_NOT_FOUND,
             )
         except CustomRoleRequiredError as e:
-            # This should be impossible. We constrain deletions to be from the user's tenant. Non-custom roles should
-            # only exist in the public tenant, and there shouldn't be any users in the public tenant. Thus,
-            # we will never find any non-custom roles to try to delete.
             return Response(
-                {"title": "An internal error occurred.", "detail": str(e)},
-                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                v2response_error_from_errors(
+                    errors=[
+                        {
+                            "detail": str(e),
+                            "status": status.HTTP_400_BAD_REQUEST,
+                            "source": "ids",
+                        }
+                    ],
+                    exc=e,
+                ),
+                status=status.HTTP_400_BAD_REQUEST,
             )
 
         # We don't allow a revert here because sending a notification in the middle could fail. This would make it

--- a/tests/management/role/test_v2_view.py
+++ b/tests/management/role/test_v2_view.py
@@ -1874,12 +1874,36 @@ class RoleV2ViewSetTests(IdentityRequest):
 
         response = self.client.put(update_url, data, format="json")
 
-        # Platform roles are filtered out in get_queryset() for update action
+        # Platform roles are filtered out by assignable() so they're invisible (404)
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
         self.assertEqual(response["Content-Type"], "application/problem+json")
         self.assertEqual(response.data["status"], 404)
         self.assertIn("title", response.data)
         self.assertIn("detail", response.data)
+
+    def test_update_seeded_role_returns_400(self):
+        """Test that attempting to update a seeded role returns 400, not 404."""
+        public_tenant, _ = Tenant.objects.get_or_create(tenant_name="public")
+        seeded_role = SeededRoleV2.objects.create(
+            name="Seeded Role For Update Test",
+            description="A seeded role",
+            tenant=public_tenant,
+        )
+        seeded_role.permissions.add(self.permission1)
+
+        update_url = reverse("v2_management:roles-detail", kwargs={"uuid": str(seeded_role.uuid)})
+        data = {
+            "name": "Attempt to Update Seeded Role",
+            "description": "This should fail with 400",
+            "permissions": [{"application": "inventory", "resource_type": "hosts", "operation": "read"}],
+        }
+
+        response = self.client.put(update_url, data, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response["Content-Type"], "application/problem+json")
+        self.assertEqual(response.data["status"], 400)
+        self.assertIn("System roles may not be updated", str(response.data))
 
     # --- Problem RFC format on errors ---
 
@@ -2072,7 +2096,7 @@ class RoleV2ViewSetTests(IdentityRequest):
         self.assertTrue(RoleV2.objects.filter(pk=role.pk).exists())
 
     def test_delete_seeded(self):
-        """Test that deleting a seeded role fails with status 404."""
+        """Test that deleting a seeded role fails with status 400, not 404."""
         seed_roles()
 
         seeded_role = SeededRoleV2.objects.first()
@@ -2080,7 +2104,23 @@ class RoleV2ViewSetTests(IdentityRequest):
 
         response = self._request_delete({"ids": [str(seeded_role.uuid)]})
 
-        self._assert_delete_not_found(response, [seeded_role.uuid])
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("System roles may not be deleted", str(response.data))
+        self.assertTrue(RoleV2.objects.filter(pk=seeded_role.pk).exists())
+
+    def test_delete_mix_of_custom_and_seeded_returns_400(self):
+        """Test that bulk-deleting a mix of custom + seeded roles returns 400 and deletes nothing."""
+        seed_roles()
+        seeded_role = SeededRoleV2.objects.first()
+        self.assertIsNotNone(seeded_role)
+
+        custom_role = self._create_role()
+
+        response = self._request_delete({"ids": [custom_role["id"], str(seeded_role.uuid)]})
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("System roles may not be deleted", str(response.data))
+        self.assertTrue(RoleV2.objects.filter(uuid=custom_role["id"]).exists())
         self.assertTrue(RoleV2.objects.filter(pk=seeded_role.pk).exists())
 
     def test_delete_missing_ids(self):


### PR DESCRIPTION
## Link(s) to Jira
- [RHCLOUD-47926](https://issues.redhat.com/browse/RHCLOUD-47926)

## Description of Intent of Change(s)

The V2 role API returned 404 when attempting to update or delete a system (seeded) role. This was misleading -- the role exists and is visible in list/retrieve, but `get_queryset()` filtered to `type=CUSTOM` for all write actions, making seeded roles invisible to DRF's `get_object()` before validation could run.

The V1 API handles this correctly: the queryset includes system roles, and the serializer rejects updates with 400 ("System roles may not be updated").

**Changes:**
- **`get_queryset()`**: Only restrict to `type=CUSTOM` for `create` action. Update/delete actions now see all assignable roles (CUSTOM + SEEDED), so DRF finds the role and validation can provide the correct error.
- **`perform_atomic_update`**: After `get_object()`, validates that the role is CUSTOM. Non-custom roles get a 400 with "System roles may not be updated."
- **`_perform_bulk_destroy`**: Pre-checks requested IDs for non-custom assignable roles before calling the service. Returns 400 with "System roles may not be deleted." Also changed the `CustomRoleRequiredError` fallback handler from 500 to 400 with proper Problem JSON format.

**Before:** PUT on seeded role -> 404. Bulk delete of seeded role -> 404.
**After:** PUT on seeded role -> 400 "System roles may not be updated." Bulk delete of seeded role -> 400 "System roles may not be deleted."

Platform roles remain 404 (excluded by `assignable()` filter, so they are truly invisible).

## Local Testing

```bash
# Run targeted tests
pipenv run tox -e py312-fast -- tests.management.role.test_v2_view

# Key tests to verify:
# - test_update_seeded_role_returns_400: PUT on a seeded role returns 400
# - test_delete_seeded: bulk delete of seeded role returns 400
# - test_delete_mix_of_custom_and_seeded_returns_400: mixed delete returns 400, nothing deleted
# - test_update_platform_role_returns_404: platform roles still return 404
# - test_update_role_success: custom role update still works (200)
```

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [x] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [x] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [x] Access Control
- [ ] Cryptographic Practices
- [x] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices

[RHCLOUD-47926]: https://redhat.atlassian.net/browse/RHCLOUD-47926?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Align V2 role management behavior with V1 by returning proper validation errors when attempting to modify system roles instead of incorrectly reporting them as missing.

Bug Fixes:
- Ensure updating a seeded system role via the V2 API returns HTTP 400 with a clear error instead of HTTP 404.
- Ensure bulk deletion requests that include seeded system roles return HTTP 400 and do not delete any roles.
- Return HTTP 400 with Problem+JSON formatting when a non-custom role deletion triggers a CustomRoleRequiredError.

Tests:
- Add and update V2 role view tests to cover 400 responses for updating and deleting seeded roles and mixed custom/seeded bulk deletes, while preserving 404 behavior for platform roles.