### PR TITLE
[RHCLOUD-48138] Do not wait for events without relationships to replicate

### DIFF
--- a/rbac/internal/pg_notify_wait.py
+++ b/rbac/internal/pg_notify_wait.py
@@ -51,6 +51,14 @@ def replicate_with_notify(
     if coordination is None:
         raise ValueError(f"Event type {event.event_type.value} is not notify-coordinated")
 
+    if not event.add and not event.remove:
+        logger.debug(
+            "%s skipping notify coordination for empty replication event",
+            coordination.log_label,
+        )
+        replicator.replicate(event)
+        return
+
     notify_token = str(uuid.uuid4())
     event.event_info["notify_token"] = notify_token
     replicator.replicate(event)

--- a/tests/internal/test_pg_notify_wait.py
+++ b/tests/internal/test_pg_notify_wait.py
@@ -93,6 +93,26 @@ class ReplicateWithNotifyTests(TestCase):
         wait_callback()
         mock_wait.assert_called_once()
 
+    @patch("internal.pg_notify_wait.connection")
+    @patch("internal.pg_notify_wait.wait_for_pg_notify")
+    @patch("internal.pg_notify_wait.uuid.uuid4", return_value="test-notify-token")
+    def test_skips_notify_wait_for_empty_replication_event(self, _mock_uuid, mock_wait, mock_connection):
+        mock_connection.in_atomic_block = False
+        replicator = Mock()
+        event = ReplicationEvent(
+            add=[],
+            remove=[],
+            event_type=ReplicationEventType.MIGRATE_BINDING_SCOPE,
+            info={"org_id": "123456"},
+            partition_key=PartitionKey.byEnvironment(),
+        )
+
+        replicate_with_notify(replicator, event)
+
+        replicator.replicate.assert_called_once_with(event)
+        self.assertNotIn("notify_token", event.event_info)
+        mock_wait.assert_not_called()
+
 
 class NotifyCoordinatedReplicatorTests(TestCase):
     """Tests for NotifyCoordinatedReplicator."""


### PR DESCRIPTION
## Link(s) to Jira
- https://redhat.atlassian.net/browse/RHCLOUD-48138

## Description of Intent of Change(s)
The job is still waiting for notification but there is no outbox events so no consumer notification on it

## Local Testing
Unit test

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Skip notify coordination for replication events without relationship changes to avoid waiting for non-existent notifications.

Bug Fixes:
- Prevent jobs from waiting on notify events when replication events contain no additions or removals.

Tests:
- Add a unit test verifying that empty replication events do not receive a notify token and do not trigger waiting for notifications.