### PR TITLE
[RHCLOUD-48007] Fix MCP confirmation tokens lost across Gunicorn workers

### DIFF
--- a/rbac/rbac/settings.py
+++ b/rbac/rbac/settings.py
@@ -392,6 +392,19 @@ elif REDIS_PASSWORD:
 else:
     _redis_auth = ""
 DEFAULT_REDIS_URL = f"{_redis_scheme}://{_redis_auth}{REDIS_HOST}:{REDIS_PORT}/0"
+DJANGO_CACHE_URL = f"{_redis_scheme}://{_redis_auth}{REDIS_HOST}:{REDIS_PORT}/2"
+
+_cache_location = ENVIRONMENT.get_value("DJANGO_CACHE_BACKEND", default=DJANGO_CACHE_URL)
+if _cache_location.startswith("locmem"):
+    CACHES = {"default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"}}
+else:
+    _cache_config: dict = {"BACKEND": "django.core.cache.backends.redis.RedisCache", "LOCATION": _cache_location}
+    if REDIS_SSL:
+        _cache_options: dict = {"ssl_cert_reqs": REDIS_SSL_CERT_REQS}
+        if REDIS_SSL_CA_CERTS:
+            _cache_options["ssl_ca_certs"] = REDIS_SSL_CA_CERTS
+        _cache_config["OPTIONS"] = _cache_options
+    CACHES = {"default": _cache_config}
 
 CELERY_BROKER_URL = ENVIRONMENT.get_value("CELERY_BROKER_URL", default=DEFAULT_REDIS_URL)
 

--- a/tox.ini
+++ b/tox.ini
@@ -69,6 +69,7 @@ setenv =
   EXTERNAL_SYNC_TOPIC=platform.rbac.sync
   EXTERNAL_CHROME_TOPIC=platform.chrome
   MOCK_KAFKA=True
+  DJANGO_CACHE_BACKEND=locmem://
   MCP_TOOL_TIMEOUT_SECONDS=0
   KAFKA_ENABLED=True
   API_PATH_PREFIX=/api/rbac


### PR DESCRIPTION
## Link(s) to Jira
- [RHCLOUD-48007](https://issues.redhat.com/browse/RHCLOUD-48007)

## Description of Intent of Change(s)

**Problem:** MCP write confirmation tokens always fail with "confirmation token is invalid or expired" in deployed environments, making the two-phase write confirmation feature (RHCLOUD-47929) non-functional.

**Root cause:** The confirmation token system uses `django.core.cache.cache` to store and retrieve tokens, but no `CACHES` setting was configured in Django settings. Django defaults to `LocMemCache` -- an in-memory, per-process cache. With multiple Gunicorn workers (`workers = cpu_resources * 2`), a token generated by Worker A is invisible to Worker B:

1. First MCP call hits Worker A -- generates token, stores in Worker A's process memory
2. Second MCP call (with confirmation token) hits Worker B -- looks up token in Worker B's empty memory -- not found
3. Result: "confirmation token is invalid or expired" on every confirmation attempt

The same problem occurs across pods behind a load balancer.

**Fix:** Add Django's `CACHES` setting using the built-in `RedisCache` backend (Django 4.0+), pointing to the existing Redis instance on DB 2 (separate from Celery on DB 0 and AccessCache on DB 1). This makes `django.core.cache.cache` shared across all workers and pods. No changes to the token logic in `mcp_views.py` -- only the cache backend configuration.

Additionally:
- SSL options (`ssl_cert_reqs`, `ssl_ca_certs`) are passed when `REDIS_SSL` is enabled, matching the pattern used by Celery and `REDIS_CACHE_CONNECTION_PARAMS`
- A `DJANGO_CACHE_BACKEND` env var allows overriding the backend (set to `locmem://` in tests)

## Local Testing

The bug requires multiple Gunicorn workers to reproduce, which is the default production setup. To verify:

1. Run with multiple workers: `gunicorn rbac.wsgi --workers 4`
2. Call any MCP write tool (e.g., `create_group`) -- should return a confirmation token
3. Call the same tool with the confirmation token -- should execute successfully instead of returning "token expired"

Unit tests verify the token flow works in single-process mode (LocMemCache):
```bash
pipenv run tox -e py312-fast -- tests.management.test_mcp_views.MCPWriteConfirmationTests
```

## Checklist
- [x] if API spec changes are required, is the spec updated? (no API changes)
- [x] are there any pre/post merge actions required? if so, document here. (none)
- [x] are theses changes covered by unit tests? (existing MCPWriteConfirmationTests cover token flow)
- [x] if warranted, are documentation changes accounted for? (config-only change)
- [x] does this require migration changes? (no)
- [ ] is there known, direct impact to dependent teams/components?
  - MCP consumers (Lightspeed) will see confirmation tokens start working correctly

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices

[RHCLOUD-48007]: https://redhat.atlassian.net/browse/RHCLOUD-48007?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Configure Django to use a shared cache backend instead of the default per-process cache so multi-phase MCP write confirmation tokens work correctly across workers and pods.

Enhancements:
- Add Django CACHES configuration using RedisCache on a dedicated Redis database, with optional SSL settings consistent with existing Redis usage.
- Allow overriding the Django cache backend via a DJANGO_CACHE_BACKEND environment variable to support alternative backends such as in-memory for tests.

Tests:
- Set DJANGO_CACHE_BACKEND to an in-memory cache in tox test environments to keep tests using LocMemCache while production uses Redis.