### PR TITLE
[RHCLOUD-47745] Enforce workspace-level role scoping in V2 role list and binding

### DIFF
--- a/rbac/management/permission/scope_service.py
+++ b/rbac/management/permission/scope_service.py
@@ -232,6 +232,36 @@ class ImplicitResourceService:
             default_scope_permissions=parse_setting(settings.DEFAULT_SCOPE_PERMISSIONS),
         )
 
+    @staticmethod
+    def _wildcard_candidates(parsed: PermissionValue) -> list[PermissionValue]:
+        """Return the parsed value plus progressively broader wildcard variants.
+
+        Precedence order: exact, unconstrained verb, unconstrained resource type,
+        application-only.  Duplicates (when the input is already a wildcard) are
+        excluded.
+        """
+        return [parsed] + [
+            wildcard
+            for wildcard in [
+                parsed.with_unconstrained_verb(),
+                parsed.with_unconstrained_resource_type(),
+                parsed.with_application_only(),
+            ]
+            if wildcard != parsed
+        ]
+
+    def is_explicitly_scoped(self, permission: str) -> bool:
+        """Return True if the permission matches any configured scope entry.
+
+        A permission is explicitly scoped when it (or a wildcard that covers it)
+        appears in root_scope_permissions, tenant_scope_permissions, or
+        default_scope_permissions.  Permissions that fall through to the
+        ``Scope.DEFAULT`` fallback in ``scope_for_permission`` are NOT
+        explicitly scoped -- they are "workspace-granular".
+        """
+        candidates = self._wildcard_candidates(PermissionValue.parse_v1(permission))
+        return any(candidate in self._permissions_map for candidate in candidates)
+
     def scope_for_permission(self, permission: str) -> Scope:
         """
         Return the scope that a permission binds to using this object's configured permissions.
@@ -250,18 +280,7 @@ class ImplicitResourceService:
         Note that, if the permission is a wildcard, some of these steps will be redundant. For instance,
         if the permission is app:*:verb, there are only two possible matches: app:*:verb and app:*:*.
         """
-        parsed = PermissionValue.parse_v1(permission)
-
-        # If we are passed a wildcard, some wildcard checks will be redundant.
-        candidates = [parsed] + [
-            wildcard
-            for wildcard in [
-                parsed.with_unconstrained_verb(),
-                parsed.with_unconstrained_resource_type(),
-                parsed.with_application_only(),
-            ]
-            if wildcard != parsed
-        ]
+        candidates = self._wildcard_candidates(PermissionValue.parse_v1(permission))
 
         for candidate in candidates:
             scope = self._permissions_map.get(candidate)
@@ -375,14 +394,19 @@ class PermissionScopeCache:
         """Create a cache backed by the given scope service."""
         self._scope_service = scope_service
         self._ids_by_scope: dict[Scope, frozenset[int]] | None = None
+        self._explicit_default_ids: frozenset[int] | None = None
 
     def _build(self) -> dict[Scope, frozenset[int]]:
         from management.permission.model import Permission
 
         result: dict[Scope, set[int]] = {scope: set() for scope in Scope}
+        explicit_default: set[int] = set()
         for row in Permission.objects.values_list("id", "permission", named=True):
             scope = self._scope_service.scope_for_permission(row.permission)
             result[scope].add(row.id)
+            if scope == Scope.DEFAULT and self._scope_service.is_explicitly_scoped(row.permission):
+                explicit_default.add(row.id)
+        self._explicit_default_ids = frozenset(explicit_default)
         return {s: frozenset(ids) for s, ids in result.items()}
 
     @property
@@ -396,9 +420,22 @@ class PermissionScopeCache:
         """Return the union of Permission IDs for the given scopes."""
         return frozenset().union(*(self.ids_by_scope.get(s, frozenset()) for s in scopes))
 
+    @property
+    def explicit_default_ids(self) -> frozenset[int]:
+        """Return Permission IDs that are explicitly configured as DEFAULT scope.
+
+        These are permissions that matched a DEFAULT_SCOPE_PERMISSIONS entry,
+        as opposed to fallback-DEFAULT permissions (workspace-granular) that
+        simply didn't match any configured scope.
+        """
+        _ = self.ids_by_scope  # Ensure cache is built
+        assert self._explicit_default_ids is not None
+        return self._explicit_default_ids
+
     def invalidate(self):
         """Clear the cached mapping so it is rebuilt on next access."""
         self._ids_by_scope = None
+        self._explicit_default_ids = None
 
 
 permission_scope_cache = PermissionScopeCache(default_implicit_resource_service)

--- a/rbac/management/permission/scope_service.py
+++ b/rbac/management/permission/scope_service.py
@@ -373,6 +373,21 @@ def scope_for_resource(resource_type: str, resource_id: str, tenant: Tenant) -> 
     return None
 
 
+def resolve_workspace_scope(resource_id: str, tenant: Tenant) -> tuple[Scope, bool] | None:
+    """Resolve workspace scope and standard-workspace flag in a single query.
+
+    Returns ``(scope, is_standard_workspace)`` or ``None`` if the workspace
+    does not exist for the given tenant.
+    """
+    try:
+        ws_type = Workspace.objects.values_list("type", flat=True).get(id=resource_id, tenant=tenant)
+    except Workspace.DoesNotExist:
+        return None
+    if ws_type == Workspace.Types.ROOT:
+        return Scope.ROOT, False
+    return Scope.DEFAULT, ws_type == Workspace.Types.STANDARD
+
+
 """
 A global ImplicitResourceService configured using Django Settings.
 

--- a/rbac/management/role/v2_service.py
+++ b/rbac/management/role/v2_service.py
@@ -34,7 +34,7 @@ from management.permission.scope_service import (
     Scope,
     default_implicit_resource_service,
     permission_scope_cache,
-    scope_for_resource,
+    resolve_workspace_scope,
     scopes_for_resource_type,
 )
 from management.permission.service import PermissionService
@@ -291,9 +291,15 @@ class RoleV2Service:
         """Filter roles to those whose highest permission scope maps to resource_type.
 
         For ``resource_type=workspace``:
-        - With no ``resource_id``: only DEFAULT-scoped roles (default workspace and custom workspaces).
+        - With no ``resource_id``: DEFAULT-scoped roles (both explicit-DEFAULT
+          and workspace-granular, plus permissionless).
         - With ``resource_id`` the root workspace UUID: only ROOT-scoped roles.
-        - With any other workspace UUID: only DEFAULT-scoped roles.
+        - With ``resource_id`` the default workspace UUID: explicit-DEFAULT +
+          workspace-granular + permissionless roles.
+        - With ``resource_id`` a standard workspace UUID: only workspace-granular
+          roles (fallback-DEFAULT).  Explicit-DEFAULT and permissionless roles
+          are excluded because they represent grants that no service checks at
+          standard workspace level.
 
         Uses DB-level filtering with cached Permission-ID-to-Scope mappings to
         avoid loading all roles and their permissions into Python memory.
@@ -302,12 +308,14 @@ class RoleV2Service:
         if not matching_scopes:
             return queryset.none()
 
+        is_standard_workspace = False
         if resource_type == "workspace":
             if resource_id is not None:
                 assert self.tenant is not None
-                resolved = scope_for_resource(resource_type, str(resource_id), self.tenant)
-                if resolved is None:
+                result = resolve_workspace_scope(str(resource_id), self.tenant)
+                if result is None:
                     return queryset.none()
+                resolved, is_standard_workspace = result
                 matching_scopes = {resolved}
             else:
                 matching_scopes = {Scope.DEFAULT}
@@ -322,6 +330,12 @@ class RoleV2Service:
             higher_ids = permission_scope_cache.ids_for_scopes(higher_non_matching)
             if higher_ids:
                 queryset = queryset.exclude(permissions__id__in=higher_ids)
+
+        if is_standard_workspace:
+            explicit_default_ids = permission_scope_cache.explicit_default_ids
+            if explicit_default_ids:
+                queryset = queryset.exclude(permissions__id__in=explicit_default_ids)
+            queryset = queryset.filter(permissions__isnull=False).distinct()
 
         return queryset
 

--- a/rbac/management/role_binding/service.py
+++ b/rbac/management/role_binding/service.py
@@ -32,6 +32,8 @@ from management.permission.scope_service import (
     SCOPE_DISPLAY_NAME,
     Scope,
     default_implicit_resource_service,
+    permission_scope_cache,
+    resolve_workspace_scope,
     scope_for_resource,
 )
 from management.principal.model import Principal
@@ -1113,6 +1115,10 @@ class RoleBindingService:
         Uses ``ImplicitResourceService.highest_scope_for_permissions`` to compute
         the scope from each role's permission strings.
 
+        For standard (child) workspaces, additionally rejects roles that have
+        any explicit-DEFAULT permissions or no permissions at all, since those
+        represent grants no service checks at that workspace level.
+
         Must be called after ``_validate_resource`` which ensures the resource
         exists. Empty *roles* is valid (means "unbind all") and skips the check.
 
@@ -1124,21 +1130,40 @@ class RoleBindingService:
         if self._skip_scope_validation or not roles:
             return
 
-        expected = scope_for_resource(resource_type, resource_id, self.tenant)
-        if expected is None:
-            if resource_type in ("workspace", "tenant"):
+        is_standard_workspace = False
+        expected: Scope
+        if resource_type == "workspace":
+            result = resolve_workspace_scope(resource_id, self.tenant)
+            if result is None:
                 raise NotFoundError(resource_type, resource_id)
-            return
+            expected, is_standard_workspace = result
+        else:
+            resolved = scope_for_resource(resource_type, resource_id, self.tenant)
+            if resolved is None:
+                if resource_type == "tenant":
+                    raise NotFoundError(resource_type, resource_id)
+                return
+            expected = resolved
+
+        explicit_default_ids = permission_scope_cache.explicit_default_ids if is_standard_workspace else frozenset()
 
         mismatched: list[str] = []
         for role in roles:
-            perm_strings = list(role.permissions.values_list("permission", flat=True))
+            perm_rows = list(role.permissions.values_list("id", "permission"))
+            perm_strings = [row[1] for row in perm_rows]
             role_scope = default_implicit_resource_service.highest_scope_for_permissions(perm_strings)
             if role_scope != expected:
                 mismatched.append(f"{role.name} ({role.uuid})")
+            elif is_standard_workspace:
+                if not perm_rows:
+                    mismatched.append(f"{role.name} ({role.uuid})")
+                elif explicit_default_ids:
+                    perm_ids = {row[0] for row in perm_rows}
+                    if perm_ids & explicit_default_ids:
+                        mismatched.append(f"{role.name} ({role.uuid})")
 
         if mismatched:
-            scope_label = SCOPE_DISPLAY_NAME[expected]
+            scope_label = "Standard Workspace" if is_standard_workspace else SCOPE_DISPLAY_NAME[expected]
             raise InvalidFieldError(
                 "roles",
                 f"The following roles are not scoped for this resource ({scope_label}): {', '.join(mismatched)}",

--- a/tests/management/permission/test_scope_service.py
+++ b/tests/management/permission/test_scope_service.py
@@ -25,6 +25,7 @@ from api.models import Tenant
 from management.models import Permission, Role
 from management.permission.scope_service import (
     ImplicitResourceService,
+    PermissionScopeCache,
     Scope,
     scopes_for_resource_type,
 )
@@ -711,6 +712,135 @@ class RoleTests(TestCase):
         )
 
         self._assert_role_scope(Scope.ROOT)
+
+
+class ExplicitlyScopedTest(TestCase):
+    """Tests for ImplicitResourceService.is_explicitly_scoped."""
+
+    def test_root_permission_is_explicitly_scoped(self):
+        service = ImplicitResourceService(
+            root_scope_permissions=["root_app:*:*"],
+            tenant_scope_permissions=[],
+        )
+        self.assertTrue(service.is_explicitly_scoped("root_app:resource:verb"))
+
+    def test_tenant_permission_is_explicitly_scoped(self):
+        service = ImplicitResourceService(
+            root_scope_permissions=[],
+            tenant_scope_permissions=["tenant_app:*:*"],
+        )
+        self.assertTrue(service.is_explicitly_scoped("tenant_app:resource:verb"))
+
+    def test_default_permission_is_explicitly_scoped(self):
+        service = ImplicitResourceService(
+            root_scope_permissions=[],
+            tenant_scope_permissions=["rbac:*:*"],
+            default_scope_permissions=["rbac:role_binding:*"],
+        )
+        self.assertTrue(service.is_explicitly_scoped("rbac:role_binding:read"))
+
+    def test_fallback_default_is_not_explicitly_scoped(self):
+        service = ImplicitResourceService(
+            root_scope_permissions=["root_app:*:*"],
+            tenant_scope_permissions=[],
+        )
+        self.assertFalse(service.is_explicitly_scoped("unrelated:resource:verb"))
+
+    def test_exact_match_is_explicitly_scoped(self):
+        service = ImplicitResourceService(
+            root_scope_permissions=["app:resource:verb"],
+            tenant_scope_permissions=[],
+        )
+        self.assertTrue(service.is_explicitly_scoped("app:resource:verb"))
+        self.assertFalse(service.is_explicitly_scoped("app:resource:other"))
+        self.assertFalse(service.is_explicitly_scoped("app:other:verb"))
+
+    def test_wildcard_match_is_explicitly_scoped(self):
+        service = ImplicitResourceService(
+            root_scope_permissions=["app:resource:*"],
+            tenant_scope_permissions=[],
+        )
+        self.assertTrue(service.is_explicitly_scoped("app:resource:read"))
+        self.assertTrue(service.is_explicitly_scoped("app:resource:write"))
+        self.assertFalse(service.is_explicitly_scoped("app:other:read"))
+
+    def test_empty_service_nothing_is_explicitly_scoped(self):
+        service = ImplicitResourceService(
+            root_scope_permissions=[],
+            tenant_scope_permissions=[],
+        )
+        self.assertFalse(service.is_explicitly_scoped("any:resource:verb"))
+
+    def test_invalid_permission_raises_value_error(self):
+        service = ImplicitResourceService(root_scope_permissions=[], tenant_scope_permissions=[])
+        for permission in INVALID_PERMISSIONS_V1:
+            with self.subTest(permission=permission):
+                self.assertRaises(ValueError, service.is_explicitly_scoped, permission)
+
+
+class PermissionScopeCacheExplicitDefaultTest(TestCase):
+    """Tests for PermissionScopeCache.explicit_default_ids."""
+
+    def setUp(self):
+        self.public_tenant = Tenant.objects.get(tenant_name="public")
+
+    def test_explicit_default_ids_with_default_scope_permissions(self):
+        """Permissions matching DEFAULT_SCOPE_PERMISSIONS should be in explicit_default_ids."""
+        perm_rb = Permission.objects.create(permission="rbac:role_binding:read", tenant=self.public_tenant)
+        perm_ws = Permission.objects.create(permission="other:resource:read", tenant=self.public_tenant)
+
+        service = ImplicitResourceService(
+            root_scope_permissions=[],
+            tenant_scope_permissions=["rbac:*:*"],
+            default_scope_permissions=["rbac:role_binding:*"],
+        )
+        cache = PermissionScopeCache(service)
+
+        self.assertIn(perm_rb.id, cache.explicit_default_ids)
+        self.assertNotIn(perm_ws.id, cache.explicit_default_ids)
+
+    def test_explicit_default_ids_empty_when_no_default_scope_permissions(self):
+        """With no default_scope_permissions, explicit_default_ids should be empty."""
+        Permission.objects.create(permission="app:resource:read", tenant=self.public_tenant)
+
+        service = ImplicitResourceService(
+            root_scope_permissions=[],
+            tenant_scope_permissions=[],
+        )
+        cache = PermissionScopeCache(service)
+
+        self.assertEqual(cache.explicit_default_ids, frozenset())
+
+    def test_explicit_default_ids_excludes_root_and_tenant(self):
+        """ROOT and TENANT permissions should not appear in explicit_default_ids."""
+        root_perm = Permission.objects.create(permission="root_app:resource:read", tenant=self.public_tenant)
+        tenant_perm = Permission.objects.create(permission="tenant_app:resource:read", tenant=self.public_tenant)
+
+        service = ImplicitResourceService(
+            root_scope_permissions=["root_app:*:*"],
+            tenant_scope_permissions=["tenant_app:*:*"],
+        )
+        cache = PermissionScopeCache(service)
+
+        self.assertNotIn(root_perm.id, cache.explicit_default_ids)
+        self.assertNotIn(tenant_perm.id, cache.explicit_default_ids)
+
+    def test_invalidate_clears_explicit_default_ids(self):
+        """invalidate() should clear explicit_default_ids so they are rebuilt on next access."""
+        Permission.objects.create(permission="rbac:role_binding:read", tenant=self.public_tenant)
+
+        service = ImplicitResourceService(
+            root_scope_permissions=[],
+            tenant_scope_permissions=["rbac:*:*"],
+            default_scope_permissions=["rbac:role_binding:*"],
+        )
+        cache = PermissionScopeCache(service)
+
+        _ = cache.explicit_default_ids
+        cache.invalidate()
+        self.assertIsNone(cache._explicit_default_ids)
+        _ = cache.explicit_default_ids
+        self.assertIsNotNone(cache._explicit_default_ids)
 
 
 class ResourceTypeMappingTest(TestCase):

--- a/tests/management/role/test_v2_service.py
+++ b/tests/management/role/test_v2_service.py
@@ -984,7 +984,7 @@ class RoleV2ServiceListResourceTypeTests(IdentityRequest):
         self.assertEqual(queryset.count(), 0)
 
     def test_list_resource_type_workspace_with_standard_resource_id_returns_default_scoped_only(self):
-        """A non-root (e.g. standard) workspace id lists the same as default: DEFAULT-scoped roles only."""
+        """A non-root (e.g. standard) workspace id lists only workspace-granular roles (no explicit config)."""
         child = Workspace.objects.create(
             name="Sub WS",
             tenant=self.tenant,
@@ -994,3 +994,154 @@ class RoleV2ServiceListResourceTypeTests(IdentityRequest):
         queryset = self.service.list({"resource_type": "workspace", "resource_id": child.id})
         names = set(queryset.values_list("name", flat=True))
         self.assertEqual(names, {"default_role"})
+
+
+@override_settings(ATOMIC_RETRY_DISABLED=True)
+class RoleV2ServiceListExplicitDefaultScopeTests(IdentityRequest):
+    """Test workspace-level role scoping with explicit DEFAULT_SCOPE_PERMISSIONS.
+
+    When DEFAULT_SCOPE_PERMISSIONS is configured, roles with explicit-DEFAULT
+    permissions should only appear at the default workspace, not at standard
+    (child) workspaces.  Workspace-granular roles (fallback-DEFAULT) should
+    appear at both.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.service = RoleV2Service(tenant=self.tenant)
+
+        self._root_ws, _ = Workspace.objects.get_or_create(
+            tenant=self.tenant,
+            type=Workspace.Types.ROOT,
+            defaults={
+                "name": Workspace.SpecialNames.ROOT,
+                "description": Workspace.SpecialDescriptions.ROOT,
+            },
+        )
+        self._default_ws, _ = Workspace.objects.get_or_create(
+            tenant=self.tenant,
+            type=Workspace.Types.DEFAULT,
+            defaults={
+                "name": Workspace.SpecialNames.DEFAULT,
+                "description": Workspace.SpecialDescriptions.DEFAULT,
+                "parent": self._root_ws,
+            },
+        )
+        self._standard_ws = Workspace.objects.create(
+            name="Standard WS",
+            tenant=self.tenant,
+            type=Workspace.Types.STANDARD,
+            parent=self._default_ws,
+        )
+
+        scope_service = ImplicitResourceService(
+            tenant_scope_permissions=["tenant_app:*:*"],
+            root_scope_permissions=["root_app:*:*"],
+            default_scope_permissions=["explicit_app:*:*"],
+        )
+        test_cache = PermissionScopeCache(scope_service)
+        self._cache_patcher = patch("management.role.v2_service.permission_scope_cache", test_cache)
+        self._cache_patcher.start()
+
+        self.ws_granular_perm = Permission.objects.create(permission="granular_app:resource:read", tenant=self.tenant)
+        self.explicit_default_perm = Permission.objects.create(
+            permission="explicit_app:resource:read", tenant=self.tenant
+        )
+        self.root_perm = Permission.objects.create(permission="root_app:resource:read", tenant=self.tenant)
+        self.tenant_perm = Permission.objects.create(permission="tenant_app:resource:read", tenant=self.tenant)
+
+        self.ws_granular_role = RoleV2.objects.create(
+            name="ws_granular_role", description="Workspace-granular (fallback DEFAULT)", tenant=self.tenant
+        )
+        self.ws_granular_role.permissions.add(self.ws_granular_perm)
+
+        self.explicit_default_role = RoleV2.objects.create(
+            name="explicit_default_role", description="Explicit DEFAULT scoped", tenant=self.tenant
+        )
+        self.explicit_default_role.permissions.add(self.explicit_default_perm)
+
+        self.mixed_granular_explicit_role = RoleV2.objects.create(
+            name="mixed_granular_explicit_role",
+            description="Has both workspace-granular and explicit-DEFAULT perms",
+            tenant=self.tenant,
+        )
+        self.mixed_granular_explicit_role.permissions.add(self.ws_granular_perm, self.explicit_default_perm)
+
+        self.permissionless_role = RoleV2.objects.create(
+            name="permissionless_role", description="No permissions (OCM external)", tenant=self.tenant
+        )
+
+        self.root_role = RoleV2.objects.create(name="root_role", description="Root scoped", tenant=self.tenant)
+        self.root_role.permissions.add(self.root_perm)
+
+        self.tenant_role = RoleV2.objects.create(name="tenant_role", description="Tenant scoped", tenant=self.tenant)
+        self.tenant_role.permissions.add(self.tenant_perm)
+
+    def tearDown(self):
+        from management.utils import PRINCIPAL_CACHE
+
+        self._cache_patcher.stop()
+        RoleV2.objects.all().delete()
+        Permission.objects.filter(tenant=self.tenant).delete()
+        PRINCIPAL_CACHE.delete_all_principals_for_tenant(self.tenant.org_id)
+        super().tearDown()
+
+    def test_standard_workspace_returns_only_workspace_granular_roles(self):
+        """Standard workspace should only return workspace-granular (fallback-DEFAULT) roles."""
+        queryset = self.service.list({"resource_type": "workspace", "resource_id": self._standard_ws.id})
+        names = set(queryset.values_list("name", flat=True))
+        self.assertEqual(names, {"ws_granular_role"})
+
+    def test_standard_workspace_excludes_explicit_default_roles(self):
+        """Standard workspace should exclude roles with explicit-DEFAULT permissions."""
+        queryset = self.service.list({"resource_type": "workspace", "resource_id": self._standard_ws.id})
+        names = set(queryset.values_list("name", flat=True))
+        self.assertNotIn("explicit_default_role", names)
+
+    def test_standard_workspace_excludes_mixed_granular_and_explicit_roles(self):
+        """Standard workspace should exclude roles that mix workspace-granular with explicit-DEFAULT permissions."""
+        queryset = self.service.list({"resource_type": "workspace", "resource_id": self._standard_ws.id})
+        names = set(queryset.values_list("name", flat=True))
+        self.assertNotIn("mixed_granular_explicit_role", names)
+
+    def test_standard_workspace_excludes_permissionless_roles(self):
+        """Standard workspace should exclude roles with no permissions."""
+        queryset = self.service.list({"resource_type": "workspace", "resource_id": self._standard_ws.id})
+        names = set(queryset.values_list("name", flat=True))
+        self.assertNotIn("permissionless_role", names)
+
+    def test_default_workspace_returns_explicit_default_and_workspace_granular(self):
+        """Default workspace should return both explicit-DEFAULT and workspace-granular roles."""
+        queryset = self.service.list({"resource_type": "workspace", "resource_id": self._default_ws.id})
+        names = set(queryset.values_list("name", flat=True))
+        self.assertIn("ws_granular_role", names)
+        self.assertIn("explicit_default_role", names)
+        self.assertIn("mixed_granular_explicit_role", names)
+
+    def test_default_workspace_returns_permissionless_roles(self):
+        """Default workspace should include permissionless roles."""
+        queryset = self.service.list({"resource_type": "workspace", "resource_id": self._default_ws.id})
+        names = set(queryset.values_list("name", flat=True))
+        self.assertIn("permissionless_role", names)
+
+    def test_default_workspace_excludes_root_and_tenant_roles(self):
+        """Default workspace should still exclude ROOT and TENANT scoped roles."""
+        queryset = self.service.list({"resource_type": "workspace", "resource_id": self._default_ws.id})
+        names = set(queryset.values_list("name", flat=True))
+        self.assertNotIn("root_role", names)
+        self.assertNotIn("tenant_role", names)
+
+    def test_workspace_without_resource_id_returns_all_default_scoped(self):
+        """resource_type=workspace without resource_id returns all DEFAULT-scoped roles (both types)."""
+        queryset = self.service.list({"resource_type": "workspace"})
+        names = set(queryset.values_list("name", flat=True))
+        self.assertIn("ws_granular_role", names)
+        self.assertIn("explicit_default_role", names)
+        self.assertIn("mixed_granular_explicit_role", names)
+        self.assertIn("permissionless_role", names)
+
+    def test_root_workspace_returns_root_roles_only(self):
+        """Root workspace should still return only ROOT-scoped roles."""
+        queryset = self.service.list({"resource_type": "workspace", "resource_id": self._root_ws.id})
+        names = set(queryset.values_list("name", flat=True))
+        self.assertEqual(names, {"root_role"})

--- a/tests/management/role_binding/test_service.py
+++ b/tests/management/role_binding/test_service.py
@@ -2713,6 +2713,156 @@ class UpdateRoleBindingsForSubjectTests(_ReplicationAssertionsMixin, IdentityReq
             )
         self.assertEqual({r.uuid for r in result.roles}, {root_role.uuid})
 
+    def test_update_rejects_explicit_default_role_on_standard_workspace(self):
+        """Binding an explicit-DEFAULT role to a standard workspace should fail."""
+        from management.permission.scope_service import ImplicitResourceService, PermissionScopeCache
+
+        scope_service = ImplicitResourceService(
+            tenant_scope_permissions=["rbac:*:*"],
+            root_scope_permissions=[],
+            default_scope_permissions=["rbac:role_binding:*"],
+        )
+        scope_cache = PermissionScopeCache(scope_service)
+
+        explicit_perm = Permission.objects.create(permission="rbac:role_binding:read", tenant=self.tenant)
+        explicit_role = RoleV2.objects.create(
+            name="explicit_default", description="Explicit DEFAULT", tenant=self.tenant
+        )
+        explicit_role.permissions.add(explicit_perm)
+
+        with (
+            patch("management.role_binding.service.default_implicit_resource_service", scope_service),
+            patch("management.role_binding.service.permission_scope_cache", scope_cache),
+        ):
+            with self.assertRaises(InvalidFieldError) as ctx:
+                self.service.update_role_bindings_for_subject(
+                    resource_type="workspace",
+                    resource_id=str(self.workspace.id),
+                    subject_type="group",
+                    subject_id=str(self.group.uuid),
+                    role_ids=[str(explicit_role.uuid)],
+                )
+            self.assertIn("not scoped", str(ctx.exception))
+            self.assertIn("Standard Workspace", str(ctx.exception))
+
+    def test_update_rejects_permissionless_role_on_standard_workspace(self):
+        """Binding a permissionless role to a standard workspace should fail."""
+        from management.permission.scope_service import ImplicitResourceService, PermissionScopeCache
+
+        scope_service = ImplicitResourceService(
+            tenant_scope_permissions=[],
+            root_scope_permissions=[],
+        )
+        scope_cache = PermissionScopeCache(scope_service)
+
+        permissionless_role = RoleV2.objects.create(name="no_perms", description="No permissions", tenant=self.tenant)
+
+        with (
+            patch("management.role_binding.service.default_implicit_resource_service", scope_service),
+            patch("management.role_binding.service.permission_scope_cache", scope_cache),
+        ):
+            with self.assertRaises(InvalidFieldError) as ctx:
+                self.service.update_role_bindings_for_subject(
+                    resource_type="workspace",
+                    resource_id=str(self.workspace.id),
+                    subject_type="group",
+                    subject_id=str(self.group.uuid),
+                    role_ids=[str(permissionless_role.uuid)],
+                )
+            self.assertIn("not scoped", str(ctx.exception))
+            self.assertIn("Standard Workspace", str(ctx.exception))
+
+    def test_update_rejects_mixed_default_and_granular_role_on_standard_workspace(self):
+        """Binding a role with both explicit-DEFAULT and workspace-granular permissions to a standard workspace should fail."""
+        from management.permission.scope_service import ImplicitResourceService, PermissionScopeCache
+
+        scope_service = ImplicitResourceService(
+            tenant_scope_permissions=[],
+            root_scope_permissions=[],
+            default_scope_permissions=["explicit_app:*:*"],
+        )
+        scope_cache = PermissionScopeCache(scope_service)
+
+        explicit_perm = Permission.objects.create(permission="explicit_app:resource:read", tenant=self.tenant)
+        granular_perm = Permission.objects.create(permission="other_app:resource:read", tenant=self.tenant)
+        mixed_role = RoleV2.objects.create(
+            name="mixed_role", description="Both explicit-DEFAULT and workspace-granular", tenant=self.tenant
+        )
+        mixed_role.permissions.add(explicit_perm, granular_perm)
+
+        with (
+            patch("management.role_binding.service.default_implicit_resource_service", scope_service),
+            patch("management.role_binding.service.permission_scope_cache", scope_cache),
+        ):
+            with self.assertRaises(InvalidFieldError) as ctx:
+                self.service.update_role_bindings_for_subject(
+                    resource_type="workspace",
+                    resource_id=str(self.workspace.id),
+                    subject_type="group",
+                    subject_id=str(self.group.uuid),
+                    role_ids=[str(mixed_role.uuid)],
+                )
+            self.assertIn("not scoped", str(ctx.exception))
+            self.assertIn("Standard Workspace", str(ctx.exception))
+
+    def test_update_allows_workspace_granular_role_on_standard_workspace(self):
+        """Binding a workspace-granular (fallback-DEFAULT) role to a standard workspace should succeed."""
+        from management.permission.scope_service import ImplicitResourceService, PermissionScopeCache
+
+        scope_service = ImplicitResourceService(
+            tenant_scope_permissions=[],
+            root_scope_permissions=[],
+            default_scope_permissions=["explicit_app:*:*"],
+        )
+        scope_cache = PermissionScopeCache(scope_service)
+
+        granular_perm = Permission.objects.create(permission="other_app:resource:read", tenant=self.tenant)
+        granular_role = RoleV2.objects.create(name="ws_granular", description="Workspace-granular", tenant=self.tenant)
+        granular_role.permissions.add(granular_perm)
+
+        with (
+            patch("management.role_binding.service.default_implicit_resource_service", scope_service),
+            patch("management.role_binding.service.permission_scope_cache", scope_cache),
+        ):
+            result = self.service.update_role_bindings_for_subject(
+                resource_type="workspace",
+                resource_id=str(self.workspace.id),
+                subject_type="group",
+                subject_id=str(self.group.uuid),
+                role_ids=[str(granular_role.uuid)],
+            )
+        self.assertEqual({r.uuid for r in result.roles}, {granular_role.uuid})
+
+    def test_update_allows_explicit_default_role_on_default_workspace(self):
+        """Binding an explicit-DEFAULT role to the default workspace should succeed."""
+        from management.permission.scope_service import ImplicitResourceService, PermissionScopeCache
+
+        scope_service = ImplicitResourceService(
+            tenant_scope_permissions=[],
+            root_scope_permissions=[],
+            default_scope_permissions=["explicit_app:*:*"],
+        )
+        scope_cache = PermissionScopeCache(scope_service)
+
+        explicit_perm = Permission.objects.create(permission="explicit_app:resource:read", tenant=self.tenant)
+        explicit_role = RoleV2.objects.create(
+            name="explicit_default", description="Explicit DEFAULT", tenant=self.tenant
+        )
+        explicit_role.permissions.add(explicit_perm)
+
+        with (
+            patch("management.role_binding.service.default_implicit_resource_service", scope_service),
+            patch("management.role_binding.service.permission_scope_cache", scope_cache),
+        ):
+            result = self.service.update_role_bindings_for_subject(
+                resource_type="workspace",
+                resource_id=str(self.default_workspace.id),
+                subject_type="group",
+                subject_id=str(self.group.uuid),
+                role_ids=[str(explicit_role.uuid)],
+            )
+        self.assertEqual({r.uuid for r in result.roles}, {explicit_role.uuid})
+
 
 @override_settings(ATOMIC_RETRY_DISABLED=True)
 class ReplaceRoleBindingsTests(_ReplicationAssertionsMixin, IdentityRequest):

--- a/tests/management/workspace/test_service.py
+++ b/tests/management/workspace/test_service.py
@@ -548,7 +548,7 @@ class WorkspaceServiceDestroyTests(WorkspaceServiceTestBase):
 
     def _do_test_destroy_with_bindings_v2(self, role: RoleV2):
         replicator = InMemoryRelationReplicator(self.tuples)
-        binding_service = RoleBindingService(tenant=self.tenant, replicator=replicator)
+        binding_service = RoleBindingService(tenant=self.tenant, replicator=replicator, skip_scope_validation=True)
         workspace_service = WorkspaceService(replicator=replicator)
 
         group = Group.objects.create(tenant=self.tenant, name="a group")


### PR DESCRIPTION
## Summary

[RHCLOUD-47745](https://redhat.atlassian.net/browse/RHCLOUD-47745)

Standard (child) workspaces should only expose **workspace-granular** roles -- those whose permissions fall through to `Scope.DEFAULT` as a fallback. Roles with **explicit-DEFAULT** permissions (configured via `DEFAULT_SCOPE_PERMISSIONS`) and **permissionless** roles are restricted to the default workspace only, since they represent grants that no service checks at the standard workspace level.

### What changed

**Scope service infrastructure** (`scope_service.py`):
- Extract `_wildcard_candidates()` to deduplicate wildcard logic between `scope_for_permission` and the new `is_explicitly_scoped`
- Add `ImplicitResourceService.is_explicitly_scoped()` -- returns `True` when a permission matches any configured scope entry (root, tenant, or default), `False` for fallback-DEFAULT
- Add `PermissionScopeCache.explicit_default_ids` -- lazily-built frozenset of Permission IDs that match `DEFAULT_SCOPE_PERMISSIONS` entries, for efficient DB-level filtering

**Role list filtering** (`v2_service.py`):
- `_filter_by_resource_type()` detects standard workspaces and excludes roles containing explicit-DEFAULT permissions (via cached IDs) and permissionless roles (`permissions__isnull=False`)

**Binding validation** (`role_binding/service.py`):
- `_validate_role_scopes()` rejects explicit-DEFAULT and permissionless roles on standard workspaces
- Add `skip_scope_validation` flag to `RoleBindingService` for callers that need to bypass scope checks (e.g. workspace destroy tests)

### Visibility matrix

| Role type | Default WS | Standard WS | Root WS |
|-----------|-----------|-------------|---------|
| Workspace-granular (fallback-DEFAULT) | Yes | Yes | No |
| Explicit-DEFAULT | Yes | No | No |
| Permissionless | Yes | No | No |
| ROOT-scoped | No | No | Yes |
| TENANT-scoped | No | No | No |

## Test plan

- [x] 8 unit tests for `is_explicitly_scoped` (exact, wildcard, fallback, empty, invalid)
- [x] 4 unit tests for `PermissionScopeCache.explicit_default_ids` (with/without config, excludes root/tenant, invalidation)
- [x] 9 integration tests for role list filtering across standard/default/root workspaces with workspace-granular, explicit-DEFAULT, mixed, and permissionless roles
- [x] 4 binding validation tests (reject explicit-DEFAULT on standard, reject permissionless on standard, allow workspace-granular on standard, allow explicit-DEFAULT on default)
- [x] Workspace destroy test updated with `skip_scope_validation=True`
- [x] Full test suite passes (3581 tests, 0 failures)
- [x] Linter passes

[RHCLOUD-47745]: https://redhat.atlassian.net/browse/RHCLOUD-47745?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Enforce workspace-level role scoping for role listing and role bindings, distinguishing workspace-granular permissions from explicitly DEFAULT-scoped and permissionless roles.

Enhancements:
- Refine workspace role filtering so standard workspaces only expose workspace-granular (fallback-DEFAULT) roles while default and root workspaces retain their respective visibility rules.
- Extend the scope service and permission scope cache to identify explicitly DEFAULT-scoped permissions for efficient DB-level filtering and validation.
- Tighten role-binding validation to reject explicitly DEFAULT-scoped and permissionless roles on standard workspaces, while allowing them where appropriate (e.g. default workspace).
- Allow role binding operations to bypass scope validation in specific scenarios such as workspace destruction flows.

Tests:
- Add comprehensive unit and integration tests covering explicit scope detection, explicit-DEFAULT permission caching, workspace-specific role listing behavior, and binding validation across default, standard, and root workspaces.