### PR TITLE
[RHCLOUD-47920] Add environment identifier to Splunk log messages

### DIFF
--- a/rbac/rbac/ECSCustom/__init__.py
+++ b/rbac/rbac/ECSCustom/__init__.py
@@ -46,6 +46,10 @@ class ECSCustomFormatter(StdlibFormatter):
             if isinstance(request, django.core.handlers.wsgi.WSGIRequest):
                 result = self.add_info_from_WSGIRequest(result, request)
 
+        if hasattr(record, "env_name"):
+            result["labels"] = result.get("labels", {})
+            result["labels"]["env"] = record.env_name
+
         # Remove some field not following standard:
         # https://www.elastic.co/guide/en/ecs/1.6/ecs-field-reference.html
         result.pop("message", None)

--- a/rbac/rbac/logging_filters.py
+++ b/rbac/rbac/logging_filters.py
@@ -1,14 +1,15 @@
 """Custom logging filters for RBAC."""
 
 import logging
-import os
-from typing import ClassVar
 
 
 class EnvironmentFilter(logging.Filter):
     """Injects the deployment environment name into every log record."""
 
-    _env_name: ClassVar[str] = os.getenv("ENV_NAME", "stage")
+    def __init__(self, env_name, **kwargs):
+        """Initialize with the deployment environment name."""
+        super().__init__(**kwargs)
+        self._env_name = env_name
 
     def filter(self, record: logging.LogRecord) -> bool:
         """Add env_name attribute to the log record."""

--- a/rbac/rbac/logging_filters.py
+++ b/rbac/rbac/logging_filters.py
@@ -1,0 +1,16 @@
+"""Custom logging filters for RBAC."""
+
+import logging
+import os
+from typing import ClassVar
+
+
+class EnvironmentFilter(logging.Filter):
+    """Injects the deployment environment name into every log record."""
+
+    _env_name: ClassVar[str] = os.getenv("ENV_NAME", "stage")
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        """Add env_name attribute to the log record."""
+        record.env_name = self._env_name
+        return True

--- a/rbac/rbac/settings.py
+++ b/rbac/rbac/settings.py
@@ -241,7 +241,8 @@ LOGGING_FORMATTER = os.getenv("DJANGO_LOG_FORMATTER", "simple")
 DJANGO_LOGGING_LEVEL = os.getenv("DJANGO_LOG_LEVEL", "INFO")
 RBAC_LOGGING_LEVEL = os.getenv("RBAC_LOG_LEVEL", "INFO")
 LOGGING_HANDLERS = os.getenv("DJANGO_LOG_HANDLERS", "console").split(",")
-VERBOSE_FORMATTING = "%(levelname)s %(asctime)s %(module)s " "%(process)d %(thread)d %(message)s"
+ENV_NAME = os.getenv("ENV_NAME", "stage")
+VERBOSE_FORMATTING = "%(levelname)s %(asctime)s [%(env_name)s] %(module)s %(process)d %(thread)d %(message)s"
 
 if DEBUG and "ecs" in LOGGING_HANDLERS:
     DEBUG_LOG_HANDLERS = [v for v in LOGGING_HANDLERS if v != "ecs"]
@@ -260,20 +261,24 @@ if CW_AWS_ACCESS_KEY_ID:
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,
+    "filters": {
+        "env_name": {"()": "rbac.logging_filters.EnvironmentFilter"},
+    },
     "formatters": {
         "verbose": {"format": VERBOSE_FORMATTING},
-        "simple": {"format": "[%(asctime)s] %(levelname)s: %(message)s"},
+        "simple": {"format": "[%(asctime)s] %(levelname)s [%(env_name)s]: %(message)s"},
         "ecs_formatter": {"()": "rbac.ECSCustom.ECSCustomFormatter"},
     },
     "handlers": {
-        "console": {"class": "logging.StreamHandler", "formatter": LOGGING_FORMATTER},
+        "console": {"class": "logging.StreamHandler", "formatter": LOGGING_FORMATTER, "filters": ["env_name"]},
         "file": {
             "level": RBAC_LOGGING_LEVEL,
             "class": "logging.FileHandler",
             "filename": LOGGING_FILE,
             "formatter": LOGGING_FORMATTER,
+            "filters": ["env_name"],
         },
-        "ecs": {"class": "logging.StreamHandler", "formatter": "ecs_formatter"},
+        "ecs": {"class": "logging.StreamHandler", "formatter": "ecs_formatter", "filters": ["env_name"]},
     },
     "loggers": {
         "django": {"handlers": LOGGING_HANDLERS, "level": DJANGO_LOGGING_LEVEL},
@@ -311,6 +316,7 @@ if CW_AWS_ACCESS_KEY_ID:
         "formatter": LOGGING_FORMATTER,
         "use_queues": True,
         "create_log_group": CW_CREATE_LOG_GROUP,
+        "filters": ["env_name"],
     }
     LOGGING["handlers"]["watchtower"] = WATCHTOWER_HANDLER
 
@@ -606,8 +612,6 @@ if CLOWDER_ENABLED:
             f"WARNING: Dependency endpoint for '{KESSEL_INVENTORY_CLOWDER_APPLICATION_NAME}' not found: {e}. "
             f"Falling back to default INVENTORY_API_SERVER value: {INVENTORY_API_SERVER}"
         )
-
-ENV_NAME = ENVIRONMENT.get_value("ENV_NAME", default="stage")
 
 # Versioned API settings
 V2_APIS_ENABLED = ENVIRONMENT.bool("V2_APIS_ENABLED", default=False)

--- a/rbac/rbac/settings.py
+++ b/rbac/rbac/settings.py
@@ -262,7 +262,7 @@ LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,
     "filters": {
-        "env_name": {"()": "rbac.logging_filters.EnvironmentFilter"},
+        "env_name": {"()": "rbac.logging_filters.EnvironmentFilter", "env_name": ENV_NAME},
     },
     "formatters": {
         "verbose": {"format": VERBOSE_FORMATTING},

--- a/tests/rbac/ECSCustom/test_ecs_custom_formatter.py
+++ b/tests/rbac/ECSCustom/test_ecs_custom_formatter.py
@@ -89,3 +89,33 @@ class TestECSCustomFormatter(TestCase):
             "http.request.bytes does not match actual Content-Length.",
         )
         self.assertEqual(log_output["http"]["request"]["method"], "POST")
+
+    def test_env_name_included_in_labels(self):
+        log_record = logging.LogRecord(
+            name="test.logger",
+            level=logging.INFO,
+            pathname="dummy_module.py",
+            lineno=0,
+            msg="Test log message.",
+            args=(),
+            exc_info=None,
+        )
+        log_record.env_name = "prod"
+        log_output = self.format(log_record)
+
+        self.assertIn("labels", log_output)
+        self.assertEqual(log_output["labels"]["env"], "prod")
+
+    def test_env_name_missing_no_labels(self):
+        log_record = logging.LogRecord(
+            name="test.logger",
+            level=logging.INFO,
+            pathname="dummy_module.py",
+            lineno=0,
+            msg="Test log message.",
+            args=(),
+            exc_info=None,
+        )
+        log_output = self.format(log_record)
+
+        self.assertNotIn("labels", log_output)

--- a/tests/rbac/test_logging_filters.py
+++ b/tests/rbac/test_logging_filters.py
@@ -1,0 +1,37 @@
+"""Tests for the EnvironmentFilter logging filter."""
+
+import logging
+
+from django.test import SimpleTestCase
+
+from rbac.logging_filters import EnvironmentFilter
+
+
+class TestEnvironmentFilter(SimpleTestCase):
+    def setUp(self):
+        self.record = logging.LogRecord(
+            name="test.logger",
+            level=logging.INFO,
+            pathname="test.py",
+            lineno=1,
+            msg="test message",
+            args=(),
+            exc_info=None,
+        )
+
+    def test_filter_injects_env_name_and_returns_true(self):
+        f = EnvironmentFilter(env_name="stage")
+        result = f.filter(self.record)
+        self.assertTrue(result)
+        self.assertTrue(hasattr(self.record, "env_name"))
+        self.assertEqual(self.record.env_name, "stage")
+
+    def test_filter_reflects_custom_env_name(self):
+        f = EnvironmentFilter(env_name="prod")
+        f.filter(self.record)
+        self.assertEqual(self.record.env_name, "prod")
+
+    def test_filter_reflects_stage_env_name(self):
+        f = EnvironmentFilter(env_name="stage")
+        f.filter(self.record)
+        self.assertEqual(self.record.env_name, "stage")


### PR DESCRIPTION
## Link(s) to Jira
- [RHCLOUD-47920](https://issues.redhat.com/browse/RHCLOUD-47920)

## Description of Intent of Change(s)

Multiple clusters spanning stage/prod forward logs to the same Splunk index (`rh_cpin-001`), making it impossible to filter by environment. This adds an explicit environment identifier to every log message so Splunk queries can distinguish environments.

The implementation uses a Django logging filter (`EnvironmentFilter`) that injects the `ENV_NAME` env var value into every log record. The value flows through three channels:

- **Text formatters** (simple/verbose): include `[env_name]` in the format string, e.g. `[2025-01-15] INFO [stage]: ...`
- **ECS formatter**: adds `labels.env` to the structured JSON output that Splunk ingests, enabling queries like `labels.env="prod"`
- **All handlers**: the filter is attached to console, file, ecs, and watchtower handlers

The `ENV_NAME` env var already exists in the ClowdApp config for all pods (default: `stage`). No deployment or ClowdApp changes are needed.

## Local Testing

1. Run the test suite: `pipenv run tox -e py312-fast`
2. Start the local server with `make serve` and observe log output -- each line should include `[stage]` (the default)
3. Set a custom value: `ENV_NAME=prod make serve` and verify logs show `[prod]`
4. For ECS format: `DJANGO_LOG_HANDLERS=ecs DJANGO_LOG_FORMATTER=ecs_formatter make serve` and verify JSON output contains `"labels": {"env": "stage"}`

## Checklist
- [x] if API spec changes are required, is the spec updated? (N/A -- no API changes)
- [x] are there any pre/post merge actions required? if so, document here. (None)
- [x] are theses changes covered by unit tests?
- [x] if warranted, are documentation changes accounted for? (N/A)
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [x] is there known, direct impact to dependent teams/components? (Log format changes are additive -- existing parsers won't break)
  - [x] if yes, how will this be handled? (The `[env_name]` field is additive to text formats; ECS `labels.env` is a new field, not a change to existing fields)

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices

[RHCLOUD-47920]: https://redhat.atlassian.net/browse/RHCLOUD-47920?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Add environment-aware logging so each log record includes an environment identifier across text and ECS formats.

New Features:
- Introduce an EnvironmentFilter logging filter that injects the deployment environment name into every log record using the ENV_NAME setting.
- Include the environment name in human-readable log formats to make environment visible in standard console and file logs.
- Expose the environment as labels.env in ECS-formatted log output for downstream systems like Splunk.

Tests:
- Add tests for the EnvironmentFilter behavior to ensure env_name is injected and respects custom values.
- Extend ECS custom formatter tests to verify env_name is propagated into labels.env when present and that labels are omitted when env_name is absent.