### PR TITLE
fix(mcp): normalize employment type references in get_user_state

### DIFF
--- a/rbac/management/mcp_views.py
+++ b/rbac/management/mcp_views.py
@@ -2998,6 +2998,8 @@ def _check_user_permission_v1(request: HttpRequest, username: str, permission: s
 @register_tool(
     description=(
         "Get comprehensive state for a specific user, returning all RBAC information in one call. "
+        "Users may be referred to by name, as contractors, vendors, temps, consultants, or other "
+        "employment types -- these are all regular RBAC principals and should be looked up the same way. "
         "This is the best tool for understanding a user's complete RBAC picture. "
         "Returns: (1) groups the user belongs to with roles assigned to each, "
         "(2) all permissions/access the user has (auto-detects V1/V2), "


### PR DESCRIPTION
## Summary
- Adds explicit normalization in the `get_user_state` tool description so LLMs recognize that "contractors", "vendors", "temps", "consultants", and name-only references are all regular RBAC principals
- Addresses LLM safety filter refusals when users ask about a "contractor" being offboarded vs a "user" being offboarded — the word "contractor" triggered stricter PII classification in some LLMs

## Test plan
- [x] All 413 MCP tests pass (`tests.management.test_mcp_views`)
- [x] Pre-commit hooks pass (black, flake8)
- [ ] Manual test: verify LLM no longer refuses "Our contractor Joe is being offboarded" queries via MCP

## Summary by Sourcery

Enhancements:
- Update the get_user_state tool description to state that contractors, vendors, temps, consultants, and name-only references are all treated as standard RBAC principals for lookup.