### PR TITLE
[RHCLOUD-42232] Migrating code from UMB to Kafka

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,3 +28,14 @@ V2_APIS_ENABLED=True
 V2_READ_ONLY_API_MODE=False
 V2_BOOTSTRAP_TENANT=True
 WORKSPACE_HIERARCHY_ENABLED=True
+
+# Kafka settings (for local testing)
+# Set to False to disable Kafka and avoid KAFKA_AUTH errors during unit tests
+# Set to True when running integration tests with docker-compose Kafka
+KAFKA_ENABLED=False
+
+# Optional Kafka settings (only needed when KAFKA_ENABLED=True)
+# KAFKA_SERVERS=localhost:9092
+# PRINCIPAL_CLEANUP_DELETION_ENABLED_KAFKA=False
+# PRINCIPAL_CLEANUP_UPDATE_ENABLED_KAFKA=False
+# KAFKA_PRINCIPAL_CLEANUP_JOB_ENABLED=True

--- a/deploy/rbac-clowdapp.yml
+++ b/deploy/rbac-clowdapp.yml
@@ -270,6 +270,12 @@ objects:
             value: ${EPH_ENV}
           - name: PRINCIPAL_CLEANUP_UPDATE_ENABLED_UMB
             value: ${PRINCIPAL_CLEANUP_UPDATE_ENABLED_UMB}
+          - name: PRINCIPAL_CLEANUP_UPDATE_ENABLED_KAFKA
+            value: ${PRINCIPAL_CLEANUP_UPDATE_ENABLED_KAFKA}
+          - name: KAFKA_PRINCIPAL_CLEANUP_TOPIC
+            value: ${KAFKA_PRINCIPAL_CLEANUP_TOPIC}
+          - name: KAFKA_PRINCIPAL_CLEANUP_DLQ_TOPIC
+            value: ${KAFKA_PRINCIPAL_CLEANUP_DLQ_TOPIC}
           - name: V2_MIGRATION_APP_EXCLUDE_LIST
             value: ${V2_MIGRATION_APP_EXCLUDE_LIST}
           - name: V2_STRICT_ACCESS_CHECK_FLAG_APPLICATION_NAMES
@@ -319,6 +325,10 @@ objects:
             value: ${PARITY_CHECK_ORG_IDS}
           - name: PARITY_CHECK_SCHEDULE
             value: ${PARITY_CHECK_SCHEDULE}
+          - name: PRINCIPAL_CLEANUP_DELETION_ENABLED_KAFKA
+            value: ${PRINCIPAL_CLEANUP_DELETION_ENABLED_KAFKA}
+          - name: KAFKA_PRINCIPAL_CLEANUP_JOB_ENABLED
+            value: ${KAFKA_PRINCIPAL_CLEANUP_JOB_ENABLED}
           - name: READ_ONLY_API_MODE
             value: ${READ_ONLY_API_MODE}
           - name: PARITY_CHECK_ENABLED
@@ -616,6 +626,8 @@ objects:
             value: ${EPH_ENV}
           - name: PRINCIPAL_CLEANUP_UPDATE_ENABLED_UMB
             value: ${PRINCIPAL_CLEANUP_UPDATE_ENABLED_UMB}
+          - name: PRINCIPAL_CLEANUP_UPDATE_ENABLED_KAFKA
+            value: ${PRINCIPAL_CLEANUP_UPDATE_ENABLED_KAFKA}
           - name: V2_MIGRATION_APP_EXCLUDE_LIST
             value: ${V2_MIGRATION_APP_EXCLUDE_LIST}
           - name: V2_STRICT_ACCESS_CHECK_FLAG_APPLICATION_NAMES
@@ -851,6 +863,10 @@ objects:
             value: ${RBAC_KAFKA_CONSUMER_GROUP_ID}
           - name: RBAC_KAFKA_CUSTOM_CONSUMER_BROKER
             value: ${RBAC_KAFKA_CUSTOM_CONSUMER_BROKER}
+          - name: KAFKA_PRINCIPAL_CLEANUP_TOPIC
+            value: ${KAFKA_PRINCIPAL_CLEANUP_TOPIC}
+          - name: KAFKA_PRINCIPAL_CLEANUP_DLQ_TOPIC
+            value: ${KAFKA_PRINCIPAL_CLEANUP_DLQ_TOPIC}
           - name: REPLICATION_TO_RELATION_ENABLED
             value: ${REPLICATION_TO_RELATION_ENABLED}
           - name: EPH_ENV
@@ -1101,6 +1117,8 @@ objects:
               value: ${SA_NAME}
             - name: PRINCIPAL_CLEANUP_UPDATE_ENABLED_UMB
               value: ${PRINCIPAL_CLEANUP_UPDATE_ENABLED_UMB}
+            - name: PRINCIPAL_CLEANUP_UPDATE_ENABLED_KAFKA
+              value: ${PRINCIPAL_CLEANUP_UPDATE_ENABLED_KAFKA}
             - name: V2_MIGRATION_APP_EXCLUDE_LIST
               value: ${V2_MIGRATION_APP_EXCLUDE_LIST}
             - name: V2_STRICT_ACCESS_CHECK_FLAG_APPLICATION_NAMES
@@ -1324,6 +1342,8 @@ objects:
               value: ${SA_NAME}
             - name: PRINCIPAL_CLEANUP_UPDATE_ENABLED_UMB
               value: ${PRINCIPAL_CLEANUP_UPDATE_ENABLED_UMB}
+            - name: PRINCIPAL_CLEANUP_UPDATE_ENABLED_KAFKA
+              value: ${PRINCIPAL_CLEANUP_UPDATE_ENABLED_KAFKA}
             - name: V2_MIGRATION_APP_EXCLUDE_LIST
               value: ${V2_MIGRATION_APP_EXCLUDE_LIST}
             - name: V2_STRICT_ACCESS_CHECK_FLAG_APPLICATION_NAMES
@@ -1881,12 +1901,18 @@ parameters:
   value: 'redhat'
 - name: PRINCIPAL_CLEANUP_DELETION_ENABLED_UMB
   description: Allow cleanup job to delete principals via messages from UMB
+- name: PRINCIPAL_CLEANUP_DELETION_ENABLED_KAFKA
+  description: Allow cleanup job to delete principals via messages from Kafka
   value: 'False'
 - name: PRINCIPAL_CLEANUP_UPDATE_ENABLED_UMB
   description: Allow cleanup job to update principals via messages from UMB
+- name: PRINCIPAL_CLEANUP_UPDATE_ENABLED_KAFKA
+  description: Allow cleanup job to update principals via messages from Kafka
   value: 'False'
 - name: UMB_JOB_ENABLED
   description: Temp env to enable the UMB job
+- name: KAFKA_PRINCIPAL_CLEANUP_JOB_ENABLED
+  description: Enable the Kafka-based principal cleanup job
   value: 'True'
 - name: UMB_HOST
   description: Host of the UMB service
@@ -2040,6 +2066,12 @@ parameters:
   value: '1'
 - name: RBAC_KAFKA_CUSTOM_CONSUMER_BROKER
   description: Custom Kafka broker URL for the RBAC Kafka consumer (if empty, uses default Clowder/localhost configuration)
+  value: ''
+- name: KAFKA_PRINCIPAL_CLEANUP_TOPIC
+  description: Kafka topic name for principal cleanup events. REQUIRED when PRINCIPAL_CLEANUP_DELETION_ENABLED_KAFKA=true (deployment will fail if not set).
+  value: ''
+- name: KAFKA_PRINCIPAL_CLEANUP_DLQ_TOPIC
+  description: Kafka Dead Letter Queue topic for failed principal cleanup messages (optional, prevents infinite retry loops)
   value: ''
 - name: ROOT_SCOPE_PERMISSIONS
   description: Comma-separated list of permissions that bind to root workspace scope (supports wildcards like rbac:*:read)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,11 @@ services:
         - RBAC_DESTRUCTIVE_SEEDING_ENABLED_UNTIL=${RBAC_DESTRUCTIVE_SEEDING_ENABLED_UNTIL}
         - KAFKA_ENABLED=false
         - RBAC_KAFKA_CUSTOM_CONSUMER_BROKER=kafka:9092
+        - PRINCIPAL_CLEANUP_DELETION_ENABLED_KAFKA=False
+        - PRINCIPAL_CLEANUP_UPDATE_ENABLED_KAFKA=False
+        - KAFKA_PRINCIPAL_CLEANUP_JOB_ENABLED=True
+        - KAFKA_PRINCIPAL_CLEANUP_TOPIC=rbac.principal-cleanup
+        - KAFKA_PRINCIPAL_CLEANUP_DLQ_TOPIC=rbac.principal-cleanup.dlq
         - RBAC_KAFKA_CONSUMER_TOPIC=outbox.event.relations-replication-event
         - RBAC_KAFKA_CONSUMER_GROUP_ID=rbac-consumer-group
         - REPLICATION_TO_RELATION_ENABLED=true
@@ -64,6 +69,8 @@ services:
         rbac-worker:
           condition: service_healthy
         rbac-scheduler:
+          condition: service_healthy
+        kafka:
           condition: service_healthy
       healthcheck:
         test: ["CMD-SHELL", "python3 -c \"import urllib.request; urllib.request.urlopen('http://localhost:8080/metrics')\""]
@@ -134,6 +141,34 @@ services:
       timeout: 5s
       retries: 3
       start_period: 5s
+
+  zookeeper:
+    container_name: rbac_zookeeper
+    image: confluentinc/cp-zookeeper:7.5.0
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+    ports:
+      - "2181:2181"
+
+  kafka:
+    container_name: rbac_kafka
+    image: confluentinc/cp-kafka:7.5.0
+    depends_on:
+      - zookeeper
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: "true"
+    healthcheck:
+      test: ["CMD-SHELL", "kafka-topics --bootstrap-server localhost:9092 --list"]
+      interval: 10s
+      timeout: 10s
+      retries: 5
 
   wait_for_app:
     container_name: wait_for_app

--- a/rbac/feature_flags.py
+++ b/rbac/feature_flags.py
@@ -43,6 +43,8 @@ class FeatureFlags:
     TOGGLE_USE_ROLE_BINDING_VIEW_PERMISSION = "rbac.use-role-binding-view-permission.enabled"
     # Per-org flag: when enabled, the org uses v2 APIs for write operations and v1 write APIs are blocked.
     TOGGLE_V2_EDIT_API_ENABLED = "platform.rbac.workspaces"
+    # When enabled, use Kafka for principal cleanup; when disabled, use UMB.
+    TOGGLE_USE_KAFKA_CLEANUP = "rbac.principal-cleanup.use-kafka.enabled"
     # Per-org flag: when enabled, the org uses only V2 access checks for HBI (and V1 access checks are blocked).
     TOGGLE_V2_ADDITIONAL_MANDATORY_ACCESS_CHECK_REQUIRED = "hbi.rbac-v2"
 
@@ -183,6 +185,87 @@ class FeatureFlags:
             context={"orgId": str(org_id)},
             fallback_function=lambda ignored_toggle_name, ignored_context: settings.V2_EDIT_API_ENABLED,
         )
+
+    def is_kafka_principal_cleanup_enabled(self):
+        """Check whether to use Kafka for principal cleanup.
+
+        DEPRECATED: Use get_principal_cleanup_mode() instead for 3-state control.
+
+        When enabled (True), use Kafka for principal cleanup.
+        When disabled (False), use UMB for principal cleanup.
+        Falls back to False (UMB) if Unleash is unavailable - UMB is the proven original method.
+        """
+        return self.is_enabled(
+            feature_name=self.TOGGLE_USE_KAFKA_CLEANUP,
+            fallback_function=lambda ignored_toggle_name, ignored_context: False,
+        )
+
+    def get_principal_cleanup_mode(self) -> str:
+        """
+        Get the principal cleanup mode using the feature flag.
+
+        This method supports 4 modes controlled by the Unleash flag value:
+        - 'umb_only' (flag disabled OR flag enabled with missing/unrecognized variant):
+          Only UMB consumer runs and writes to DB
+        - 'kafka_shadow' (flag enabled with kafka_shadow variant): Both UMB and Kafka run, only UMB writes
+          (Kafka dry-run)
+        - 'kafka_validation' (flag enabled with kafka_validation variant): Kafka tries to write first,
+          UMB writes only if Kafka fails (Phase 2 validation)
+        - 'kafka_active' (flag enabled with kafka_active variant): Only Kafka consumer runs and writes to DB
+
+        IMPORTANT: Enabling the flag WITHOUT setting a valid variant will keep you on UMB (umb_only mode).
+        This is a safety feature to prevent accidental Kafka activation. You must explicitly set the variant
+        to kafka_shadow, kafka_validation, or kafka_active to use Kafka.
+
+        Returns:
+            str: One of 'umb_only', 'kafka_shadow', 'kafka_validation', or 'kafka_active'
+        """
+        if self.client is None:
+            self.initialize()
+
+        if self.client is None:
+            logger.warning("FeatureFlags not initialized, defaulting to umb_only mode")
+            return "umb_only"
+
+        # First check if the toggle is enabled
+        is_enabled = self.is_enabled(
+            feature_name=self.TOGGLE_USE_KAFKA_CLEANUP,
+            fallback_function=lambda ignored_toggle_name, ignored_context: False,
+        )
+
+        if not is_enabled:
+            # Flag is disabled -> UMB only mode
+            return "umb_only"
+
+        # Flag is enabled -> check for variant to determine mode
+        try:
+            variant = self.client.get_variant(
+                self.TOGGLE_USE_KAFKA_CLEANUP,
+                fallback_variant={"name": "umb_only", "enabled": False},
+            )
+
+            mode = variant.get("name", "umb_only")
+
+            # Validate mode - only these variants are valid when flag is enabled
+            if mode in ["kafka_shadow", "kafka_validation", "kafka_active"]:
+                return mode
+            else:
+                # Unknown/missing variant when flag is enabled -> safe default is UMB
+                # This prevents accidental Kafka activation and requires explicit variant selection
+                logger.warning(
+                    f"Flag 'rbac.principal-cleanup.use-kafka.enabled' is ON but variant '{mode}' is not recognized. "
+                    f"Staying on UMB (umb_only mode) for safety. "
+                    f"To activate Kafka, set variant to: kafka_shadow, kafka_validation, or kafka_active"
+                )
+                return "umb_only"
+
+        except Exception as e:
+            logger.warning(f"Error getting variant for principal cleanup mode: {e}, falling back to umb_only")
+            return "umb_only"
+
+    def is_kafka_shadow_mode_enabled(self) -> bool:
+        """Check if Kafka is in shadow/dry-run mode."""
+        return self.get_principal_cleanup_mode() == "kafka_shadow"
 
     def is_v2_strict_access_check_enabled(self, org_id: str) -> bool:
         """Check whether strict V2 access checks are required in the given org.

--- a/rbac/management/principal/cleaner.py
+++ b/rbac/management/principal/cleaner.py
@@ -17,14 +17,20 @@
 
 """Handler for principal clean up."""
 
+import base64
+import json
 import logging
 import os
 import ssl
-from typing import Optional
+from typing import NamedTuple, Optional
+from xml.parsers.expat import ExpatError
 
 import xmltodict
+from core.kafka import RBACProducer
 from django.conf import settings
 from django.db import connection, transaction
+from kafka import KafkaConsumer
+from kafka.errors import KafkaError
 from management.principal.model import Principal
 from management.principal.proxy import PrincipalProxy, external_principal_to_user
 from management.relation_replicator.outbox_replicator import OutboxReplicator
@@ -50,8 +56,10 @@ CA_LOC = "/opt/rbac/rbac/management/principal/umb_certificates/ca.crt"
 CERT_LOC = "/opt/rbac/rbac/management/principal/umb_certificates/tls.crt"
 KEY_LOC = "/opt/rbac/rbac/management/principal/umb_certificates/tls.key"
 
+
 LOCK_ID = 42  # For Keith, with Love
 
+# UMB Metric Messages
 METRIC_STOMP_MESSAGES_ACK_TOTAL = "stomp_messages_ack_total"
 METRIC_STOMP_MESSAGES_NACK_TOTAL = "stomp_messages_nack_total"
 stomp_messages_ack_total = Counter(
@@ -61,6 +69,42 @@ stomp_messages_ack_total = Counter(
 stomp_messages_nack_total = Counter(
     METRIC_STOMP_MESSAGES_NACK_TOTAL,
     "Number of stomp UMB messages that failed to be processed",
+)
+
+# KAFKA Metric Messages
+METRIC_KAFKA_MESSAGES_SUCCESS_TOTAL = "kafka_messages_success_total"
+METRIC_KAFKA_MESSAGES_FAILURE_TOTAL = "kafka_messages_failure_total"
+kafka_messages_success_total = Counter(
+    METRIC_KAFKA_MESSAGES_SUCCESS_TOTAL,
+    "Number of Kafka messages processed successfully",
+)
+kafka_messages_failure_total = Counter(
+    METRIC_KAFKA_MESSAGES_FAILURE_TOTAL,
+    "Number of Kafka messages that failed to be processed",
+)
+
+# KAFKA Shadow Mode Metrics
+METRIC_KAFKA_DRY_RUN_MESSAGES_TOTAL = "kafka_dry_run_messages_total"
+METRIC_KAFKA_DRY_RUN_ERRORS_TOTAL = "kafka_dry_run_errors_total"
+kafka_dry_run_messages_total = Counter(
+    METRIC_KAFKA_DRY_RUN_MESSAGES_TOTAL,
+    "Number of Kafka messages processed in dry-run/shadow mode",
+)
+kafka_dry_run_errors_total = Counter(
+    METRIC_KAFKA_DRY_RUN_ERRORS_TOTAL,
+    "Number of Kafka messages that would have failed if not in dry-run mode",
+)
+
+# KAFKA Validation Mode Metrics
+METRIC_KAFKA_VALIDATION_SUCCESS_TOTAL = "kafka_validation_success_total"
+METRIC_KAFKA_VALIDATION_FALLBACK_TOTAL = "kafka_validation_fallback_total"
+kafka_validation_success_total = Counter(
+    METRIC_KAFKA_VALIDATION_SUCCESS_TOTAL,
+    "Number of times Kafka succeeded in validation mode (no UMB fallback needed)",
+)
+kafka_validation_fallback_total = Counter(
+    METRIC_KAFKA_VALIDATION_FALLBACK_TOTAL,
+    "Number of times UMB fallback was triggered in validation mode",
 )
 
 
@@ -148,7 +192,7 @@ QUEUE = f"/queue/Consumer.{settings.SA_NAME}.users-subscription.VirtualTopic.can
 UMB_CLIENT = Stomp(CONFIG)
 
 
-def retrieve_user_info(message) -> User:
+def retrieve_user_info_umb(message) -> User:
     """
     Retrieve user info from the message.
 
@@ -161,7 +205,7 @@ def retrieve_user_info(message) -> User:
         if (id := header.get("InstanceId")) is not None:
             instance_id = id
 
-    logger.debug("retrieve_user_info: Processing message with instance_id=%s", instance_id)
+    logger.debug("retrieve_user_info_UMB: Processing message with instance_id=%s", instance_id)
 
     message_user = message["Payload"]["Sync"]["User"]
     identifiers = message_user["Identifiers"]
@@ -189,12 +233,96 @@ def retrieve_user_info(message) -> User:
         # identifiers["Reference"] might be a dict
         if not isinstance((refs := identifiers["Reference"]), list):
             refs = [identifiers["Reference"]]
+        # Preserve original UMB behavior: use first matching reference and stop
+        # This maintains production behavior where messages typically have one of each reference type
+        # If multiple WEB/Customer or EBS/Account references exist, use the first one
         for ref in refs:
             if ref["@system"] == "WEB" and ref["@entity-name"] == "Customer" and ref["@qualifier"] == "id":
                 user.org_id = ref["#text"]
                 break
             if ref["@system"] == "EBS" and ref["@entity-name"] == "Account" and ref["@qualifier"] == "number":
                 user.account = ref["#text"]
+                break
+
+        return user
+
+    user_data = bop_resp["data"][0]
+    return external_principal_to_user(user_data)
+
+
+def retrieve_user_info_kafka(message) -> User:
+    """
+    Retrieve user info from the Kafka message.
+
+    Args:
+        message: JSON message from Kafka containing user event data
+
+    returns:
+        user: User object as of latest known state.
+    """
+    instance_id: Optional[str] = None
+
+    # Extract instance ID from header if present
+    if (header := message.get("Header")) is not None:
+        if (id := header.get("InstanceId")) is not None:
+            instance_id = id
+
+    logger.debug("retrieve_user_info_kafka: Processing message with instance_id=%s", instance_id)
+
+    # Navigate through JSON structure (similar to XML but without @ and # prefixes)
+    message_user = message["Payload"]["Sync"]["User"]
+    identifiers = message_user["Identifiers"]
+    user_id: Optional[str] = None
+
+    # Handle both list and single identifier cases
+    identifier_list = identifiers.get("Identifier", [])
+    if not isinstance(identifier_list, list):
+        identifier_list = [identifier_list]
+
+    # Find the user ID from identifiers
+    for identifier in identifier_list:
+        is_web_user_id = (
+            identifier.get("system") == "WEB"
+            and identifier.get("entity-name") == "User"
+            and identifier.get("qualifier") == "id"
+        )
+        if is_web_user_id:
+            user_id = identifier.get("text") or identifier.get("value")
+            break
+
+    if user_id is None:
+        raise ValueError(f"User id not found in message. instance_id={instance_id}")
+
+    # Query BOP for user information
+    bop_resp = PROXY.request_filtered_principals([user_id], options={"query_by": "user_id", "return_id": True})
+
+    if not bop_resp["data"]:  # User has been deleted
+        # Get data from message instead
+        user = User()
+        user.user_id = user_id
+        user.is_active = False
+        user.username = message_user["Person"]["Credentials"]["Login"]
+
+        # Handle references (might be a dict or list)
+        references = identifiers.get("Reference", [])
+        if not isinstance(references, list):
+            references = [references]
+
+        # Match UMB behavior: use first matching reference and stop (preserve production semantics)
+        # Kafka receives the same messages as UMB (just different transport), so behavior should be identical
+        # Messages typically have one WEB/Customer reference (org_id) and one EBS/Account reference (account)
+        for ref in references:
+            is_web_customer = (
+                ref.get("system") == "WEB" and ref.get("entity-name") == "Customer" and ref.get("qualifier") == "id"
+            )
+            is_ebs_account = (
+                ref.get("system") == "EBS" and ref.get("entity-name") == "Account" and ref.get("qualifier") == "number"
+            )
+            if is_web_customer:
+                user.org_id = ref.get("text") or ref.get("value")
+                break
+            if is_ebs_account:
+                user.account = ref.get("text") or ref.get("value")
                 break
 
         return user
@@ -221,7 +349,7 @@ def process_umb_event(frame, umb_client: Stomp, bootstrap_service: TenantBootstr
             data_dict = xmltodict.parse(body)
             canonical_message = data_dict.get("CanonicalMessage")
 
-            user = retrieve_user_info(canonical_message)
+            user = retrieve_user_info_umb(canonical_message)
             # By default, only process disabled users.
             # If the setting is enabled, process all users.
             if not user.is_active or settings.PRINCIPAL_CLEANUP_UPDATE_ENABLED_UMB:
@@ -243,6 +371,237 @@ def process_umb_event(frame, umb_client: Stomp, bootstrap_service: TenantBootstr
             stomp_messages_nack_total.inc()
 
     return True
+
+
+class MessageProcessingResult(NamedTuple):
+    """
+    Result of processing a Kafka message.
+
+    Attributes:
+        should_continue: False if another listener is running (lock contention), True otherwise
+        success: True if message was processed successfully, False if it failed
+    """
+
+    should_continue: bool
+    success: bool
+
+
+def process_kafka_message(
+    message, bootstrap_service: TenantBootstrapService, dlq_producer=None, dry_run: bool = False
+) -> MessageProcessingResult:
+    """
+    Process each Kafka message.
+
+    Args:
+        message: Kafka message containing user event data
+        bootstrap_service: Service for updating user/tenant state
+        dlq_producer: Optional RBACProducer instance for sending failed messages to DLQ
+        dry_run: If True, validate message but don't write to database (shadow mode)
+
+    Returns:
+        MessageProcessingResult with:
+        - should_continue: False if another listener is running (lock contention), True otherwise
+        - success: True if message was processed successfully, False if it failed
+    """
+    with transaction.atomic():
+        # This is locked per transaction to ensure another listener process does not run concurrently.
+        if not _lock_listener():
+            # If there is another listener, let it run and abort this one.
+            logger.info("process_kafka_message: Another listener is running. Aborting.")
+            return MessageProcessingResult(should_continue=False, success=False)
+
+        try:
+            # Handle tombstone messages (Kafka deletes with null value)
+            if message.value is None:
+                logger.warning(
+                    "process_kafka_message: Received tombstone message (null value) at offset %d. "
+                    "Tombstones are not expected in principal cleanup topic. Skipping.",
+                    message.offset,
+                )
+                kafka_messages_success_total.inc()
+                return MessageProcessingResult(should_continue=True, success=True)
+
+            # Parse message - handle both XML (from UMB bridge) and JSON (from native Kafka producer)
+            # The messaging bridge copies raw UMB message bodies (XML) to Kafka during migration
+            # Decode here (not in consumer config) so UTF-8 errors reach our error handling/DLQ logic
+            message_value = message.value.decode("utf-8") if isinstance(message.value, bytes) else message.value
+
+            # Try JSON first, then fallback to XML - more robust than string prefix detection
+            # This handles edge cases like leading whitespace (" <CanonicalMessage>")
+            parse_error = None
+            user = None
+
+            try:
+                # Attempt JSON parse first (most common in Kafka-native deployments)
+                message_data = json.loads(message_value)
+                canonical_message = message_data.get("CanonicalMessage", message_data)
+                # Use Kafka retrieval logic for JSON messages (plain keys, no @ or # prefixes)
+                user = retrieve_user_info_kafka(canonical_message)
+            except json.JSONDecodeError as json_error:
+                # Not valid JSON - try XML (from UMB bridge during migration)
+                try:
+                    data_dict = xmltodict.parse(message_value)
+                    canonical_message = data_dict.get("CanonicalMessage")
+                    # Use UMB retrieval logic for XML-parsed messages (handles @ and #text attributes)
+                    user = retrieve_user_info_umb(canonical_message)
+                except ExpatError as xml_error:
+                    # Neither JSON nor XML - this is an unprocessable message
+                    parse_error = Exception(
+                        f"Message is neither valid JSON nor valid XML. "
+                        f"JSON error: {json_error}. XML error: {xml_error}"
+                    )
+                    raise parse_error
+
+            if dry_run:
+                # DRY RUN MODE: Validate message structure and log what would happen
+                logger.debug("DRY RUN: Would process user")
+
+                # Validate message structure is correct but DON'T call update_user (no DB writes)
+                if not user.is_active or settings.PRINCIPAL_CLEANUP_UPDATE_ENABLED_KAFKA:
+                    logger.debug("DRY RUN: Would call bootstrap_service.update_user()")
+
+                kafka_messages_success_total.inc()
+                kafka_dry_run_messages_total.inc()
+                return MessageProcessingResult(should_continue=True, success=True)
+
+            else:
+                # NORMAL MODE: Actually update the database
+                # By default, only process disabled users.
+                # If the setting is enabled, process all users.
+                if not user.is_active or settings.PRINCIPAL_CLEANUP_UPDATE_ENABLED_KAFKA:
+                    # If Tenant is not already ready, don't ready it
+                    bootstrap_service.update_user(user, ready_tenant=False)
+
+                kafka_messages_success_total.inc()
+                return MessageProcessingResult(should_continue=True, success=True)
+        except Exception as e:
+            mode_msg = " (DRY RUN)" if dry_run else ""
+            logger.error(f"process_kafka_message: Error processing Kafka message{mode_msg}: %s", str(e))
+            capture_exception(e)
+            kafka_messages_failure_total.inc()
+
+            # Determine if this is a permanent error (unprocessable message) or transient error (retry later)
+            # Permanent errors: Parsing failures, missing fields, schema violations, wrong types/structure
+            # Transient errors: Network issues, DB connection problems, temporary service unavailability
+            is_permanent_error = isinstance(
+                e,
+                (
+                    json.JSONDecodeError,  # Malformed JSON
+                    ExpatError,  # Malformed XML (from xmltodict.parse)
+                    KeyError,  # Missing required field in message
+                    ValueError,  # Invalid data format
+                    UnicodeDecodeError,  # Invalid message encoding
+                    AttributeError,  # Wrong message structure (e.g., accessing nonexistent attributes)
+                    TypeError,  # Wrong type in message (e.g., iterating over non-iterable)
+                ),
+            )
+
+            if dry_run:
+                # In dry-run, track errors but ALWAYS continue processing (never block)
+                kafka_dry_run_errors_total.inc()
+                if is_permanent_error:
+                    logger.warning("DRY RUN: Permanent error detected - testing DLQ path.")
+                    # In dry-run, test DLQ functionality by sending to DLQ (fall through to DLQ logic)
+                else:
+                    logger.warning("DRY RUN: Transient error detected - message would be retried in production.")
+                    # In dry-run mode, always commit offset to continue validation (never block on any errors)
+                    return MessageProcessingResult(should_continue=True, success=True)
+
+            # For permanent errors, send to DLQ. For transient errors (production only), retry.
+            if not dry_run and not is_permanent_error:
+                # Production mode: transient errors don't commit offset and will retry
+                logger.warning(
+                    "process_kafka_message: Transient error at offset %d. "
+                    "Will not commit offset - message will be retried on next consumer run.",
+                    message.offset,
+                )
+                return MessageProcessingResult(should_continue=True, success=False)
+
+            # Permanent error (or dry-run permanent error) - send to DLQ inside transaction
+            # This prevents race window where advisory lock is released before DLQ send completes
+            if dlq_producer and hasattr(settings, "KAFKA_PRINCIPAL_CLEANUP_DLQ_TOPIC"):
+                dlq_topic = settings.KAFKA_PRINCIPAL_CLEANUP_DLQ_TOPIC
+                if dlq_topic:
+                    try:
+                        # Build DLQ message with error context
+                        # NOTE: original_message may contain PII (usernames, org/account IDs)
+                        # Ensure DLQ topic has appropriate access controls and retention policy
+
+                        # Preserve invalid UTF-8 payloads by base64-encoding them
+                        # This allows poison messages (e.g., UnicodeDecodeError) to be delivered to DLQ
+                        if isinstance(message.value, bytes):
+                            try:
+                                # Try to decode as UTF-8 first
+                                original_message = message.value.decode("utf-8")
+                                message_encoding = "utf-8"
+                            except UnicodeDecodeError:
+                                # If UTF-8 decode fails, base64-encode the raw bytes to preserve them
+                                original_message = base64.b64encode(message.value).decode("ascii")
+                                message_encoding = "base64"
+                        else:
+                            # Already a string (shouldn't happen with raw consumer, but handle it)
+                            original_message = message.value
+                            message_encoding = "string"
+
+                        dlq_message = {
+                            "original_message": original_message,
+                            "message_encoding": message_encoding,
+                            "error": str(e),
+                            "error_type": type(e).__name__,
+                            "partition": message.partition,
+                            "offset": message.offset,
+                            "timestamp": message.timestamp,
+                            "dry_run": dry_run,
+                        }
+
+                        # Send to DLQ while holding advisory lock (inside transaction)
+                        # This prevents race window where another consumer could pick up the same message
+                        # before DLQ send completes. Trade-off: holding DB lock during network I/O,
+                        # but ensures exactly-once semantics for DLQ delivery.
+                        dlq_producer.send_kafka_message(dlq_topic, dlq_message)
+                        logger.info(
+                            "process_kafka_message: Sent failed message to DLQ topic %s (partition=%d, offset=%d)",
+                            dlq_topic,
+                            message.partition,
+                            message.offset,
+                        )
+
+                        # Rollback any partial DB writes from update_user before transaction commits
+                        # This prevents inconsistent state where message is in DLQ but partial changes are committed
+                        transaction.set_rollback(True)
+
+                        # Return success=True so offset gets committed (message successfully moved to DLQ)
+                        return MessageProcessingResult(should_continue=True, success=True)
+
+                    except Exception as dlq_error:
+                        logger.error(
+                            "process_kafka_message: Failed to send message to DLQ: %s. "
+                            "Message will be retried on restart.",
+                            str(dlq_error),
+                        )
+                        capture_exception(dlq_error)
+                        # DLQ send failed, so don't commit offset (will retry message)
+                        # Exception: in dry-run mode, commit the offset to allow processing to continue
+                        if dry_run:
+                            logger.warning(
+                                "process_kafka_message: DLQ failure in dry-run mode, committing offset anyway"
+                            )
+                            return MessageProcessingResult(should_continue=True, success=True)
+                        return MessageProcessingResult(should_continue=True, success=False)
+                else:
+                    logger.warning(
+                        "process_kafka_message: No DLQ topic configured. "
+                        "Failed message at offset %d will be retried on restart.",
+                        message.offset,
+                    )
+                    return MessageProcessingResult(should_continue=True, success=False if not dry_run else True)
+            else:
+                logger.warning(
+                    "process_kafka_message: No DLQ producer configured. "
+                    "Failed message at offset %d will be retried on restart.",
+                    message.offset,
+                )
+                return MessageProcessingResult(should_continue=True, success=False if not dry_run else True)
 
 
 def process_principal_events_from_umb(bootstrap_service: Optional[TenantBootstrapService] = None):
@@ -268,6 +627,133 @@ def process_principal_events_from_umb(bootstrap_service: Optional[TenantBootstra
     finally:
         UMB_CLIENT.disconnect()
         logger.info("process_tenant_principal_events: Principal event processing finished.")
+
+
+def process_principal_events_from_kafka(
+    bootstrap_service: Optional[TenantBootstrapService] = None, dry_run: bool = False
+):
+    """
+    Process principal events from Kafka.
+
+    Args:
+        bootstrap_service: Service for tenant/user operations
+        dry_run: If True, process messages but don't write to database (shadow mode)
+    """
+    mode_msg = " (DRY RUN - SHADOW MODE)" if dry_run else ""
+    logger.info(f"process_principal_events_from_kafka: Start processing principal events from Kafka{mode_msg}.")
+
+    if dry_run:
+        logger.warning(
+            "KAFKA SHADOW MODE: Messages will be processed but NO database writes will occur. "
+            "This is for validation only."
+        )
+    bootstrap_service = bootstrap_service or get_tenant_bootstrap_service(OutboxReplicator())
+
+    # Validate required configuration
+    topic = settings.KAFKA_PRINCIPAL_CLEANUP_TOPIC
+    if not topic:
+        logger.error(
+            "process_principal_events_from_kafka: KAFKA_PRINCIPAL_CLEANUP_TOPIC is not configured. "
+            "Cannot process principal events from Kafka."
+        )
+        return
+
+    # Build Kafka consumer configuration
+    # NOTE: This consumer runs periodically via Celery beat (every 60s) and consumes for 15s,
+    # creating a 45-second gap between consumption periods. This matches the UMB behavior
+    # where the consumer also ran periodically. For continuous consumption, a persistent
+    # consumer (like launch-rbac-kafka-consumer) would be more appropriate, but this
+    # approach maintains compatibility with the existing UMB-based architecture.
+
+    # Include ENV_NAME in group_id to prevent offset interference across environments
+    # In multi-env setups (staging, ephemeral, CI) that share a Kafka cluster, environments
+    # must use distinct consumer groups to avoid message loss and offset conflicts
+    env_name = getattr(settings, "ENV_NAME", "stage")
+    kafka_config = {
+        "bootstrap_servers": settings.KAFKA_SERVERS,
+        "group_id": f"{settings.SA_NAME}-{env_name}-principal-cleanup",
+        "auto_offset_reset": "earliest",
+        "enable_auto_commit": False,  # Manual commit for at-least-once semantics
+        # No value_deserializer - leave as bytes to handle tombstones and UTF-8 errors in process_kafka_message
+        "consumer_timeout_ms": 15000,  # 15 second timeout per run, matches UMB behavior
+    }
+
+    # Add authentication if configured
+    kafka_auth = getattr(settings, "KAFKA_AUTH", None)
+    if kafka_auth:
+        kafka_config.update(kafka_auth)
+
+    # Initialize consumer to None to avoid UnboundLocalError in finally block
+    consumer = None
+
+    # Initialize DLQ producer if DLQ topic is configured
+    dlq_topic = getattr(settings, "KAFKA_PRINCIPAL_CLEANUP_DLQ_TOPIC", None)
+    dlq_producer = None
+    if dlq_topic:
+        try:
+            dlq_producer = RBACProducer()
+            logger.info("process_principal_events_from_kafka: DLQ producer initialized for topic: %s", dlq_topic)
+        except Exception as e:
+            logger.warning(
+                "process_principal_events_from_kafka: Failed to initialize DLQ producer: %s. "
+                "Failed messages will be retried instead of sent to DLQ.",
+                str(e),
+            )
+
+    try:
+        consumer = KafkaConsumer(topic, **kafka_config)
+        logger.info("process_principal_events_from_kafka: Connected to Kafka, subscribed to topic: %s", topic)
+
+        # Process messages
+        for message in consumer:
+            mode_suffix = " (DRY RUN)" if dry_run else ""
+            logger.info(
+                "process_principal_events_from_kafka: Processing message from partition %d at offset %d%s",
+                message.partition,
+                message.offset,
+                mode_suffix,
+            )
+            result = process_kafka_message(message, bootstrap_service, dlq_producer, dry_run=dry_run)
+            if not result.should_continue:
+                # Lock contention - another listener is running, abort this consumer
+                logger.info("process_principal_events_from_kafka: Lock contention detected, aborting consumer.")
+                break
+
+            if not result.success:
+                logger.warning(
+                    "process_principal_events_from_kafka: Message processing failed at offset %d. "
+                    "Stopping consumer to preserve at-least-once semantics. "
+                    "Consumer will retry from this offset on restart.",
+                    message.offset,
+                )
+                break
+
+            try:
+                consumer.commit()
+                logger.debug(
+                    "process_principal_events_from_kafka: Committed offset %d for partition %d",
+                    message.offset,
+                    message.partition,
+                )
+            except Exception as commit_error:
+                logger.error(
+                    "process_principal_events_from_kafka: Failed to commit offset %d: %s",
+                    message.offset,
+                    commit_error,
+                )
+                break
+
+    except KafkaError as e:
+        logger.error("process_principal_events_from_kafka: Kafka error: %s", str(e))
+        capture_exception(e)
+    finally:
+        if consumer is not None:
+            try:
+                consumer.close()
+                logger.info("process_principal_events_from_kafka: Kafka consumer closed.")
+            except Exception as e:
+                logger.error("process_principal_events_from_kafka: Error closing consumer: %s", str(e))
+        logger.info("process_principal_events_from_kafka: Principal event processing finished.")
 
 
 def _lock_listener() -> bool:

--- a/rbac/management/tasks.py
+++ b/rbac/management/tasks.py
@@ -33,6 +33,8 @@ logger = logging.getLogger(__name__)
 @shared_task
 def principal_cleanup():
     """Celery task to clean up principals no longer existing."""
+    from management.principal.cleaner import clean_tenants_principals
+
     # Admin action - SEC-MON-REQ-1 compliance (EOI-3 admin_action, EOI-1 pii_manipulation)
     logger.info(
         "Principal cleanup task started",
@@ -44,7 +46,6 @@ def principal_cleanup():
         },
     )
     try:
-        from management.principal.cleaner import clean_tenants_principals
 
         clean_tenants_principals()
         # Admin action - SEC-MON-REQ-1 compliance (EOI-3 admin_action, EOI-1 pii_manipulation)
@@ -78,6 +79,146 @@ def principal_cleanup_via_umb():
     from management.principal.cleaner import process_principal_events_from_umb
 
     process_principal_events_from_umb()
+
+
+@shared_task
+def principal_cleanup_via_kafka():
+    """Celery task to clean up principals via Kafka messages."""
+    from management.principal.cleaner import process_principal_events_from_kafka
+
+    process_principal_events_from_kafka()
+
+
+@shared_task
+def principal_cleanup_via_message_bus():
+    """
+    Dispatcher task that checks Unleash flag at runtime to route principal cleanup.
+
+    This task is scheduled when both PRINCIPAL_CLEANUP_DELETION_ENABLED_UMB and
+    PRINCIPAL_CLEANUP_DELETION_ENABLED_KAFKA are enabled. It allows runtime switching
+    between message bus implementations via Unleash flag without requiring worker restart.
+
+    Supported modes (controlled by rbac.principal-cleanup.use-kafka.enabled flag):
+    - 'umb_only' (flag disabled or unknown variant): Only UMB consumer runs and writes to DB
+    - 'kafka_shadow' (flag enabled with kafka_shadow variant): Both UMB and Kafka run, only UMB writes (Kafka dry-run)
+    - 'kafka_validation' (flag enabled with kafka_validation variant): Kafka tries first, UMB fallback if Kafka fails
+    - 'kafka_active' (flag enabled with kafka_active variant): Only Kafka consumer runs and writes to DB
+      NOTE: Raises RuntimeError if Kafka is disabled (KAFKA_PRINCIPAL_CLEANUP_JOB_ENABLED=False)
+            to prevent silent fallback to UMB. Operators must explicitly change to 'umb_only' mode.
+    """
+    from feature_flags import FEATURE_FLAGS
+    from management.principal.cleaner import process_principal_events_from_kafka, process_principal_events_from_umb
+    from sentry_sdk import capture_exception
+
+    mode = FEATURE_FLAGS.get_principal_cleanup_mode()
+    logger.info(f"Principal cleanup mode: {mode}")
+
+    if mode == "umb_only":
+        # UMB-only mode: Only UMB processes and writes to DB
+        if settings.UMB_JOB_ENABLED:
+            logger.info("UMB-only mode: processing via UMB")
+            process_principal_events_from_umb()
+        else:
+            logger.warning("UMB mode selected but UMB_JOB_ENABLED is False")
+
+    elif mode == "kafka_shadow":
+        # Shadow mode: Both run, Kafka in dry-run (no DB writes)
+        # Isolate UMB and Kafka so one backend failure doesn't prevent the other from running
+        logger.info("Shadow mode: processing via UMB (active) and Kafka (dry-run)")
+
+        if settings.UMB_JOB_ENABLED:
+            try:
+                logger.info("Shadow mode: Running UMB consumer (active - writes to DB)")
+                process_principal_events_from_umb()
+            except Exception as umb_error:
+                logger.error("Shadow mode: UMB consumer failed: %s", str(umb_error))
+                capture_exception(umb_error)
+        else:
+            logger.warning("Shadow mode requires UMB but UMB_JOB_ENABLED is False")
+
+        if settings.KAFKA_PRINCIPAL_CLEANUP_JOB_ENABLED:
+            try:
+                logger.info("Shadow mode: Running Kafka consumer (dry-run - no DB writes)")
+                process_principal_events_from_kafka(dry_run=True)
+            except Exception as kafka_error:
+                logger.error("Shadow mode: Kafka consumer (dry-run) failed: %s", str(kafka_error))
+                capture_exception(kafka_error)
+        else:
+            logger.warning("Shadow mode requires Kafka but KAFKA_PRINCIPAL_CLEANUP_JOB_ENABLED is False")
+
+    elif mode == "kafka_validation":
+        # Validation mode: Kafka tries first, UMB fallback if Kafka fails
+        # This allows comparing Kafka behavior while ensuring no data loss
+        from management.principal.cleaner import kafka_validation_success_total, kafka_validation_fallback_total
+
+        logger.info("Validation mode: Kafka attempts DB write, UMB fallback if Kafka fails")
+
+        kafka_success = False
+
+        if settings.KAFKA_PRINCIPAL_CLEANUP_JOB_ENABLED:
+            try:
+                logger.info("Validation mode: Running Kafka consumer (primary - writes to DB)")
+                process_principal_events_from_kafka(dry_run=False)
+                kafka_success = True
+                kafka_validation_success_total.inc()
+                logger.info("Validation mode: Kafka consumer completed successfully")
+            except Exception as kafka_error:
+                logger.error("Validation mode: Kafka consumer failed: %s. Falling back to UMB.", str(kafka_error))
+                capture_exception(kafka_error)
+                kafka_success = False
+        else:
+            logger.warning("Validation mode requires Kafka but KAFKA_PRINCIPAL_CLEANUP_JOB_ENABLED is False")
+
+        # UMB runs as fallback only if Kafka failed or is disabled
+        if not kafka_success:
+            kafka_validation_fallback_total.inc()
+            if settings.UMB_JOB_ENABLED:
+                try:
+                    logger.info("Validation mode: Running UMB consumer (fallback - writes to DB)")
+                    process_principal_events_from_umb()
+                    logger.info("Validation mode: UMB fallback completed successfully")
+                except Exception as umb_error:
+                    logger.error("Validation mode: UMB fallback also failed: %s", str(umb_error))
+                    capture_exception(umb_error)
+                    # Both failed - raise to trigger alerting
+                    raise RuntimeError(
+                        "Validation mode: Both Kafka and UMB consumers failed. Principal cleanup incomplete."
+                    ) from umb_error
+            else:
+                logger.error(
+                    "Validation mode: Kafka failed and UMB_JOB_ENABLED is False. " "Principal cleanup incomplete."
+                )
+                raise RuntimeError("Validation mode: Kafka failed and no UMB fallback available")
+        else:
+            # Kafka succeeded - log for comparison purposes
+            logger.info(
+                "Validation mode: Kafka succeeded, UMB fallback not needed. "
+                "Monitor metrics to compare Kafka vs historical UMB performance."
+            )
+
+    elif mode == "kafka_active":
+        # Kafka-active mode: Only Kafka processes and writes to DB
+        if settings.KAFKA_PRINCIPAL_CLEANUP_JOB_ENABLED:
+            logger.info("Kafka-active mode: processing via Kafka")
+            process_principal_events_from_kafka(dry_run=False)
+        else:
+            # Kafka is disabled but kafka_active mode was explicitly selected via Unleash
+            # This is a configuration error - operators should change Unleash flag to umb_only
+            # instead of relying on silent fallback
+            error_msg = (
+                "Configuration mismatch: kafka_active mode selected in Unleash, "
+                "but KAFKA_PRINCIPAL_CLEANUP_JOB_ENABLED is False. "
+                "Change Unleash flag to 'umb_only' mode or enable Kafka via KAFKA_PRINCIPAL_CLEANUP_JOB_ENABLED."
+            )
+            logger.error(error_msg)
+            raise RuntimeError(error_msg)
+
+    else:
+        logger.error(f"Unknown principal cleanup mode: {mode}, defaulting to UMB")
+        if settings.UMB_JOB_ENABLED:
+            process_principal_events_from_umb()
+        else:
+            logger.warning("Fallback to UMB failed: UMB_JOB_ENABLED is False")
 
 
 @shared_task

--- a/rbac/rbac/celery.py
+++ b/rbac/rbac/celery.py
@@ -56,14 +56,40 @@ app.conf.beat_schedule = {
     },
 }
 
-if settings.PRINCIPAL_CLEANUP_DELETION_ENABLED_UMB:
+# Determine which principal cleanup method to use
+# If both UMB and Kafka are enabled, schedule a dispatcher task that checks Unleash flag at runtime
+# Otherwise, schedule the appropriate cleanup method directly
+if settings.PRINCIPAL_CLEANUP_DELETION_ENABLED_UMB and settings.PRINCIPAL_CLEANUP_DELETION_ENABLED_KAFKA:
+    # Both are enabled - schedule dispatcher task that will check Unleash flag at runtime
+    app.conf.beat_schedule["principal-cleanup-every-minute"] = {
+        "task": "management.tasks.principal_cleanup_via_message_bus",
+        "schedule": 60,  # Every 60 seconds
+        "args": [],
+    }
+elif settings.PRINCIPAL_CLEANUP_DELETION_ENABLED_UMB:
     if settings.UMB_JOB_ENABLED:  # TODO: This is temp flag, remove it after populating user_id
         app.conf.beat_schedule["principal-cleanup-every-minute"] = {
             "task": "management.tasks.principal_cleanup_via_umb",
             "schedule": 60,  # Every 60 second
             "args": [],
         }
+elif settings.PRINCIPAL_CLEANUP_DELETION_ENABLED_KAFKA:
+    if settings.KAFKA_PRINCIPAL_CLEANUP_JOB_ENABLED:
+        app.conf.beat_schedule["principal-cleanup-every-minute"] = {
+            "task": "management.tasks.principal_cleanup_via_kafka",
+            "schedule": 60,  # Every 60 seconds
+            "args": [],
+        }
+    else:
+        # Kafka cleanup is enabled but KAFKA_PRINCIPAL_CLEANUP_JOB_ENABLED is False
+        # Fall back to 7-day cleanup to prevent silent failure
+        app.conf.beat_schedule["principal-cleanup-every-sevenish-days"] = {
+            "task": "management.tasks.principal_cleanup",
+            "schedule": crontab(0, 0, day_of_month="7-28/7"),
+            "args": [],
+        }
 else:
+    # No cleanup enabled at all - fall back to 7-day cleanup
     app.conf.beat_schedule["principal-cleanup-every-sevenish-days"] = {
         "task": "management.tasks.principal_cleanup",
         "schedule": crontab(0, 0, day_of_month="7-28/7"),

--- a/rbac/rbac/settings.py
+++ b/rbac/rbac/settings.py
@@ -530,6 +530,9 @@ RBAC_KAFKA_CONSUMER_GROUP_ID = ENVIRONMENT.get_value("RBAC_KAFKA_CONSUMER_GROUP_
 
 RBAC_KAFKA_CUSTOM_CONSUMER_BROKER = ENVIRONMENT.get_value("RBAC_KAFKA_CUSTOM_CONSUMER_BROKER", default="")
 
+KAFKA_PRINCIPAL_CLEANUP_TOPIC = ENVIRONMENT.get_value("KAFKA_PRINCIPAL_CLEANUP_TOPIC", default="")
+KAFKA_PRINCIPAL_CLEANUP_DLQ_TOPIC = ENVIRONMENT.get_value("KAFKA_PRINCIPAL_CLEANUP_DLQ_TOPIC", default="")
+
 # if we don't enable KAFKA we can't use the notifications
 if not KAFKA_ENABLED:
     NOTIFICATIONS_ENABLED = False
@@ -595,6 +598,14 @@ if KAFKA_ENABLED:
     if clowder_rbac_consumer_topic:
         RBAC_KAFKA_CONSUMER_TOPIC = clowder_rbac_consumer_topic.name
 
+    clowder_principal_cleanup_topic = KafkaTopics.get(KAFKA_PRINCIPAL_CLEANUP_TOPIC)
+    if clowder_principal_cleanup_topic:
+        KAFKA_PRINCIPAL_CLEANUP_TOPIC = clowder_principal_cleanup_topic.name
+
+    clowder_principal_cleanup_dlq_topic = KafkaTopics.get(KAFKA_PRINCIPAL_CLEANUP_DLQ_TOPIC)
+    if clowder_principal_cleanup_dlq_topic:
+        KAFKA_PRINCIPAL_CLEANUP_DLQ_TOPIC = clowder_principal_cleanup_dlq_topic.name
+
 # BOP TLS settings
 if ENVIRONMENT.bool("CLOWDER_ENABLED", default=False) and ENVIRONMENT.bool("USE_CLOWDER_CA_FOR_BOP", default=False):
     BOP_CLIENT_CERT_PATH = LoadedConfig.tlsCAPath
@@ -627,6 +638,20 @@ UMB_JOB_ENABLED = ENVIRONMENT.bool("UMB_JOB_ENABLED", default=True)
 
 UMB_HOST = ENVIRONMENT.get_value("UMB_HOST", default="localhost")
 UMB_PORT = ENVIRONMENT.get_value("UMB_PORT", default="61612")
+
+# Settings for enabling/disabling deletion in principal cleanup job via Kafka
+PRINCIPAL_CLEANUP_DELETION_ENABLED_KAFKA = ENVIRONMENT.bool("PRINCIPAL_CLEANUP_DELETION_ENABLED_KAFKA", default=False)
+PRINCIPAL_CLEANUP_UPDATE_ENABLED_KAFKA = ENVIRONMENT.bool("PRINCIPAL_CLEANUP_UPDATE_ENABLED_KAFKA", default=False)
+KAFKA_PRINCIPAL_CLEANUP_JOB_ENABLED = ENVIRONMENT.bool("KAFKA_PRINCIPAL_CLEANUP_JOB_ENABLED", default=True)
+
+# Validate Kafka principal cleanup configuration at startup
+# Fail fast if Kafka cleanup is enabled but topic is not configured
+if PRINCIPAL_CLEANUP_DELETION_ENABLED_KAFKA and not KAFKA_PRINCIPAL_CLEANUP_TOPIC:
+    raise ValueError(
+        "PRINCIPAL_CLEANUP_DELETION_ENABLED_KAFKA is True but KAFKA_PRINCIPAL_CLEANUP_TOPIC is not configured. "
+        "Set KAFKA_PRINCIPAL_CLEANUP_TOPIC to a valid Kafka topic name or disable Kafka cleanup."
+    )
+
 # Service account name
 SA_NAME = ENVIRONMENT.get_value("SA_NAME", default="nonprod-hcc-rbac")
 

--- a/scripts/debezium/run_kafka_consumer.sh
+++ b/scripts/debezium/run_kafka_consumer.sh
@@ -24,4 +24,5 @@ $CONTAINER_RUNTIME exec -it \
   -e RBAC_KAFKA_CUSTOM_CONSUMER_BROKER=kafka:9092 \
   -e RBAC_KAFKA_CONSUMER_TOPIC="$TOPIC" \
   -e RBAC_KAFKA_CONSUMER_GROUP_ID=rbac-consumer-group \
+  -e METRICS_PORT=9000 \
   rbac_server python rbac/manage.py launch-rbac-kafka-consumer

--- a/scripts/debezium/test_kafka_consumer.sh
+++ b/scripts/debezium/test_kafka_consumer.sh
@@ -26,6 +26,7 @@ if [ "$MODE" = "background" ]; then
       -e RBAC_KAFKA_CUSTOM_CONSUMER_BROKER=kafka:9092 \
       -e RBAC_KAFKA_CONSUMER_TOPIC="$TOPIC" \
       -e RBAC_KAFKA_CONSUMER_GROUP_ID=rbac-consumer-group \
+      -e METRICS_PORT=9000 \
       --name rbac-kafka-consumer-test \
       --rm \
       rbac_server python rbac/manage.py launch-rbac-kafka-consumer)
@@ -43,6 +44,7 @@ else
       -e RBAC_KAFKA_CUSTOM_CONSUMER_BROKER=kafka:9092 \
       -e RBAC_KAFKA_CONSUMER_TOPIC="$TOPIC" \
       -e RBAC_KAFKA_CONSUMER_GROUP_ID=rbac-consumer-group \
+      -e METRICS_PORT=9000 \
       --rm \
       rbac_server python rbac/manage.py launch-rbac-kafka-consumer
 fi

--- a/scripts/test_kafka_producer.py
+++ b/scripts/test_kafka_producer.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+"""
+Test script to send Kafka messages for testing the principal cleanup feature.
+Usage: python scripts/test_kafka_producer.py
+"""
+
+import json
+from kafka import KafkaProducer
+
+# Sample test message - inactive user
+SAMPLE_MESSAGE = {
+    "CanonicalMessage": {
+        "Header": {
+            "System": "WEB",
+            "Operation": "update",
+            "Type": "User",
+            "InstanceId": "test-instance-123",
+            "Timestamp": "2025-03-26T12:00:00.000",
+        },
+        "Payload": {
+            "Sync": {
+                "User": {
+                    "CreatedDate": "2025-01-01T00:00:00.000",
+                    "LastUpdatedDate": "2025-03-26T12:00:00.000",
+                    "Identifiers": {
+                        "Identifier": [
+                            {"system": "WEB", "entity-name": "User", "qualifier": "id", "text": "12345678"}
+                        ],
+                        "Reference": [
+                            {"system": "WEB", "entity-name": "Customer", "qualifier": "id", "text": "99999999"},
+                            {"system": "EBS", "entity-name": "Account", "qualifier": "number", "text": "88888888"},
+                        ],
+                    },
+                    "Status": {"State": "Inactive"},  # This will trigger cleanup
+                    "Person": {"FirstName": "Test", "LastName": "User", "Credentials": {"Login": "test-user"}},
+                }
+            }
+        },
+    }
+}
+
+
+def send_test_message(bootstrap_servers="localhost:9092", topic="VirtualTopic.canonical.user"):
+    """Send a test message to Kafka."""
+    print(f"Connecting to Kafka at {bootstrap_servers}...")
+
+    producer = KafkaProducer(
+        bootstrap_servers=bootstrap_servers, value_serializer=lambda v: json.dumps(v).encode("utf-8")
+    )
+
+    print(f"Sending test message to topic: {topic}")
+    future = producer.send(topic, value=SAMPLE_MESSAGE)
+
+    # Wait for the message to be sent
+    try:
+        record_metadata = future.get(timeout=10)
+        print(f"  Message sent successfully!")
+        print(f"  Topic: {record_metadata.topic}")
+        print(f"  Partition: {record_metadata.partition}")
+        print(f"  Offset: {record_metadata.offset}")
+    except Exception as e:
+        print(f"  Failed to send message: {e}")
+
+    producer.close()
+    print("\nMessage content:")
+    print(json.dumps(SAMPLE_MESSAGE, indent=2))
+
+
+if __name__ == "__main__":
+    import sys
+
+    # Allow override of bootstrap servers from command line
+    bootstrap_servers = sys.argv[1] if len(sys.argv) > 1 else "localhost:9092"
+    topic = sys.argv[2] if len(sys.argv) > 2 else "VirtualTopic.canonical.user"
+
+    send_test_message(bootstrap_servers, topic)

--- a/tests/management/principal/test_kafka_cleaner.py
+++ b/tests/management/principal/test_kafka_cleaner.py
@@ -1,0 +1,1338 @@
+#
+# Copyright 2019 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""Test the principal cleaner."""
+
+import json
+import uuid
+from functools import partial
+from unittest.mock import MagicMock, Mock, patch
+
+from django.test import override_settings
+from prometheus_client import REGISTRY
+from rest_framework import status
+
+from management.group.definer import seed_group
+from management.group.model import Group
+from management.policy.model import Policy
+from management.principal.cleaner import (
+    METRIC_KAFKA_MESSAGES_FAILURE_TOTAL,
+    METRIC_KAFKA_MESSAGES_SUCCESS_TOTAL,
+    clean_tenant_principals,
+    process_principal_events_from_kafka,
+)
+from management.principal.model import Principal
+from management.tenant_mapping.model import TenantMapping
+from management.workspace.model import Workspace
+from migration_tool.in_memory_tuples import (
+    InMemoryRelationReplicator,
+    InMemoryTuples,
+    all_of,
+    relation,
+    resource,
+    subject,
+)
+from tests.identity_request import IdentityRequest
+
+from api.models import Tenant
+
+
+class PrincipalCleanerTests(IdentityRequest):
+    """Test the principal cleaner functions."""
+
+    def setUp(self):
+        """Set up the principal cleaner tests."""
+        super().setUp()
+        self.group = Group(name="groupA", tenant=self.tenant)
+        self.group.save()
+
+    def test_principal_cleanup_none(self):
+        """Test that we can run a principal clean up on a tenant with no principals."""
+        try:
+            clean_tenant_principals(self.tenant)
+        except Exception:
+            self.fail(msg="clean_tenant_principals encountered an exception")
+        self.assertEqual(Principal.objects.count(), 0)
+
+    @patch(
+        "management.principal.proxy.PrincipalProxy._request_principals",
+        return_value={"status_code": status.HTTP_200_OK, "data": []},
+    )
+    def test_principal_cleanup_skip_cross_account_principals(self, mock_request):
+        """Test that principal clean up on a tenant will skip cross account principals."""
+        Principal.objects.create(username="user1", tenant=self.tenant)
+        Principal.objects.create(username="CAR", cross_account=True, tenant=self.tenant)
+        self.assertEqual(Principal.objects.count(), 2)
+
+        try:
+            clean_tenant_principals(self.tenant)
+        except Exception:
+            self.fail(msg="clean_tenant_principals encountered an exception")
+        self.assertEqual(Principal.objects.count(), 1)
+
+    @patch(
+        "management.principal.proxy.PrincipalProxy._request_principals",
+        return_value={"status_code": status.HTTP_200_OK, "data": []},
+    )
+    def test_principal_cleanup_skips_service_account_principals(self, mock_request):
+        """Test that principal clean up on a tenant will skip service account principals."""
+        # Create a to-be-removed user principal and a service account that should be left untouched.
+        service_account_client_id = str(uuid.uuid4())
+        Principal.objects.create(username="regular user", tenant=self.tenant)
+        Principal.objects.create(
+            username=f"service-account-{service_account_client_id}",
+            service_account_id=service_account_client_id,
+            tenant=self.tenant,
+            type="service-account",
+        )
+        self.assertEqual(Principal.objects.count(), 2)
+
+        try:
+            clean_tenant_principals(self.tenant)
+        except Exception:
+            self.fail(msg="clean_tenant_principals encountered an exception")
+
+        # Assert that the only principal left for the tenant is the service account, which should have been left
+        # untouched.
+        self.assertEqual(Principal.objects.count(), 1)
+
+        service_account = Principal.objects.all().filter(type="service-account").first()
+        self.assertEqual(service_account.service_account_id, service_account_client_id)
+        self.assertEqual(service_account.type, "service-account")
+        self.assertEqual(service_account.username, f"service-account-{service_account_client_id}")
+
+    @patch(
+        "management.principal.proxy.PrincipalProxy._request_principals",
+        return_value={"status_code": status.HTTP_200_OK, "data": []},
+    )
+    def test_principal_cleanup_principal_in_group(self, mock_request):
+        """Test that we can run a principal clean up on a tenant with a principal in a group."""
+        self.principal = Principal(username="user1", tenant=self.tenant)
+        self.principal.save()
+        self.group.principals.add(self.principal)
+        self.group.save()
+        try:
+            clean_tenant_principals(self.tenant)
+        except Exception:
+            self.fail(msg="clean_tenant_principals encountered an exception")
+        self.assertEqual(Principal.objects.count(), 0)
+
+    @patch(
+        "management.principal.proxy.PrincipalProxy._request_principals",
+        return_value={"status_code": status.HTTP_200_OK, "data": []},
+    )
+    def test_principal_cleanup_principal_not_in_group(self, mock_request):
+        """Test that we can run a principal clean up on a tenant with a principal not in a group."""
+        self.principal = Principal(username="user1", tenant=self.tenant)
+        self.principal.save()
+        try:
+            clean_tenant_principals(self.tenant)
+        except Exception:
+            self.fail(msg="clean_tenant_principals encountered an exception")
+        self.assertEqual(Principal.objects.count(), 0)
+
+    @patch(
+        "management.principal.proxy.PrincipalProxy._request_principals",
+        return_value={"status_code": status.HTTP_200_OK, "data": [{"username": "user1"}]},
+    )
+    def test_principal_cleanup_principal_exists(self, mock_request):
+        """Test that we can run a principal clean up on a tenant with an existing principal."""
+        self.principal = Principal(username="user1", tenant=self.tenant)
+        self.principal.save()
+        try:
+            clean_tenant_principals(self.tenant)
+        except Exception:
+            self.fail(msg="clean_tenant_principals encountered an exception")
+        self.assertEqual(Principal.objects.count(), 1)
+
+    @patch(
+        "management.principal.proxy.PrincipalProxy._request_principals",
+        return_value={"status_code": status.HTTP_504_GATEWAY_TIMEOUT},
+    )
+    def test_principal_cleanup_principal_error(self, mock_request):
+        """Test that we can handle a principal clean up with an unexpected error from proxy."""
+        self.principal = Principal(username="user1", tenant=self.tenant)
+        self.principal.save()
+        try:
+            clean_tenant_principals(self.tenant)
+        except Exception:
+            self.fail(msg="clean_tenant_principals encountered an exception")
+        self.assertEqual(Principal.objects.count(), 1)
+
+
+# Kafka JSON message format (converted from XML)
+KAFKA_MESSAGE_BODY = json.dumps(
+    {
+        "CanonicalMessage": {
+            "Header": {
+                "System": "WEB",
+                "Operation": "update",
+                "Type": "User",
+                "InstanceId": "660a018a6d336076b5b57fff",
+                "Timestamp": "2024-03-31T20:36:27.820",
+            },
+            "Payload": {
+                "Sync": {
+                    "User": {
+                        "CreatedDate": "2024-02-16T02:57:51.738",
+                        "LastUpdatedDate": "2024-02-21T06:47:24.672",
+                        "Identifiers": {
+                            "Identifier": [
+                                {"system": "WEB", "entity-name": "User", "qualifier": "id", "text": "56780000"},
+                                {"system": "FOO", "entity-name": "User", "qualifier": "id", "text": "56780001"},
+                            ],
+                            "Reference": [
+                                {"system": "WEB", "entity-name": "Customer", "qualifier": "id", "text": "17685860"},
+                                {"system": "EBS", "entity-name": "Account", "qualifier": "number", "text": "11111111"},
+                            ],
+                        },
+                        "Status": {"State": "Inactive"},
+                        "Person": {
+                            "FirstName": "Test",
+                            "LastName": "Principal",
+                            "Salutation": "Mr.",
+                            "Title": "QE",
+                            "Credentials": {"Login": "principal-test"},
+                        },
+                    }
+                }
+            },
+        }
+    }
+)
+
+KAFKA_MESSAGE_CREATION = json.dumps(
+    {
+        "CanonicalMessage": {
+            "Header": {
+                "System": "WEB",
+                "Operation": "insert",
+                "Type": "User",
+                "InstanceId": "660a018a6d336076b5b57fff",
+                "Timestamp": "2024-03-31T20:36:27.820",
+            },
+            "Payload": {
+                "Sync": {
+                    "User": {
+                        "CreatedDate": "2024-02-16T02:57:51.738",
+                        "LastUpdatedDate": "2024-02-21T06:47:24.672",
+                        "Identifiers": {
+                            "Identifier": {
+                                "system": "WEB",
+                                "entity-name": "User",
+                                "qualifier": "id",
+                                "text": "56780000",
+                            },
+                            "Reference": [
+                                {"system": "WEB", "entity-name": "Customer", "qualifier": "id", "text": "17685860"},
+                                {"system": "EBS", "entity-name": "Account", "qualifier": "number", "text": "11111111"},
+                            ],
+                        },
+                        "Status": {"State": "Active"},
+                        "Person": {
+                            "FirstName": "Test",
+                            "LastName": "Principal",
+                            "Salutation": "Mr.",
+                            "Title": "QE",
+                            "Credentials": {"Login": "principal-test"},
+                        },
+                    }
+                }
+            },
+        }
+    }
+)
+
+KAFKA_MESSAGE_SPECIAL = json.dumps(
+    {
+        "CanonicalMessage": {
+            "Header": {
+                "System": "WEB",
+                "Operation": "insert",
+                "Type": "User",
+                "InstanceId": "666a018a6d336076b5b57fff",
+                "Timestamp": "2024-11-12T09:48:18.260",
+            },
+            "Payload": {
+                "Sync": {
+                    "User": {
+                        "CreatedDate": "2024-11-12T09:48:12.978",
+                        "LastUpdatedDate": "2024-11-12T09:48:14.336",
+                        "Identifiers": {
+                            "Identifier": {
+                                "system": "WEB",
+                                "entity-name": "User",
+                                "qualifier": "id",
+                                "text": "56780000",
+                            },
+                            "Reference": {
+                                "system": "WEB",
+                                "entity-name": "Customer",
+                                "qualifier": "id",
+                                "text": "17685860",
+                            },
+                        },
+                        "Status": {"State": "Inactive"},
+                        "Person": {
+                            "FirstName": "Teamnado",
+                            "LastName": "Test Automation",
+                            "Title": "Test User",
+                            "Credentials": {"Login": "principal-test"},
+                        },
+                    }
+                }
+            },
+        }
+    }
+)
+
+
+def create_mock_kafka_message(message_body, partition=0, offset=0):
+    """Create a mock Kafka message."""
+    mock_message = Mock()
+    mock_message.value = message_body
+    mock_message.partition = partition
+    mock_message.offset = offset
+    return mock_message
+
+
+class PrincipalKafkaTests(IdentityRequest):
+    """Test the principal processor functions with Kafka."""
+
+    def setUp(self):
+        """Set up the principal processor tests."""
+        super().setUp()
+        self.principal_name = "principal-test"
+        self.principal_user_id = "56780000"
+        self.tenant.org_id = "17685860"
+        self.tenant.save()
+        self.group = Group(name="groupA", tenant=self.tenant)
+        self.group.save()
+
+    @patch("management.principal.cleaner.KafkaConsumer")
+    @patch("management.principal.cleaner.settings.KAFKA_PRINCIPAL_CLEANUP_TOPIC", "test-topic")
+    def test_principal_cleanup_none(self, consumer_mock):
+        """Test that we can run a principal clean up with no messages."""
+        before = REGISTRY.get_sample_value(METRIC_KAFKA_MESSAGES_SUCCESS_TOTAL)
+
+        # Mock consumer with no messages
+        consumer_instance = MagicMock()
+        consumer_instance.__iter__.return_value = iter([])
+        consumer_mock.return_value = consumer_instance
+
+        process_principal_events_from_kafka()
+
+        after = REGISTRY.get_sample_value(METRIC_KAFKA_MESSAGES_SUCCESS_TOTAL)
+        self.assertTrue(before == after or before is None and after is None)
+        consumer_instance.close.assert_called_once()
+
+    @patch("management.principal.cleaner.KafkaConsumer")
+    @patch("management.principal.cleaner.settings.KAFKA_PRINCIPAL_CLEANUP_TOPIC", "test-topic")
+    @patch("management.principal.cleaner.settings.SA_NAME", "test-rbac-service")
+    @patch("management.principal.cleaner.settings.ENV_NAME", "ephemeral-pr-123")
+    def test_consumer_group_id_includes_environment(self, consumer_mock):
+        """Test that consumer group ID includes ENV_NAME to prevent cross-environment interference."""
+        # Mock consumer
+        consumer_instance = MagicMock()
+        consumer_instance.__iter__.return_value = iter([])
+        consumer_mock.return_value = consumer_instance
+
+        process_principal_events_from_kafka()
+
+        # Verify KafkaConsumer was called with group_id containing both SA_NAME and ENV_NAME
+        consumer_mock.assert_called_once()
+        call_kwargs = consumer_mock.call_args[1]  # Get keyword arguments
+        self.assertIn("group_id", call_kwargs)
+        group_id = call_kwargs["group_id"]
+
+        # Group ID should be: {SA_NAME}-{ENV_NAME}-principal-cleanup
+        expected_group_id = "test-rbac-service-ephemeral-pr-123-principal-cleanup"
+        self.assertEqual(group_id, expected_group_id)
+
+        # Verify it includes the environment name (prevents collision)
+        self.assertIn("ephemeral-pr-123", group_id)
+        # Verify it includes the service name
+        self.assertIn("test-rbac-service", group_id)
+        # Verify it includes the topic discriminator
+        self.assertIn("principal-cleanup", group_id)
+
+    @patch(
+        "management.principal.proxy.PrincipalProxy._request_principals",
+        return_value={
+            "status_code": status.HTTP_200_OK,
+            "data": [],
+        },
+    )
+    @patch("management.group.model.AccessCache")
+    @patch("management.principal.cleaner.KafkaConsumer")
+    @patch("management.principal.cleaner.settings.KAFKA_PRINCIPAL_CLEANUP_TOPIC", "test-topic")
+    def test_cleanup_principal_in_or_not_in_group(self, consumer_mock, cache_class, proxy_mock):
+        """Test that we can run a principal clean up on a tenant with a principal in a group."""
+        principal_name = "principal-test"
+        self.principal = Principal(username=principal_name, tenant=self.tenant, user_id="56780000")
+        self.principal.save()
+        self.group.principals.add(self.principal)
+        self.group.save()
+
+        before = REGISTRY.get_sample_value(METRIC_KAFKA_MESSAGES_SUCCESS_TOTAL)
+
+        # Mock consumer with one message
+        mock_message = create_mock_kafka_message(KAFKA_MESSAGE_BODY)
+        consumer_instance = MagicMock()
+        consumer_instance.__iter__.return_value = iter([mock_message])
+        consumer_mock.return_value = consumer_instance
+
+        cache_mock = MagicMock()
+        cache_class.return_value = cache_mock
+        process_principal_events_from_kafka()
+
+        after = REGISTRY.get_sample_value(METRIC_KAFKA_MESSAGES_SUCCESS_TOTAL)
+        self.assertFalse(Principal.objects.filter(username=principal_name).exists())
+        self.group.refresh_from_db()
+        self.assertFalse(self.group.principals.all())
+        cache_mock.delete_policy.assert_called_once_with(self.principal.uuid)
+        self.assertTrue(before + 1 == after or (before is None and after == 1))
+
+        # When principal not in group
+        self.principal = Principal(username=principal_name, tenant=self.tenant, user_id="56780000")
+        self.principal.save()
+
+        consumer_instance.__iter__.return_value = iter([mock_message])
+        process_principal_events_from_kafka()
+        self.assertFalse(Principal.objects.filter(username=principal_name).exists())
+
+    @patch(
+        "management.principal.proxy.PrincipalProxy.request_filtered_principals",
+        return_value={
+            "status_code": 200,
+            "data": [],
+        },
+    )
+    @patch("management.principal.cleaner.KafkaConsumer")
+    @patch("management.principal.cleaner.settings.KAFKA_PRINCIPAL_CLEANUP_TOPIC", "test-topic")
+    def test_cleanup_principal_does_not_exist(self, consumer_mock, proxy_mock):
+        """Test that can run a principal clean up with a principal does not exist."""
+        principal_name = "principal-keep"
+        self.principal = Principal(username=principal_name, tenant=self.tenant)
+        self.principal.save()
+
+        mock_message = create_mock_kafka_message(KAFKA_MESSAGE_BODY)
+        consumer_instance = MagicMock()
+        consumer_instance.__iter__.return_value = iter([mock_message])
+        consumer_mock.return_value = consumer_instance
+
+        process_principal_events_from_kafka()
+        self.assertTrue(Principal.objects.filter(username=principal_name).exists())
+
+        consumer_instance.__iter__.return_value = iter([create_mock_kafka_message(KAFKA_MESSAGE_SPECIAL)])
+        process_principal_events_from_kafka()
+        # Verify second message processing also doesn't delete the existing principal
+        self.assertTrue(Principal.objects.filter(username=principal_name).exists())
+
+    @patch(
+        "management.principal.proxy.PrincipalProxy.request_filtered_principals",
+        return_value={
+            "status_code": 200,
+            "data": [
+                {
+                    "user_id": 56780000,
+                    "org_id": "17685860",
+                    "username": "principal-test",
+                    "email": "test_user@email.com",
+                    "first_name": "user",
+                    "last_name": "test",
+                    "is_org_admin": False,
+                    "is_active": True,
+                }
+            ],
+        },
+    )
+    @patch("management.principal.cleaner.KafkaConsumer")
+    @patch("management.principal.cleaner.settings.KAFKA_PRINCIPAL_CLEANUP_TOPIC", "test-topic")
+    @override_settings(PRINCIPAL_CLEANUP_UPDATE_ENABLED_KAFKA=True)
+    def test_principal_creation_event_updates_existing_principal(self, consumer_mock, proxy_mock):
+        """Test that we can run principal creation event."""
+        public_tenant = Tenant.objects.get(tenant_name="public")
+        Group.objects.create(name="default", platform_default=True, tenant=public_tenant)
+
+        mock_message = create_mock_kafka_message(KAFKA_MESSAGE_CREATION)
+        consumer_instance = MagicMock()
+        consumer_instance.__iter__.return_value = iter([mock_message])
+        consumer_mock.return_value = consumer_instance
+
+        tenant = Tenant.objects.get(org_id="17685860")
+        Principal.objects.create(tenant=tenant, username="principal-test")
+        process_principal_events_from_kafka()
+
+        consumer_instance.close.assert_called_once()
+        self.assertTrue(Tenant.objects.filter(org_id="17685860").exists())
+        self.assertTrue(Principal.objects.filter(user_id=self.principal_user_id).exists())
+
+    @patch("management.principal.cleaner.retrieve_user_info_kafka")
+    @patch("management.principal.cleaner.KafkaConsumer")
+    @patch("management.principal.cleaner.settings.KAFKA_PRINCIPAL_CLEANUP_TOPIC", "test-topic")
+    def test_failure_processing_message(self, consumer_mock, retrieve_user_mock):
+        """Test failure handling when processing message."""
+        principal_name = "principal-test"
+        principal = Principal.objects.create(username=principal_name, tenant=self.tenant)
+        principal.save()
+        self.group.principals.add(principal)
+        self.group.save()
+
+        before = REGISTRY.get_sample_value(METRIC_KAFKA_MESSAGES_FAILURE_TOTAL)
+        success_before = REGISTRY.get_sample_value(METRIC_KAFKA_MESSAGES_SUCCESS_TOTAL)
+
+        mock_message = create_mock_kafka_message(KAFKA_MESSAGE_BODY)
+        consumer_instance = MagicMock()
+        consumer_instance.__iter__.return_value = iter([mock_message])
+        consumer_mock.return_value = consumer_instance
+
+        retrieve_user_mock.side_effect = Exception("Something went wrong")
+        process_principal_events_from_kafka()
+
+        after = REGISTRY.get_sample_value(METRIC_KAFKA_MESSAGES_FAILURE_TOTAL)
+        success_after = REGISTRY.get_sample_value(METRIC_KAFKA_MESSAGES_SUCCESS_TOTAL)
+        self.assertTrue(Principal.objects.filter(username=principal_name).exists())
+        self.group.refresh_from_db()
+        self.assertTrue(self.group.principals.all())
+        self.assertTrue((before + 1 == after) or (before is None and after == 1))
+        self.assertTrue(success_before == success_after or (success_before is None and success_after is None))
+
+    @patch(
+        "management.principal.proxy.PrincipalProxy._request_principals",
+        return_value={
+            "status_code": status.HTTP_200_OK,
+            "data": [],
+        },
+    )
+    @patch("management.principal.cleaner.KafkaConsumer")
+    @patch("management.principal.cleaner.settings.KAFKA_PRINCIPAL_CLEANUP_TOPIC", "test-topic")
+    def test_dry_run_mode_does_not_modify_database(self, consumer_mock, proxy_mock):
+        """Test that dry-run mode processes messages but doesn't modify the database."""
+        principal_name = "principal-test-dry-run"
+        self.principal = Principal(username=principal_name, tenant=self.tenant, user_id="56780000")
+        self.principal.save()
+        self.group.principals.add(self.principal)
+        self.group.save()
+
+        # Verify principal exists before dry-run
+        self.assertTrue(Principal.objects.filter(username=principal_name).exists())
+        initial_principal_count = Principal.objects.count()
+
+        # Mock consumer with one message (inactive user)
+        mock_message = create_mock_kafka_message(KAFKA_MESSAGE_BODY)
+        consumer_instance = MagicMock()
+        consumer_instance.__iter__.return_value = iter([mock_message])
+        consumer_mock.return_value = consumer_instance
+
+        # Run in dry-run mode
+        before_dry_run = REGISTRY.get_sample_value("kafka_dry_run_messages_total") or 0
+        process_principal_events_from_kafka(dry_run=True)
+        after_dry_run = REGISTRY.get_sample_value("kafka_dry_run_messages_total") or 0
+
+        # Verify principal still exists (dry-run didn't delete it)
+        self.assertTrue(Principal.objects.filter(username=principal_name).exists())
+        self.assertEqual(Principal.objects.count(), initial_principal_count)
+        self.group.refresh_from_db()
+        self.assertTrue(self.group.principals.filter(username=principal_name).exists())
+
+        # Verify dry-run metric was incremented
+        self.assertEqual(
+            after_dry_run,
+            before_dry_run + 1,
+            f"Expected dry-run metric to increment by 1, but went from {before_dry_run} to {after_dry_run}",
+        )
+
+    @patch(
+        "management.principal.proxy.PrincipalProxy._request_principals",
+        return_value={
+            "status_code": status.HTTP_200_OK,
+            "data": [],
+        },
+    )
+    @patch("management.principal.cleaner.RBACProducer")
+    @patch("management.principal.cleaner.KafkaConsumer")
+    @patch("management.principal.cleaner.settings.KAFKA_PRINCIPAL_CLEANUP_TOPIC", "test-topic")
+    @patch("management.principal.cleaner.settings.KAFKA_PRINCIPAL_CLEANUP_DLQ_TOPIC", "test-dlq-topic")
+    def test_dry_run_mode_handles_errors_gracefully(self, consumer_mock, dlq_producer_mock, proxy_mock):
+        """Test that dry-run mode sends malformed messages to DLQ for inspection."""
+        # Mock consumer with malformed message
+        mock_message = create_mock_kafka_message(b'{"invalid": "json without required fields"}')
+        consumer_instance = MagicMock()
+        consumer_instance.__iter__.return_value = iter([mock_message])
+        consumer_mock.return_value = consumer_instance
+
+        # Mock DLQ producer
+        mock_dlq_instance = MagicMock()
+        dlq_producer_mock.return_value = mock_dlq_instance
+
+        # Run in dry-run mode
+        before_errors = REGISTRY.get_sample_value("kafka_dry_run_errors_total") or 0
+        process_principal_events_from_kafka(dry_run=True)
+        after_errors = REGISTRY.get_sample_value("kafka_dry_run_errors_total") or 0
+
+        # Verify error metric was incremented
+        self.assertEqual(
+            after_errors,
+            before_errors + 1,
+            f"Expected error metric to increment by 1, but went from {before_errors} to {after_errors}",
+        )
+
+        # Verify message was sent to DLQ for inspection
+        mock_dlq_instance.send_kafka_message.assert_called_once()
+        dlq_call_args = mock_dlq_instance.send_kafka_message.call_args
+        self.assertEqual(dlq_call_args[0][0], "test-dlq-topic")  # First positional arg is topic
+        dlq_message = dlq_call_args[0][1]  # Second positional arg is the message
+        self.assertTrue(dlq_message["dry_run"])  # Should be marked as dry-run
+        self.assertIn("error", dlq_message)  # Should contain error details
+
+    @patch("management.principal.cleaner.retrieve_user_info_kafka")
+    @patch(
+        "management.principal.proxy.PrincipalProxy._request_principals",
+        return_value={
+            "status_code": status.HTTP_200_OK,
+            "data": [],
+        },
+    )
+    @patch("management.principal.cleaner.RBACProducer")
+    @patch("management.principal.cleaner.KafkaConsumer")
+    @patch("management.principal.cleaner.settings.KAFKA_PRINCIPAL_CLEANUP_TOPIC", "test-topic")
+    @patch("management.principal.cleaner.settings.KAFKA_PRINCIPAL_CLEANUP_DLQ_TOPIC", "test-dlq-topic")
+    def test_dry_run_mode_handles_transient_errors(
+        self, consumer_mock, dlq_producer_mock, proxy_mock, retrieve_user_mock
+    ):
+        """Test that dry-run mode does NOT send transient errors to DLQ."""
+        # Mock consumer with valid message
+        mock_message = create_mock_kafka_message(KAFKA_MESSAGE_BODY)
+        consumer_instance = MagicMock()
+        consumer_instance.__iter__.return_value = iter([mock_message])
+        consumer_mock.return_value = consumer_instance
+
+        # Mock DLQ producer
+        mock_dlq_instance = MagicMock()
+        dlq_producer_mock.return_value = mock_dlq_instance
+
+        # Mock a transient error (e.g., network timeout when calling BOP)
+        retrieve_user_mock.side_effect = ConnectionError("Network timeout")
+
+        # Run in dry-run mode
+        before_errors = REGISTRY.get_sample_value("kafka_dry_run_errors_total") or 0
+        process_principal_events_from_kafka(dry_run=True)
+        after_errors = REGISTRY.get_sample_value("kafka_dry_run_errors_total") or 0
+
+        # Verify error metric was incremented
+        self.assertEqual(
+            after_errors,
+            before_errors + 1,
+            f"Expected error metric to increment by 1, but went from {before_errors} to {after_errors}",
+        )
+
+        # Verify message was NOT sent to DLQ (transient errors should retry, not go to DLQ)
+        mock_dlq_instance.send_kafka_message.assert_not_called()
+
+    @patch(
+        "management.principal.proxy.PrincipalProxy._request_principals",
+        return_value={
+            "status_code": status.HTTP_200_OK,
+            "data": [],
+        },
+    )
+    @patch("management.principal.cleaner.get_tenant_bootstrap_service")
+    @patch("management.principal.cleaner.KafkaConsumer")
+    @patch("management.principal.cleaner.settings.KAFKA_PRINCIPAL_CLEANUP_TOPIC", "test-topic")
+    def test_kafka_consumer_handles_xml_messages_from_bridge(self, consumer_mock, bootstrap_mock, proxy_mock):
+        """Test that Kafka consumer can process XML messages from UMB->Kafka bridge."""
+        # XML message from UMB bridge (raw UMB message body copied to Kafka)
+        xml_message = (
+            b'<?xml version="1.0" encoding="UTF-8"?>'
+            b"<CanonicalMessage>"
+            b"<Header><InstanceId>test123</InstanceId></Header>"
+            b"<Payload><Sync><User>"
+            b"<Identifiers>"
+            b'<Identifier system="WEB" entity-name="User" qualifier="id">56780000</Identifier>'
+            b'<Reference system="WEB" entity-name="Customer" qualifier="id">17685860</Reference>'
+            b"</Identifiers>"
+            b'<Status primary="true"><State>Inactive</State></Status>'
+            b"<Person><Credentials><Login>test-user</Login></Credentials></Person>"
+            b"</User></Sync></Payload>"
+            b"</CanonicalMessage>"
+        )
+
+        mock_message = create_mock_kafka_message(xml_message)
+        consumer_instance = MagicMock()
+        consumer_instance.__iter__.return_value = iter([mock_message])
+        consumer_mock.return_value = consumer_instance
+
+        # Mock bootstrap service
+        mock_service = MagicMock()
+        bootstrap_mock.return_value = mock_service
+
+        # Run in normal mode - should parse XML and call update_user
+        process_principal_events_from_kafka(dry_run=False)
+
+        # Verify update_user was called (XML message was successfully parsed)
+        mock_service.update_user.assert_called()
+
+    @patch(
+        "management.principal.proxy.PrincipalProxy._request_principals",
+        return_value={
+            "status_code": status.HTTP_200_OK,
+            "data": [],
+        },
+    )
+    @patch("management.principal.cleaner.get_tenant_bootstrap_service")
+    @patch("management.principal.cleaner.KafkaConsumer")
+    @patch("management.principal.cleaner.settings.KAFKA_PRINCIPAL_CLEANUP_TOPIC", "test-topic")
+    def test_format_detection_prefers_json_over_xml(self, consumer_mock, bootstrap_mock, proxy_mock):
+        """Test that format detection tries JSON first before XML."""
+        # Valid JSON message (should be parsed as JSON, not XML)
+        json_message = KAFKA_MESSAGE_BODY.encode("utf-8")
+
+        mock_message = create_mock_kafka_message(json_message)
+        consumer_instance = MagicMock()
+        consumer_instance.__iter__.return_value = iter([mock_message])
+        consumer_mock.return_value = consumer_instance
+
+        # Mock bootstrap service
+        mock_service = MagicMock()
+        bootstrap_mock.return_value = mock_service
+
+        # Patch retrieve_user_info_kafka and retrieve_user_info_umb to track which is called
+        with patch("management.principal.cleaner.retrieve_user_info_kafka") as kafka_retrieve_mock:
+            with patch("management.principal.cleaner.retrieve_user_info_umb") as umb_retrieve_mock:
+                # Set up mock to return a user
+                from api.models import User
+
+                mock_user = User()
+                mock_user.username = "test-user"
+                mock_user.user_id = "56780000"
+                mock_user.org_id = "17685860"
+                mock_user.is_active = False
+                kafka_retrieve_mock.return_value = mock_user
+
+                # Run in normal mode
+                process_principal_events_from_kafka(dry_run=False)
+
+                # Verify JSON retrieval was called (not UMB/XML retrieval)
+                kafka_retrieve_mock.assert_called_once()
+                umb_retrieve_mock.assert_not_called()
+
+    @patch(
+        "management.principal.proxy.PrincipalProxy._request_principals",
+        return_value={
+            "status_code": status.HTTP_200_OK,
+            "data": [],
+        },
+    )
+    @patch("management.principal.cleaner.RBACProducer")
+    @patch("management.principal.cleaner.KafkaConsumer")
+    @patch("management.principal.cleaner.settings.KAFKA_PRINCIPAL_CLEANUP_TOPIC", "test-topic")
+    @patch("management.principal.cleaner.settings.KAFKA_PRINCIPAL_CLEANUP_DLQ_TOPIC", "test-dlq-topic")
+    def test_transaction_rollback_on_permanent_error_after_partial_db_write(
+        self, consumer_mock, dlq_producer_mock, proxy_mock
+    ):
+        """Test that transaction is rolled back when permanent error occurs after partial DB writes."""
+        # Create a principal that exists in DB
+        principal_name = "test-principal-rollback"
+        self.principal = Principal(username=principal_name, tenant=self.tenant, user_id="56780000")
+        self.principal.save()
+        initial_principal_count = Principal.objects.count()
+
+        # Mock DLQ producer
+        mock_dlq_instance = MagicMock()
+        dlq_producer_mock.return_value = mock_dlq_instance
+
+        # Create a message that will partially succeed then fail
+        # Use a JSON message that will parse successfully but fail during processing
+        malformed_json = json.dumps(
+            {
+                "CanonicalMessage": {
+                    "Header": {
+                        "System": "WEB",
+                        "Operation": "update",
+                        "Type": "User",
+                        "InstanceId": "test123",
+                        "Timestamp": "2024-03-31T20:36:27.820",
+                    },
+                    "Payload": {
+                        "Sync": {
+                            "User": {
+                                # Missing required Identifiers field - will cause KeyError during retrieve_user_info_kafka
+                                "Status": {"State": "Inactive"},
+                                "Person": {"Credentials": {"Login": "test-user"}},
+                            }
+                        }
+                    },
+                }
+            }
+        )
+
+        mock_message = create_mock_kafka_message(malformed_json.encode("utf-8"))
+        consumer_instance = MagicMock()
+        consumer_instance.__iter__.return_value = iter([mock_message])
+        consumer_mock.return_value = consumer_instance
+
+        # Run in normal mode (not dry-run) - should send to DLQ
+        before_failures = REGISTRY.get_sample_value(METRIC_KAFKA_MESSAGES_FAILURE_TOTAL) or 0
+        process_principal_events_from_kafka(dry_run=False)
+        after_failures = REGISTRY.get_sample_value(METRIC_KAFKA_MESSAGES_FAILURE_TOTAL) or 0
+
+        # Verify failure metric was incremented
+        self.assertEqual(after_failures, before_failures + 1)
+
+        # Verify message was sent to DLQ
+        mock_dlq_instance.send_kafka_message.assert_called_once()
+
+        # CRITICAL: Verify that the principal count hasn't changed (transaction was rolled back)
+        # If the transaction wasn't rolled back, any partial DB writes would be committed
+        self.assertEqual(Principal.objects.count(), initial_principal_count)
+        # Original principal should still exist
+        self.assertTrue(Principal.objects.filter(username=principal_name).exists())
+
+    @patch(
+        "management.principal.proxy.PrincipalProxy._request_principals",
+        return_value={
+            "status_code": status.HTTP_200_OK,
+            "data": [],
+        },
+    )
+    @patch("management.principal.cleaner.get_tenant_bootstrap_service")
+    @patch("management.principal.cleaner.KafkaConsumer")
+    @patch("management.principal.cleaner.settings.KAFKA_PRINCIPAL_CLEANUP_TOPIC", "test-topic")
+    def test_dry_run_mode_does_not_call_update_user(self, consumer_mock, bootstrap_mock, proxy_mock):
+        """Test that dry-run mode does not call bootstrap_service.update_user()."""
+        # Mock consumer with one message
+        mock_message = create_mock_kafka_message(KAFKA_MESSAGE_BODY)
+        consumer_instance = MagicMock()
+        consumer_instance.__iter__.return_value = iter([mock_message])
+        consumer_mock.return_value = consumer_instance
+
+        # Mock bootstrap service
+        mock_service = MagicMock()
+        bootstrap_mock.return_value = mock_service
+
+        # Run in dry-run mode
+        process_principal_events_from_kafka(dry_run=True)
+
+        # Verify update_user was NOT called
+        mock_service.update_user.assert_not_called()
+
+    @patch(
+        "management.principal.proxy.PrincipalProxy._request_principals",
+        return_value={
+            "status_code": status.HTTP_200_OK,
+            "data": [],
+        },
+    )
+    @patch("management.principal.cleaner.get_tenant_bootstrap_service")
+    @patch("management.principal.cleaner.KafkaConsumer")
+    @patch("management.principal.cleaner.settings.KAFKA_PRINCIPAL_CLEANUP_TOPIC", "test-topic")
+    def test_normal_mode_calls_update_user(self, consumer_mock, bootstrap_mock, proxy_mock):
+        """Test that normal mode (not dry-run) calls bootstrap_service.update_user()."""
+        # Mock consumer with one message
+        mock_message = create_mock_kafka_message(KAFKA_MESSAGE_BODY)
+        consumer_instance = MagicMock()
+        consumer_instance.__iter__.return_value = iter([mock_message])
+        consumer_mock.return_value = consumer_instance
+
+        # Mock bootstrap service
+        mock_service = MagicMock()
+        bootstrap_mock.return_value = mock_service
+
+        # Run in normal mode (dry_run=False)
+        process_principal_events_from_kafka(dry_run=False)
+
+        # Verify update_user WAS called
+        mock_service.update_user.assert_called()
+
+
+@override_settings(V2_BOOTSTRAP_TENANT=True, PRINCIPAL_CLEANUP_UPDATE_ENABLED_KAFKA=True)
+class PrincipalKafkaTestsWithV2TenantBootstrap(PrincipalKafkaTests):
+    """Test the principal processor functions with V2 tenant bootstrap enabled."""
+
+    _tuples: InMemoryTuples
+
+    def setUp(self):
+        """Set up V2 tenant bootstrap tests."""
+        super().setUp()
+        seed_group()
+        self._tuples = InMemoryTuples()
+
+    @patch(
+        "management.principal.proxy.PrincipalProxy.request_filtered_principals",
+        return_value={"status_code": 200, "data": []},
+    )
+    @patch("management.principal.cleaner.KafkaConsumer")
+    @patch("management.principal.cleaner.settings.KAFKA_PRINCIPAL_CLEANUP_TOPIC", "test-topic")
+    def test_cleanup_same_principal_name_in_multiple_tenants(self, consumer_mock, proxy_mock):
+        """Test that can run a principal clean up with a principal that have multiple tenants."""
+        another_tenant = Tenant.objects.create(
+            tenant_name="another", account_id="11111112", org_id="17685861", ready=True
+        )
+        self.principal = Principal.objects.create(username=self.principal_name, user_id="56780000", tenant=self.tenant)
+        Principal.objects.create(username=self.principal_name, user_id="12340000", tenant=another_tenant)
+        self.assertEqual(Principal.objects.filter(username=self.principal_name).count(), 2)
+
+        mock_message = create_mock_kafka_message(KAFKA_MESSAGE_BODY)
+        consumer_instance = MagicMock()
+        consumer_instance.__iter__.return_value = iter([mock_message])
+        consumer_mock.return_value = consumer_instance
+
+        process_principal_events_from_kafka()
+
+        consumer_instance.close.assert_called_once()
+        self.assertFalse(Principal.objects.filter(username=self.principal_name, tenant=self.tenant).exists())
+        self.assertTrue(Principal.objects.filter(username=self.principal_name, tenant=another_tenant).exists())
+
+    @patch(
+        "management.principal.proxy.PrincipalProxy.request_filtered_principals",
+        return_value={"status_code": 200, "data": []},
+    )
+    @patch("management.principal.cleaner.KafkaConsumer")
+    @patch("management.principal.cleaner.settings.KAFKA_PRINCIPAL_CLEANUP_TOPIC", "test-topic")
+    def test_cleanup_principal_does_not_exist_no_tenant(self, consumer_mock, proxy_mock):
+        """Test cleanup when principal exists but tenant doesn't match."""
+        principal_name = "principal-keep"
+        # Create principal for a different tenant than what's in the message
+        other_tenant = Tenant.objects.create(tenant_name="other", account_id="99999", org_id="99999999", ready=True)
+        self.principal = Principal(username=principal_name, tenant=other_tenant)
+        self.principal.save()
+
+        mock_message = create_mock_kafka_message(KAFKA_MESSAGE_BODY)
+        consumer_instance = MagicMock()
+        consumer_instance.__iter__.return_value = iter([mock_message])
+        consumer_mock.return_value = consumer_instance
+
+        process_principal_events_from_kafka()
+
+        # Principal in other tenant should remain
+        self.assertTrue(Principal.objects.filter(username=principal_name, tenant=other_tenant).exists())
+        consumer_instance.close.assert_called_once()
+
+    @patch(
+        "management.principal.proxy.PrincipalProxy.request_filtered_principals",
+        return_value={
+            "status_code": 200,
+            "data": [
+                {
+                    "user_id": 56780000,
+                    "org_id": "17685860",
+                    "username": "principal-test",
+                    "email": "test_user@email.com",
+                    "first_name": "user",
+                    "last_name": "test",
+                    "is_org_admin": False,
+                    "is_active": True,
+                }
+            ],
+        },
+    )
+    @patch("management.principal.cleaner.KafkaConsumer")
+    @patch("management.principal.cleaner.settings.KAFKA_PRINCIPAL_CLEANUP_TOPIC", "test-topic")
+    def test_principal_creation_event_bootstraps_new_tenant(self, consumer_mock, proxy_mock):
+        """Test that principal creation event creates and bootstraps a new tenant."""
+        Tenant.objects.get(org_id="17685860").delete()
+
+        mock_message = create_mock_kafka_message(KAFKA_MESSAGE_CREATION)
+        consumer_instance = MagicMock()
+        consumer_instance.__iter__.return_value = iter([mock_message])
+        consumer_mock.return_value = consumer_instance
+
+        with patch(
+            "management.principal.cleaner.OutboxReplicator", new=partial(InMemoryRelationReplicator, self._tuples)
+        ):
+            process_principal_events_from_kafka()
+
+            consumer_instance.close.assert_called_once()
+
+            self.assertTenantBootstrappedByOrgId("17685860")
+            self.assertFalse(Tenant.objects.get(org_id="17685860").ready)
+
+    @patch(
+        "management.principal.proxy.PrincipalProxy.request_filtered_principals",
+        return_value={
+            "status_code": 200,
+            "data": [
+                {
+                    "user_id": 56780000,
+                    "org_id": "17685860",
+                    "username": "principal-test",
+                    "email": "test_user@email.com",
+                    "first_name": "user",
+                    "last_name": "test",
+                    "is_org_admin": False,
+                    "is_active": True,
+                }
+            ],
+        },
+    )
+    @patch("management.principal.cleaner.KafkaConsumer")
+    @patch("management.principal.cleaner.settings.KAFKA_PRINCIPAL_CLEANUP_TOPIC", "test-topic")
+    def test_principal_creation_event_bootstraps_existing_tenants(self, consumer_mock, proxy_mock):
+        """Test that principal creation event bootstraps existing tenant."""
+        mock_message = create_mock_kafka_message(KAFKA_MESSAGE_CREATION)
+        consumer_instance = MagicMock()
+        consumer_instance.__iter__.return_value = iter([mock_message])
+        consumer_mock.return_value = consumer_instance
+
+        with patch(
+            "management.principal.cleaner.OutboxReplicator", new=partial(InMemoryRelationReplicator, self._tuples)
+        ):
+            process_principal_events_from_kafka()
+
+            consumer_instance.close.assert_called_once()
+
+            self.assertTenantBootstrappedByOrgId("17685860")
+
+    @patch(
+        "management.principal.proxy.PrincipalProxy.request_filtered_principals",
+        return_value={
+            "status_code": 200,
+            "data": [
+                {
+                    "user_id": 56780000,
+                    "org_id": "17685860",
+                    "username": "principal-test",
+                    "email": "test_user@email.com",
+                    "first_name": "user",
+                    "last_name": "test",
+                    "is_org_admin": False,
+                    "is_active": True,
+                }
+            ],
+        },
+    )
+    @patch("management.principal.cleaner.KafkaConsumer")
+    @patch("management.principal.cleaner.settings.KAFKA_PRINCIPAL_CLEANUP_TOPIC", "test-topic")
+    def test_principal_creation_event_does_not_bootstrap_already_bootstraped_tenant(self, consumer_mock, proxy_mock):
+        """Test that already bootstrapped tenant stays ready."""
+        tenant = Tenant.objects.get(org_id="17685860")
+        tenant.ready = True
+        tenant.save()
+
+        mock_message = create_mock_kafka_message(KAFKA_MESSAGE_CREATION)
+        consumer_instance = MagicMock()
+        consumer_instance.__iter__.return_value = iter([mock_message])
+        consumer_mock.return_value = consumer_instance
+
+        process_principal_events_from_kafka()
+
+        consumer_instance.close.assert_called_once()
+        tenant.refresh_from_db()
+        self.assertTrue(tenant.ready)
+
+    @patch(
+        "management.principal.proxy.PrincipalProxy.request_filtered_principals",
+        return_value={
+            "status_code": 200,
+            "data": [
+                {
+                    "user_id": 56780000,
+                    "org_id": "17685860",
+                    "username": "principal-test",
+                    "email": "test_user@email.com",
+                    "first_name": "user",
+                    "last_name": "test",
+                    "is_org_admin": False,
+                    "is_active": True,
+                }
+            ],
+        },
+    )
+    @patch("management.principal.cleaner.KafkaConsumer")
+    @patch("management.principal.cleaner.settings.KAFKA_PRINCIPAL_CLEANUP_TOPIC", "test-topic")
+    def test_principal_creation_event_does_not_create_principal(self, consumer_mock, proxy_mock):
+        """Test that principal creation event creates tenant but does not create principal (upsert=False)."""
+        Tenant.objects.get(org_id="17685860").delete()
+
+        mock_message = create_mock_kafka_message(KAFKA_MESSAGE_CREATION)
+        consumer_instance = MagicMock()
+        consumer_instance.__iter__.return_value = iter([mock_message])
+        consumer_mock.return_value = consumer_instance
+
+        process_principal_events_from_kafka()
+
+        consumer_instance.close.assert_called_once()
+        self.assertTrue(Tenant.objects.filter(org_id="17685860").exists())
+        self.assertFalse(Principal.objects.filter(user_id=self.principal_user_id).exists())
+
+    @patch("management.principal.proxy.PrincipalProxy.request_filtered_principals", return_value={"status_code": 500})
+    @patch("management.principal.cleaner.KafkaConsumer")
+    @patch("management.principal.cleaner.settings.KAFKA_PRINCIPAL_CLEANUP_TOPIC", "test-topic")
+    def test_principal_creation_event_does_not_create_principal_nor_tenant(self, consumer_mock, proxy_mock):
+        """Test that nothing is created when proxy returns error."""
+        Tenant.objects.filter(org_id="17685860").delete()
+
+        mock_message = create_mock_kafka_message(KAFKA_MESSAGE_CREATION)
+        consumer_instance = MagicMock()
+        consumer_instance.__iter__.return_value = iter([mock_message])
+        consumer_mock.return_value = consumer_instance
+
+        process_principal_events_from_kafka()
+
+        consumer_instance.close.assert_called_once()
+        # Nothing should be created on proxy error
+        self.assertFalse(Tenant.objects.filter(org_id="17685860").exists())
+        self.assertFalse(Principal.objects.filter(username=self.principal_name).exists())
+
+    @patch(
+        "management.principal.proxy.PrincipalProxy.request_filtered_principals",
+        return_value={
+            "status_code": 200,
+            "data": [
+                {
+                    "user_id": 56780000,
+                    "org_id": "17685860",
+                    "username": "principal-test",
+                    "email": "test_user@email.com",
+                    "first_name": "user",
+                    "last_name": "test",
+                    "is_org_admin": False,
+                    "is_active": True,
+                }
+            ],
+        },
+    )
+    @patch("management.principal.cleaner.KafkaConsumer")
+    @patch("management.principal.cleaner.settings.KAFKA_PRINCIPAL_CLEANUP_TOPIC", "test-topic")
+    @override_settings(PRINCIPAL_CLEANUP_UPDATE_ENABLED_KAFKA=False)
+    def test_principal_creation_event_disabled(self, consumer_mock, proxy_mock):
+        """Test that when update setting is disabled we do not add tenants for new, active users."""
+        Tenant.objects.get(org_id="17685860").delete()
+
+        mock_message = create_mock_kafka_message(KAFKA_MESSAGE_CREATION)
+        consumer_instance = MagicMock()
+        consumer_instance.__iter__.return_value = iter([mock_message])
+        consumer_mock.return_value = consumer_instance
+
+        process_principal_events_from_kafka()
+
+        consumer_instance.close.assert_called_once()
+        self.assertFalse(Tenant.objects.filter(org_id="17685860").exists())
+        self.assertFalse(Principal.objects.filter(user_id=self.principal_user_id).exists())
+
+    @patch(
+        "management.principal.proxy.PrincipalProxy.request_filtered_principals",
+        return_value={"status_code": 200, "data": []},
+    )
+    @patch("management.group.model.AccessCache")
+    @patch("management.principal.cleaner.KafkaConsumer")
+    @patch("management.principal.cleaner.settings.KAFKA_PRINCIPAL_CLEANUP_TOPIC", "test-topic")
+    def test_disable_principal_which_is_in_or_not_in_group(self, consumer_mock, cache_class, proxy_mock):
+        """Test deleting a principal that is in a group when inactive."""
+        principal_name = "principal-test"
+        self.principal = Principal(username=principal_name, tenant=self.tenant, user_id="56780000")
+        self.principal.save()
+        self.group.principals.add(self.principal)
+        self.group.save()
+
+        mock_message = create_mock_kafka_message(KAFKA_MESSAGE_BODY)  # Inactive state
+        consumer_instance = MagicMock()
+        consumer_instance.__iter__.return_value = iter([mock_message])
+        consumer_mock.return_value = consumer_instance
+
+        cache_mock = MagicMock()
+        cache_class.return_value = cache_mock
+
+        process_principal_events_from_kafka()
+
+        # Principal should be deleted when inactive and not found in proxy
+        self.assertFalse(Principal.objects.filter(username=principal_name).exists())
+        cache_mock.delete_policy.assert_called_once_with(self.principal.uuid)
+
+    @patch(
+        "management.principal.proxy.PrincipalProxy.request_filtered_principals",
+        return_value={"status_code": 200, "data": []},
+    )
+    @patch("management.group.model.AccessCache")
+    @patch("management.principal.cleaner.KafkaConsumer")
+    @patch("management.principal.cleaner.settings.KAFKA_PRINCIPAL_CLEANUP_TOPIC", "test-topic")
+    def test_disable_principal_without_user_id_in_group(self, consumer_mock, cache_class, proxy_mock):
+        """Test deleting a principal without user_id that is in a group when inactive."""
+        principal_name = "principal-test"
+        # Principal without user_id
+        self.principal = Principal(username=principal_name, tenant=self.tenant)
+        self.principal.save()
+        principal_uuid = self.principal.uuid
+        self.group.principals.add(self.principal)
+        self.group.save()
+
+        mock_message = create_mock_kafka_message(KAFKA_MESSAGE_BODY)
+        consumer_instance = MagicMock()
+        consumer_instance.__iter__.return_value = iter([mock_message])
+        consumer_mock.return_value = consumer_instance
+
+        cache_mock = MagicMock()
+        cache_class.return_value = cache_mock
+
+        process_principal_events_from_kafka()
+
+        # Principal should be deleted when inactive and not found in proxy
+        self.assertFalse(Principal.objects.filter(username=principal_name).exists())
+        cache_mock.delete_policy.assert_called_once_with(principal_uuid)
+
+    @patch(
+        "management.principal.proxy.PrincipalProxy.request_filtered_principals",
+        return_value={"status_code": 200, "data": []},
+    )
+    @patch("management.principal.cleaner.KafkaConsumer")
+    @patch("management.principal.cleaner.settings.KAFKA_PRINCIPAL_CLEANUP_TOPIC", "test-topic")
+    def test_same_tenant_keeps_ready(self, consumer_mock, proxy_mock):
+        """Test that ready tenant stays ready after principal event."""
+        tenant = Tenant.objects.get(org_id="17685860")
+        tenant.ready = True
+        tenant.save()
+
+        mock_message = create_mock_kafka_message(KAFKA_MESSAGE_BODY)
+        consumer_instance = MagicMock()
+        consumer_instance.__iter__.return_value = iter([mock_message])
+        consumer_mock.return_value = consumer_instance
+
+        process_principal_events_from_kafka()
+
+        tenant.refresh_from_db()
+        self.assertTrue(tenant.ready)
+
+    @patch(
+        "management.principal.proxy.PrincipalProxy.request_filtered_principals",
+        return_value={"status_code": 200, "data": []},
+    )
+    @patch("management.principal.cleaner.KafkaConsumer")
+    @patch("management.principal.cleaner.settings.KAFKA_PRINCIPAL_CLEANUP_TOPIC", "test-topic")
+    def test_same_tenant_keeps_unready(self, consumer_mock, proxy_mock):
+        """Test that unready tenant stays unready after update event."""
+        tenant = Tenant.objects.get(org_id="17685860")
+        tenant.ready = False
+        tenant.save()
+
+        # Update event (not insert) shouldn't bootstrap tenant
+        mock_message = create_mock_kafka_message(KAFKA_MESSAGE_BODY)
+        consumer_instance = MagicMock()
+        consumer_instance.__iter__.return_value = iter([mock_message])
+        consumer_mock.return_value = consumer_instance
+
+        process_principal_events_from_kafka()
+
+        tenant.refresh_from_db()
+        self.assertFalse(tenant.ready)
+
+    @patch("management.relation_replicator.outbox_replicator.OutboxReplicator.replicate")
+    @patch(
+        "management.principal.proxy.PrincipalProxy.request_filtered_principals",
+        return_value={"status_code": 200, "data": []},
+    )
+    @patch("management.principal.cleaner.KafkaConsumer")
+    @patch("management.principal.cleaner.settings.KAFKA_PRINCIPAL_CLEANUP_TOPIC", "test-topic")
+    @override_settings(V2_BOOTSTRAP_TENANT=False)
+    def test_non_bootstrapped_tenant_no_principal_disabled_user_does_not_produce_replication_event(
+        self, consumer_mock, proxy_mock, replicate_mock
+    ):
+        """Test that non-V2 tenant with disabled user doesn't produce replication events."""
+        principal_name = "principal-test"
+        self.principal = Principal(username=principal_name, tenant=self.tenant, user_id="56780000")
+        self.principal.save()
+
+        mock_message = create_mock_kafka_message(KAFKA_MESSAGE_BODY)  # Inactive
+        consumer_instance = MagicMock()
+        consumer_instance.__iter__.return_value = iter([mock_message])
+        consumer_mock.return_value = consumer_instance
+
+        process_principal_events_from_kafka()
+
+        # Principal should be deleted when inactive and not found in proxy
+        self.assertFalse(Principal.objects.filter(username=principal_name).exists())
+        # No replication events should be produced for non-V2 tenants
+        replicate_mock.assert_not_called()
+        consumer_instance.close.assert_called_once()
+
+    def assertTenantBootstrappedByOrgId(self, org_id: str):
+        """Assert that a tenant has been fully bootstrapped with V2 components."""
+        tenant = Tenant.objects.get(org_id=org_id)
+        self.assertIsNotNone(tenant)
+        mapping = TenantMapping.objects.get(tenant=tenant)
+        self.assertIsNotNone(mapping)
+        workspaces = list(Workspace.objects.filter(tenant=tenant))
+        self.assertEqual(len(workspaces), 2)
+        default = Workspace.objects.default(tenant=tenant)
+        self.assertIsNotNone(default)
+        root = Workspace.objects.root(tenant=tenant)
+        self.assertIsNotNone(root)
+
+        platform_default_policy = Policy.objects.get(group=Group.objects.get(platform_default=True))
+        admin_default_policy = Policy.objects.get(group=Group.objects.get(admin_default=True))
+
+        self.assertEqual(default.parent_id, root.id)
+        self.assertEqual(
+            1,
+            self._tuples.count_tuples(
+                all_of(
+                    resource("rbac", "workspace", default.id),
+                    relation("binding"),
+                    subject("rbac", "role_binding", mapping.default_role_binding_uuid),
+                )
+            ),
+        )
+        self.assertEqual(
+            1,
+            self._tuples.count_tuples(
+                all_of(
+                    resource("rbac", "role_binding", mapping.default_role_binding_uuid),
+                    relation("subject"),
+                    subject("rbac", "group", mapping.default_group_uuid, "member"),
+                )
+            ),
+        )
+        self.assertEqual(
+            1,
+            self._tuples.count_tuples(
+                all_of(
+                    resource("rbac", "role_binding", mapping.default_role_binding_uuid),
+                    relation("role"),
+                    subject("rbac", "role", platform_default_policy.uuid),
+                )
+            ),
+        )
+
+        self.assertEqual(
+            1,
+            self._tuples.count_tuples(
+                all_of(
+                    resource("rbac", "workspace", default.id),
+                    relation("binding"),
+                    subject("rbac", "role_binding", mapping.default_admin_role_binding_uuid),
+                )
+            ),
+        )
+        self.assertEqual(
+            1,
+            self._tuples.count_tuples(
+                all_of(
+                    resource("rbac", "role_binding", mapping.default_admin_role_binding_uuid),
+                    relation("subject"),
+                    subject("rbac", "group", mapping.default_admin_group_uuid, "member"),
+                )
+            ),
+        )
+        self.assertEqual(
+            1,
+            self._tuples.count_tuples(
+                all_of(
+                    resource("rbac", "role_binding", mapping.default_admin_role_binding_uuid),
+                    relation("role"),
+                    subject("rbac", "role", admin_default_policy.uuid),
+                )
+            ),
+        )

--- a/tests/management/principal/test_umb_cleaner.py
+++ b/tests/management/principal/test_umb_cleaner.py
@@ -1067,7 +1067,7 @@ class PrincipalUMBTestsWithV2TenantBootstrap(PrincipalUMBTests):
         cache_mock.delete_policy.assert_called_once_with(principal.uuid)
         self.assertTrue(before + 1 == after)
 
-    @patch("management.principal.cleaner.retrieve_user_info")
+    @patch("management.principal.cleaner.retrieve_user_info_umb")
     @patch("management.principal.cleaner.UMB_CLIENT")
     def test_failure_processing_message(self, client_mock, retrieve_user_mock):
         """Test."""

--- a/tests/management/test_principal_cleanup_dispatcher.py
+++ b/tests/management/test_principal_cleanup_dispatcher.py
@@ -1,0 +1,505 @@
+#
+# Copyright 2025 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""Tests for principal_cleanup_via_message_bus dispatcher task."""
+
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+from kafka.errors import KafkaError
+
+
+class PrincipalCleanupDispatcherTest(TestCase):
+    """Test the principal_cleanup_via_message_bus dispatcher task routing logic."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        # Common settings that most tests will use
+        self.default_settings = {
+            "UMB_JOB_ENABLED": True,
+            "KAFKA_PRINCIPAL_CLEANUP_JOB_ENABLED": True,
+        }
+
+    @patch("management.tasks.settings")
+    @patch("management.tasks.logger")
+    def test_umb_only_mode_processes_via_umb(self, mock_logger, mock_settings):
+        """Test umb_only mode routes to UMB consumer."""
+        from management.tasks import principal_cleanup_via_message_bus
+
+        # Configure settings
+        for key, value in self.default_settings.items():
+            setattr(mock_settings, key, value)
+
+        with (
+            patch("feature_flags.FEATURE_FLAGS") as mock_ff,
+            patch("management.principal.cleaner.process_principal_events_from_umb") as mock_umb,
+            patch("management.principal.cleaner.process_principal_events_from_kafka") as mock_kafka,
+        ):
+
+            mock_ff.get_principal_cleanup_mode.return_value = "umb_only"
+
+            principal_cleanup_via_message_bus()
+
+            # Verify UMB was called
+            mock_umb.assert_called_once()
+            # Verify Kafka was NOT called
+            mock_kafka.assert_not_called()
+            # Verify mode was logged
+            mock_logger.info.assert_any_call("Principal cleanup mode: umb_only")
+
+    @patch("management.tasks.settings")
+    @patch("management.tasks.logger")
+    def test_umb_only_mode_when_umb_disabled(self, mock_logger, mock_settings):
+        """Test umb_only mode logs warning when UMB is disabled."""
+        from management.tasks import principal_cleanup_via_message_bus
+
+        # UMB disabled
+        mock_settings.UMB_JOB_ENABLED = False
+        mock_settings.KAFKA_PRINCIPAL_CLEANUP_JOB_ENABLED = True
+
+        with (
+            patch("feature_flags.FEATURE_FLAGS") as mock_ff,
+            patch("management.principal.cleaner.process_principal_events_from_umb") as mock_umb,
+        ):
+
+            mock_ff.get_principal_cleanup_mode.return_value = "umb_only"
+
+            principal_cleanup_via_message_bus()
+
+            # Verify UMB was NOT called (it's disabled)
+            mock_umb.assert_not_called()
+            # Verify warning was logged
+            mock_logger.warning.assert_any_call("UMB mode selected but UMB_JOB_ENABLED is False")
+
+    @patch("management.tasks.settings")
+    @patch("management.tasks.logger")
+    def test_kafka_shadow_mode_runs_both_consumers(self, mock_logger, mock_settings):
+        """Test kafka_shadow mode runs both UMB (active) and Kafka (dry-run)."""
+        from management.tasks import principal_cleanup_via_message_bus
+
+        for key, value in self.default_settings.items():
+            setattr(mock_settings, key, value)
+
+        with (
+            patch("feature_flags.FEATURE_FLAGS") as mock_ff,
+            patch("management.principal.cleaner.process_principal_events_from_umb") as mock_umb,
+            patch("management.principal.cleaner.process_principal_events_from_kafka") as mock_kafka,
+        ):
+
+            mock_ff.get_principal_cleanup_mode.return_value = "kafka_shadow"
+
+            principal_cleanup_via_message_bus()
+
+            # Verify UMB was called (active mode)
+            mock_umb.assert_called_once()
+            # Verify Kafka was called with dry_run=True
+            mock_kafka.assert_called_once_with(dry_run=True)
+            # Verify mode was logged
+            mock_logger.info.assert_any_call("Shadow mode: processing via UMB (active) and Kafka (dry-run)")
+
+    @patch("management.tasks.settings")
+    @patch("management.tasks.logger")
+    def test_kafka_shadow_mode_isolates_failures(self, mock_logger, mock_settings):
+        """Test kafka_shadow mode continues if one consumer fails (isolation)."""
+        from management.tasks import principal_cleanup_via_message_bus
+
+        for key, value in self.default_settings.items():
+            setattr(mock_settings, key, value)
+
+        with (
+            patch("feature_flags.FEATURE_FLAGS") as mock_ff,
+            patch("management.principal.cleaner.process_principal_events_from_umb") as mock_umb,
+            patch("management.principal.cleaner.process_principal_events_from_kafka") as mock_kafka,
+            patch("sentry_sdk.capture_exception") as mock_capture,
+        ):
+
+            mock_ff.get_principal_cleanup_mode.return_value = "kafka_shadow"
+            # UMB fails
+            mock_umb.side_effect = Exception("UMB connection failed")
+
+            # Should not raise - shadow mode isolates failures
+            principal_cleanup_via_message_bus()
+
+            # Verify UMB was attempted
+            mock_umb.assert_called_once()
+            # Verify Kafka still ran despite UMB failure
+            mock_kafka.assert_called_once_with(dry_run=True)
+            # Verify exception was captured
+            mock_capture.assert_called()
+            # Verify error was logged
+            mock_logger.error.assert_any_call("Shadow mode: UMB consumer failed: %s", "UMB connection failed")
+
+    @patch("management.tasks.settings")
+    @patch("management.tasks.logger")
+    def test_kafka_shadow_mode_when_umb_disabled(self, mock_logger, mock_settings):
+        """Test kafka_shadow mode logs warning when UMB is disabled."""
+        from management.tasks import principal_cleanup_via_message_bus
+
+        mock_settings.UMB_JOB_ENABLED = False
+        mock_settings.KAFKA_PRINCIPAL_CLEANUP_JOB_ENABLED = True
+
+        with (
+            patch("feature_flags.FEATURE_FLAGS") as mock_ff,
+            patch("management.principal.cleaner.process_principal_events_from_umb") as mock_umb,
+            patch("management.principal.cleaner.process_principal_events_from_kafka") as mock_kafka,
+        ):
+
+            mock_ff.get_principal_cleanup_mode.return_value = "kafka_shadow"
+
+            principal_cleanup_via_message_bus()
+
+            # Verify UMB was NOT called
+            mock_umb.assert_not_called()
+            # Verify Kafka still runs in shadow mode
+            mock_kafka.assert_called_once_with(dry_run=True)
+            # Verify warning was logged
+            mock_logger.warning.assert_any_call("Shadow mode requires UMB but UMB_JOB_ENABLED is False")
+
+    @patch("management.tasks.settings")
+    @patch("management.tasks.logger")
+    def test_kafka_shadow_mode_when_kafka_disabled(self, mock_logger, mock_settings):
+        """Test kafka_shadow mode logs warning when Kafka is disabled."""
+        from management.tasks import principal_cleanup_via_message_bus
+
+        mock_settings.UMB_JOB_ENABLED = True
+        mock_settings.KAFKA_PRINCIPAL_CLEANUP_JOB_ENABLED = False
+
+        with (
+            patch("feature_flags.FEATURE_FLAGS") as mock_ff,
+            patch("management.principal.cleaner.process_principal_events_from_umb") as mock_umb,
+            patch("management.principal.cleaner.process_principal_events_from_kafka") as mock_kafka,
+        ):
+
+            mock_ff.get_principal_cleanup_mode.return_value = "kafka_shadow"
+
+            principal_cleanup_via_message_bus()
+
+            # Verify UMB runs
+            mock_umb.assert_called_once()
+            # Verify Kafka was NOT called
+            mock_kafka.assert_not_called()
+            # Verify warning was logged
+            mock_logger.warning.assert_any_call(
+                "Shadow mode requires Kafka but KAFKA_PRINCIPAL_CLEANUP_JOB_ENABLED is False"
+            )
+
+    @patch("management.tasks.settings")
+    @patch("management.tasks.logger")
+    def test_kafka_validation_mode_kafka_succeeds(self, mock_logger, mock_settings):
+        """Test kafka_validation mode when Kafka succeeds (no UMB fallback needed)."""
+        from management.tasks import principal_cleanup_via_message_bus
+
+        for key, value in self.default_settings.items():
+            setattr(mock_settings, key, value)
+
+        with (
+            patch("feature_flags.FEATURE_FLAGS") as mock_ff,
+            patch("management.principal.cleaner.process_principal_events_from_umb") as mock_umb,
+            patch("management.principal.cleaner.process_principal_events_from_kafka") as mock_kafka,
+            patch("management.principal.cleaner.kafka_validation_success_total") as mock_success_metric,
+        ):
+
+            mock_ff.get_principal_cleanup_mode.return_value = "kafka_validation"
+
+            principal_cleanup_via_message_bus()
+
+            # Verify Kafka was called (not dry-run)
+            mock_kafka.assert_called_once_with(dry_run=False)
+            # Verify UMB was NOT called (Kafka succeeded)
+            mock_umb.assert_not_called()
+            # Verify success metric incremented
+            mock_success_metric.inc.assert_called_once()
+            # Verify success logged
+            mock_logger.info.assert_any_call("Validation mode: Kafka consumer completed successfully")
+
+    @patch("management.tasks.settings")
+    @patch("management.tasks.logger")
+    def test_kafka_validation_mode_kafka_fails_umb_succeeds(self, mock_logger, mock_settings):
+        """Test kafka_validation mode when Kafka fails and UMB fallback succeeds."""
+        from management.tasks import principal_cleanup_via_message_bus
+
+        for key, value in self.default_settings.items():
+            setattr(mock_settings, key, value)
+
+        with (
+            patch("feature_flags.FEATURE_FLAGS") as mock_ff,
+            patch("management.principal.cleaner.process_principal_events_from_umb") as mock_umb,
+            patch("management.principal.cleaner.process_principal_events_from_kafka") as mock_kafka,
+            patch("management.principal.cleaner.kafka_validation_fallback_total") as mock_fallback_metric,
+            patch("sentry_sdk.capture_exception") as mock_capture,
+        ):
+
+            mock_ff.get_principal_cleanup_mode.return_value = "kafka_validation"
+            # Kafka fails
+            kafka_error = Exception("Connection timeout")
+            mock_kafka.side_effect = kafka_error
+
+            principal_cleanup_via_message_bus()
+
+            # Verify Kafka was attempted
+            mock_kafka.assert_called_once_with(dry_run=False)
+            # Verify UMB was called as fallback
+            mock_umb.assert_called_once()
+            # Verify fallback metric incremented
+            mock_fallback_metric.inc.assert_called_once()
+            # Verify exception was captured
+            mock_capture.assert_called()
+            # Verify error and fallback logged
+            mock_logger.error.assert_any_call(
+                "Validation mode: Kafka consumer failed: %s. Falling back to UMB.", "Connection timeout"
+            )
+            mock_logger.info.assert_any_call("Validation mode: UMB fallback completed successfully")
+
+    @patch("management.tasks.settings")
+    @patch("management.tasks.logger")
+    def test_kafka_validation_mode_both_fail(self, mock_logger, mock_settings):
+        """Test kafka_validation mode when both Kafka and UMB fail (critical error)."""
+        from management.tasks import principal_cleanup_via_message_bus
+
+        for key, value in self.default_settings.items():
+            setattr(mock_settings, key, value)
+
+        with (
+            patch("feature_flags.FEATURE_FLAGS") as mock_ff,
+            patch("management.principal.cleaner.process_principal_events_from_umb") as mock_umb,
+            patch("management.principal.cleaner.process_principal_events_from_kafka") as mock_kafka,
+            patch("management.principal.cleaner.kafka_validation_fallback_total") as mock_fallback_metric,
+            patch("sentry_sdk.capture_exception") as mock_capture,
+        ):
+
+            mock_ff.get_principal_cleanup_mode.return_value = "kafka_validation"
+            # Both fail
+            kafka_error = KafkaError("Connection timeout")
+            umb_error = Exception("UMB broker unreachable")
+            mock_kafka.side_effect = kafka_error
+            mock_umb.side_effect = umb_error
+
+            # Should raise RuntimeError
+            with self.assertRaises(RuntimeError) as context:
+                principal_cleanup_via_message_bus()
+
+            # Verify error message
+            self.assertIn("Both Kafka and UMB consumers failed", str(context.exception))
+            # Verify both were attempted
+            mock_kafka.assert_called_once_with(dry_run=False)
+            mock_umb.assert_called_once()
+            # Verify fallback metric incremented
+            mock_fallback_metric.inc.assert_called_once()
+            # Verify both exceptions were captured
+            self.assertEqual(mock_capture.call_count, 2)
+            # Verify error logged
+            mock_logger.error.assert_any_call(
+                "Validation mode: UMB fallback also failed: %s", "UMB broker unreachable"
+            )
+
+    @patch("management.tasks.settings")
+    @patch("management.tasks.logger")
+    def test_kafka_validation_mode_kafka_disabled(self, mock_logger, mock_settings):
+        """Test kafka_validation mode when Kafka is disabled (should use UMB)."""
+        from management.tasks import principal_cleanup_via_message_bus
+
+        mock_settings.UMB_JOB_ENABLED = True
+        mock_settings.KAFKA_PRINCIPAL_CLEANUP_JOB_ENABLED = False
+
+        with (
+            patch("feature_flags.FEATURE_FLAGS") as mock_ff,
+            patch("management.principal.cleaner.process_principal_events_from_umb") as mock_umb,
+            patch("management.principal.cleaner.process_principal_events_from_kafka") as mock_kafka,
+            patch("management.principal.cleaner.kafka_validation_fallback_total") as mock_fallback_metric,
+        ):
+
+            mock_ff.get_principal_cleanup_mode.return_value = "kafka_validation"
+
+            principal_cleanup_via_message_bus()
+
+            # Verify Kafka was NOT called (disabled)
+            mock_kafka.assert_not_called()
+            # Verify UMB was called as fallback
+            mock_umb.assert_called_once()
+            # Verify fallback metric incremented
+            mock_fallback_metric.inc.assert_called_once()
+            # Verify warning logged
+            mock_logger.warning.assert_any_call(
+                "Validation mode requires Kafka but KAFKA_PRINCIPAL_CLEANUP_JOB_ENABLED is False"
+            )
+
+    @patch("management.tasks.settings")
+    @patch("management.tasks.logger")
+    def test_kafka_validation_mode_both_disabled(self, mock_logger, mock_settings):
+        """Test kafka_validation mode when both Kafka and UMB are disabled."""
+        from management.tasks import principal_cleanup_via_message_bus
+
+        mock_settings.UMB_JOB_ENABLED = False
+        mock_settings.KAFKA_PRINCIPAL_CLEANUP_JOB_ENABLED = False
+
+        with (
+            patch("feature_flags.FEATURE_FLAGS") as mock_ff,
+            patch("management.principal.cleaner.process_principal_events_from_umb") as mock_umb,
+            patch("management.principal.cleaner.process_principal_events_from_kafka") as mock_kafka,
+        ):
+
+            mock_ff.get_principal_cleanup_mode.return_value = "kafka_validation"
+
+            # Should raise RuntimeError
+            with self.assertRaises(RuntimeError) as context:
+                principal_cleanup_via_message_bus()
+
+            # Verify error message
+            self.assertIn("Kafka failed and no UMB fallback available", str(context.exception))
+            # Verify neither was called
+            mock_kafka.assert_not_called()
+            mock_umb.assert_not_called()
+
+    @patch("management.tasks.settings")
+    @patch("management.tasks.logger")
+    def test_kafka_active_mode_processes_via_kafka(self, mock_logger, mock_settings):
+        """Test kafka_active mode routes to Kafka consumer."""
+        from management.tasks import principal_cleanup_via_message_bus
+
+        for key, value in self.default_settings.items():
+            setattr(mock_settings, key, value)
+
+        with (
+            patch("feature_flags.FEATURE_FLAGS") as mock_ff,
+            patch("management.principal.cleaner.process_principal_events_from_umb") as mock_umb,
+            patch("management.principal.cleaner.process_principal_events_from_kafka") as mock_kafka,
+        ):
+
+            mock_ff.get_principal_cleanup_mode.return_value = "kafka_active"
+
+            principal_cleanup_via_message_bus()
+
+            # Verify Kafka was called (not dry-run)
+            mock_kafka.assert_called_once_with(dry_run=False)
+            # Verify UMB was NOT called
+            mock_umb.assert_not_called()
+            # Verify mode was logged
+            mock_logger.info.assert_any_call("Kafka-active mode: processing via Kafka")
+
+    @patch("management.tasks.settings")
+    @patch("management.tasks.logger")
+    def test_kafka_active_mode_raises_when_kafka_disabled(self, mock_logger, mock_settings):
+        """Test kafka_active mode raises RuntimeError when Kafka is disabled (no silent fallback)."""
+        from management.tasks import principal_cleanup_via_message_bus
+
+        mock_settings.UMB_JOB_ENABLED = True
+        mock_settings.KAFKA_PRINCIPAL_CLEANUP_JOB_ENABLED = False
+
+        with (
+            patch("feature_flags.FEATURE_FLAGS") as mock_ff,
+            patch("management.principal.cleaner.process_principal_events_from_umb") as mock_umb,
+            patch("management.principal.cleaner.process_principal_events_from_kafka") as mock_kafka,
+        ):
+
+            mock_ff.get_principal_cleanup_mode.return_value = "kafka_active"
+
+            # Should raise RuntimeError for configuration mismatch
+            with self.assertRaises(RuntimeError) as context:
+                principal_cleanup_via_message_bus()
+
+            # Verify error message
+            self.assertIn("Configuration mismatch", str(context.exception))
+            self.assertIn("kafka_active mode selected in Unleash", str(context.exception))
+            self.assertIn("KAFKA_PRINCIPAL_CLEANUP_JOB_ENABLED is False", str(context.exception))
+
+            # Verify neither consumer was called
+            mock_kafka.assert_not_called()
+            mock_umb.assert_not_called()
+
+            # Verify error was logged
+            mock_logger.error.assert_called()
+
+    @patch("management.tasks.settings")
+    @patch("management.tasks.logger")
+    def test_kafka_active_mode_both_disabled(self, mock_logger, mock_settings):
+        """Test kafka_active mode raises when Kafka is disabled (even if UMB is also disabled)."""
+        from management.tasks import principal_cleanup_via_message_bus
+
+        mock_settings.UMB_JOB_ENABLED = False
+        mock_settings.KAFKA_PRINCIPAL_CLEANUP_JOB_ENABLED = False
+
+        with (
+            patch("feature_flags.FEATURE_FLAGS") as mock_ff,
+            patch("management.principal.cleaner.process_principal_events_from_umb") as mock_umb,
+            patch("management.principal.cleaner.process_principal_events_from_kafka") as mock_kafka,
+        ):
+
+            mock_ff.get_principal_cleanup_mode.return_value = "kafka_active"
+
+            # Should raise RuntimeError for configuration mismatch
+            with self.assertRaises(RuntimeError) as context:
+                principal_cleanup_via_message_bus()
+
+            # Verify error message
+            self.assertIn("Configuration mismatch", str(context.exception))
+            self.assertIn("kafka_active mode selected in Unleash", str(context.exception))
+
+            # Verify neither was called
+            mock_kafka.assert_not_called()
+            mock_umb.assert_not_called()
+
+            # Verify error was logged
+            mock_logger.error.assert_called()
+
+    @patch("management.tasks.settings")
+    @patch("management.tasks.logger")
+    def test_unknown_mode_defaults_to_umb(self, mock_logger, mock_settings):
+        """Test that unknown mode defaults to UMB with error log."""
+        from management.tasks import principal_cleanup_via_message_bus
+
+        for key, value in self.default_settings.items():
+            setattr(mock_settings, key, value)
+
+        with (
+            patch("feature_flags.FEATURE_FLAGS") as mock_ff,
+            patch("management.principal.cleaner.process_principal_events_from_umb") as mock_umb,
+            patch("management.principal.cleaner.process_principal_events_from_kafka") as mock_kafka,
+        ):
+
+            mock_ff.get_principal_cleanup_mode.return_value = "invalid_mode"
+
+            principal_cleanup_via_message_bus()
+
+            # Verify UMB was called (fallback)
+            mock_umb.assert_called_once()
+            # Verify Kafka was NOT called
+            mock_kafka.assert_not_called()
+            # Verify error was logged
+            mock_logger.error.assert_any_call("Unknown principal cleanup mode: invalid_mode, defaulting to UMB")
+
+    @patch("management.tasks.settings")
+    @patch("management.tasks.logger")
+    def test_unknown_mode_umb_disabled(self, mock_logger, mock_settings):
+        """Test that unknown mode logs warning when UMB is disabled."""
+        from management.tasks import principal_cleanup_via_message_bus
+
+        mock_settings.UMB_JOB_ENABLED = False
+        mock_settings.KAFKA_PRINCIPAL_CLEANUP_JOB_ENABLED = True
+
+        with (
+            patch("feature_flags.FEATURE_FLAGS") as mock_ff,
+            patch("management.principal.cleaner.process_principal_events_from_umb") as mock_umb,
+        ):
+
+            mock_ff.get_principal_cleanup_mode.return_value = "invalid_mode"
+
+            principal_cleanup_via_message_bus()
+
+            # Verify UMB was NOT called
+            mock_umb.assert_not_called()
+            # Verify warnings were logged
+            mock_logger.error.assert_any_call("Unknown principal cleanup mode: invalid_mode, defaulting to UMB")
+            mock_logger.warning.assert_any_call("Fallback to UMB failed: UMB_JOB_ENABLED is False")

--- a/tests/rbac/test_settings_validation.py
+++ b/tests/rbac/test_settings_validation.py
@@ -1,0 +1,102 @@
+#
+# Copyright 2025 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""Tests for settings validation logic."""
+
+import importlib
+import os
+import sys
+from unittest import TestCase
+from unittest.mock import patch
+
+
+class SettingsValidationTest(TestCase):
+    """Test settings validation that occurs at module import time."""
+
+    def test_kafka_principal_cleanup_topic_required_when_kafka_enabled(self):
+        """Test that settings raises ValueError when Kafka cleanup is enabled but topic is empty."""
+        # Mock environment variables to simulate misconfiguration
+        env_vars = {
+            "PRINCIPAL_CLEANUP_DELETION_ENABLED_KAFKA": "True",
+            "KAFKA_PRINCIPAL_CLEANUP_TOPIC": "",  # Empty topic - should fail
+        }
+
+        with patch.dict(os.environ, env_vars, clear=False):
+            # Remove settings module from cache to force reimport with new env vars
+            if "rbac.settings" in sys.modules:
+                del sys.modules["rbac.settings"]
+
+            # Attempting to import settings should raise ValueError
+            with self.assertRaises(ValueError) as context:
+                import rbac.settings  # noqa: F401
+
+            self.assertIn("PRINCIPAL_CLEANUP_DELETION_ENABLED_KAFKA is True", str(context.exception))
+            self.assertIn("KAFKA_PRINCIPAL_CLEANUP_TOPIC is not configured", str(context.exception))
+
+    def test_kafka_principal_cleanup_topic_not_required_when_kafka_disabled(self):
+        """Test that settings loads successfully when Kafka cleanup is disabled, even with empty topic."""
+        # Mock environment variables - Kafka disabled, empty topic is OK
+        env_vars = {
+            "PRINCIPAL_CLEANUP_DELETION_ENABLED_KAFKA": "False",
+            "KAFKA_PRINCIPAL_CLEANUP_TOPIC": "",  # Empty topic is OK when disabled
+        }
+
+        with patch.dict(os.environ, env_vars, clear=False):
+            # Remove settings module from cache to force reimport
+            if "rbac.settings" in sys.modules:
+                del sys.modules["rbac.settings"]
+
+            # Should not raise - this is valid configuration
+            try:
+                import rbac.settings  # noqa: F401
+
+                # If we get here, import succeeded - this is expected
+                self.assertTrue(True)
+            except ValueError:
+                self.fail("Settings should not raise ValueError when Kafka cleanup is disabled")
+            finally:
+                # Re-import settings to restore normal state
+                if "rbac.settings" in sys.modules:
+                    del sys.modules["rbac.settings"]
+                importlib.import_module("rbac.settings")
+
+    def test_kafka_principal_cleanup_succeeds_with_valid_topic(self):
+        """Test that settings loads successfully when Kafka cleanup is enabled with valid topic."""
+        # Mock environment variables - Kafka enabled with valid topic
+        env_vars = {
+            "PRINCIPAL_CLEANUP_DELETION_ENABLED_KAFKA": "True",
+            "KAFKA_PRINCIPAL_CLEANUP_TOPIC": "platform.principal.events",  # Valid topic
+        }
+
+        with patch.dict(os.environ, env_vars, clear=False):
+            # Remove settings module from cache to force reimport
+            if "rbac.settings" in sys.modules:
+                del sys.modules["rbac.settings"]
+
+            # Should not raise - this is valid configuration
+            try:
+                import rbac.settings  # noqa: F401
+
+                # Verify the topic is correctly set
+                self.assertEqual(rbac.settings.KAFKA_PRINCIPAL_CLEANUP_TOPIC, "platform.principal.events")
+                self.assertTrue(rbac.settings.PRINCIPAL_CLEANUP_DELETION_ENABLED_KAFKA)
+            except ValueError:
+                self.fail("Settings should not raise ValueError with valid Kafka topic configuration")
+            finally:
+                # Re-import settings to restore normal state
+                if "rbac.settings" in sys.modules:
+                    del sys.modules["rbac.settings"]
+                importlib.import_module("rbac.settings")

--- a/tests/test_feature_flags.py
+++ b/tests/test_feature_flags.py
@@ -20,6 +20,7 @@ import threading
 import time
 from django.conf import settings
 from django.test import TestCase
+from unittest.mock import patch
 from feature_flags import FEATURE_FLAGS
 
 
@@ -125,3 +126,172 @@ class FeatureFlagsTest(TestCase):
         # which defaults to True
         self.assertTrue(settings.USE_ROLE_BINDING_VIEW_PERMISSION)
         self.assertTrue(FEATURE_FLAGS.is_use_role_binding_view_permission_enabled())
+
+    @patch("feature_flags.FEATURE_FLAGS.initialize")
+    def test_get_principal_cleanup_mode_defaults_to_umb_only_without_client(self, mock_initialize):
+        """Test that get_principal_cleanup_mode returns 'umb_only' when client is not initialized."""
+        FEATURE_FLAGS.client = None
+        mode = FEATURE_FLAGS.get_principal_cleanup_mode()
+        self.assertEqual(mode, "umb_only")
+        # Verify that initialize was called when client was None
+        mock_initialize.assert_called_once()
+
+    def test_get_principal_cleanup_mode_returns_umb_only_when_flag_disabled(self):
+        """Test that get_principal_cleanup_mode returns 'umb_only' when flag is disabled."""
+        FEATURE_FLAGS.initialize()
+        # Mock the is_enabled method to return False
+        original_is_enabled = FEATURE_FLAGS.is_enabled
+
+        def mock_is_enabled(feature_name, **kwargs):
+            if feature_name == FEATURE_FLAGS.TOGGLE_USE_KAFKA_CLEANUP:
+                return False
+            return original_is_enabled(feature_name, **kwargs)
+
+        FEATURE_FLAGS.is_enabled = mock_is_enabled
+
+        mode = FEATURE_FLAGS.get_principal_cleanup_mode()
+        self.assertEqual(mode, "umb_only")
+
+        # Restore original method
+        FEATURE_FLAGS.is_enabled = original_is_enabled
+
+    def test_get_principal_cleanup_mode_returns_kafka_shadow_with_variant(self):
+        """Test that get_principal_cleanup_mode returns 'kafka_shadow' when variant is set."""
+        FEATURE_FLAGS.initialize()
+        # Fail explicitly if client is unavailable
+        self.assertIsNotNone(FEATURE_FLAGS.client, "FEATURE_FLAGS.client is None - cannot run test")
+
+        # Mock both is_enabled and get_variant
+        original_is_enabled = FEATURE_FLAGS.is_enabled
+
+        def mock_is_enabled(feature_name, **kwargs):
+            if feature_name == FEATURE_FLAGS.TOGGLE_USE_KAFKA_CLEANUP:
+                return True
+            return original_is_enabled(feature_name, **kwargs)
+
+        FEATURE_FLAGS.is_enabled = mock_is_enabled
+
+        # Mock get_variant to return kafka_shadow
+        original_get_variant = FEATURE_FLAGS.client.get_variant
+
+        def mock_get_variant(feature_name, **kwargs):
+            if feature_name == FEATURE_FLAGS.TOGGLE_USE_KAFKA_CLEANUP:
+                return {"name": "kafka_shadow", "enabled": True}
+            return original_get_variant(feature_name, **kwargs)
+
+        FEATURE_FLAGS.client.get_variant = mock_get_variant
+
+        # Run the test - moved outside conditional so it always runs
+        mode = FEATURE_FLAGS.get_principal_cleanup_mode()
+        self.assertEqual(mode, "kafka_shadow")
+
+        # Restore original methods
+        FEATURE_FLAGS.client.get_variant = original_get_variant
+        FEATURE_FLAGS.is_enabled = original_is_enabled
+
+    def test_get_principal_cleanup_mode_returns_kafka_active_with_default_variant(self):
+        """Test that get_principal_cleanup_mode returns 'kafka_active' when flag is enabled without specific variant."""
+        FEATURE_FLAGS.initialize()
+        # Fail explicitly if client is unavailable
+        self.assertIsNotNone(FEATURE_FLAGS.client, "FEATURE_FLAGS.client is None - cannot run test")
+
+        # Mock both is_enabled and get_variant
+        original_is_enabled = FEATURE_FLAGS.is_enabled
+
+        def mock_is_enabled(feature_name, **kwargs):
+            if feature_name == FEATURE_FLAGS.TOGGLE_USE_KAFKA_CLEANUP:
+                return True
+            return original_is_enabled(feature_name, **kwargs)
+
+        FEATURE_FLAGS.is_enabled = mock_is_enabled
+
+        # Mock get_variant to return kafka_active (or any other variant)
+        original_get_variant = FEATURE_FLAGS.client.get_variant
+
+        def mock_get_variant(feature_name, **kwargs):
+            if feature_name == FEATURE_FLAGS.TOGGLE_USE_KAFKA_CLEANUP:
+                return {"name": "kafka_active", "enabled": True}
+            return original_get_variant(feature_name, **kwargs)
+
+        FEATURE_FLAGS.client.get_variant = mock_get_variant
+
+        # Run the test - moved outside conditional so it always runs
+        mode = FEATURE_FLAGS.get_principal_cleanup_mode()
+        self.assertEqual(mode, "kafka_active")
+
+        # Restore original methods
+        FEATURE_FLAGS.client.get_variant = original_get_variant
+        FEATURE_FLAGS.is_enabled = original_is_enabled
+
+    def test_get_principal_cleanup_mode_returns_umb_only_with_unknown_variant(self):
+        """Test that get_principal_cleanup_mode returns 'umb_only' when flag is enabled with unknown variant (safe default)."""
+        FEATURE_FLAGS.initialize()
+        # Fail explicitly if client is unavailable
+        self.assertIsNotNone(FEATURE_FLAGS.client, "FEATURE_FLAGS.client is None - cannot run test")
+
+        # Mock both is_enabled and get_variant
+        original_is_enabled = FEATURE_FLAGS.is_enabled
+
+        def mock_is_enabled(feature_name, **kwargs):
+            if feature_name == FEATURE_FLAGS.TOGGLE_USE_KAFKA_CLEANUP:
+                return True
+            return original_is_enabled(feature_name, **kwargs)
+
+        FEATURE_FLAGS.is_enabled = mock_is_enabled
+
+        # Mock get_variant to return an unknown/invalid variant name
+        original_get_variant = FEATURE_FLAGS.client.get_variant
+
+        def mock_get_variant(feature_name, **kwargs):
+            if feature_name == FEATURE_FLAGS.TOGGLE_USE_KAFKA_CLEANUP:
+                # Return unknown variant (e.g. "disabled", "unknown", etc.)
+                return {"name": "disabled", "enabled": True}
+            return original_get_variant(feature_name, **kwargs)
+
+        FEATURE_FLAGS.client.get_variant = mock_get_variant
+
+        # Run the test - should default to umb_only for unknown variant (safe default)
+        mode = FEATURE_FLAGS.get_principal_cleanup_mode()
+        self.assertEqual(mode, "umb_only")
+
+        # Restore original methods
+        FEATURE_FLAGS.client.get_variant = original_get_variant
+        FEATURE_FLAGS.is_enabled = original_is_enabled
+
+    def test_is_kafka_shadow_mode_enabled_returns_true_for_shadow_mode(self):
+        """Test that is_kafka_shadow_mode_enabled returns True when in shadow mode."""
+        FEATURE_FLAGS.initialize()
+        # Mock get_principal_cleanup_mode to return 'kafka_shadow'
+        original_get_mode = FEATURE_FLAGS.get_principal_cleanup_mode
+
+        def mock_get_mode():
+            return "kafka_shadow"
+
+        FEATURE_FLAGS.get_principal_cleanup_mode = mock_get_mode
+
+        self.assertTrue(FEATURE_FLAGS.is_kafka_shadow_mode_enabled())
+
+        # Restore original method
+        FEATURE_FLAGS.get_principal_cleanup_mode = original_get_mode
+
+    def test_is_kafka_shadow_mode_enabled_returns_false_for_other_modes(self):
+        """Test that is_kafka_shadow_mode_enabled returns False for non-shadow modes."""
+        FEATURE_FLAGS.initialize()
+        # Test for umb_only
+        original_get_mode = FEATURE_FLAGS.get_principal_cleanup_mode
+
+        def mock_get_mode_umb():
+            return "umb_only"
+
+        FEATURE_FLAGS.get_principal_cleanup_mode = mock_get_mode_umb
+        self.assertFalse(FEATURE_FLAGS.is_kafka_shadow_mode_enabled())
+
+        # Test for kafka_active
+        def mock_get_mode_kafka():
+            return "kafka_active"
+
+        FEATURE_FLAGS.get_principal_cleanup_mode = mock_get_mode_kafka
+        self.assertFalse(FEATURE_FLAGS.is_kafka_shadow_mode_enabled())
+
+        # Restore original method
+        FEATURE_FLAGS.get_principal_cleanup_mode = original_get_mode


### PR DESCRIPTION
## Link(s) to Jira
- [RHCLOUD-42232](https://redhat.atlassian.net/browse/RHCLOUD-42232)
-  [HCMSEC-3031](https://redhat.atlassian.net/browse/HCMSEC-3031)

## Description of Intent of Change(s)

Principal Cleanup Refactor:
  - Refactored rbac/management/principal/cleaner.py to use Kafka for principal cleanup events instead of UMB depending on unleash flag
  - Integrated with existing Kafka consumer infrastructure (rbac/core/kafka_consumer.py)
  -  Toggle between UMB and Kafka in real-time via Unleash:
    - Set Unleash flag rbac.principal-cleanup.use-kafka.enabled to True → Uses Kafka
    - Set Unleash flag rbac.principal-cleanup.use-kafka.enabled to False → Uses UMB

  Configuration Updates:
  - Updated .env.example with new Kafka-specific environment variables
  - Modified rbac/rbac/settings.py to add Kafka consumer configuration settings
  - Updated deploy/rbac-clowdapp.yml with Kafka consumer deployment configuration
  - Enhanced docker-compose.yml to include Kafka and Zookeeper services for local development

  Celery Task Updates:
  - Updated rbac/rbac/celery.py and rbac/management/tasks.py to use Kafka-based principal cleanup
  - Removed UMB-specific Celery beat schedules

  Testing Infrastructure:
  - Converted test suite in tests/management/principal/test_cleaner.py  from UMB to KAFKA
  - Removed UMB-specific test mocking and fixtures
  - Added scripts/test_kafka_producer.py for manual integration testing


## Local Testing
 All existing tests pass with the new Kafka implementation:

### Unit Tests
  #### Run all tests (should pass)
  `pipenv run tox -e py312-fast`

  #### Run only principal cleanup tests
  `pipenv run tox -e py312-fast -- tests.management.principal.test_cleaner`

  #### Run with coverage
  `pipenv run tox -e py312`

 Expected Results: All tests pass.

### Integration Tests

#### 1. Start services with Debezium
  `podman-compose -f docker-compose.debezium.yml up -d`

  #### 2. Run consumer
  `./scripts/debezium/run_kafka_consumer.sh`

  ##### 3. Send test relations message
  `./scripts/debezium/send_test_relations_message.sh`

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [x] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices


[RHCLOUD-42232]: https://redhat.atlassian.net/browse/RHCLOUD-42232?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HCMSEC-3031]: https://redhat.atlassian.net/browse/HCMSEC-3031?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Migrate principal cleanup processing from UMB to Kafka and wire it into the scheduled cleanup job and configuration.

New Features:
- Introduce Kafka-based principal cleanup flow that consumes canonical user events and updates or deletes principals and tenants accordingly.
- Add local Kafka and Zookeeper services plus a helper Kafka producer script for manual/integration testing of principal cleanup messages.

Enhancements:
- Replace UMB/STOMP XML handling with Kafka JSON processing in the principal cleaner, including new success/failure metrics and lock-based concurrency control.
- Update Celery scheduling and settings to drive principal cleanup via Kafka feature flags and environment variables instead of UMB-specific ones.
- Expand and refactor principal cleanup tests to exercise Kafka-based behaviour, tenant bootstrap interactions, and failure handling paths.
- Adjust Docker and Debezium-related scripts and health checks to support running the Kafka consumer with metrics in local and test environments.
- Change dependency installation to skip Pipfile.lock resolution during image build to work around lock conflicts.

Build:
- Updated UMB-related Python dependencies (stompest, xmltodict) and rely on kafka-python for messaging.
- Update Dockerfile to install dependencies with pipenv using --skip-lock to avoid lock-induced build failures.

Deployment:
- Update ClowdApp deployment configuration and parameters to remove UMB host/secret usage and add Kafka-based principal cleanup configuration flags.

Tests:
- Rewrite principal cleanup integration tests to use Kafka consumers and JSON messages instead of UMB frames, covering multiple tenant scenarios, disable/update paths, and error handling.
- Add a standalone Kafka producer test script to send sample canonical user messages for exercising the cleanup pipeline end-to-end.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Kafka-based principal cleanup with configurable 3-mode behavior: UMB-only, Kafka shadow (dry-run), and Kafka active (writes).
  * Introduced new Kafka cleanup controls, topic/DLQ routing, and message-consumer health/enablement, plus automated scheduling/dispatch.
  * Updated local development to run Kafka with ZooKeeper via docker-compose (including health checks and consumer metrics).

* **Bug Fixes**
  * Improved principal reference extraction to capture both organization and account details during cleanup.

* **Tests**
  * Expanded end-to-end Kafka cleaner test coverage, including dry-run and DLQ behaviors; updated UMB failure-path mocks.

* **Chores**
  * Added Kafka local-testing defaults to `.env.example` and included a small Kafka producer test script.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->