### PR TITLE
[RHCLOUD-47973] Fix resource.id type from UUID to string in OpenAPI spec

### DIFF
--- a/docs/source/specs/typespec/main.tsp
+++ b/docs/source/specs/typespec/main.tsp
@@ -770,7 +770,7 @@ namespace RoleBindings {
 
     model Resource {
         @doc("Resource identifier")
-        id?: UUID;
+        id?: string;
         @doc("Resource name")
         name?: string;
         @doc("Resource type")
@@ -784,11 +784,16 @@ namespace RoleBindings {
         subject: #{ id: "3fa85f64-5717-4562-b3fc-2c963f66afa6", type: BindingSubjectType.group },
         role: #{ id: "550e8400-e29b-41d4-a716-446655440002" }
     })
+    @example(#{
+        resource: #{ id: "redhat/12345", type: "tenant" },
+        subject: #{ id: "3fa85f64-5717-4562-b3fc-2c963f66afa6", type: BindingSubjectType.group },
+        role: #{ id: "550e8400-e29b-41d4-a716-446655440002" }
+    })
     model CreateRoleBindingsRequest {
         @doc("Resource to bind the role to")
         resource: {
-            @doc("UUID that uniquely identifies the resource")
-            id: UUID;
+            @doc("Identifier of the resource")
+            id: string;
             @doc("Type of resource")
             @example("workspace")
             type: string;

--- a/docs/source/specs/v2/openapi.json
+++ b/docs/source/specs/v2/openapi.json
@@ -3499,12 +3499,8 @@
             "type": "object",
             "properties": {
               "id": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/UUID"
-                  }
-                ],
-                "description": "UUID that uniquely identifies the resource"
+                "type": "string",
+                "description": "Identifier of the resource"
               },
               "type": {
                 "type": "string",
@@ -3565,8 +3561,8 @@
         "description": "Request body for creating role bindings",
         "example": {
           "resource": {
-            "id": "550e8400-e29b-41d4-a716-446655440001",
-            "type": "workspace"
+            "id": "redhat/12345",
+            "type": "tenant"
           },
           "subject": {
             "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
@@ -3636,11 +3632,7 @@
         "type": "object",
         "properties": {
           "id": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/UUID"
-              }
-            ],
+            "type": "string",
             "description": "Resource identifier"
           },
           "name": {

--- a/docs/source/specs/v2/openapi.yaml
+++ b/docs/source/specs/v2/openapi.yaml
@@ -2297,9 +2297,8 @@ components:
           type: object
           properties:
             id:
-              allOf:
-                - $ref: '#/components/schemas/UUID'
-              description: UUID that uniquely identifies the resource
+              type: string
+              description: Identifier of the resource
             type:
               type: string
               description: Type of resource
@@ -2336,8 +2335,8 @@ components:
       description: Request body for creating role bindings
       example:
         resource:
-          id: 550e8400-e29b-41d4-a716-446655440001
-          type: workspace
+          id: redhat/12345
+          type: tenant
         subject:
           id: 3fa85f64-5717-4562-b3fc-2c963f66afa6
           type: group
@@ -2383,8 +2382,7 @@ components:
       type: object
       properties:
         id:
-          allOf:
-            - $ref: '#/components/schemas/UUID'
+          type: string
           description: Resource identifier
         name:
           type: string


### PR DESCRIPTION
## Link(s) to Jira
- [RHCLOUD-47973](https://issues.redhat.com/browse/RHCLOUD-47973)

## Description of Intent of Change(s)

**What**: Changes the `resource.id` field type from `UUID` to `string` in two TypeSpec models:
- `CreateRoleBindingsRequest.resource.id` (request model for creating role bindings)
- `Resource.id` (response model used in role binding list/detail responses)

**Why**: Tenant resources use IDs in the format `domain/org_id` (e.g., `redhat/000000`), which are not valid UUIDs. OpenAPI Generator clients validate field types against the spec and reject these non-UUID values at the client side, preventing consumers from creating or reading role bindings for tenant-scoped resources.

**How**: Updated the TypeSpec source (`main.tsp`) and regenerated the OpenAPI spec (JSON + YAML). No Python code changes needed -- the Django serializer (`ResourceInputSerializer`) already uses `CharField` for `resource.id`, so the runtime behavior is unchanged. This fix aligns the spec with the actual API behavior.

## Local Testing

Spec-only change. Verify by inspecting the generated OpenAPI spec:

```bash
# Check the request model
grep -A 5 'Identifier of the resource' docs/source/specs/v2/openapi.yaml

# Check the response model
grep -A 10 'RoleBindings.Resource:' docs/source/specs/v2/openapi.yaml
```

Both should show `type: string` without any UUID format constraint.

Full test suite passes with no changes (3548 tests).

## Checklist
- [x] if API spec changes are required, is the spec updated?
- [x] are there any pre/post merge actions required? if so, document here.
- [x] are theses changes covered by unit tests?
- [x] if warranted, are documentation changes accounted for?
- [x] does this require migration changes?
  - [x] N/A -- no database changes
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] Yes -- consumers using OpenAPI Generator clients will now be able to use tenant resource IDs without client-side validation errors

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices

[RHCLOUD-47973]: https://redhat.atlassian.net/browse/RHCLOUD-47973?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Align the role binding resource ID schema with actual API behavior by representing it as a generic string identifier instead of a UUID.

Bug Fixes:
- Correct the OpenAPI and TypeSpec definitions of role binding resource IDs to use string identifiers, preventing client-side UUID validation errors for tenant-scoped resources.

Enhancements:
- Update TypeSpec models and regenerate the OpenAPI JSON/YAML specs so resource IDs are documented as strings with clearer descriptions.