### PR TITLE
[RHCLOUD-48138] Split the mixed scope roles that contains tenant scope

### DIFF
--- a/rbac/management/group/relation_api_dual_write_group_handler.py
+++ b/rbac/management/group/relation_api_dual_write_group_handler.py
@@ -189,21 +189,23 @@ class RelationApiDualWriteGroupHandler(RelationApiDualWriteSubjectHandler):
         # Add back subject
         # Replicate this addition
         for role in roles:
-            # Note that we do not attempt to handle the case where the scope has changed. At time of writing
-            # (2025-10-08), this case is expected to be handled during seeding for system roles. It is unclear how
-            # custom roles should be handled.
-            scope = self._resource_service.scope_for_role(role)
+            # When a role has mixed scopes including TENANT, create bindings at each scope
+            # so that workspace-scoped permissions are not lost.
+            binding_scopes = self._resource_service.binding_scopes_for_role(role)
 
-            self._update_mapping_for_role(
-                role,
-                scope=scope,
-                update_mapping=reset_mapping,
-                create_default_mapping_for_system_role=lambda resource: self._create_default_mapping_for_system_role(
-                    system_role=role,
-                    resource=resource,
-                    groups=frozenset([str(self.group.uuid)]),
-                ),
-            )
+            for scope in binding_scopes:
+                self._update_mapping_for_role(
+                    role,
+                    scope=scope,
+                    update_mapping=reset_mapping,
+                    create_default_mapping_for_system_role=(
+                        lambda resource, system_role=role: self._create_default_mapping_for_system_role(
+                            system_role=system_role,
+                            resource=resource,
+                            groups=frozenset([str(self.group.uuid)]),
+                        )
+                    ),
+                )
 
         if remove_default_access_from is not None:
             self.relations_to_remove.extend(

--- a/rbac/management/inventory_checker/inventory_api_check.py
+++ b/rbac/management/inventory_checker/inventory_api_check.py
@@ -485,9 +485,7 @@ def generate_seeded_role_hierarchy_tuples(
 
     if v1_role.admin_default:
         try:
-            admin_scope = admin_platform_parent_scope_for_seeded_system_role(
-                v1_role.name, v1_role.admin_default, scope, apply_override=True
-            )
+            admin_scope = admin_platform_parent_scope_for_seeded_system_role(v1_role.name, scope, apply_override=True)
             parent_uuid = platform_v2_role_uuid_for(DefaultAccessType.ADMIN, admin_scope, policy_service)
             tuples.append(role_child_relationship(parent_uuid, seeded_role.uuid))
         except DefaultGroupNotAvailableError:

--- a/rbac/management/permission/model.py
+++ b/rbac/management/permission/model.py
@@ -107,6 +107,25 @@ class PermissionValue:
         """Return the V1 representation of this permission: app:resource:verb."""
         return f"{self.application}:{self.resource_type}:{self.verb}"
 
+    @property
+    def is_wildcard(self) -> bool:
+        """Return True if the resource type or verb is the wildcard ``*``."""
+        return self.resource_type == "*" or self.verb == "*"
+
+    def subsumes(self, other: "PermissionValue") -> bool:
+        """Return True if this pattern covers ``other`` (is equal to or broader than it).
+
+        A wildcard in this value's resource type or verb matches any value in the
+        corresponding component of ``other``.  Applications must match exactly.
+        """
+        if self.application != other.application:
+            return False
+        if self.resource_type != "*" and self.resource_type != other.resource_type:
+            return False
+        if self.verb != "*" and self.verb != other.verb:
+            return False
+        return True
+
     @classmethod
     def from_v2_dict(cls, data: dict) -> "PermissionValue":
         """

--- a/rbac/management/permission/scope_service.py
+++ b/rbac/management/permission/scope_service.py
@@ -304,19 +304,13 @@ class ImplicitResourceService:
         primary_scope = self.scope_for_permission(permission)
         scopes = {primary_scope}
 
-        is_wildcard = parsed.resource_type == "*" or parsed.verb == "*"
-        if not is_wildcard:
+        if not parsed.is_wildcard:
             return scopes
 
         for configured_perm, configured_scope in self._permissions_map.items():
-            if configured_perm.application != parsed.application:
-                continue
             if configured_scope == primary_scope:
                 continue
-            # Check if the configured pattern is narrower than (subsumed by) our wildcard.
-            resource_match = parsed.resource_type == "*" or parsed.resource_type == configured_perm.resource_type
-            verb_match = parsed.verb == "*" or parsed.verb == configured_perm.verb
-            if resource_match and verb_match:
+            if parsed.subsumes(configured_perm):
                 scopes.add(configured_scope)
 
         return scopes
@@ -336,15 +330,6 @@ class ImplicitResourceService:
         """Return the implicit scope for a role based on its permissions."""
         # TODO: this may need to eventually take into account resource definitions for custom roles.
         return self.highest_scope_for_permissions(a.permission.permission for a in role.access.all())
-
-    def permissions_by_scope_for_role(self, role: Role) -> dict["Scope", list[str]]:
-        """Group a role's permissions by their individual scope."""
-        result: dict[Scope, list[str]] = {}
-        for access in role.access.all():
-            perm = access.permission.permission
-            scope = self.scope_for_permission(perm)
-            result.setdefault(scope, []).append(perm)
-        return result
 
     def binding_scopes_for_role(self, role: Role) -> list["Scope"]:
         """Return the scopes at which bindings should be created for this role.
@@ -505,40 +490,6 @@ class PermissionScopeCache:
 permission_scope_cache = PermissionScopeCache(default_implicit_resource_service)
 
 
-def binding_scopes_for_permissions(
-    permissions: Iterable[str],
-    resource_service: ImplicitResourceService | None = None,
-) -> list[Scope]:
-    """Return the distinct binding scopes needed for a set of permissions.
-
-    If the permissions span multiple scopes and one of them is TENANT,
-    TENANT is kept separate and the remaining workspace-level scopes are
-    merged to the highest among them (ROOT > DEFAULT).
-
-    If only ROOT and DEFAULT are mixed, a single ROOT scope is returned
-    because workspace parent inheritance covers DEFAULT.
-
-    Wildcard permissions (e.g. ``subscriptions:*:*``) that subsume patterns
-    configured in other scopes are treated as spanning those scopes too.
-    """
-    if resource_service is None:
-        resource_service = default_implicit_resource_service
-
-    scopes: set[Scope] = set()
-    for p in permissions:
-        scopes |= resource_service.all_scopes_for_permission(p)
-
-    if not scopes:
-        return [Scope.DEFAULT]
-
-    if Scope.TENANT in scopes and len(scopes) > 1:
-        workspace_scopes = scopes - {Scope.TENANT}
-        workspace_max = max(workspace_scopes)
-        return sorted({Scope.TENANT, workspace_max}, key=lambda s: s.value)
-
-    return [max(scopes)]
-
-
 def split_permissions_by_binding_scope(
     permissions: Iterable[str],
     resource_service: ImplicitResourceService | None = None,
@@ -560,25 +511,38 @@ def split_permissions_by_binding_scope(
     if not permissions:
         return {}
 
-    scopes_needed = binding_scopes_for_permissions(permissions, resource_service)
-
-    if len(scopes_needed) == 1:
-        return {scopes_needed[0]: permissions}
-
-    # Multiple scopes: split TENANT permissions out, rest go to workspace scope.
-    # Wildcards that span both are duplicated into each group.
-    workspace_scope = max(s for s in scopes_needed if s != Scope.TENANT)
-    result: dict[Scope, list[str]] = {}
+    permissions_by_scope: dict[Scope, set[str]] = {}
     for perm in permissions:
-        perm_scopes = resource_service.all_scopes_for_permission(perm)
-        placed = False
-        if Scope.TENANT in perm_scopes:
-            result.setdefault(Scope.TENANT, []).append(perm)
-            placed = True
-        if perm_scopes & {Scope.ROOT, Scope.DEFAULT}:
-            result.setdefault(workspace_scope, []).append(perm)
-            placed = True
-        if not placed:
-            result.setdefault(workspace_scope, []).append(perm)
+        for scope in resource_service.all_scopes_for_permission(perm):
+            permissions_by_scope.setdefault(scope, set()).add(perm)
 
-    return result
+    if not permissions_by_scope:
+        return {Scope.DEFAULT: permissions}
+
+    if Scope.DEFAULT in permissions_by_scope and Scope.ROOT in permissions_by_scope:
+        permissions_by_scope[Scope.ROOT].update(permissions_by_scope[Scope.DEFAULT])
+        del permissions_by_scope[Scope.DEFAULT]
+
+    return {scope: list(scoped_perms) for scope, scoped_perms in permissions_by_scope.items()}
+
+
+def binding_scopes_for_permissions(
+    permissions: Iterable[str],
+    resource_service: ImplicitResourceService | None = None,
+) -> list[Scope]:
+    """Return the distinct binding scopes needed for a set of permissions.
+
+    If the permissions span multiple scopes and one of them is TENANT,
+    TENANT is kept separate and the remaining workspace-level scopes are
+    merged to the highest among them (ROOT > DEFAULT).
+
+    If only ROOT and DEFAULT are mixed, a single ROOT scope is returned
+    because workspace parent inheritance covers DEFAULT.
+
+    Wildcard permissions (e.g. ``subscriptions:*:*``) that subsume patterns
+    configured in other scopes are treated as spanning those scopes too.
+    """
+    split = split_permissions_by_binding_scope(permissions, resource_service)
+    if not split:
+        return [Scope.DEFAULT]
+    return sorted(split.keys(), key=lambda s: s.value)

--- a/rbac/management/permission/scope_service.py
+++ b/rbac/management/permission/scope_service.py
@@ -290,6 +290,37 @@ class ImplicitResourceService:
 
         return Scope.DEFAULT
 
+    def all_scopes_for_permission(self, permission: str) -> set["Scope"]:
+        """Return every scope that a permission covers, including scopes of narrower patterns it subsumes.
+
+        For a concrete permission like ``subscriptions:organization:read``, this returns the
+        same single scope as ``scope_for_permission``.
+
+        For a wildcard like ``subscriptions:*:*``, this additionally checks whether any
+        more-specific patterns in the scope map (e.g. ``subscriptions:reports:*``) belong to
+        a different scope. If so, the wildcard effectively spans both scopes.
+        """
+        parsed = PermissionValue.parse_v1(permission)
+        primary_scope = self.scope_for_permission(permission)
+        scopes = {primary_scope}
+
+        is_wildcard = parsed.resource_type == "*" or parsed.verb == "*"
+        if not is_wildcard:
+            return scopes
+
+        for configured_perm, configured_scope in self._permissions_map.items():
+            if configured_perm.application != parsed.application:
+                continue
+            if configured_scope == primary_scope:
+                continue
+            # Check if the configured pattern is narrower than (subsumed by) our wildcard.
+            resource_match = parsed.resource_type == "*" or parsed.resource_type == configured_perm.resource_type
+            verb_match = parsed.verb == "*" or parsed.verb == configured_perm.verb
+            if resource_match and verb_match:
+                scopes.add(configured_scope)
+
+        return scopes
+
     def highest_scope_for_permissions(self, permissions: Iterable[str]) -> Scope:
         """
         Return the highest scope to which any permission in permissions is assigned.
@@ -305,6 +336,24 @@ class ImplicitResourceService:
         """Return the implicit scope for a role based on its permissions."""
         # TODO: this may need to eventually take into account resource definitions for custom roles.
         return self.highest_scope_for_permissions(a.permission.permission for a in role.access.all())
+
+    def permissions_by_scope_for_role(self, role: Role) -> dict["Scope", list[str]]:
+        """Group a role's permissions by their individual scope."""
+        result: dict[Scope, list[str]] = {}
+        for access in role.access.all():
+            perm = access.permission.permission
+            scope = self.scope_for_permission(perm)
+            result.setdefault(scope, []).append(perm)
+        return result
+
+    def binding_scopes_for_role(self, role: Role) -> list["Scope"]:
+        """Return the scopes at which bindings should be created for this role.
+
+        If the role has mixed scopes including TENANT, TENANT is split out and the
+        remaining workspace scopes are merged to the highest among them.
+        ROOT+DEFAULT without TENANT collapses to ROOT (workspace parent inheritance).
+        """
+        return binding_scopes_for_permissions((a.permission.permission for a in role.access.all()), self)
 
     def v2_bound_resource_for_permission(
         self,
@@ -454,3 +503,82 @@ class PermissionScopeCache:
 
 
 permission_scope_cache = PermissionScopeCache(default_implicit_resource_service)
+
+
+def binding_scopes_for_permissions(
+    permissions: Iterable[str],
+    resource_service: ImplicitResourceService | None = None,
+) -> list[Scope]:
+    """Return the distinct binding scopes needed for a set of permissions.
+
+    If the permissions span multiple scopes and one of them is TENANT,
+    TENANT is kept separate and the remaining workspace-level scopes are
+    merged to the highest among them (ROOT > DEFAULT).
+
+    If only ROOT and DEFAULT are mixed, a single ROOT scope is returned
+    because workspace parent inheritance covers DEFAULT.
+
+    Wildcard permissions (e.g. ``subscriptions:*:*``) that subsume patterns
+    configured in other scopes are treated as spanning those scopes too.
+    """
+    if resource_service is None:
+        resource_service = default_implicit_resource_service
+
+    scopes: set[Scope] = set()
+    for p in permissions:
+        scopes |= resource_service.all_scopes_for_permission(p)
+
+    if not scopes:
+        return [Scope.DEFAULT]
+
+    if Scope.TENANT in scopes and len(scopes) > 1:
+        workspace_scopes = scopes - {Scope.TENANT}
+        workspace_max = max(workspace_scopes)
+        return sorted({Scope.TENANT, workspace_max}, key=lambda s: s.value)
+
+    return [max(scopes)]
+
+
+def split_permissions_by_binding_scope(
+    permissions: Iterable[str],
+    resource_service: ImplicitResourceService | None = None,
+) -> dict[Scope, list[str]]:
+    """Group permissions by their binding scope.
+
+    If all permissions share one scope, returns ``{scope: [all_perms]}``.
+    If mixed with TENANT, returns ``{TENANT: [...], max(others): [...]}``.
+    If only ROOT+DEFAULT mixed, returns ``{ROOT: [all_perms]}`` because ROOT
+    inherits to DEFAULT via workspace parent chain.
+
+    Wildcard permissions that span both TENANT and workspace scopes are placed
+    in **both** groups so that the permission is effective at every level.
+    """
+    if resource_service is None:
+        resource_service = default_implicit_resource_service
+
+    permissions = list(permissions)
+    if not permissions:
+        return {}
+
+    scopes_needed = binding_scopes_for_permissions(permissions, resource_service)
+
+    if len(scopes_needed) == 1:
+        return {scopes_needed[0]: permissions}
+
+    # Multiple scopes: split TENANT permissions out, rest go to workspace scope.
+    # Wildcards that span both are duplicated into each group.
+    workspace_scope = max(s for s in scopes_needed if s != Scope.TENANT)
+    result: dict[Scope, list[str]] = {}
+    for perm in permissions:
+        perm_scopes = resource_service.all_scopes_for_permission(perm)
+        placed = False
+        if Scope.TENANT in perm_scopes:
+            result.setdefault(Scope.TENANT, []).append(perm)
+            placed = True
+        if perm_scopes & {Scope.ROOT, Scope.DEFAULT}:
+            result.setdefault(workspace_scope, []).append(perm)
+            placed = True
+        if not placed:
+            result.setdefault(workspace_scope, []).append(perm)
+
+    return result

--- a/rbac/management/role/definer.py
+++ b/rbac/management/role/definer.py
@@ -354,22 +354,26 @@ def _seed_v2_role_from_v1(v1_role, display_name, description, public_tenant, pla
         if v1_permissions:
             v2_role.permissions.set(v1_permissions)
             logger.info("Added %d permissions to V2 role %s.", len(v1_permissions), display_name)
-        scope = resource_service.scope_for_role(v1_role)
+
+        binding_scopes = resource_service.binding_scopes_for_role(v1_role)
 
         # Clear parents first since scope may have changed since previous seeding
         v2_role.parents.clear()
-        platform_role = platform_roles[(DefaultAccessType.USER, scope)]
-        if v1_role.platform_default:
-            platform_role.children.add(v2_role)
-            logger.info("Added %s as child of platform role %s", display_name, platform_role.name)
 
-        admin_scope = admin_platform_parent_scope_for_seeded_system_role(
-            v1_role.name, v1_role.admin_default, scope, apply_override=True
-        )
-        admin_platform_role = platform_roles[(DefaultAccessType.ADMIN, admin_scope)]
+        if v1_role.platform_default:
+            for scope in binding_scopes:
+                platform_role = platform_roles[(DefaultAccessType.USER, scope)]
+                platform_role.children.add(v2_role)
+                logger.info("Added %s as child of platform role %s", display_name, platform_role.name)
+
         if v1_role.admin_default:
-            admin_platform_role.children.add(v2_role)
-            logger.info("Added %s as child of admin platform role %s", display_name, admin_platform_role.name)
+            for scope in binding_scopes:
+                admin_scope = admin_platform_parent_scope_for_seeded_system_role(
+                    v1_role.name, v1_role.admin_default, scope, apply_override=True
+                )
+                admin_platform_role = platform_roles[(DefaultAccessType.ADMIN, admin_scope)]
+                admin_platform_role.children.add(v2_role)
+                logger.info("Added %s as child of admin platform role %s", display_name, admin_platform_role.name)
 
         return v2_role
     except Exception as e:

--- a/rbac/management/role/definer.py
+++ b/rbac/management/role/definer.py
@@ -369,7 +369,7 @@ def _seed_v2_role_from_v1(v1_role, display_name, description, public_tenant, pla
         if v1_role.admin_default:
             for scope in binding_scopes:
                 admin_scope = admin_platform_parent_scope_for_seeded_system_role(
-                    v1_role.name, v1_role.admin_default, scope, apply_override=True
+                    v1_role.name, scope, apply_override=True
                 )
                 admin_platform_role = platform_roles[(DefaultAccessType.ADMIN, admin_scope)]
                 admin_platform_role.children.add(v2_role)

--- a/rbac/management/role/platform.py
+++ b/rbac/management/role/platform.py
@@ -35,15 +35,15 @@ ADMIN_DEFAULT_SEEDED_ROLES_FORCE_ROOT_SCOPE = frozenset(
 
 
 def admin_platform_parent_scope_for_seeded_system_role(
-    role_name: str, admin_default: bool, permission_derived_scope: Scope, *, apply_override: bool
+    role_name: str, permission_derived_scope: Scope, *, apply_override: bool
 ) -> Scope:
     """
-    Return the scope of the admin platform role that should be the parent of this seeded system role.
+    Return the scope of the admin platform role that should be the parent of this admin_default seeded role.
 
-    When apply_override is False (e.g. when generating tuples to strip all historical variants), the
-    caller's scope is used as-is.
+    Call only for roles with ``admin_default=True``. When apply_override is False (e.g. when generating
+    tuples to strip all historical variants), the caller's scope is used as-is.
     """
-    if apply_override and admin_default and role_name in ADMIN_DEFAULT_SEEDED_ROLES_FORCE_ROOT_SCOPE:
+    if apply_override and role_name in ADMIN_DEFAULT_SEEDED_ROLES_FORCE_ROOT_SCOPE:
         return Scope.ROOT
     return permission_derived_scope
 

--- a/rbac/management/role/relation_api_dual_write_handler.py
+++ b/rbac/management/role/relation_api_dual_write_handler.py
@@ -49,7 +49,11 @@ from management.tenant_mapping.model import DefaultAccessType
 from management.tenant_mapping.v2_activation import assert_v1_write_allowed
 from migration_tool.migrate_role import migrate_role, relation_tuples_for_bindings
 from migration_tool.models import V2boundresource
-from migration_tool.sharedSystemRolesReplicatedRoleBindings import v1_perm_to_v2_perm
+from migration_tool.sharedSystemRolesReplicatedRoleBindings import (
+    bound_resource_resolver_from_map,
+    v1_perm_to_v2_perm,
+    with_workspace_scope_inheritance,
+)
 from migration_tool.utils import create_relationship
 
 
@@ -153,7 +157,6 @@ class SeedingRelationApiDualWriteHandler(BaseRelationApiDualWriteHandler):
             try:
                 admin_scope = admin_platform_parent_scope_for_seeded_system_role(
                     role.name,
-                    role.admin_default,
                     role_scope,
                     apply_override=apply_seeded_admin_scope_override,
                 )
@@ -419,30 +422,23 @@ class RelationApiDualWriteHandler(BaseRelationApiDualWriteHandler):
             logger.info("[Dual Write] Generate new relations from role(%s): '%s'", self.role.uuid, self.role.name)
 
             binding_scopes = self.resource_service.binding_scopes_for_role(self.role)
-
-            if len(binding_scopes) > 1:
-                target_resources: dict[Scope, V2boundresource] = {}
-                for scope in binding_scopes:
-                    model = bound_model_for_scope(
-                        scope=scope,
-                        tenant=self.tenant,
-                        root_workspace=self.root_workspace,
-                        default_workspace=self.default_workspace,
+            resource_map = with_workspace_scope_inheritance(
+                {
+                    scope: V2boundresource.for_model(
+                        bound_model_for_scope(
+                            scope=scope,
+                            tenant=self.tenant,
+                            root_workspace=self.root_workspace,
+                            default_workspace=self.default_workspace,
+                        )
                     )
-                    target_resources[scope] = V2boundresource.for_model(model)
-                default_resource_arg: V2boundresource | dict = target_resources
-            else:
-                target_model = bound_model_for_scope(
-                    scope=binding_scopes[0],
-                    tenant=self.tenant,
-                    root_workspace=self.root_workspace,
-                    default_workspace=self.default_workspace,
-                )
-                default_resource_arg = V2boundresource.for_model(target_model)
+                    for scope in binding_scopes
+                }
+            )
 
             relations, migrate_result = migrate_role(
                 self.role,
-                default_resource=default_resource_arg,
+                resource_for_scope=bound_resource_resolver_from_map(resource_map),
                 current_bindings=self.binding_mappings.values(),
                 current_v2_roles=self.v2_roles.values(),
             )

--- a/rbac/management/role/relation_api_dual_write_handler.py
+++ b/rbac/management/role/relation_api_dual_write_handler.py
@@ -207,13 +207,13 @@ class SeedingRelationApiDualWriteHandler(BaseRelationApiDualWriteHandler):
                     )
                 )
         else:
-            # Determine highest scope for the role's permissions
-            highest_scope: Scope = self.implicit_resource_service.scope_for_role(self.role)
-            relations.extend(
-                self._check_create_admin_platform_relation(
-                    self.role, highest_scope, apply_seeded_admin_scope_override=True
+            binding_scopes = self.implicit_resource_service.binding_scopes_for_role(self.role)
+            for scope in binding_scopes:
+                relations.extend(
+                    self._check_create_admin_platform_relation(
+                        self.role, scope, apply_seeded_admin_scope_override=True
+                    )
                 )
-            )
 
         for permission in v2_permissions:
             relations.append(
@@ -418,18 +418,31 @@ class RelationApiDualWriteHandler(BaseRelationApiDualWriteHandler):
         try:
             logger.info("[Dual Write] Generate new relations from role(%s): '%s'", self.role.uuid, self.role.name)
 
-            target_model = bound_model_for_scope(
-                scope=self.resource_service.scope_for_role(self.role),
-                tenant=self.tenant,
-                root_workspace=self.root_workspace,
-                default_workspace=self.default_workspace,
-            )
+            binding_scopes = self.resource_service.binding_scopes_for_role(self.role)
 
-            target_resource = V2boundresource.for_model(target_model)
+            if len(binding_scopes) > 1:
+                target_resources: dict[Scope, V2boundresource] = {}
+                for scope in binding_scopes:
+                    model = bound_model_for_scope(
+                        scope=scope,
+                        tenant=self.tenant,
+                        root_workspace=self.root_workspace,
+                        default_workspace=self.default_workspace,
+                    )
+                    target_resources[scope] = V2boundresource.for_model(model)
+                default_resource_arg: V2boundresource | dict = target_resources
+            else:
+                target_model = bound_model_for_scope(
+                    scope=binding_scopes[0],
+                    tenant=self.tenant,
+                    root_workspace=self.root_workspace,
+                    default_workspace=self.default_workspace,
+                )
+                default_resource_arg = V2boundresource.for_model(target_model)
 
             relations, migrate_result = migrate_role(
                 self.role,
-                default_resource=target_resource,
+                default_resource=default_resource_arg,
                 current_bindings=self.binding_mappings.values(),
                 current_v2_roles=self.v2_roles.values(),
             )

--- a/rbac/migration_tool/migrate_role.py
+++ b/rbac/migration_tool/migrate_role.py
@@ -17,6 +17,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 from typing import Iterable
 
+from management.permission.scope_service import Scope
 from management.relation_replicator.types import RelationTuple
 from management.role.model import BindingMapping, Role
 from management.role.v2_model import CustomRoleV2
@@ -42,7 +43,7 @@ def relation_tuples_for_bindings(bindings: Iterable[BindingMapping]) -> list[Rel
 
 def migrate_role(
     role: Role,
-    default_resource: V2boundresource,
+    default_resource: "V2boundresource | dict[Scope, V2boundresource]",
     current_bindings: Iterable[BindingMapping],
     current_v2_roles: Iterable[CustomRoleV2],
 ) -> tuple[list[RelationTuple], MigrateCustomRoleResult]:

--- a/rbac/migration_tool/migrate_role.py
+++ b/rbac/migration_tool/migrate_role.py
@@ -17,12 +17,15 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 from typing import Iterable
 
-from management.permission.scope_service import Scope
 from management.relation_replicator.types import RelationTuple
 from management.role.model import BindingMapping, Role
 from management.role.v2_model import CustomRoleV2
-from migration_tool.models import V2boundresource, V2rolebinding
-from migration_tool.sharedSystemRolesReplicatedRoleBindings import MigrateCustomRoleResult, v1_role_to_v2_bindings
+from migration_tool.models import V2rolebinding
+from migration_tool.sharedSystemRolesReplicatedRoleBindings import (
+    MigrateCustomRoleResult,
+    ScopeBoundResourceResolver,
+    v1_role_to_v2_bindings,
+)
 
 
 def _get_kessel_relation_tuples(
@@ -43,7 +46,7 @@ def relation_tuples_for_bindings(bindings: Iterable[BindingMapping]) -> list[Rel
 
 def migrate_role(
     role: Role,
-    default_resource: "V2boundresource | dict[Scope, V2boundresource]",
+    resource_for_scope: ScopeBoundResourceResolver,
     current_bindings: Iterable[BindingMapping],
     current_v2_roles: Iterable[CustomRoleV2],
 ) -> tuple[list[RelationTuple], MigrateCustomRoleResult]:
@@ -53,6 +56,6 @@ def migrate_role(
     The mappings are returned so that we can reconstitute the corresponding tuples for a given role.
     This is needed so we can remove those tuples when the role changes if needed.
     """
-    migrate_result = v1_role_to_v2_bindings(role, default_resource, current_bindings, current_v2_roles)
+    migrate_result = v1_role_to_v2_bindings(role, resource_for_scope, current_bindings, current_v2_roles)
     relationships = relation_tuples_for_bindings(migrate_result.binding_mappings)
     return relationships, migrate_result

--- a/rbac/migration_tool/sharedSystemRolesReplicatedRoleBindings.py
+++ b/rbac/migration_tool/sharedSystemRolesReplicatedRoleBindings.py
@@ -17,6 +17,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import dataclasses
 import logging
+from collections.abc import Callable
 from typing import Any, Iterable, Optional, Tuple, Union
 
 import uuid_utils.compat as uuid
@@ -39,6 +40,36 @@ from migration_tool.models import (
 logger = logging.getLogger(__name__)
 
 _PermissionGroupings = dict[V2boundresource, set[Permission]]
+
+ScopeBoundResourceResolver = Callable[[Scope], V2boundresource]
+
+
+def constant_bound_resource(resource: V2boundresource) -> ScopeBoundResourceResolver:
+    """Return a resolver that always returns the same bound resource."""
+    return lambda _scope: resource
+
+
+def with_workspace_scope_inheritance(resource_map: dict[Scope, V2boundresource]) -> dict[Scope, V2boundresource]:
+    """Return a copy of ``resource_map`` with DEFAULT aliased to ROOT when needed.
+
+    Workspace bindings at ROOT cover the default workspace via parent inheritance,
+    so callers building a map from ``binding_scopes_for_role`` should apply this
+    before resolving per-permission scopes that may include DEFAULT.
+    """
+    result = dict(resource_map)
+    if Scope.ROOT in result and Scope.DEFAULT not in result:
+        result[Scope.DEFAULT] = result[Scope.ROOT]
+    return result
+
+
+def bound_resource_resolver_from_map(resource_map: dict[Scope, V2boundresource]) -> ScopeBoundResourceResolver:
+    """Return a resolver that maps scope to resource.
+
+    ``resource_map`` must contain an entry for every scope returned by
+    ``scope_for_permission`` for permissions being migrated. Use
+    ``with_workspace_scope_inheritance`` when building from binding scopes.
+    """
+    return lambda scope: resource_map[scope]
 
 
 def add_system_role(system_roles, role: V2role):
@@ -111,45 +142,26 @@ class MigrateCustomRoleResult:
 
 def v1_role_to_v2_bindings(
     v1_role: Role,
-    default_resource: "V2boundresource | dict[Scope, V2boundresource]",
+    resource_for_scope: ScopeBoundResourceResolver,
     existing_role_bindings: Iterable[BindingMapping],
     existing_v2_roles: Iterable[CustomRoleV2],
 ) -> MigrateCustomRoleResult:
     """Convert a V1 role to a set of V2 role bindings.
 
-    ``default_resource`` may be a single V2boundresource (legacy behavior: all
-    permissions without explicit resource definitions go there) or a dict
-    mapping Scope → V2boundresource.  When a dict is provided, each permission
-    without a resource definition is routed to the resource for its individual
-    scope (determined by the global scope service).
+    ``resource_for_scope`` maps each permission's implicit scope (from the scope
+    service) to the V2boundresource for permissions without explicit resource
+    definitions.
     """
     from internal.utils import (
         get_or_create_ungrouped_workspace,
         get_workspace_ids_from_resource_definition,
     )
 
-    # Normalise default_resource into a resolver function.
-    if isinstance(default_resource, dict):
-        _resource_map: dict[Scope, V2boundresource] = default_resource
-        _scope_service = ImplicitResourceService.from_settings()
+    _scope_service = ImplicitResourceService.from_settings()
 
-        def _resolve_default(permission: Permission) -> V2boundresource:
-            scope = _scope_service.scope_for_permission(permission.permission)
-            # Fall back to the highest-scope resource if scope not explicitly mapped.
-            if scope in _resource_map:
-                return _resource_map[scope]
-            # Merge ROOT/DEFAULT to highest available workspace scope.
-            for fallback in sorted(_resource_map.keys(), reverse=True):
-                if fallback != Scope.TENANT:
-                    return _resource_map[fallback]
-            # Final fallback: any available resource.
-            return next(iter(_resource_map.values()))
-
-    else:
-        _single_resource = default_resource
-
-        def _resolve_default(permission: Permission) -> V2boundresource:
-            return _single_resource
+    def _resolve_default(permission: Permission) -> V2boundresource:
+        scope = _scope_service.scope_for_permission(permission.permission)
+        return resource_for_scope(scope)
 
     perm_groupings: _PermissionGroupings = {}
 

--- a/rbac/migration_tool/sharedSystemRolesReplicatedRoleBindings.py
+++ b/rbac/migration_tool/sharedSystemRolesReplicatedRoleBindings.py
@@ -24,6 +24,7 @@ from django.db.models import F
 from feature_flags import FEATURE_FLAGS
 from management.models import BindingMapping, Workspace
 from management.permission.model import Permission
+from management.permission.scope_service import ImplicitResourceService, Scope
 from management.role.model import Role
 from management.role.v2_model import CustomRoleV2, RoleV2
 from management.role_binding.model import RoleBinding, RoleBindingGroup
@@ -110,15 +111,45 @@ class MigrateCustomRoleResult:
 
 def v1_role_to_v2_bindings(
     v1_role: Role,
-    default_resource: V2boundresource,
+    default_resource: "V2boundresource | dict[Scope, V2boundresource]",
     existing_role_bindings: Iterable[BindingMapping],
     existing_v2_roles: Iterable[CustomRoleV2],
 ) -> MigrateCustomRoleResult:
-    """Convert a V1 role to a set of V2 role bindings."""
+    """Convert a V1 role to a set of V2 role bindings.
+
+    ``default_resource`` may be a single V2boundresource (legacy behavior: all
+    permissions without explicit resource definitions go there) or a dict
+    mapping Scope → V2boundresource.  When a dict is provided, each permission
+    without a resource definition is routed to the resource for its individual
+    scope (determined by the global scope service).
+    """
     from internal.utils import (
         get_or_create_ungrouped_workspace,
         get_workspace_ids_from_resource_definition,
     )
+
+    # Normalise default_resource into a resolver function.
+    if isinstance(default_resource, dict):
+        _resource_map: dict[Scope, V2boundresource] = default_resource
+        _scope_service = ImplicitResourceService.from_settings()
+
+        def _resolve_default(permission: Permission) -> V2boundresource:
+            scope = _scope_service.scope_for_permission(permission.permission)
+            # Fall back to the highest-scope resource if scope not explicitly mapped.
+            if scope in _resource_map:
+                return _resource_map[scope]
+            # Merge ROOT/DEFAULT to highest available workspace scope.
+            for fallback in sorted(_resource_map.keys(), reverse=True):
+                if fallback != Scope.TENANT:
+                    return _resource_map[fallback]
+            # Final fallback: any available resource.
+            return next(iter(_resource_map.values()))
+
+    else:
+        _single_resource = default_resource
+
+        def _resolve_default(permission: Permission) -> V2boundresource:
+            return _single_resource
 
     perm_groupings: _PermissionGroupings = {}
 
@@ -179,7 +210,7 @@ def v1_role_to_v2_bindings(
         if default:
             add_element(
                 perm_groupings,
-                default_resource,
+                _resolve_default(permission),
                 permission,
                 collection=set,
             )

--- a/tests/internal/test_migrate_binding_scope_api.py
+++ b/tests/internal/test_migrate_binding_scope_api.py
@@ -44,6 +44,8 @@ from migration_tool.in_memory_tuples import (
     resource,
     relation,
     subject,
+    subject_id,
+    subject_type,
 )
 from migration_tool.migrate_binding_scope import (
     migrate_custom_role_bindings,
@@ -1237,6 +1239,7 @@ class ComprehensiveBootstrapMigrationTest(DualWriteTestCase):
         # Use a mock resource service that returns wrong scopes to simulate historical incorrect bindings
         mock_wrong_scope_service = Mock(spec=ImplicitResourceService)
         mock_wrong_scope_service.scope_for_role = Mock(side_effect=wrong_scope_for_role)
+        mock_wrong_scope_service.binding_scopes_for_role = Mock(side_effect=lambda role: [wrong_scope_for_role(role)])
 
         # Temporarily patch ImplicitResourceService.from_settings to return wrong scopes when creating bindings
         with patch(
@@ -1354,3 +1357,179 @@ class ComprehensiveBootstrapMigrationTest(DualWriteTestCase):
                 v2_role_id=platform_default_v2_role_id,
                 group_id=str(custom_default_group.uuid),
             )
+
+
+@override_settings(
+    ROOT_SCOPE_PERMISSIONS="advisor:*:*",
+    TENANT_SCOPE_PERMISSIONS="subscriptions:*:*",
+    REPLICATION_TO_RELATION_ENABLED=True,
+)
+class MixedScopeBindingMigrationTest(TestCase):
+    """Tests that migrate_binding_scope correctly splits mixed TENANT+workspace bindings."""
+
+    def setUp(self):
+        self.tuples = InMemoryTuples()
+        self.replicator = InMemoryRelationReplicator(self.tuples)
+        self.public_tenant = Tenant.objects.get_or_create(tenant_name="public")[0]
+        self.tenant = Tenant.objects.create(tenant_name="test_tenant", account_id="12345", org_id="67890")
+        bootstrap_result = bootstrap_tenant_for_v2_test(self.tenant, tuples=self.tuples)
+        self.root_workspace = bootstrap_result.root_workspace
+        self.default_workspace = bootstrap_result.default_workspace
+
+    def tearDown(self):
+        with self.subTest(msg="V2 consistency"):
+            assert_v2_tuples_consistent(test=self, tuples=self.tuples)
+        super().tearDown()
+
+    def test_custom_role_migrates_from_tenant_only_to_split(self):
+        """A custom role with mixed permissions migrated from tenant-only binding to tenant + workspace bindings."""
+        sub_perm = Permission.objects.create(
+            tenant=self.tenant,
+            application="subscriptions",
+            resource_type="organization",
+            verb="read",
+            permission="subscriptions:organization:read",
+        )
+        inv_perm = Permission.objects.create(
+            tenant=self.tenant,
+            application="inventory",
+            resource_type="hosts",
+            verb="read",
+            permission="inventory:hosts:read",
+        )
+
+        role = Role.objects.create(tenant=self.tenant, name="Mixed Custom Role", system=False)
+        Access.objects.create(role=role, permission=sub_perm, tenant=self.tenant)
+        Access.objects.create(role=role, permission=inv_perm, tenant=self.tenant)
+
+        # Simulate old state: a single binding at tenant (highest scope under old logic)
+        tenant_resource_id = self.tenant.tenant_resource_id()
+        bm_uuid = uuid.uuid4()
+        BindingMapping.objects.create(
+            role=role,
+            mappings={
+                "id": str(bm_uuid),
+                "groups": [],
+                "users": {},
+                "role": {"id": str(role.uuid), "is_system": False, "permissions": []},
+            },
+            resource_type_namespace="rbac",
+            resource_type_name="tenant",
+            resource_id=tenant_resource_id,
+        )
+
+        # Verify starting tuples: only binding at tenant, nothing at workspace
+        tenant_binding_tuples_before = self.tuples.find_tuples(
+            all_of(resource("rbac", "tenant", tenant_resource_id), relation("binding"))
+        )
+        default_ws_binding_tuples_before = self.tuples.find_tuples(
+            all_of(resource("rbac", "workspace", str(self.default_workspace.id)), relation("binding"))
+        )
+        # Bootstrap creates default-access bindings on the workspace; filter to non-bootstrap ones
+        self.assertEqual(len(tenant_binding_tuples_before), 0, "No tenant binding tuples before migration")
+
+        # Run migration
+        result = migrate_custom_role_bindings(role, self.replicator)
+        self.assertEqual(result, 1)
+
+        # Verify tuples: binding tuple on tenant resource for TENANT-scoped permission
+        tenant_binding_tuples_after = self.tuples.find_tuples(
+            all_of(resource("rbac", "tenant", tenant_resource_id), relation("binding"))
+        )
+        self.assertEqual(len(tenant_binding_tuples_after), 1, "Should have one binding tuple on tenant")
+
+        # Verify tuples: binding tuple on default workspace for DEFAULT-scoped permission
+        default_ws_id = str(self.default_workspace.id)
+        ws_binding_tuples_after = self.tuples.find_tuples(
+            all_of(resource("rbac", "workspace", default_ws_id), relation("binding"))
+        )
+        # Filter to bindings from this role (exclude bootstrap default-access bindings)
+        role_binding_uuids = set(str(rb.uuid) for rb in RoleBinding.objects.filter(role__v1_source=role))
+        role_ws_tuples = [t for t in ws_binding_tuples_after if t.subject.subject.id in role_binding_uuids]
+        self.assertEqual(len(role_ws_tuples), 1, "Should have one binding tuple on default workspace")
+
+        # Verify permission tuples on each V2 role
+        for rb in RoleBinding.objects.filter(role__v1_source=role):
+            rb_tuples = self.tuples.find_tuples(
+                all_of(resource("rbac", "role_binding", str(rb.uuid)), relation("role"))
+            )
+            self.assertEqual(len(rb_tuples), 1, f"RoleBinding {rb.uuid} should have exactly one role tuple")
+
+        assert_v1_v2_tuples_fully_consistent(test=self, tuples=self.tuples)
+
+    def test_system_role_migrates_from_tenant_only_to_split(self):
+        """A system role binding for a group migrates from tenant-only to tenant + workspace scoped bindings."""
+        sub_perm = Permission.objects.create(
+            tenant=self.public_tenant,
+            application="subscriptions",
+            resource_type="organization",
+            verb="read",
+            permission="subscriptions:organization:read",
+        )
+        inv_perm = Permission.objects.create(
+            tenant=self.public_tenant,
+            application="inventory",
+            resource_type="hosts",
+            verb="read",
+            permission="inventory:hosts:read",
+        )
+
+        system_role = Role.objects.create(
+            tenant=self.public_tenant,
+            name="Mixed System Role",
+            system=True,
+        )
+        Access.objects.create(role=system_role, permission=sub_perm, tenant=self.public_tenant)
+        Access.objects.create(role=system_role, permission=inv_perm, tenant=self.public_tenant)
+
+        seed_v2_role_from_v1(system_role)
+
+        group = Group.objects.create(name="Test Group", tenant=self.tenant, system=False)
+        add_roles(group, [system_role.uuid], self.tenant)
+
+        tenant_resource_id = self.tenant.tenant_resource_id()
+        default_ws_id = str(self.default_workspace.id)
+        group_uuid = str(group.uuid)
+
+        # Run migration
+        result = migrate_system_role_bindings_for_group(group, self.replicator)
+
+        # Verify tuples: binding on tenant resource
+        tenant_binding_tuples = self.tuples.find_tuples(
+            all_of(resource("rbac", "tenant", tenant_resource_id), relation("binding"))
+        )
+        self.assertGreaterEqual(len(tenant_binding_tuples), 1, "Should have binding tuple on tenant")
+
+        # Verify tuples: binding on workspace resource (default or root)
+        ws_binding_tuples = self.tuples.find_tuples(
+            all_of(resource("rbac", "workspace", default_ws_id), relation("binding"))
+        )
+        self.assertGreaterEqual(len(ws_binding_tuples), 1, "Should have binding tuple on workspace")
+
+        # Verify the group is a subject of bindings at both levels.
+        # System role bindings use rbac/role_binding#subject@rbac/group:uuid#member.
+        all_subject_tuples = self.tuples.find_tuples(
+            all_of(
+                relation("subject"),
+                subject_type("rbac", "group", any_relation=True),
+                subject_id(group_uuid),
+            )
+        )
+
+        # Each subject tuple's resource is a role_binding; collect which resource it's bound to.
+        bound_resource_types = set()
+        for st in all_subject_tuples:
+            rb_uuid = st.resource.id
+            # Check where this role_binding is attached (tenant or workspace)
+            for rt in ["tenant", "workspace"]:
+                binding_tuples = self.tuples.find_tuples(
+                    all_of(
+                        relation("binding"),
+                        subject("rbac", "role_binding", rb_uuid),
+                    )
+                )
+                for bt in binding_tuples:
+                    bound_resource_types.add(bt.resource.type.name)
+
+        self.assertIn("tenant", bound_resource_types, "Group should be bound at tenant scope")
+        self.assertIn("workspace", bound_resource_types, "Group should be bound at workspace scope")

--- a/tests/management/permission/test_model.py
+++ b/tests/management/permission/test_model.py
@@ -120,6 +120,29 @@ class PermissionValueTests(TestCase):
         self.assertEqual(app_only, app_only.with_unconstrained_resource_type())
         self.assertEqual(app_only, app_only.with_application_only())
 
+    def test_is_wildcard(self):
+        """Test that is_wildcard is true when resource type or verb is *."""
+        self.assertFalse(PermissionValue("app", "resource", "verb").is_wildcard)
+        self.assertTrue(PermissionValue("app", "*", "verb").is_wildcard)
+        self.assertTrue(PermissionValue("app", "resource", "*").is_wildcard)
+        self.assertTrue(PermissionValue("app", "*", "*").is_wildcard)
+
+    def test_subsumes(self):
+        """Test that subsumes reflects wildcard coverage between patterns."""
+        concrete = PermissionValue("app", "resource", "verb")
+        resource_wildcard = PermissionValue("app", "*", "verb")
+        verb_wildcard = PermissionValue("app", "resource", "*")
+        app_wildcard = PermissionValue("app", "*", "*")
+
+        self.assertTrue(app_wildcard.subsumes(concrete))
+        self.assertTrue(resource_wildcard.subsumes(concrete))
+        self.assertTrue(verb_wildcard.subsumes(concrete))
+        self.assertTrue(concrete.subsumes(concrete))
+
+        self.assertFalse(concrete.subsumes(resource_wildcard))
+        self.assertFalse(resource_wildcard.subsumes(verb_wildcard))
+        self.assertFalse(app_wildcard.subsumes(PermissionValue("other", "resource", "verb")))
+
 
 class PermissionModelTests(IdentityRequest):
     """Test the permission model."""

--- a/tests/management/permission/test_scope_service.py
+++ b/tests/management/permission/test_scope_service.py
@@ -854,3 +854,193 @@ class ResourceTypeMappingTest(TestCase):
 
     def test_scopes_for_unknown_resource_type(self):
         self.assertEqual(scopes_for_resource_type("unknown"), set())
+
+
+class SplitPermissionsTest(TestCase):
+    """Tests for split_permissions_by_binding_scope and binding_scopes_for_permissions."""
+
+    def setUp(self):
+        self.service = ImplicitResourceService(
+            root_scope_permissions=["advisor:*:*", "patch:*:*"],
+            tenant_scope_permissions=["rbac:*:*", "subscriptions:*:*"],
+            default_scope_permissions=["subscriptions:reports:*", "subscriptions:manifests:*"],
+        )
+
+    def test_single_scope_default(self):
+        """All DEFAULT permissions → single DEFAULT scope."""
+        from management.permission.scope_service import split_permissions_by_binding_scope
+
+        result = split_permissions_by_binding_scope(["inventory:hosts:read", "compliance:policy:read"], self.service)
+        self.assertEqual(set(result.keys()), {Scope.DEFAULT})
+        self.assertCountEqual(result[Scope.DEFAULT], ["inventory:hosts:read", "compliance:policy:read"])
+
+    def test_single_scope_root(self):
+        """All ROOT permissions → single ROOT scope."""
+        from management.permission.scope_service import split_permissions_by_binding_scope
+
+        result = split_permissions_by_binding_scope(
+            ["advisor:recommendation:read", "patch:system:write"], self.service
+        )
+        self.assertEqual(set(result.keys()), {Scope.ROOT})
+        self.assertCountEqual(result[Scope.ROOT], ["advisor:recommendation:read", "patch:system:write"])
+
+    def test_single_scope_tenant(self):
+        """All TENANT permissions → single TENANT scope."""
+        from management.permission.scope_service import split_permissions_by_binding_scope
+
+        result = split_permissions_by_binding_scope(
+            ["rbac:role:read", "subscriptions:organization:read"], self.service
+        )
+        self.assertEqual(set(result.keys()), {Scope.TENANT})
+        self.assertCountEqual(result[Scope.TENANT], ["rbac:role:read", "subscriptions:organization:read"])
+
+    def test_root_default_not_split(self):
+        """ROOT+DEFAULT mixed → collapsed to single ROOT (workspace parent inheritance)."""
+        from management.permission.scope_service import split_permissions_by_binding_scope
+
+        result = split_permissions_by_binding_scope(
+            ["advisor:recommendation:read", "inventory:hosts:read"], self.service
+        )
+        self.assertEqual(set(result.keys()), {Scope.ROOT})
+        self.assertCountEqual(result[Scope.ROOT], ["advisor:recommendation:read", "inventory:hosts:read"])
+
+    def test_tenant_default_split(self):
+        """TENANT+DEFAULT → two groups."""
+        from management.permission.scope_service import split_permissions_by_binding_scope
+
+        result = split_permissions_by_binding_scope(
+            ["subscriptions:organization:read", "inventory:hosts:read", "compliance:policy:read"],
+            self.service,
+        )
+        self.assertEqual(set(result.keys()), {Scope.TENANT, Scope.DEFAULT})
+        self.assertEqual(result[Scope.TENANT], ["subscriptions:organization:read"])
+        self.assertCountEqual(result[Scope.DEFAULT], ["inventory:hosts:read", "compliance:policy:read"])
+
+    def test_tenant_root_default_split(self):
+        """TENANT+ROOT+DEFAULT → TENANT split out, ROOT+DEFAULT merge to ROOT."""
+        from management.permission.scope_service import split_permissions_by_binding_scope
+
+        result = split_permissions_by_binding_scope(
+            [
+                "subscriptions:organization:read",
+                "advisor:recommendation:read",
+                "inventory:hosts:read",
+            ],
+            self.service,
+        )
+        self.assertEqual(set(result.keys()), {Scope.TENANT, Scope.ROOT})
+        self.assertEqual(result[Scope.TENANT], ["subscriptions:organization:read"])
+        self.assertCountEqual(result[Scope.ROOT], ["advisor:recommendation:read", "inventory:hosts:read"])
+
+    def test_subscriptions_wildcard_spans_tenant_and_default(self):
+        """subscriptions:*:* subsumes DEFAULT patterns → duplicated to both scopes."""
+        from management.permission.scope_service import split_permissions_by_binding_scope
+
+        result = split_permissions_by_binding_scope(["subscriptions:*:*"], self.service)
+        self.assertEqual(set(result.keys()), {Scope.TENANT, Scope.DEFAULT})
+        self.assertIn("subscriptions:*:*", result[Scope.TENANT])
+        self.assertIn("subscriptions:*:*", result[Scope.DEFAULT])
+
+    def test_rbac_wildcard_spans_tenant_and_default(self):
+        """rbac:*:* subsumes rbac:role_binding:* in DEFAULT → duplicated to both scopes."""
+        from management.permission.scope_service import split_permissions_by_binding_scope
+
+        svc = ImplicitResourceService(
+            root_scope_permissions=["advisor:*:*"],
+            tenant_scope_permissions=["rbac:*:*", "subscriptions:*:*"],
+            default_scope_permissions=["rbac:role_binding:*", "subscriptions:reports:*"],
+        )
+        result = split_permissions_by_binding_scope(["rbac:*:*"], svc)
+        self.assertEqual(set(result.keys()), {Scope.TENANT, Scope.DEFAULT})
+        self.assertIn("rbac:*:*", result[Scope.TENANT])
+        self.assertIn("rbac:*:*", result[Scope.DEFAULT])
+
+    def test_default_scope_override_respected(self):
+        """subscriptions:reports:read matches DEFAULT override, not TENANT wildcard."""
+        from management.permission.scope_service import split_permissions_by_binding_scope
+
+        result = split_permissions_by_binding_scope(
+            ["subscriptions:reports:read", "subscriptions:organization:read"], self.service
+        )
+        self.assertEqual(set(result.keys()), {Scope.TENANT, Scope.DEFAULT})
+        self.assertEqual(result[Scope.TENANT], ["subscriptions:organization:read"])
+        self.assertEqual(result[Scope.DEFAULT], ["subscriptions:reports:read"])
+
+    def test_empty_permissions(self):
+        """Empty permissions → empty dict."""
+        from management.permission.scope_service import split_permissions_by_binding_scope
+
+        result = split_permissions_by_binding_scope([], self.service)
+        self.assertEqual(result, {})
+
+    def test_binding_scopes_single(self):
+        """binding_scopes_for_permissions with single scope returns one entry."""
+        from management.permission.scope_service import binding_scopes_for_permissions
+
+        result = binding_scopes_for_permissions(["inventory:hosts:read"], self.service)
+        self.assertEqual(result, [Scope.DEFAULT])
+
+    def test_binding_scopes_mixed_tenant(self):
+        """binding_scopes_for_permissions with TENANT mix returns both."""
+        from management.permission.scope_service import binding_scopes_for_permissions
+
+        result = binding_scopes_for_permissions(
+            ["subscriptions:organization:read", "advisor:recommendation:read", "inventory:hosts:read"],
+            self.service,
+        )
+        self.assertEqual(sorted(result), sorted([Scope.TENANT, Scope.ROOT]))
+
+    def test_wildcard_tenant_perm_spanning_default_scope_is_mixed(self):
+        """subscriptions:*:* alone is mixed because DEFAULT_SCOPE has subscriptions:reports:* etc."""
+        from management.permission.scope_service import (
+            binding_scopes_for_permissions,
+            split_permissions_by_binding_scope,
+        )
+
+        result = binding_scopes_for_permissions(["subscriptions:*:*"], self.service)
+        self.assertEqual(sorted(result), sorted([Scope.TENANT, Scope.DEFAULT]))
+
+    def test_wildcard_tenant_perm_split_duplicates_to_both_scopes(self):
+        """subscriptions:*:* is placed in both TENANT and workspace groups."""
+        from management.permission.scope_service import split_permissions_by_binding_scope
+
+        result = split_permissions_by_binding_scope(["subscriptions:*:*"], self.service)
+        self.assertEqual(set(result.keys()), {Scope.TENANT, Scope.DEFAULT})
+        self.assertIn("subscriptions:*:*", result[Scope.TENANT])
+        self.assertIn("subscriptions:*:*", result[Scope.DEFAULT])
+
+    def test_wildcard_tenant_perm_with_other_perms_split_correctly(self):
+        """subscriptions:*:* + inventory:hosts:read → both groups, wildcard duplicated."""
+        from management.permission.scope_service import split_permissions_by_binding_scope
+
+        result = split_permissions_by_binding_scope(["subscriptions:*:*", "inventory:hosts:read"], self.service)
+        self.assertEqual(set(result.keys()), {Scope.TENANT, Scope.DEFAULT})
+        self.assertIn("subscriptions:*:*", result[Scope.TENANT])
+        self.assertIn("subscriptions:*:*", result[Scope.DEFAULT])
+        self.assertIn("inventory:hosts:read", result[Scope.DEFAULT])
+
+    def test_rbac_wildcard_no_default_patterns_stays_tenant(self):
+        """rbac:*:* with no rbac:... entries in DEFAULT_SCOPE → single TENANT (no overlap)."""
+        from management.permission.scope_service import binding_scopes_for_permissions
+
+        result = binding_scopes_for_permissions(["rbac:*:*"], self.service)
+        self.assertEqual(result, [Scope.TENANT])
+
+    def test_rbac_wildcard_with_default_pattern_spans_both(self):
+        """rbac:*:* spans TENANT+DEFAULT when rbac:role_binding:* is in DEFAULT_SCOPE."""
+        from management.permission.scope_service import binding_scopes_for_permissions
+
+        svc = ImplicitResourceService(
+            root_scope_permissions=["advisor:*:*"],
+            tenant_scope_permissions=["rbac:*:*", "subscriptions:*:*"],
+            default_scope_permissions=["rbac:role_binding:*", "subscriptions:reports:*"],
+        )
+        result = binding_scopes_for_permissions(["rbac:*:*"], svc)
+        self.assertEqual(sorted(result), sorted([Scope.TENANT, Scope.DEFAULT]))
+
+    def test_non_wildcard_tenant_perm_not_spanning(self):
+        """subscriptions:organization:read is concrete, not a wildcard → TENANT only."""
+        from management.permission.scope_service import binding_scopes_for_permissions
+
+        result = binding_scopes_for_permissions(["subscriptions:organization:read"], self.service)
+        self.assertEqual(result, [Scope.TENANT])

--- a/tests/management/role/test_definer.py
+++ b/tests/management/role/test_definer.py
@@ -794,6 +794,8 @@ class RoleDefinerTests(IdentityRequest):
             "Expected overall number of tuples not to change.",
         )
 
+        count_after_first_update = len(tuples)
+
         # Check that we can also move roles between non-default scopes.
         # This puts both approval_role and inventory_role permissions in tenant scope.
         with self.settings(
@@ -844,9 +846,10 @@ class RoleDefinerTests(IdentityRequest):
         )
 
         self.assertEqual(
-            initial_count,
+            count_after_first_update + 2,
             len(tuples),
-            "Expected overall number of tuples not to change.",
+            "Approval platform-default roles with mixed TENANT and workspace permissions "
+            "gain an additional platform parent binding per role.",
         )
 
     def test_admin_default_seeded_roles_force_root_scope(self):
@@ -1144,7 +1147,7 @@ class V2RoleSeedingTests(IdentityRequest):
         )
 
     def test_v2_role_parents_cleared_when_scope_changes_to_tenant(self):
-        """Test that v2_role.parents is cleared when scope changes from DEFAULT to TENANT."""
+        """Test that v2_role.parents reflect binding scopes when tenant scope is introduced."""
         seed_group()
 
         # First seeding with role in DEFAULT scope
@@ -1163,7 +1166,7 @@ class V2RoleSeedingTests(IdentityRequest):
 
         self.assertIn(default_platform_role, list(v2_role.parents.all()))
 
-        # Change to TENANT scope
+        # notifications:notifications:read becomes TENANT-scoped; integrations:endpoints:read stays DEFAULT.
         with self.settings(ROOT_SCOPE_PERMISSIONS="", TENANT_SCOPE_PERMISSIONS="notifications:*:*"):
             seed_roles()
 
@@ -1174,15 +1177,15 @@ class V2RoleSeedingTests(IdentityRequest):
         tenant_platform_role = PlatformRoleV2.objects.get(uuid=tenant_platform_role_uuid)
 
         parents = list(v2_role.parents.all())
-        self.assertNotIn(
+        self.assertIn(
             default_platform_role,
             parents,
-            "DEFAULT platform role should be removed after scope change to TENANT",
+            "DEFAULT platform role remains for workspace-scoped permissions after TENANT scope is introduced",
         )
         self.assertIn(
             tenant_platform_role,
             parents,
-            "TENANT platform role should be added after scope change",
+            "TENANT platform role should be added for tenant-scoped permissions",
         )
 
     def test_v2_role_seeded_for_unchanged_v1_role(self):
@@ -1262,3 +1265,157 @@ class V2RoleSeedingTests(IdentityRequest):
         # V2 should now match V1's permissions (which were reset during seeding)
         v1_permissions = set(access.permission for access in v1_role.access.all())
         self.assertEqual(v2_permissions, v1_permissions)
+
+
+@override_settings(
+    REPLICATION_TO_RELATION_ENABLED=True,
+    ROOT_SCOPE_PERMISSIONS="advisor:*:*",
+    TENANT_SCOPE_PERMISSIONS="subscriptions:*:*",
+    SYSTEM_DEFAULT_TENANT_ROLE_UUID="3c9e6f1a-8b2d-4e5c-9a7f-1d3b5c8e2a4f",
+    SYSTEM_DEFAULT_ROOT_WORKSPACE_ROLE_UUID="5e8a2c4f-9d1b-4c7e-8f3a-6d2b9c1e5a7f",
+    SYSTEM_ADMIN_TENANT_ROLE_UUID="a7f3c8b2-1d4e-4f9a-8c6d-2b5e7a9f1c3d",
+    SYSTEM_ADMIN_ROOT_WORKSPACE_ROLE_UUID="9b4c7e1f-3a5d-4f8c-9e2a-7c1d5b8f3a6e",
+)
+@patch("management.relation_replicator.outbox_replicator.OutboxReplicator.replicate")
+class SeedMixedScopeTest(IdentityRequest):
+    """Test that seeding a mixed-scope system role attaches to multiple platform parents."""
+
+    def setUp(self):
+        super().setUp()
+        self.public_tenant = Tenant.objects.get(tenant_name="public")
+
+    def test_seed_mixed_scope_system_role_multiple_platform_parents(self, replicate):
+        """A mixed-scope system role generates platform parent relations at each binding scope."""
+        tuples = InMemoryTuples()
+        replicate.side_effect = InMemoryRelationReplicator(tuples).replicate
+
+        # Create a system role with mixed permissions directly (bypasses full seeding).
+        from management.permission.scope_service import ImplicitResourceService
+
+        resource_service = ImplicitResourceService.from_settings()
+
+        role = Role.objects.create(
+            name="Mixed Scope Test Role",
+            system=True,
+            platform_default=True,
+            tenant=self.public_tenant,
+        )
+        # subscriptions → TENANT, advisor → ROOT
+        sub_perm, _ = Permission.objects.get_or_create(
+            permission="subscriptions:organization:read", tenant=self.public_tenant
+        )
+        adv_perm, _ = Permission.objects.get_or_create(
+            permission="advisor:recommendation:read", tenant=self.public_tenant
+        )
+        Access.objects.create(role=role, permission=sub_perm, tenant=self.public_tenant)
+        Access.objects.create(role=role, permission=adv_perm, tenant=self.public_tenant)
+
+        # Verify the role is mixed TENANT + ROOT
+        binding_scopes = resource_service.binding_scopes_for_role(role)
+        self.assertEqual(sorted(binding_scopes), sorted([Scope.TENANT, Scope.ROOT]))
+
+        # Replicate as new system role via the SeedingHandler
+        handler = SeedingRelationApiDualWriteHandler(role=role, replicator=InMemoryRelationReplicator(tuples))
+        handler.replicate_new_system_role()
+
+        # The handler should generate platform parent relations for BOTH scopes.
+        # It generates child relations: platform_role#child@this_role
+        platform_tenant_uuid = settings.SYSTEM_DEFAULT_TENANT_ROLE_UUID
+        platform_root_uuid = settings.SYSTEM_DEFAULT_ROOT_WORKSPACE_ROLE_UUID
+
+        tenant_parent_tuples = tuples.find_tuples(
+            all_of(
+                resource("rbac", "role", platform_tenant_uuid),
+                relation("child"),
+                subject("rbac", "role", str(role.uuid)),
+            )
+        )
+        self.assertEqual(
+            len(tenant_parent_tuples),
+            1,
+            "Mixed-scope role should have TENANT platform parent relation",
+        )
+
+        root_parent_tuples = tuples.find_tuples(
+            all_of(
+                resource("rbac", "role", platform_root_uuid),
+                relation("child"),
+                subject("rbac", "role", str(role.uuid)),
+            )
+        )
+        self.assertEqual(
+            len(root_parent_tuples),
+            1,
+            "Mixed-scope role should have ROOT platform parent relation",
+        )
+
+    def test_existing_tenant_only_role_splits_on_re_seed(self, replicate):
+        """A role initially seeded at TENANT-only scope gains a ROOT parent when re-seeded with mixed permissions."""
+        tuples = InMemoryTuples()
+        replicate.side_effect = InMemoryRelationReplicator(tuples).replicate
+
+        platform_tenant_uuid = settings.SYSTEM_DEFAULT_TENANT_ROLE_UUID
+        platform_root_uuid = settings.SYSTEM_DEFAULT_ROOT_WORKSPACE_ROLE_UUID
+
+        # Phase 1: create a role with only TENANT-scoped permissions.
+        role = Role.objects.create(
+            name="Re-seed Split Role",
+            system=True,
+            platform_default=True,
+            tenant=self.public_tenant,
+        )
+        sub_perm, _ = Permission.objects.get_or_create(
+            permission="subscriptions:organization:read", tenant=self.public_tenant
+        )
+        Access.objects.create(role=role, permission=sub_perm, tenant=self.public_tenant)
+
+        handler = SeedingRelationApiDualWriteHandler(role=role, replicator=InMemoryRelationReplicator(tuples))
+        handler.replicate_new_system_role()
+
+        # Only TENANT parent should exist.
+        tenant_tuples_before = tuples.find_tuples(
+            all_of(
+                resource("rbac", "role", platform_tenant_uuid),
+                relation("child"),
+                subject("rbac", "role", str(role.uuid)),
+            )
+        )
+        self.assertEqual(len(tenant_tuples_before), 1, "Should start with TENANT parent")
+
+        root_tuples_before = tuples.find_tuples(
+            all_of(
+                resource("rbac", "role", platform_root_uuid),
+                relation("child"),
+                subject("rbac", "role", str(role.uuid)),
+            )
+        )
+        self.assertEqual(len(root_tuples_before), 0, "Should NOT have ROOT parent initially")
+
+        # Phase 2: add a ROOT-scoped permission (advisor) and re-seed.
+        adv_perm, _ = Permission.objects.get_or_create(
+            permission="advisor:recommendation:read", tenant=self.public_tenant
+        )
+        Access.objects.create(role=role, permission=adv_perm, tenant=self.public_tenant)
+
+        handler2 = SeedingRelationApiDualWriteHandler(role=role, replicator=InMemoryRelationReplicator(tuples))
+        handler2.prepare_for_update()
+        handler2.replicate_update_system_role()
+
+        # Now BOTH parents should exist.
+        tenant_tuples_after = tuples.find_tuples(
+            all_of(
+                resource("rbac", "role", platform_tenant_uuid),
+                relation("child"),
+                subject("rbac", "role", str(role.uuid)),
+            )
+        )
+        self.assertEqual(len(tenant_tuples_after), 1, "Should still have TENANT parent after split")
+
+        root_tuples_after = tuples.find_tuples(
+            all_of(
+                resource("rbac", "role", platform_root_uuid),
+                relation("child"),
+                subject("rbac", "role", str(role.uuid)),
+            )
+        )
+        self.assertEqual(len(root_tuples_after), 1, "Should now also have ROOT parent after split")

--- a/tests/management/role/test_definer.py
+++ b/tests/management/role/test_definer.py
@@ -824,6 +824,11 @@ class RoleDefinerTests(IdentityRequest):
         )
         self._assert_child(
             tuples,
+            parent_uuid=default_platform_default_uuid,
+            child_uuid=approval_role.uuid,
+        )
+        self._assert_child(
+            tuples,
             parent_uuid=tenant_admin_default_uuid,
             child_uuid=user_access_role.uuid,
         )
@@ -845,11 +850,16 @@ class RoleDefinerTests(IdentityRequest):
             child_uuid=inventory_role.uuid,
         )
 
+        # Second force-update net tuple delta (+2): both platform-default approval roles in
+        # approval_local_test.json move from ROOT-only to TENANT + DEFAULT platform parents.
+        #   • Approval Approver: remove root platform parent, add tenant + default (+1)
+        #   • Approval Administrator Local Test: same scope change (+1)
+        # All other roles seeded here keep the same binding scopes, so their parent tuples
+        # are removed and re-added unchanged (net 0).
         self.assertEqual(
             count_after_first_update + 2,
             len(tuples),
-            "Approval platform-default roles with mixed TENANT and workspace permissions "
-            "gain an additional platform parent binding per role.",
+            "Both approval platform-default roles gain tenant and default workspace platform parents.",
         )
 
     def test_admin_default_seeded_roles_force_root_scope(self):
@@ -857,7 +867,7 @@ class RoleDefinerTests(IdentityRequest):
         for role_name in ADMIN_DEFAULT_SEEDED_ROLES_FORCE_ROOT_SCOPE:
             for derived_scope in Scope:
                 result = admin_platform_parent_scope_for_seeded_system_role(
-                    role_name, admin_default=True, permission_derived_scope=derived_scope, apply_override=True
+                    role_name, derived_scope, apply_override=True
                 )
                 self.assertEqual(
                     result,
@@ -865,27 +875,19 @@ class RoleDefinerTests(IdentityRequest):
                     f"{role_name!r} with derived scope {derived_scope.name} should be forced to ROOT",
                 )
 
-    def test_admin_default_force_root_does_not_apply_without_admin_default(self):
-        """Test that the ROOT override only applies when admin_default=True."""
-        for role_name in ADMIN_DEFAULT_SEEDED_ROLES_FORCE_ROOT_SCOPE:
-            result = admin_platform_parent_scope_for_seeded_system_role(
-                role_name, admin_default=False, permission_derived_scope=Scope.DEFAULT, apply_override=True
-            )
-            self.assertEqual(result, Scope.DEFAULT)
-
     def test_admin_default_force_root_does_not_apply_without_override(self):
         """Test that the ROOT override is skipped when apply_override=False."""
         for role_name in ADMIN_DEFAULT_SEEDED_ROLES_FORCE_ROOT_SCOPE:
             for derived_scope in Scope:
                 result = admin_platform_parent_scope_for_seeded_system_role(
-                    role_name, admin_default=True, permission_derived_scope=derived_scope, apply_override=False
+                    role_name, derived_scope, apply_override=False
                 )
                 self.assertEqual(result, derived_scope)
 
     def test_admin_default_force_root_does_not_apply_to_other_roles(self):
         """Test that ordinary admin_default roles are NOT forced to ROOT."""
         result = admin_platform_parent_scope_for_seeded_system_role(
-            "Some Other Role", admin_default=True, permission_derived_scope=Scope.DEFAULT, apply_override=True
+            "Some Other Role", Scope.DEFAULT, apply_override=True
         )
         self.assertEqual(result, Scope.DEFAULT)
 
@@ -1115,9 +1117,9 @@ class V2RoleSeedingTests(IdentityRequest):
         default_platform_role_uuid = platform_v2_role_uuid_for(DefaultAccessType.USER, Scope.DEFAULT, policy_service)
         default_platform_role = PlatformRoleV2.objects.get(uuid=default_platform_role_uuid)
 
-        self.assertIn(
-            default_platform_role,
+        self.assertCountEqual(
             list(v2_role.parents.all()),
+            [default_platform_role],
             "v2_role should have DEFAULT platform role as parent initially",
         )
 
@@ -1135,15 +1137,10 @@ class V2RoleSeedingTests(IdentityRequest):
 
         # Verify: old parent (DEFAULT) should be removed, new parent (ROOT) should be present
         parents = list(v2_role.parents.all())
-        self.assertNotIn(
-            default_platform_role,
+        self.assertCountEqual(
             parents,
-            "DEFAULT platform role should be removed from parents after scope change",
-        )
-        self.assertIn(
-            root_platform_role,
-            parents,
-            "ROOT platform role should be added as parent after scope change",
+            [root_platform_role],
+            "Scope change to ROOT should leave a single ROOT platform parent",
         )
 
     def test_v2_role_parents_cleared_when_scope_changes_to_tenant(self):
@@ -1164,7 +1161,7 @@ class V2RoleSeedingTests(IdentityRequest):
         default_platform_role_uuid = platform_v2_role_uuid_for(DefaultAccessType.USER, Scope.DEFAULT, policy_service)
         default_platform_role = PlatformRoleV2.objects.get(uuid=default_platform_role_uuid)
 
-        self.assertIn(default_platform_role, list(v2_role.parents.all()))
+        self.assertCountEqual(list(v2_role.parents.all()), [default_platform_role])
 
         # notifications:notifications:read becomes TENANT-scoped; integrations:endpoints:read stays DEFAULT.
         with self.settings(ROOT_SCOPE_PERMISSIONS="", TENANT_SCOPE_PERMISSIONS="notifications:*:*"):
@@ -1177,15 +1174,10 @@ class V2RoleSeedingTests(IdentityRequest):
         tenant_platform_role = PlatformRoleV2.objects.get(uuid=tenant_platform_role_uuid)
 
         parents = list(v2_role.parents.all())
-        self.assertIn(
-            default_platform_role,
+        self.assertCountEqual(
             parents,
-            "DEFAULT platform role remains for workspace-scoped permissions after TENANT scope is introduced",
-        )
-        self.assertIn(
-            tenant_platform_role,
-            parents,
-            "TENANT platform role should be added for tenant-scoped permissions",
+            [default_platform_role, tenant_platform_role],
+            "Mixed TENANT and DEFAULT permissions should yield both platform parents",
         )
 
     def test_v2_role_seeded_for_unchanged_v1_role(self):

--- a/tests/management/role/test_dual_write.py
+++ b/tests/management/role/test_dual_write.py
@@ -1004,30 +1004,38 @@ class DualWriteGroupTestCase(DualWriteTestCase):
                 self.expect_binding_absent(tenant, v2_role_id=role_id, group_id=group_id)
 
     def test_custom_role_scope(self):
-        """Test that custom roles are bound in the correct scope."""
+        """Test that custom roles with mixed TENANT+ROOT scope create per-scope bindings."""
         role = self.given_v1_role("a role", default=["root:resource:verb", "tenant:resource:verb"])
 
         group, _ = self.given_group(name="a group")
         self.given_roles_assigned_to_group(group, [role])
 
-        v2_role_id: str = BindingMapping.objects.get(role=role).mappings["role"]["id"]
+        # With mixed scopes, we now get two bindings: one at tenant, one at root workspace.
+        mappings = BindingMapping.objects.filter(role=role)
+        self.assertEqual(mappings.count(), 2)
+
+        tenant_bm = mappings.get(resource_type_name="tenant")
+        ws_bm = mappings.get(resource_type_name="workspace")
         group_id = str(group.uuid)
 
-        self.expect_binding_absent(
-            self.default_workspace_resource(),
-            v2_role_id=v2_role_id,
-            group_id=group_id,
-        )
+        tenant_v2_role_id = tenant_bm.mappings["role"]["id"]
+        ws_v2_role_id = ws_bm.mappings["role"]["id"]
 
-        self.expect_binding_absent(
-            self.root_workspace_resource(),
-            v2_role_id=v2_role_id,
+        self.expect_binding_present(
+            self.tenant_resource(),
+            v2_role_id=tenant_v2_role_id,
             group_id=group_id,
         )
 
         self.expect_binding_present(
-            self.tenant_resource(),
-            v2_role_id=v2_role_id,
+            self.root_workspace_resource(),
+            v2_role_id=ws_v2_role_id,
+            group_id=group_id,
+        )
+
+        self.expect_binding_absent(
+            self.default_workspace_resource(),
+            v2_role_id=tenant_v2_role_id,
             group_id=group_id,
         )
 
@@ -2551,14 +2559,23 @@ class DualWriteCustomRolesTestCase(DualWriteTestCase):
         self.expect_binding_absent(tenant, v2_role_id=v2_role_id, group_id=group_id)
         self._expect_v2_consistent()
 
-        # Adding a new permission in tenant scope should bind the role to the tenant.
+        # Adding a new permission in tenant scope should split the role: tenant + root bindings.
         with self.settings(ROOT_SCOPE_PERMISSIONS="app:*:*", TENANT_SCOPE_PERMISSIONS="other_app:*:*"):
             self.given_update_to_v1_role(role, default=["app:resource:verb", "other_app:resource:verb"])
-            v2_role_id = get_v2_role_id()
 
-        self.expect_binding_absent(default_workspace, v2_role_id=v2_role_id, group_id=group_id)
-        self.expect_binding_absent(root_workspace, v2_role_id=v2_role_id, group_id=group_id)
-        self.expect_binding_present(tenant, v2_role_id=v2_role_id, group_id=group_id)
+        # With the split, we now have two V2 roles (one per scope group).
+        mappings = BindingMapping.objects.filter(role=role)
+        tenant_bm = mappings.filter(resource_type_name="tenant")
+        ws_bm = mappings.filter(resource_type_name="workspace")
+        self.assertEqual(tenant_bm.count(), 1, "Should have tenant binding for other_app")
+        self.assertEqual(ws_bm.count(), 1, "Should have workspace binding for app")
+
+        tenant_v2_role_id = tenant_bm.first().mappings["role"]["id"]
+        ws_v2_role_id = ws_bm.first().mappings["role"]["id"]
+
+        self.expect_binding_present(tenant, v2_role_id=tenant_v2_role_id, group_id=group_id)
+        self.expect_binding_present(root_workspace, v2_role_id=ws_v2_role_id, group_id=group_id)
+        self.expect_binding_absent(default_workspace, v2_role_id=tenant_v2_role_id, group_id=group_id)
         self._expect_v2_consistent()
 
     def test_role_with_mixed_resource_definitions_creates_multiple_bindings(self):
@@ -2648,6 +2665,106 @@ class DualWriteCustomRolesTestCase(DualWriteTestCase):
         # There should be no binding in the other tenant's workspace because it should be ignored.
         self.assertFalse(BindingMapping.objects.filter(role=role).exists())
         self.assertFalse(RoleBinding.objects.filter(role__v1_source=role).exists())
+
+
+@override_settings(ROOT_SCOPE_PERMISSIONS="advisor:*:*", TENANT_SCOPE_PERMISSIONS="subscriptions:*:*")
+class DualWriteMixedScopeTestCase(DualWriteTestCase):
+    """Test that mixed TENANT + workspace scope roles create per-scope bindings."""
+
+    def tearDown(self):
+        with self.subTest(msg="V2 consistency"):
+            assert_v1_v2_tuples_fully_consistent(test=self, tuples=self.tuples)
+        super().tearDown()
+
+    def test_custom_role_mixed_tenant_default_creates_two_bindings(self):
+        """A custom role with TENANT + DEFAULT perms creates bindings at both levels."""
+        role = self.given_v1_role(
+            "mixed_td",
+            default=["subscriptions:organization:read", "inventory:hosts:read"],
+        )
+
+        mappings = BindingMapping.objects.filter(role=role)
+        self.assertEqual(mappings.count(), 2, "Should have 2 BindingMapping records (tenant + workspace)")
+
+        tenant_bm = mappings.filter(resource_type_name="tenant")
+        ws_bm = mappings.filter(resource_type_name="workspace")
+        self.assertEqual(tenant_bm.count(), 1)
+        self.assertEqual(ws_bm.count(), 1)
+
+        # Tenant binding should have the subscriptions permission
+        tenant_binding = tenant_bm.first().get_role_binding()
+        self.assertIn("subscriptions_organization_read", tenant_binding.role.permissions)
+
+        # Workspace binding should have the inventory permission
+        ws_binding = ws_bm.first().get_role_binding()
+        self.assertIn("inventory_hosts_read", ws_binding.role.permissions)
+
+    def test_custom_role_mixed_tenant_root_default_splits_to_tenant_and_root(self):
+        """TENANT + ROOT + DEFAULT: TENANT perms at tenant, rest at root workspace."""
+        role = self.given_v1_role(
+            "mixed_trd",
+            default=["subscriptions:organization:read", "advisor:recommendation:read", "inventory:hosts:read"],
+        )
+
+        mappings = BindingMapping.objects.filter(role=role)
+        self.assertEqual(mappings.count(), 2, "Should have 2 BindingMapping records (tenant + root ws)")
+
+        tenant_bm = mappings.filter(resource_type_name="tenant")
+        ws_bm = mappings.filter(resource_type_name="workspace")
+        self.assertEqual(tenant_bm.count(), 1)
+        self.assertEqual(ws_bm.count(), 1)
+
+        # Workspace binding should be at root workspace (ROOT > DEFAULT)
+        ws_mapping = ws_bm.first()
+        root_ws = Workspace.objects.root(tenant=self.tenant)
+        self.assertEqual(ws_mapping.resource_id, str(root_ws.id))
+
+        # Verify permissions are split correctly
+        tenant_binding = tenant_bm.first().get_role_binding()
+        self.assertIn("subscriptions_organization_read", tenant_binding.role.permissions)
+
+        ws_binding = ws_mapping.get_role_binding()
+        self.assertIn("advisor_recommendation_read", ws_binding.role.permissions)
+        self.assertIn("inventory_hosts_read", ws_binding.role.permissions)
+
+    def test_custom_role_single_tenant_scope_no_split(self):
+        """A role with only TENANT-scoped permissions gets a single tenant binding."""
+        role = self.given_v1_role(
+            "tenant_only",
+            default=["subscriptions:organization:read", "subscriptions:products:write"],
+        )
+
+        mappings = BindingMapping.objects.filter(role=role)
+        self.assertEqual(mappings.count(), 1)
+        self.assertEqual(mappings.first().resource_type_name, "tenant")
+
+    def test_system_role_mixed_scope_creates_per_scope_bindings(self):
+        """A system role with mixed TENANT + workspace perms creates bindings at each scope when assigned to a group."""
+        seed_group()
+        role = self.given_v1_system_role(
+            "mixed_system",
+            permissions=["subscriptions:organization:read", "inventory:hosts:read"],
+            platform_default=True,
+        )
+
+        group, _ = self.given_group("test_group")
+        self.given_roles_assigned_to_group(group, [role])
+
+        # Should have bindings at both tenant and workspace scopes
+        group_uuid = str(group.uuid)
+        mappings = BindingMapping.objects.filter(role=role)
+
+        tenant_mappings = [m for m in mappings if m.resource_type_name == "tenant"]
+        ws_mappings = [m for m in mappings if m.resource_type_name == "workspace"]
+
+        self.assertGreaterEqual(len(tenant_mappings), 1, "Should have tenant-scope binding")
+        self.assertGreaterEqual(len(ws_mappings), 1, "Should have workspace-scope binding")
+
+        # Verify group is assigned in both
+        for m in tenant_mappings:
+            self.assertIn(group_uuid, m.mappings.get("groups", []))
+        for m in ws_mappings:
+            self.assertIn(group_uuid, m.mappings.get("groups", []))
 
 
 @override_settings(ATOMIC_RETRY_DISABLED=True)


### PR DESCRIPTION
## Link(s) to Jira
- https://redhat.atlassian.net/browse/RHCLOUD-48138

## Description of Intent of Change(s)
Split the mixed scope roles that contains tenant scope into two roles

## Local Testing
Unit test

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Split mixed-scope roles that include tenant-level permissions into separate tenant and workspace/root bindings and ensure system role seeding, relation replication, and group-role dual-write mappings respect these per-scope bindings.

Bug Fixes:
- Ensure roles with mixed TENANT and workspace scopes create bindings at each appropriate scope instead of collapsing to a single workspace binding, preventing loss of tenant- or workspace-scoped access.

Enhancements:
- Introduce binding scope calculations and permission splitting utilities to derive per-scope bindings from a role's permissions, including special handling for mixed TENANT and ROOT/DEFAULT scopes.
- Update role migration, dual-write handlers, and system role seeding to support multiple binding scopes per role and route permissions to the correct V2 resources and platform parent roles.

Tests:
- Add unit tests covering binding scope derivation, permission splitting logic, mixed-scope custom and system roles, and seeding behavior to verify correct creation of tenant and workspace/root bindings.