### PR TITLE
fix(mcp): sanitize exception messages in JSON-RPC error responses

### DIFF
--- a/rbac/management/mcp_views.py
+++ b/rbac/management/mcp_views.py
@@ -356,8 +356,15 @@ def _call_view_json(
     if response.status_code == 204:
         return json.dumps({"status": "no_content"})
     content = response.content.decode()
+    if response.status_code >= 500:
+        logger.warning("mcp: _call_view_json got HTTP %d from %s: %s", response.status_code, path, content[:500])
+        return json.dumps({"error": f"HTTP {response.status_code}", "detail": "Internal server error"})
     if response.status_code >= 400:
-        return json.dumps({"error": f"HTTP {response.status_code}", "detail": content})
+        try:
+            detail = json.loads(content)
+        except (json.JSONDecodeError, ValueError):
+            detail = f"HTTP {response.status_code}"
+        return json.dumps({"error": f"HTTP {response.status_code}", "detail": detail})
     return content
 
 
@@ -2724,9 +2731,10 @@ def _check_user_permission_v1(request: HttpRequest, username: str, permission: s
     try:
         raw = _call_view(request, _access_view, path, query_params)
     except Exception as e:
+        logger.warning("mcp: check_user_permission failed for user=%s: %s", username, e)
         return json.dumps(
             {
-                "error": f"Failed to check permissions: {e}",
+                "error": "Failed to check permissions",
                 "hint": "Requires org admin or rbac:principal:read permission to check another user.",
             }
         )
@@ -2734,10 +2742,13 @@ def _check_user_permission_v1(request: HttpRequest, username: str, permission: s
     data = json.loads(raw)
 
     if "detail" in data:
+        detail = data["detail"]
+        if not isinstance(detail, str) or len(detail) > 256:
+            detail = "Access denied or unexpected error"
         return json.dumps(
             {
                 "allowed": False,
-                "error": data["detail"],
+                "error": detail,
                 "hint": "Requires org admin or rbac:principal:read permission to check another user.",
             }
         )
@@ -3592,7 +3603,7 @@ def investigate_user_access(
             data = json.loads(raw)
             effective_access = data.get("data", [])
         except Exception as e:
-            effective_access_error = str(e)
+            effective_access_error = "Failed to retrieve effective access"
             logger.warning("mcp: failed to get effective access for user=%s app=%s: %s", username, application, e)
 
     # Step 5: Analyze the expected permission
@@ -5465,7 +5476,8 @@ def _handle_tools_call(request: HttpRequest, request_id: Any, params: dict[str, 
     except TypeError as exc:
         if track:
             _record_metric(tool_name, "invalid_params", time.monotonic() - start)
-        return _error_response(request_id, -32602, f"Invalid params for tool '{tool_name}': {exc}")
+        logger.warning("mcp: tools/call tool='%s' TypeError: %s", tool_name, exc)
+        return _error_response(request_id, -32602, f"Invalid params for tool '{tool_name}'")
     except Exception:
         if track:
             _record_metric(tool_name, "error", time.monotonic() - start)


### PR DESCRIPTION
## Summary
- Sanitize raw Python exception messages (`str(e)`) that were being included in JSON-RPC error responses returned to MCP clients
- These messages can leak internal file paths, database connection details, function signatures, and schema information
- Each fix follows the pattern: log the raw exception server-side for operators, return a generic message to the client

## Changes

| Location | Risk | Fix |
|----------|------|-----|
| `_check_user_permission_v1` (line 2729) | `f"Failed to check permissions: {e}"` leaked DB errors, connection strings | Generic message + `logger.warning` |
| `investigate_user_access` (line 3595) | `str(e)` stored and returned as `effective_access_error` | Generic message, existing logger retained |
| `_handle_tools_call` TypeError (line 5468) | `f"...{exc}"` leaked function signatures and param names | Strip `exc` from response + `logger.warning` |
| `_call_view_json` (line 360) | Raw HTTP response body (possibly debug HTML) as `detail` | Suppress body for 5xx; parse JSON for 4xx |
| `_check_user_permission_v1` detail (line 2740) | Unfiltered `data["detail"]` pass-through from upstream | Validate type and length before returning |

## Test plan
- [x] `tox -e lint` passes
- [x] All 386 MCP tests pass (`tests.management.test_mcp_views`)
- [x] No regressions — only `mcp_views.py` modified

## Summary by Sourcery

Sanitize MCP JSON-RPC and HTTP error responses to avoid leaking internal exception details while preserving diagnostics in server logs.

Bug Fixes:
- Prevent internal HTTP response bodies and debug content from being returned directly to MCP clients, especially for 5xx errors.
- Avoid exposing raw upstream error details and arbitrary content in permission-check responses returned to clients.
- Stop surfacing raw exception messages in effective access investigations and tool call parameter validation errors, limiting client-visible information to generic messages.

Enhancements:
- Log full exception and response details server-side when sanitizing client-facing error messages to aid operators in debugging.