### PR TITLE
Add listen/notify for migrate_binding_scope

### DIFF
--- a/rbac/core/kafka_consumer.py
+++ b/rbac/core/kafka_consumer.py
@@ -30,13 +30,12 @@ import grpc
 from django.conf import settings
 from django.db import connection
 from google.protobuf import json_format
-from internal.pg_notify_wait import REMOVE_LEGACY_ROOT_WORKSPACE_PARENT_NOTIFY_CHANNEL
+from internal.pg_notify_wait import notify_migration_batch_completion
 from kafka import KafkaConsumer, TopicPartition
 from kafka.consumer.subscription_state import ConsumerRebalanceListener
 from kafka.errors import KafkaError
 from kafka.structs import OffsetAndMetadata
 from kessel.relations.v1beta1 import common_pb2
-from management.relation_replicator.relation_replicator import ReplicationEventType
 from management.relation_replicator.relations_api_replicator import (
     RelationsApiReplicator,
 )
@@ -1374,15 +1373,11 @@ class RBACKafkaConsumer:
                     f"read-your-writes after workspace create (workspace_id={resource_id})",
                 )
 
-            # remove_legacy_root_workspace_tenant_parent_relations job LISTENs for batch completion
-            batch_notify_token = resource_context.get("notify_token") if resource_context else None
-            if event_type == ReplicationEventType.REMOVE_ROOT_PARENT_TENANT_RELATIONSHIPS.value and batch_notify_token:
-                payload = str(batch_notify_token).strip()
-                _send_pg_notify_best_effort(
-                    REMOVE_LEGACY_ROOT_WORKSPACE_PARENT_NOTIFY_CHANNEL,
-                    payload,
-                    f"remove_root_parent_tenant_relationships batch (token={payload})",
-                )
+            notify_migration_batch_completion(
+                event_type,
+                resource_context,
+                lambda channel, payload, context: _send_pg_notify_best_effort(channel, payload, context),
+            )
 
             # Calculate processing duration and replication latency
             processing_duration_seconds = time.time() - processing_start

--- a/rbac/core/kafka_consumer.py
+++ b/rbac/core/kafka_consumer.py
@@ -30,7 +30,7 @@ import grpc
 from django.conf import settings
 from django.db import connection
 from google.protobuf import json_format
-from internal.pg_notify_wait import notify_migration_batch_completion
+from internal.migration_coordination import notify_migration_batch_completion
 from kafka import KafkaConsumer, TopicPartition
 from kafka.consumer.subscription_state import ConsumerRebalanceListener
 from kafka.errors import KafkaError

--- a/rbac/internal/migration_coordination.py
+++ b/rbac/internal/migration_coordination.py
@@ -1,0 +1,126 @@
+#
+# Copyright 2026 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+"""Migration job NOTIFY coordination shared by outbox, producers, and the Kafka consumer."""
+
+import logging
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+# Coordinates ``remove_legacy_root_workspace_tenant_parent_relations`` with the RBAC Kafka consumer.
+REMOVE_LEGACY_ROOT_WORKSPACE_PARENT_NOTIFY_CHANNEL = "remove_legacy_root_workspace_parent_batch"
+
+# Coordinates ``migrate_binding_scope`` with the RBAC Kafka consumer.
+MIGRATE_BINDING_SCOPE_NOTIFY_CHANNEL = "migrate_binding_scope_batch"
+
+MIGRATION_NOTIFY_TIMEOUT_SECONDS = 600
+
+REMOVE_ROOT_PARENT_TENANT_RELATIONSHIPS = "remove_root_parent_tenant_relationships"
+MIGRATE_BINDING_SCOPE = "migrate_binding_scope"
+
+
+@dataclass(frozen=True)
+class MigrationNotifyCoordination:
+    """Configuration shared by migration producers, outbox context, and the Kafka consumer."""
+
+    channel: str
+    log_label: str
+    timeout_seconds: float = MIGRATION_NOTIFY_TIMEOUT_SECONDS
+    include_org_id_in_context: bool = True
+    require_notify_token: bool = True
+
+
+MIGRATION_NOTIFY_COORDINATIONS: dict[str, MigrationNotifyCoordination] = {
+    REMOVE_ROOT_PARENT_TENANT_RELATIONSHIPS: MigrationNotifyCoordination(
+        channel=REMOVE_LEGACY_ROOT_WORKSPACE_PARENT_NOTIFY_CHANNEL,
+        log_label="remove_legacy_root_workspace_tenant_parent",
+        include_org_id_in_context=False,
+        require_notify_token=True,
+    ),
+    MIGRATE_BINDING_SCOPE: MigrationNotifyCoordination(
+        channel=MIGRATE_BINDING_SCOPE_NOTIFY_CHANNEL,
+        log_label="migrate_binding_scope",
+        include_org_id_in_context=True,
+        require_notify_token=False,
+    ),
+}
+
+
+def _event_type_key(event_type: object) -> str:
+    return event_type.value if hasattr(event_type, "value") else str(event_type)
+
+
+def migration_notify_coordination(
+    event_type: object,
+) -> MigrationNotifyCoordination | None:
+    """Return coordination config for ``event_type``, or ``None`` if not a coordinated migration."""
+    return MIGRATION_NOTIFY_COORDINATIONS.get(_event_type_key(event_type))
+
+
+def build_migration_notify_resource_context(
+    event_type: object,
+    event_info: dict[str, object],
+    coordination: MigrationNotifyCoordination,
+) -> dict[str, object] | None:
+    """Build resource context when ``notify_token`` is present; otherwise return ``None``."""
+    token = event_info.get("notify_token")
+    if not token:
+        if coordination.require_notify_token:
+            logger.warning(
+                "%s event missing notify_token in event_info=%s",
+                _event_type_key(event_type),
+                event_info,
+            )
+        else:
+            logger.debug(
+                "%s event missing optional notify_token in event_info=%s",
+                _event_type_key(event_type),
+                event_info,
+            )
+        return None
+
+    org_id = str(event_info.get("org_id", "")) if coordination.include_org_id_in_context else ""
+    return {
+        "org_id": org_id,
+        "event_type": _event_type_key(event_type),
+        "created_at": int(time.time()),
+        "notify_token": str(token),
+    }
+
+
+def notify_migration_batch_completion(
+    event_type: str | None,
+    resource_context: dict[str, object] | None,
+    send_notify: Callable[[str, str, str], None],
+) -> None:
+    """NOTIFY the migration producer after the consumer applies a coordinated batch."""
+    if not event_type or not resource_context:
+        return
+
+    notify_token = resource_context.get("notify_token")
+    if not notify_token:
+        return
+
+    coordination = migration_notify_coordination(event_type)
+    if coordination is None:
+        return
+
+    payload = str(notify_token).strip()
+    send_notify(coordination.channel, payload, f"{event_type} batch (token={payload})")

--- a/rbac/internal/pg_notify_wait.py
+++ b/rbac/internal/pg_notify_wait.py
@@ -23,13 +23,12 @@ import time
 import uuid
 from collections import deque
 from collections.abc import Callable
-from dataclasses import dataclass
 
-from django.db import connection
+from django.db import connection, transaction
+from internal.migration_coordination import migration_notify_coordination
 from management.relation_replicator.relation_replicator import (
     RelationReplicator,
     ReplicationEvent,
-    ReplicationEventResourceContext,
     ReplicationEventType,
     WorkspaceEvent,
     WorkspaceEventStream,
@@ -38,84 +37,16 @@ from psycopg2 import sql
 
 logger = logging.getLogger(__name__)
 
-# Coordinates ``remove_legacy_root_workspace_tenant_parent_relations`` with the RBAC Kafka consumer.
-REMOVE_LEGACY_ROOT_WORKSPACE_PARENT_NOTIFY_CHANNEL = "remove_legacy_root_workspace_parent_batch"
-
-# Coordinates ``migrate_binding_scope`` with the RBAC Kafka consumer.
-MIGRATE_BINDING_SCOPE_NOTIFY_CHANNEL = "migrate_binding_scope_batch"
-
-MIGRATION_NOTIFY_TIMEOUT_SECONDS = 600
-
-
-@dataclass(frozen=True)
-class MigrationNotifyCoordination:
-    """Configuration shared by migration producers, outbox context, and the Kafka consumer."""
-
-    channel: str
-    log_label: str
-    timeout_seconds: float = MIGRATION_NOTIFY_TIMEOUT_SECONDS
-    include_org_id_in_context: bool = True
-    require_notify_token: bool = True
-
-
-MIGRATION_NOTIFY_COORDINATIONS: dict[ReplicationEventType, MigrationNotifyCoordination] = {
-    ReplicationEventType.REMOVE_ROOT_PARENT_TENANT_RELATIONSHIPS: MigrationNotifyCoordination(
-        channel=REMOVE_LEGACY_ROOT_WORKSPACE_PARENT_NOTIFY_CHANNEL,
-        log_label="remove_legacy_root_workspace_tenant_parent",
-        include_org_id_in_context=False,
-        require_notify_token=True,
-    ),
-    ReplicationEventType.MIGRATE_BINDING_SCOPE: MigrationNotifyCoordination(
-        channel=MIGRATE_BINDING_SCOPE_NOTIFY_CHANNEL,
-        log_label="migrate_binding_scope",
-        include_org_id_in_context=True,
-        require_notify_token=False,
-    ),
-}
-
-
-def migration_notify_coordination(
-    event_type: ReplicationEventType | str,
-) -> MigrationNotifyCoordination | None:
-    """Return coordination config for ``event_type``, or ``None`` if not a coordinated migration."""
-    if not isinstance(event_type, ReplicationEventType):
-        try:
-            event_type = ReplicationEventType(str(event_type))
-        except ValueError:
-            return None
-    return MIGRATION_NOTIFY_COORDINATIONS.get(event_type)
-
-
-def build_migration_notify_resource_context(
-    event_type: ReplicationEventType,
-    event_info: dict[str, object],
-    coordination: MigrationNotifyCoordination,
-) -> dict[str, object] | None:
-    """Build resource context when ``notify_token`` is present; otherwise return ``None``."""
-    token = event_info.get("notify_token")
-    if not token:
-        logger.warning(
-            "%s event missing notify_token in event_info=%s",
-            event_type.value,
-            event_info,
-        )
-        return None
-
-    org_id = str(event_info.get("org_id", "")) if coordination.include_org_id_in_context else ""
-    context = ReplicationEventResourceContext(
-        org_id=org_id,
-        event_type=event_type.value,
-    )
-    result = context.to_json()
-    result["notify_token"] = str(token)
-    return result
-
 
 def replicate_with_notify(
     replicator: RelationReplicator,
     event: ReplicationEvent,
 ) -> None:
-    """Enqueue a replication event and LISTEN until the consumer NOTIFYs batch completion."""
+    """Enqueue a replication event and LISTEN until the consumer NOTIFYs batch completion.
+
+    When called inside ``transaction.atomic``, the LISTEN is deferred until after commit so the
+    outbox row is visible to Debezium before the consumer can process it and send NOTIFY.
+    """
     coordination = migration_notify_coordination(event.event_type)
     if coordination is None:
         raise ValueError(f"Event type {event.event_type.value} is not notify-coordinated")
@@ -123,33 +54,19 @@ def replicate_with_notify(
     notify_token = str(uuid.uuid4())
     event.event_info["notify_token"] = notify_token
     replicator.replicate(event)
-    wait_for_pg_notify(
-        channel=coordination.channel,
-        expected_payload=notify_token,
-        timeout_seconds=coordination.timeout_seconds,
-        log_label=coordination.log_label,
-    )
 
+    def wait_for_batch_completion() -> None:
+        wait_for_pg_notify(
+            channel=coordination.channel,
+            expected_payload=notify_token,
+            timeout_seconds=coordination.timeout_seconds,
+            log_label=coordination.log_label,
+        )
 
-def notify_migration_batch_completion(
-    event_type: str | None,
-    resource_context: dict[str, object] | None,
-    send_notify: Callable[[str, str, str], None],
-) -> None:
-    """NOTIFY the migration producer after the consumer applies a coordinated batch."""
-    if not event_type or not resource_context:
-        return
-
-    notify_token = resource_context.get("notify_token")
-    if not notify_token:
-        return
-
-    coordination = migration_notify_coordination(event_type)
-    if coordination is None:
-        return
-
-    payload = str(notify_token).strip()
-    send_notify(coordination.channel, payload, f"{event_type} batch (token={payload})")
+    if connection.in_atomic_block:
+        transaction.on_commit(wait_for_batch_completion)
+    else:
+        wait_for_batch_completion()
 
 
 def wait_for_pg_notify(

--- a/rbac/internal/pg_notify_wait.py
+++ b/rbac/internal/pg_notify_wait.py
@@ -20,17 +20,136 @@
 import logging
 import select
 import time
+import uuid
 from collections import deque
 from collections.abc import Callable
+from dataclasses import dataclass
 
 from django.db import connection
+from management.relation_replicator.relation_replicator import (
+    RelationReplicator,
+    ReplicationEvent,
+    ReplicationEventResourceContext,
+    ReplicationEventType,
+    WorkspaceEvent,
+    WorkspaceEventStream,
+)
 from psycopg2 import sql
 
 logger = logging.getLogger(__name__)
 
 # Coordinates ``remove_legacy_root_workspace_tenant_parent_relations`` with the RBAC Kafka consumer.
 REMOVE_LEGACY_ROOT_WORKSPACE_PARENT_NOTIFY_CHANNEL = "remove_legacy_root_workspace_parent_batch"
-REMOVE_LEGACY_ROOT_WORKSPACE_PARENT_NOTIFY_TIMEOUT_SECONDS = 600
+
+# Coordinates ``migrate_binding_scope`` with the RBAC Kafka consumer.
+MIGRATE_BINDING_SCOPE_NOTIFY_CHANNEL = "migrate_binding_scope_batch"
+
+MIGRATION_NOTIFY_TIMEOUT_SECONDS = 600
+
+
+@dataclass(frozen=True)
+class MigrationNotifyCoordination:
+    """Configuration shared by migration producers, outbox context, and the Kafka consumer."""
+
+    channel: str
+    log_label: str
+    timeout_seconds: float = MIGRATION_NOTIFY_TIMEOUT_SECONDS
+    include_org_id_in_context: bool = True
+    require_notify_token: bool = True
+
+
+MIGRATION_NOTIFY_COORDINATIONS: dict[ReplicationEventType, MigrationNotifyCoordination] = {
+    ReplicationEventType.REMOVE_ROOT_PARENT_TENANT_RELATIONSHIPS: MigrationNotifyCoordination(
+        channel=REMOVE_LEGACY_ROOT_WORKSPACE_PARENT_NOTIFY_CHANNEL,
+        log_label="remove_legacy_root_workspace_tenant_parent",
+        include_org_id_in_context=False,
+        require_notify_token=True,
+    ),
+    ReplicationEventType.MIGRATE_BINDING_SCOPE: MigrationNotifyCoordination(
+        channel=MIGRATE_BINDING_SCOPE_NOTIFY_CHANNEL,
+        log_label="migrate_binding_scope",
+        include_org_id_in_context=True,
+        require_notify_token=False,
+    ),
+}
+
+
+def migration_notify_coordination(
+    event_type: ReplicationEventType | str,
+) -> MigrationNotifyCoordination | None:
+    """Return coordination config for ``event_type``, or ``None`` if not a coordinated migration."""
+    if not isinstance(event_type, ReplicationEventType):
+        try:
+            event_type = ReplicationEventType(str(event_type))
+        except ValueError:
+            return None
+    return MIGRATION_NOTIFY_COORDINATIONS.get(event_type)
+
+
+def build_migration_notify_resource_context(
+    event_type: ReplicationEventType,
+    event_info: dict[str, object],
+    coordination: MigrationNotifyCoordination,
+) -> dict[str, object] | None:
+    """Build resource context when ``notify_token`` is present; otherwise return ``None``."""
+    token = event_info.get("notify_token")
+    if not token:
+        logger.warning(
+            "%s event missing notify_token in event_info=%s",
+            event_type.value,
+            event_info,
+        )
+        return None
+
+    org_id = str(event_info.get("org_id", "")) if coordination.include_org_id_in_context else ""
+    context = ReplicationEventResourceContext(
+        org_id=org_id,
+        event_type=event_type.value,
+    )
+    result = context.to_json()
+    result["notify_token"] = str(token)
+    return result
+
+
+def replicate_with_notify(
+    replicator: RelationReplicator,
+    event: ReplicationEvent,
+) -> None:
+    """Enqueue a replication event and LISTEN until the consumer NOTIFYs batch completion."""
+    coordination = migration_notify_coordination(event.event_type)
+    if coordination is None:
+        raise ValueError(f"Event type {event.event_type.value} is not notify-coordinated")
+
+    notify_token = str(uuid.uuid4())
+    event.event_info["notify_token"] = notify_token
+    replicator.replicate(event)
+    wait_for_pg_notify(
+        channel=coordination.channel,
+        expected_payload=notify_token,
+        timeout_seconds=coordination.timeout_seconds,
+        log_label=coordination.log_label,
+    )
+
+
+def notify_migration_batch_completion(
+    event_type: str | None,
+    resource_context: dict[str, object] | None,
+    send_notify: Callable[[str, str, str], None],
+) -> None:
+    """NOTIFY the migration producer after the consumer applies a coordinated batch."""
+    if not event_type or not resource_context:
+        return
+
+    notify_token = resource_context.get("notify_token")
+    if not notify_token:
+        return
+
+    coordination = migration_notify_coordination(event_type)
+    if coordination is None:
+        return
+
+    payload = str(notify_token).strip()
+    send_notify(coordination.channel, payload, f"{event_type} batch (token={payload})")
 
 
 def wait_for_pg_notify(
@@ -158,3 +277,32 @@ def wait_for_pg_notify(
                 cursor.execute(unlisten_sql)
         except Exception:
             pass
+
+
+class NotifyCoordinatedReplicator(RelationReplicator):
+    """Replicator wrapper that waits for the Kafka consumer to acknowledge each replicated event."""
+
+    def __init__(
+        self,
+        inner: RelationReplicator,
+        *,
+        event_type: ReplicationEventType,
+    ):
+        """Wrap ``inner`` and wait for consumer NOTIFY after each coordinated ``replicate`` call."""
+        if migration_notify_coordination(event_type) is None:
+            raise ValueError(f"Event type {event_type.value} is not notify-coordinated")
+        self._inner = inner
+        self._event_type = event_type
+
+    def replicate(self, event: ReplicationEvent) -> None:
+        """Replicate ``event`` and block until the consumer acknowledges it."""
+        if event.event_type != self._event_type:
+            raise ValueError(
+                f"NotifyCoordinatedReplicator configured for {self._event_type.value}, "
+                f"got {event.event_type.value}"
+            )
+        replicate_with_notify(self._inner, event)
+
+    def replicate_workspace(self, event: WorkspaceEvent, event_stream: WorkspaceEventStream) -> None:
+        """Delegate workspace replication to the wrapped replicator."""
+        self._inner.replicate_workspace(event, event_stream)

--- a/rbac/internal/utils.py
+++ b/rbac/internal/utils.py
@@ -31,11 +31,7 @@ from django.conf import settings
 from django.db import transaction
 from django.db.models import Q
 from django.urls import resolve
-from internal.pg_notify_wait import (
-    REMOVE_LEGACY_ROOT_WORKSPACE_PARENT_NOTIFY_CHANNEL,
-    REMOVE_LEGACY_ROOT_WORKSPACE_PARENT_NOTIFY_TIMEOUT_SECONDS,
-    wait_for_pg_notify,
-)
+from internal.pg_notify_wait import replicate_with_notify
 from internal.schemas import INVENTORY_INPUT_SCHEMAS, RELATION_INPUT_SCHEMAS
 from jsonschema import validate
 from management.atomic_transactions import atomic, atomic_block, atomic_with_retry
@@ -467,27 +463,18 @@ def remove_legacy_root_workspace_tenant_parent_relations() -> dict:
     def flush_batch() -> None:
         if not batch:
             return
-        notify_token = str(uuid.uuid4())
-        replicator.replicate(
+        replicate_with_notify(
+            replicator,
             ReplicationEvent(
                 event_type=ReplicationEventType.REMOVE_ROOT_PARENT_TENANT_RELATIONSHIPS,
-                info={
-                    "batch_size": len(batch),
-                    "notify_token": notify_token,
-                },
+                info={"batch_size": len(batch)},
                 partition_key=PartitionKey.byEnvironment(),
                 add=[],
                 remove=batch,
-            )
+            ),
         )
         batch.clear()
         logger.info(f"Processed {tenants_processed} of {tenants_total} tenants")
-        wait_for_pg_notify(
-            channel=REMOVE_LEGACY_ROOT_WORKSPACE_PARENT_NOTIFY_CHANNEL,
-            expected_payload=notify_token,
-            timeout_seconds=float(REMOVE_LEGACY_ROOT_WORKSPACE_PARENT_NOTIFY_TIMEOUT_SECONDS),
-            log_label="remove_legacy_root_workspace_tenant_parent",
-        )
 
     for tenant in qs.iterator(chunk_size=500):
         tenants_processed += 1

--- a/rbac/management/relation_replicator/relation_replicator.py
+++ b/rbac/management/relation_replicator/relation_replicator.py
@@ -114,21 +114,15 @@ class ReplicationEvent:
 
     def resource_context(self) -> Dict[str, object] | None:
         """Build context for all replication events that have identifiable resources."""
-        if self.event_type == ReplicationEventType.REMOVE_ROOT_PARENT_TENANT_RELATIONSHIPS:
-            token = self.event_info.get("notify_token")
-            if not token:
-                logger.warning(
-                    "remove_root_parent_tenant_relationships batch missing notify_token in event_info=%s",
-                    self.event_info,
-                )
+        from internal.pg_notify_wait import build_migration_notify_resource_context, migration_notify_coordination
+
+        coordination = migration_notify_coordination(self.event_type)
+        if coordination is not None:
+            context = build_migration_notify_resource_context(self.event_type, self.event_info, coordination)
+            if context is not None:
+                return context
+            if coordination.require_notify_token:
                 return None
-            context = ReplicationEventResourceContext(
-                org_id="",
-                event_type=self.event_type.value,
-            )
-            result = context.to_json()
-            result["notify_token"] = str(token)
-            return result
 
         # Validate org_id exists for all events
         org_id = str(self.event_info.get("org_id", ""))

--- a/rbac/management/relation_replicator/relation_replicator.py
+++ b/rbac/management/relation_replicator/relation_replicator.py
@@ -24,6 +24,10 @@ from enum import Enum
 from typing import Dict, TYPE_CHECKING, Union
 
 from django.conf import settings
+from internal.migration_coordination import (
+    build_migration_notify_resource_context,
+    migration_notify_coordination,
+)
 from kessel.relations.v1beta1 import common_pb2
 
 if TYPE_CHECKING:
@@ -114,13 +118,11 @@ class ReplicationEvent:
 
     def resource_context(self) -> Dict[str, object] | None:
         """Build context for all replication events that have identifiable resources."""
-        from internal.pg_notify_wait import build_migration_notify_resource_context, migration_notify_coordination
-
         coordination = migration_notify_coordination(self.event_type)
         if coordination is not None:
-            context = build_migration_notify_resource_context(self.event_type, self.event_info, coordination)
-            if context is not None:
-                return context
+            migration_context = build_migration_notify_resource_context(self.event_type, self.event_info, coordination)
+            if migration_context is not None:
+                return migration_context
             if coordination.require_notify_token:
                 return None
 

--- a/rbac/migration_tool/migrate_binding_scope.py
+++ b/rbac/migration_tool/migrate_binding_scope.py
@@ -20,6 +20,7 @@ from typing import Optional
 
 from django.conf import settings
 from django.db import transaction
+from internal.pg_notify_wait import NotifyCoordinatedReplicator
 from management.atomic_transactions import atomic as atomic_serializable
 from management.group.model import Group
 from management.group.relation_api_dual_write_group_handler import RelationApiDualWriteGroupHandler
@@ -329,7 +330,7 @@ _all_sources = {custom_role_source, system_role_source, car_source}
 
 
 def migrate_all_role_bindings(
-    replicator: RelationReplicator = OutboxReplicator(),
+    replicator: RelationReplicator | None = None,
     tenant: Optional[Tenant] = None,
     sources: Optional[set[str]] = None,
 ):
@@ -346,6 +347,12 @@ def migrate_all_role_bindings(
 
     Returns: Tuple of (items_checked, items_migrated)
     """
+    if replicator is None:
+        replicator = NotifyCoordinatedReplicator(
+            OutboxReplicator(),
+            event_type=ReplicationEventType.MIGRATE_BINDING_SCOPE,
+        )
+
     if tenant:
         if tenant.tenant_name == "public":
             raise ValueError("Cannot migrate binding scope for the public tenant.")

--- a/tests/core/test_kafka_consumer.py
+++ b/tests/core/test_kafka_consumer.py
@@ -710,18 +710,19 @@ class RBACKafkaConsumerTests(TestCase):
         self.assertEqual(delete_fencing_check.lock_id, "test-group/0")
         self.assertEqual(delete_fencing_check.lock_token, "test-lock-token")
 
-    @patch("core.kafka_consumer.REMOVE_LEGACY_ROOT_WORKSPACE_PARENT_NOTIFY_CHANNEL", "test_legacy_ch")
+    @patch("internal.pg_notify_wait.migration_notify_coordination")
     @patch("core.kafka_consumer.connection.cursor")
     @patch("core.kafka_consumer.json_format.ParseDict")
     @patch("core.kafka_consumer.relations_api_replication.write_relationships")
     @patch("core.kafka_consumer.relations_api_replication.delete_relationships")
     @patch("core.kafka_consumer.Tenant.objects.get")
     def test_process_relations_message_remove_legacy_root_parent_sends_notify(
-        self, mock_tenant_get, mock_delete, mock_write, mock_parse_dict, mock_conn_cursor
+        self, mock_tenant_get, mock_delete, mock_write, mock_parse_dict, mock_conn_cursor, mock_coordination
     ):
         """Consumer NOTIFYs after remove_root_parent_tenant_relationships batch replication."""
         from management.relation_replicator.relation_replicator import ReplicationEventType
 
+        mock_coordination.return_value = Mock(channel="test_legacy_ch")
         mock_tenant_get.return_value = Mock(org_id="12345")
         mock_parse_dict.return_value = Mock()
         mock_write.return_value = Mock(consistency_token=Mock(token="tok"))
@@ -763,6 +764,61 @@ class RBACKafkaConsumerTests(TestCase):
         notify_sql_calls = [c for c in mock_cursor.execute.call_args_list if "PG_NOTIFY" in str(c[0][0]).upper()]
         self.assertEqual(len(notify_sql_calls), 1)
         self.assertEqual(notify_sql_calls[0][0][1], ["test_legacy_ch", "batch-ack-token"])
+
+    @patch("internal.pg_notify_wait.migration_notify_coordination")
+    @patch("core.kafka_consumer.connection.cursor")
+    @patch("core.kafka_consumer.json_format.ParseDict")
+    @patch("core.kafka_consumer.relations_api_replication.write_relationships")
+    @patch("core.kafka_consumer.relations_api_replication.delete_relationships")
+    @patch("core.kafka_consumer.Tenant.objects.get")
+    def test_process_relations_message_migrate_binding_scope_sends_notify(
+        self, mock_tenant_get, mock_delete, mock_write, mock_parse_dict, mock_conn_cursor, mock_coordination
+    ):
+        """Consumer NOTIFYs after migrate_binding_scope batch replication."""
+        from management.relation_replicator.relation_replicator import ReplicationEventType
+
+        mock_coordination.return_value = Mock(channel="test_migrate_binding_scope_ch")
+        mock_tenant_get.return_value = Mock(org_id="12345")
+        mock_parse_dict.return_value = Mock()
+        mock_write.return_value = Mock(consistency_token=Mock(token="tok"))
+        mock_delete.return_value = Mock(consistency_token=Mock(token=None))
+
+        mock_cursor = Mock()
+        mock_cm = Mock()
+        mock_cm.__enter__ = Mock(return_value=mock_cursor)
+        mock_cm.__exit__ = Mock(return_value=False)
+        mock_conn_cursor.return_value = mock_cm
+
+        consumer = RBACKafkaConsumer()
+        consumer.lock_id = "test-group/0"
+        consumer.lock_token = "test-lock-token"
+
+        debezium_msg = DebeziumMessage(
+            aggregatetype="relations",
+            aggregateid="test-id",
+            event_type=ReplicationEventType.MIGRATE_BINDING_SCOPE.value,
+            payload={
+                "relations_to_add": [],
+                "relations_to_remove": [
+                    {
+                        "resource": {"type": "rbac", "id": "role1"},
+                        "subject": {"type": "rbac", "id": "binding1"},
+                        "relation": "member",
+                    }
+                ],
+                "resource_context": {
+                    "org_id": "12345",
+                    "event_type": ReplicationEventType.MIGRATE_BINDING_SCOPE.value,
+                    "notify_token": "migrate-scope-ack-token",
+                },
+            },
+        )
+
+        self.assertTrue(consumer._process_relations_message(debezium_msg, 0, 0))
+
+        notify_sql_calls = [c for c in mock_cursor.execute.call_args_list if "PG_NOTIFY" in str(c[0][0]).upper()]
+        self.assertEqual(len(notify_sql_calls), 1)
+        self.assertEqual(notify_sql_calls[0][0][1], ["test_migrate_binding_scope_ch", "migrate-scope-ack-token"])
 
     def test_process_relations_message_invalid_payload(self):
         """Test relations message processing with invalid payload raises ValidationError."""

--- a/tests/core/test_kafka_consumer.py
+++ b/tests/core/test_kafka_consumer.py
@@ -52,6 +52,7 @@ from core.kafka_consumer import (
 )
 from django.test import TestCase
 from django.test.utils import override_settings
+from internal.migration_coordination import MigrationNotifyCoordination
 from kafka.errors import KafkaError
 
 
@@ -710,7 +711,7 @@ class RBACKafkaConsumerTests(TestCase):
         self.assertEqual(delete_fencing_check.lock_id, "test-group/0")
         self.assertEqual(delete_fencing_check.lock_token, "test-lock-token")
 
-    @patch("internal.pg_notify_wait.migration_notify_coordination")
+    @patch("internal.migration_coordination.migration_notify_coordination")
     @patch("core.kafka_consumer.connection.cursor")
     @patch("core.kafka_consumer.json_format.ParseDict")
     @patch("core.kafka_consumer.relations_api_replication.write_relationships")
@@ -722,7 +723,10 @@ class RBACKafkaConsumerTests(TestCase):
         """Consumer NOTIFYs after remove_root_parent_tenant_relationships batch replication."""
         from management.relation_replicator.relation_replicator import ReplicationEventType
 
-        mock_coordination.return_value = Mock(channel="test_legacy_ch")
+        mock_coordination.return_value = MigrationNotifyCoordination(
+            channel="test_legacy_ch",
+            log_label="test_remove_legacy",
+        )
         mock_tenant_get.return_value = Mock(org_id="12345")
         mock_parse_dict.return_value = Mock()
         mock_write.return_value = Mock(consistency_token=Mock(token="tok"))
@@ -765,7 +769,7 @@ class RBACKafkaConsumerTests(TestCase):
         self.assertEqual(len(notify_sql_calls), 1)
         self.assertEqual(notify_sql_calls[0][0][1], ["test_legacy_ch", "batch-ack-token"])
 
-    @patch("internal.pg_notify_wait.migration_notify_coordination")
+    @patch("internal.migration_coordination.migration_notify_coordination")
     @patch("core.kafka_consumer.connection.cursor")
     @patch("core.kafka_consumer.json_format.ParseDict")
     @patch("core.kafka_consumer.relations_api_replication.write_relationships")
@@ -777,7 +781,10 @@ class RBACKafkaConsumerTests(TestCase):
         """Consumer NOTIFYs after migrate_binding_scope batch replication."""
         from management.relation_replicator.relation_replicator import ReplicationEventType
 
-        mock_coordination.return_value = Mock(channel="test_migrate_binding_scope_ch")
+        mock_coordination.return_value = MigrationNotifyCoordination(
+            channel="test_migrate_binding_scope_ch",
+            log_label="test_migrate_binding_scope",
+        )
         mock_tenant_get.return_value = Mock(org_id="12345")
         mock_parse_dict.return_value = Mock()
         mock_write.return_value = Mock(consistency_token=Mock(token="tok"))

--- a/tests/internal/test_pg_notify_wait.py
+++ b/tests/internal/test_pg_notify_wait.py
@@ -1,0 +1,135 @@
+"""Tests for PostgreSQL NOTIFY coordination helpers."""
+
+#
+# Copyright 2026 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+from unittest.mock import Mock, patch
+
+from django.test import TestCase
+from internal.pg_notify_wait import (
+    MIGRATION_NOTIFY_COORDINATIONS,
+    MIGRATION_NOTIFY_TIMEOUT_SECONDS,
+    NotifyCoordinatedReplicator,
+    build_migration_notify_resource_context,
+    notify_migration_batch_completion,
+    replicate_with_notify,
+)
+from management.relation_replicator.relation_replicator import (
+    PartitionKey,
+    ReplicationEvent,
+    ReplicationEventType,
+)
+from migration_tool.utils import create_relationship
+
+
+class ReplicateWithNotifyTests(TestCase):
+    """Tests for replicate_with_notify."""
+
+    @patch("internal.pg_notify_wait.wait_for_pg_notify")
+    @patch("internal.pg_notify_wait.uuid.uuid4", return_value="test-notify-token")
+    def test_replicate_injects_notify_token_and_waits(self, _mock_uuid, mock_wait):
+        replicator = Mock()
+        coordination = MIGRATION_NOTIFY_COORDINATIONS[ReplicationEventType.MIGRATE_BINDING_SCOPE]
+        relation = create_relationship(("rbac", "role"), "r1", ("rbac", "principal"), "localhost/p1", "member")
+        event = ReplicationEvent(
+            add=[relation],
+            remove=[],
+            event_type=ReplicationEventType.MIGRATE_BINDING_SCOPE,
+            info={"org_id": "123456"},
+            partition_key=PartitionKey.byEnvironment(),
+        )
+
+        replicate_with_notify(replicator, event)
+
+        replicator.replicate.assert_called_once_with(event)
+        self.assertEqual(event.event_info["notify_token"], "test-notify-token")
+        mock_wait.assert_called_once_with(
+            channel=coordination.channel,
+            expected_payload="test-notify-token",
+            timeout_seconds=MIGRATION_NOTIFY_TIMEOUT_SECONDS,
+            log_label=coordination.log_label,
+        )
+
+
+class NotifyCoordinatedReplicatorTests(TestCase):
+    """Tests for NotifyCoordinatedReplicator."""
+
+    @patch("internal.pg_notify_wait.replicate_with_notify")
+    def test_replicate_delegates_to_replicate_with_notify(self, mock_replicate_with_notify):
+        inner = Mock()
+        replicator = NotifyCoordinatedReplicator(
+            inner,
+            event_type=ReplicationEventType.MIGRATE_BINDING_SCOPE,
+        )
+        relation = create_relationship(("rbac", "role"), "r1", ("rbac", "principal"), "localhost/p1", "member")
+        event = ReplicationEvent(
+            add=[relation],
+            remove=[],
+            event_type=ReplicationEventType.MIGRATE_BINDING_SCOPE,
+            info={"org_id": "123456"},
+            partition_key=PartitionKey.byEnvironment(),
+        )
+
+        replicator.replicate(event)
+
+        mock_replicate_with_notify.assert_called_once_with(inner, event)
+
+
+class MigrationNotifyResourceContextTests(TestCase):
+    """Tests for build_migration_notify_resource_context."""
+
+    def test_includes_notify_token_for_migrate_binding_scope(self):
+        coordination = MIGRATION_NOTIFY_COORDINATIONS[ReplicationEventType.MIGRATE_BINDING_SCOPE]
+        context = build_migration_notify_resource_context(
+            ReplicationEventType.MIGRATE_BINDING_SCOPE,
+            {"org_id": "123456", "notify_token": "scope-batch-token"},
+            coordination,
+        )
+        self.assertEqual(context["org_id"], "123456")
+        self.assertEqual(context["event_type"], ReplicationEventType.MIGRATE_BINDING_SCOPE.value)
+        self.assertEqual(context["notify_token"], "scope-batch-token")
+
+    def test_without_token_returns_none(self):
+        coordination = MIGRATION_NOTIFY_COORDINATIONS[ReplicationEventType.REMOVE_ROOT_PARENT_TENANT_RELATIONSHIPS]
+        context = build_migration_notify_resource_context(
+            ReplicationEventType.REMOVE_ROOT_PARENT_TENANT_RELATIONSHIPS,
+            {"batch_size": 1},
+            coordination,
+        )
+        self.assertIsNone(context)
+
+
+class NotifyMigrationBatchCompletionTests(TestCase):
+    """Tests for notify_migration_batch_completion."""
+
+    def test_sends_notify_for_coordinated_event(self):
+        send_notify = Mock()
+        notify_migration_batch_completion(
+            ReplicationEventType.MIGRATE_BINDING_SCOPE.value,
+            {"notify_token": "batch-ack-token"},
+            send_notify,
+        )
+        send_notify.assert_called_once_with(
+            MIGRATION_NOTIFY_COORDINATIONS[ReplicationEventType.MIGRATE_BINDING_SCOPE].channel,
+            "batch-ack-token",
+            f"{ReplicationEventType.MIGRATE_BINDING_SCOPE.value} batch (token=batch-ack-token)",
+        )
+
+    def test_ignores_non_coordinated_event(self):
+        send_notify = Mock()
+        notify_migration_batch_completion("create_group", {"notify_token": "token"}, send_notify)
+        send_notify.assert_not_called()

--- a/tests/internal/test_pg_notify_wait.py
+++ b/tests/internal/test_pg_notify_wait.py
@@ -20,12 +20,14 @@
 from unittest.mock import Mock, patch
 
 from django.test import TestCase
-from internal.pg_notify_wait import (
+from internal.migration_coordination import (
     MIGRATION_NOTIFY_COORDINATIONS,
     MIGRATION_NOTIFY_TIMEOUT_SECONDS,
-    NotifyCoordinatedReplicator,
     build_migration_notify_resource_context,
     notify_migration_batch_completion,
+)
+from internal.pg_notify_wait import (
+    NotifyCoordinatedReplicator,
     replicate_with_notify,
 )
 from management.relation_replicator.relation_replicator import (
@@ -39,11 +41,13 @@ from migration_tool.utils import create_relationship
 class ReplicateWithNotifyTests(TestCase):
     """Tests for replicate_with_notify."""
 
+    @patch("internal.pg_notify_wait.connection")
     @patch("internal.pg_notify_wait.wait_for_pg_notify")
     @patch("internal.pg_notify_wait.uuid.uuid4", return_value="test-notify-token")
-    def test_replicate_injects_notify_token_and_waits(self, _mock_uuid, mock_wait):
+    def test_replicate_injects_notify_token_and_waits(self, _mock_uuid, mock_wait, mock_connection):
+        mock_connection.in_atomic_block = False
         replicator = Mock()
-        coordination = MIGRATION_NOTIFY_COORDINATIONS[ReplicationEventType.MIGRATE_BINDING_SCOPE]
+        coordination = MIGRATION_NOTIFY_COORDINATIONS[ReplicationEventType.MIGRATE_BINDING_SCOPE.value]
         relation = create_relationship(("rbac", "role"), "r1", ("rbac", "principal"), "localhost/p1", "member")
         event = ReplicationEvent(
             add=[relation],
@@ -63,6 +67,31 @@ class ReplicateWithNotifyTests(TestCase):
             timeout_seconds=MIGRATION_NOTIFY_TIMEOUT_SECONDS,
             log_label=coordination.log_label,
         )
+
+    @patch("internal.pg_notify_wait.connection")
+    @patch("internal.pg_notify_wait.transaction.on_commit")
+    @patch("internal.pg_notify_wait.wait_for_pg_notify")
+    @patch("internal.pg_notify_wait.uuid.uuid4", return_value="test-notify-token")
+    def test_defer_wait_until_transaction_commits(self, _mock_uuid, mock_wait, mock_on_commit, mock_connection):
+        mock_connection.in_atomic_block = True
+        replicator = Mock()
+        relation = create_relationship(("rbac", "role"), "r1", ("rbac", "principal"), "localhost/p1", "member")
+        event = ReplicationEvent(
+            add=[relation],
+            remove=[],
+            event_type=ReplicationEventType.MIGRATE_BINDING_SCOPE,
+            info={"org_id": "123456"},
+            partition_key=PartitionKey.byEnvironment(),
+        )
+
+        replicate_with_notify(replicator, event)
+
+        replicator.replicate.assert_called_once_with(event)
+        mock_wait.assert_not_called()
+        mock_on_commit.assert_called_once()
+        wait_callback = mock_on_commit.call_args[0][0]
+        wait_callback()
+        mock_wait.assert_called_once()
 
 
 class NotifyCoordinatedReplicatorTests(TestCase):
@@ -93,7 +122,7 @@ class MigrationNotifyResourceContextTests(TestCase):
     """Tests for build_migration_notify_resource_context."""
 
     def test_includes_notify_token_for_migrate_binding_scope(self):
-        coordination = MIGRATION_NOTIFY_COORDINATIONS[ReplicationEventType.MIGRATE_BINDING_SCOPE]
+        coordination = MIGRATION_NOTIFY_COORDINATIONS[ReplicationEventType.MIGRATE_BINDING_SCOPE.value]
         context = build_migration_notify_resource_context(
             ReplicationEventType.MIGRATE_BINDING_SCOPE,
             {"org_id": "123456", "notify_token": "scope-batch-token"},
@@ -104,13 +133,27 @@ class MigrationNotifyResourceContextTests(TestCase):
         self.assertEqual(context["notify_token"], "scope-batch-token")
 
     def test_without_token_returns_none(self):
-        coordination = MIGRATION_NOTIFY_COORDINATIONS[ReplicationEventType.REMOVE_ROOT_PARENT_TENANT_RELATIONSHIPS]
+        coordination = MIGRATION_NOTIFY_COORDINATIONS[
+            ReplicationEventType.REMOVE_ROOT_PARENT_TENANT_RELATIONSHIPS.value
+        ]
         context = build_migration_notify_resource_context(
             ReplicationEventType.REMOVE_ROOT_PARENT_TENANT_RELATIONSHIPS,
             {"batch_size": 1},
             coordination,
         )
         self.assertIsNone(context)
+
+    @patch("internal.migration_coordination.logger")
+    def test_without_optional_token_does_not_warn(self, mock_logger):
+        coordination = MIGRATION_NOTIFY_COORDINATIONS[ReplicationEventType.MIGRATE_BINDING_SCOPE.value]
+        context = build_migration_notify_resource_context(
+            ReplicationEventType.MIGRATE_BINDING_SCOPE,
+            {"org_id": "123456"},
+            coordination,
+        )
+        self.assertIsNone(context)
+        mock_logger.warning.assert_not_called()
+        mock_logger.debug.assert_called_once()
 
 
 class NotifyMigrationBatchCompletionTests(TestCase):
@@ -124,7 +167,7 @@ class NotifyMigrationBatchCompletionTests(TestCase):
             send_notify,
         )
         send_notify.assert_called_once_with(
-            MIGRATION_NOTIFY_COORDINATIONS[ReplicationEventType.MIGRATE_BINDING_SCOPE].channel,
+            MIGRATION_NOTIFY_COORDINATIONS[ReplicationEventType.MIGRATE_BINDING_SCOPE.value].channel,
             "batch-ack-token",
             f"{ReplicationEventType.MIGRATE_BINDING_SCOPE.value} batch (token=batch-ack-token)",
         )

--- a/tests/internal/test_utils.py
+++ b/tests/internal/test_utils.py
@@ -1105,9 +1105,9 @@ class RemoveLegacyRootWorkspaceTenantParentRelationsTest(TestCase):
     """Tests for remove_legacy_root_workspace_tenant_parent_relations."""
 
     def setUp(self):
-        timeout_patcher = patch("internal.utils.REMOVE_LEGACY_ROOT_WORKSPACE_PARENT_NOTIFY_TIMEOUT_SECONDS", 0)
-        timeout_patcher.start()
-        self.addCleanup(timeout_patcher.stop)
+        wait_patcher = patch("internal.pg_notify_wait.wait_for_pg_notify")
+        self.mock_wait_for_pg_notify = wait_patcher.start()
+        self.addCleanup(wait_patcher.stop)
         self.tenant = Tenant.objects.create(tenant_name="legacy_root_cleanup", org_id="9918877")
         self.tuples = InMemoryTuples()
         bootstrap_tenant_for_v2_test(self.tenant, tuples=self.tuples)

--- a/tests/management/relation_replicator/test_outbox_replicator.py
+++ b/tests/management/relation_replicator/test_outbox_replicator.py
@@ -374,6 +374,42 @@ class OutboxReplicatorTest(TestCase):
         self.assertEqual(context["org_id"], "")
         self.assertEqual(context["event_type"], ReplicationEventType.CREATE_GROUP.value)
 
+    def test_resource_context_for_migrate_binding_scope_with_notify_token(self):
+        """Test resource context includes notify_token for migrate_binding_scope events."""
+        relation = create_relationship(("rbac", "role"), "r1", ("rbac", "principal"), "localhost/p1", "member")
+
+        event = ReplicationEvent(
+            add=[relation],
+            remove=[],
+            event_type=ReplicationEventType.MIGRATE_BINDING_SCOPE,
+            info={"org_id": "123456", "notify_token": "scope-batch-token"},
+            partition_key=PartitionKey.byEnvironment(),
+        )
+        self.replicator.replicate(event)
+
+        logged_event = self.log[0]
+        context = logged_event.payload["resource_context"]
+        self.assertEqual(context["org_id"], "123456")
+        self.assertEqual(context["event_type"], ReplicationEventType.MIGRATE_BINDING_SCOPE.value)
+        self.assertEqual(context["notify_token"], "scope-batch-token")
+
+    def test_resource_context_for_migrate_binding_scope_without_notify_token(self):
+        """Test migrate_binding_scope without notify_token falls back to standard context."""
+        relation = create_relationship(("rbac", "role"), "r1", ("rbac", "principal"), "localhost/p1", "member")
+
+        event = ReplicationEvent(
+            add=[relation],
+            remove=[],
+            event_type=ReplicationEventType.MIGRATE_BINDING_SCOPE,
+            info={"org_id": "123456"},
+            partition_key=PartitionKey.byEnvironment(),
+        )
+
+        context = event.resource_context()
+        self.assertEqual(context["org_id"], "123456")
+        self.assertEqual(context["event_type"], ReplicationEventType.MIGRATE_BINDING_SCOPE.value)
+        self.assertNotIn("notify_token", context)
+
     def test_replicate_empty_event_warns_instead_of_saving(self):
         """Test replicate with empty event warns."""
         event = ReplicationEvent(


### PR DESCRIPTION
## Link(s) to Jira
- None

## Description of Intent of Change(s)
To make migrate binding scope not blocking

## Local Testing
Unit test

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Introduce a generalized PostgreSQL LISTEN/NOTIFY coordination mechanism for long-running RBAC migrations and apply it to both remove-legacy-root-workspace relations and migrate_binding_scope.

New Features:
- Add migration notification coordination configuration mapping replication event types to LISTEN/NOTIFY channels and behavior.
- Provide helpers to enqueue replication events with notify tokens and to emit NOTIFY acknowledgements from the Kafka consumer after batch completion.
- Introduce a NotifyCoordinatedReplicator wrapper that transparently coordinates replication with NOTIFY for supported migration event types.
- Default migrate_all_role_bindings to use a notify-coordinated replicator so binding scope migration can run non-blockingly.

Enhancements:
- Refactor replication event resource context construction to reuse shared migration notification helpers and support multiple coordinated migrations.
- Simplify remove_legacy_root_workspace_tenant_parent_relations batching by delegating notification handling to the shared coordination helper.

Tests:
- Add focused tests for the new PostgreSQL notification coordination helpers and the NotifyCoordinatedReplicator.
- Extend Kafka consumer tests to cover NOTIFY behavior for both legacy root parent removal and migrate_binding_scope events.
- Extend outbox replicator tests to verify resource context behavior for migrate_binding_scope events, including optional notify_token handling.
- Adjust existing internal utils tests to mock the new wait_for_pg_notify integration.