### PR TITLE
[RHCLOUD-47941] Default V2 name filter to substring matching

### DIFF
--- a/docs/source/specs/typespec/main.tsp
+++ b/docs/source/specs/typespec/main.tsp
@@ -519,7 +519,7 @@ namespace Workspaces {
 
         @doc("Filter by workspace type. Supports comma-separated values (e.g. type=standard,ungrouped-hosts). Defaults to all when not supplied. Case-insensitive.")
         @query type?: string = "all";
-        @doc("Filter by workspace name. Case-insensitive exact match by default; use * as a wildcard for partial matching (e.g. foo*).")
+        @doc("Filter by workspace name. Case-insensitive substring match by default; use * for glob patterns (e.g. foo*).")
         @query name?: string;
         @doc("Filter workspaces by parent workspace UUID. Returns only direct children of the specified workspace. Useful for lazy-loading a nested tree structure.")
         @query parent_id?: UUID;
@@ -1381,7 +1381,7 @@ namespace Roles {
         @doc("Cursor for cursor-based pagination.")
         @query cursor?: Cursor;
 
-        @doc("Filter by role name. Exact match by default; use * as a wildcard for partial matching (e.g. foo*).")
+        @doc("Filter by role name. Case-insensitive substring match by default; use * for glob patterns (e.g. foo*).")
         @query name?: string;
 
         @doc("Filter roles by the resource type (e.g. 'tenant', 'workspace'). When omitted, returns roles from all scopes.")

--- a/docs/source/specs/v2/openapi.json
+++ b/docs/source/specs/v2/openapi.json
@@ -1078,7 +1078,7 @@
             "name": "name",
             "in": "query",
             "required": false,
-            "description": "Filter by role name. Exact match by default; use * as a wildcard for partial matching (e.g. foo*).",
+            "description": "Filter by role name. Case-insensitive substring match by default; use * for glob patterns (e.g. foo*).",
             "schema": {
               "type": "string"
             },
@@ -1960,7 +1960,7 @@
             "name": "name",
             "in": "query",
             "required": false,
-            "description": "Filter by workspace name. Case-insensitive exact match by default; use * as a wildcard for partial matching (e.g. foo*).",
+            "description": "Filter by workspace name. Case-insensitive substring match by default; use * for glob patterns (e.g. foo*).",
             "schema": {
               "type": "string"
             },

--- a/docs/source/specs/v2/openapi.yaml
+++ b/docs/source/specs/v2/openapi.yaml
@@ -684,7 +684,7 @@ paths:
         - name: name
           in: query
           required: false
-          description: Filter by role name. Exact match by default; use * as a wildcard for partial matching (e.g. foo*).
+          description: Filter by role name. Case-insensitive substring match by default; use * for glob patterns (e.g. foo*).
           schema:
             type: string
           explode: false
@@ -1252,7 +1252,7 @@ paths:
         - name: name
           in: query
           required: false
-          description: Filter by workspace name. Case-insensitive exact match by default; use * as a wildcard for partial matching (e.g. foo*).
+          description: Filter by workspace name. Case-insensitive substring match by default; use * for glob patterns (e.g. foo*).
           schema:
             type: string
           explode: false

--- a/rbac/management/role/v2_serializer.py
+++ b/rbac/management/role/v2_serializer.py
@@ -158,7 +158,9 @@ class RoleV2ListSerializer(serializers.Serializer):
     name = serializers.CharField(
         required=False,
         allow_blank=True,
-        help_text="Filter by role name. Use * as wildcard for partial matching.",
+        help_text=(
+            "Filter by role name. Case-insensitive substring match by default;" " use * for glob patterns (e.g. foo*)."
+        ),
     )
     permission = serializers.CharField(
         required=False,

--- a/rbac/management/v2_filters.py
+++ b/rbac/management/v2_filters.py
@@ -30,7 +30,7 @@ def _glob_to_regex(pattern: str) -> str:
 def v2_name_filter(queryset: QuerySet, name: str, field: str = "name") -> QuerySet:
     """Filter a queryset by name with '*' glob support.
 
-    Without wildcards, performs case-insensitive exact match.
+    Without wildcards, performs case-insensitive substring match.
     With '*' wildcards, converts to regex for pattern matching.
     A bare '*' matches everything (no filter applied).
     """
@@ -38,4 +38,4 @@ def v2_name_filter(queryset: QuerySet, name: str, field: str = "name") -> QueryS
         return queryset
     if "*" in name:
         return queryset.filter(**{f"{field}__iregex": _glob_to_regex(name)})
-    return queryset.filter(**{f"{field}__iexact": name})
+    return queryset.filter(**{f"{field}__icontains": name})

--- a/rbac/management/workspace/serializer.py
+++ b/rbac/management/workspace/serializer.py
@@ -41,7 +41,10 @@ class WorkspaceListInputSerializer(serializers.Serializer):
     name = serializers.CharField(
         required=False,
         allow_blank=True,
-        help_text="Filter by workspace name. Use * as wildcard for partial matching.",
+        help_text=(
+            "Filter by workspace name. Case-insensitive substring match by default;"
+            " use * for glob patterns (e.g. foo*)."
+        ),
     )
     parent_id = serializers.CharField(required=False, allow_blank=True, help_text="Filter by parent workspace ID")
     ids = serializers.CharField(required=False, allow_blank=True, help_text="Filter by comma-separated workspace IDs")

--- a/tests/management/role/test_v2_service.py
+++ b/tests/management/role/test_v2_service.py
@@ -745,11 +745,13 @@ class RoleV2ServiceListTests(IdentityRequest):
         self.assertEqual(queryset.count(), 1)
         self.assertEqual(queryset.first().name, "role_one")
 
-    def test_list_name_exact_match_unchanged(self):
-        """Test that name without wildcard still requires exact match."""
+    def test_list_name_substring_match(self):
+        """Test that name without wildcard does substring match."""
         queryset = self.service.list({"name": "role"})
 
-        self.assertEqual(queryset.count(), 0)
+        self.assertEqual(queryset.count(), 2)
+        names = set(queryset.values_list("name", flat=True))
+        self.assertEqual(names, {"role_one", "role_two"})
 
     def test_list_filters_by_name_wildcard_no_match(self):
         """Test that a wildcard pattern matching nothing returns empty."""

--- a/tests/management/role/test_v2_view.py
+++ b/tests/management/role/test_v2_view.py
@@ -684,14 +684,15 @@ class RoleV2ViewSetTests(IdentityRequest):
         RoleV2.objects.create(name="test_role_beta", description="Beta", tenant=self.tenant)
         RoleV2.objects.create(name="other_role", description="Other", tenant=self.tenant)
 
-        # Filter by name containing "test_role" and order by last_modified descending
+        # Filter by substring "test_role" and order by last_modified descending
         url = f"{self.list_url}&name=test_role&order_by=-last_modified"
         response = self.client.get(url, **self.headers)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        # Should only return exact match "test_role" from setUp()
-        self.assertEqual(len(response.data["data"]), 1)
-        self.assertEqual(response.data["data"][0]["name"], "test_role")
+        # Substring "test_role" matches test_role, test_role_alpha, test_role_beta
+        self.assertEqual(len(response.data["data"]), 3)
+        names = [r["name"] for r in response.data["data"]]
+        self.assertCountEqual(names, ["test_role", "test_role_alpha", "test_role_beta"])
 
     def test_list_roles_with_invalid_order_by(self):
         """Test that invalid order_by field returns 400 error."""

--- a/tests/management/test_v2_name_filter.py
+++ b/tests/management/test_v2_name_filter.py
@@ -48,21 +48,31 @@ class V2NameFilterTest(TestCase):
         )
         self.qs = Workspace.objects.filter(tenant=self.tenant, type="standard")
 
-    def test_exact_match(self):
-        """Without wildcards, name filter does case-insensitive exact match."""
+    def test_full_name_match(self):
+        """Without wildcards, full name matches via substring."""
         result = v2_name_filter(self.qs, "Sales Team Alpha")
         self.assertEqual(list(result.values_list("name", flat=True)), ["Sales Team Alpha"])
 
-    def test_exact_match_no_substring(self):
-        """Without wildcards, partial strings do not match."""
+    def test_substring_match(self):
+        """Without wildcards, partial strings match via icontains."""
         result = v2_name_filter(self.qs, "Sales")
-        self.assertEqual(result.count(), 0)
+        self.assertCountEqual(list(result.values_list("name", flat=True)), ["Sales Team Alpha", "Sales Team Beta"])
 
-    def test_exact_match_case_insensitive(self):
-        """Exact match is case-insensitive."""
+    def test_substring_match_case_insensitive(self):
+        """Substring match is case-insensitive."""
         result = v2_name_filter(self.qs, "sales team alpha")
         self.assertEqual(result.count(), 1)
         self.assertEqual(result.first().name, "Sales Team Alpha")
+
+    def test_substring_match_middle(self):
+        """Substring in the middle of a name matches."""
+        result = v2_name_filter(self.qs, "Team")
+        self.assertCountEqual(list(result.values_list("name", flat=True)), ["Sales Team Alpha", "Sales Team Beta"])
+
+    def test_substring_no_match(self):
+        """Substring matching nothing returns empty queryset."""
+        result = v2_name_filter(self.qs, "zzz")
+        self.assertEqual(result.count(), 0)
 
     def test_wildcard_prefix(self):
         """Prefix pattern matches names starting with the given string."""

--- a/tests/management/workspace/test_view.py
+++ b/tests/management/workspace/test_view.py
@@ -2975,8 +2975,8 @@ class WorkspaceTestsList(WorkspaceViewTests):
         self.assertEqual(payload.get("data")[0]["id"], str(self.root_workspace.id))
         self.assertType(payload, "root")
 
-    def test_workspace_list_filter_by_name_exact(self):
-        """Test that name filter without wildcards does case-insensitive exact match."""
+    def test_workspace_list_filter_by_name_substring(self):
+        """Test that name filter without wildcards does case-insensitive substring match."""
         ws_name_1 = "Sales Team Alpha"
         ws_name_2 = "Sales Team Beta"
         ws_name_3 = "Engineering Squad"
@@ -3006,20 +3006,20 @@ class WorkspaceTestsList(WorkspaceViewTests):
         url = reverse("v2_management:workspace-list")
         client = APIClient()
 
-        # Exact match "Sales Team Alpha" returns only that workspace
+        # Full name "Sales Team Alpha" returns only that workspace
         response = client.get(f"{url}?name=Sales Team Alpha", None, format="json", **self.headers)
         payload = response.data
         self.assertSuccessfulList(response, payload)
         self.assertEqual(payload.get("meta").get("count"), 1)
         self.assertEqual(payload.get("data")[0]["name"], ws_name_1)
 
-        # Partial string "Sales" without wildcard does NOT match (exact match semantics)
+        # Partial string "Sales" matches both Sales workspaces (substring semantics)
         response = client.get(f"{url}?name=Sales", None, format="json", **self.headers)
         payload = response.data
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(payload.get("meta").get("count"), 0)
+        self.assertSuccessfulList(response, payload)
+        self.assertEqual(payload.get("meta").get("count"), 2)
 
-        # Exact match for "Engineering Squad"
+        # Full name match for "Engineering Squad"
         response = client.get(f"{url}?name=Engineering Squad", None, format="json", **self.headers)
         payload = response.data
         self.assertSuccessfulList(response, payload)
@@ -3110,7 +3110,7 @@ class WorkspaceTestsList(WorkspaceViewTests):
         self.assertEqual(payload.get("meta").get("count"), total_count)
 
     def test_workspace_list_filter_by_name_is_case_insensitive(self):
-        """Test that name filter is case-insensitive for both exact and wildcard matching."""
+        """Test that name filter is case-insensitive for both substring and wildcard matching."""
         Workspace.objects.create(
             name="Sales Team Alpha",
             tenant=self.tenant,
@@ -3121,14 +3121,14 @@ class WorkspaceTestsList(WorkspaceViewTests):
         url = reverse("v2_management:workspace-list")
         client = APIClient()
 
-        # Lowercase exact match
+        # Lowercase substring match
         response = client.get(f"{url}?name=sales team alpha", None, format="json", **self.headers)
         payload = response.data
         self.assertSuccessfulList(response, payload)
         self.assertEqual(payload.get("meta").get("count"), 1)
         self.assertEqual(payload.get("data")[0]["name"], "Sales Team Alpha")
 
-        # Uppercase exact match
+        # Uppercase substring match
         response = client.get(f"{url}?name=SALES TEAM ALPHA", None, format="json", **self.headers)
         payload = response.data
         self.assertSuccessfulList(response, payload)


### PR DESCRIPTION
## Link(s) to Jira
- [RHCLOUD-47941](https://issues.redhat.com/browse/RHCLOUD-47941)

## Description of Intent of Change(s)

Commit c6ecb349 (May 20) changed workspace name filtering from substring match (`icontains`) to exact match (`iexact`) for consistency with the roles endpoint. This broke HBI's `/groups` endpoint, which proxies to RBAC's workspace list and relied on substring matching -- `name=foo` no longer matched workspaces containing "foo".

This PR changes `v2_name_filter()` so that bare names (no wildcards) perform case-insensitive **substring** matching (`icontains`) instead of exact matching (`iexact`). The change applies to both workspaces and roles for consistency.

**Before:** `name=foo` matched only a resource named exactly "foo" (case-insensitive)
**After:** `name=foo` matches any resource whose name contains "foo" (case-insensitive)

Wildcard patterns remain unchanged:
- `name=foo*` -- prefix match
- `name=*foo*` -- explicit substring match
- `name=*foo` -- suffix match
- `name=*` -- match all

Reported by Zhamilya in Slack. Confirmed by fstavela (HBI team) that substring matching is the expected and preferred behavior.

## Local Testing

V2 APIs require Kessel for auth locally, so unit tests are the verification path:

```bash
pipenv run tox -e py312-fast -- tests.management.test_v2_name_filter
pipenv run tox -e py312-fast -- tests.management.workspace.test_view.WorkspaceTestsList.test_workspace_list_filter_by_name_substring
pipenv run tox -e py312-fast -- tests.management.role.test_v2_view.RoleV2ViewSetTests.test_list_roles_with_name_filter
pipenv run tox -e py312-fast -- tests.management.role.test_v2_service.RoleV2ServiceListTests.test_list_name_substring_match
```

Full suite: `pipenv run tox -e py312-fast` (1201 tests pass).

After merge, HBI team (fstavela, Zhamilya) should confirm workspace search works as expected in stage.

## Checklist
- [x] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [x] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [x] does this require migration changes?
  - No migration changes needed -- this is a queryset filter change only.
- [x] is there known, direct impact to dependent teams/components?
  - [x] HBI team is the affected downstream consumer. This PR restores the substring matching behavior they depend on.

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices

[RHCLOUD-47941]: https://redhat.atlassian.net/browse/RHCLOUD-47941?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Restore case-insensitive substring matching as the default behavior for V2 name filters across workspaces and roles, and align tests and documentation with the updated semantics.

Bug Fixes:
- Reinstate substring-based name filtering for workspace and role V2 endpoints so bare name queries match partial names as expected.

Enhancements:
- Update V2 name filter helper to use case-insensitive substring matching by default while retaining glob wildcard support.
- Refresh serializer help texts and API specs to document substring-based name matching semantics.

Documentation:
- Clarify workspace and role V2 API documentation to describe case-insensitive substring name matching and glob pattern usage.

Tests:
- Adjust and extend workspace and role V2 tests to validate substring matching behavior for bare names and ensure case-insensitive handling.