### PR TITLE
[RHCLOUD-36475] Remove target_account from cross-access API

### DIFF
--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -915,7 +915,7 @@ List cross-account access requests. These allow users from one org (e.g. Red Hat
 **Auth:** `x-rh-identity` required
 **Calls:** `GET /api/v1/cross-account-requests/`
 
-**Returns:** `{meta: {count}, links, data: [{request_id, target_account, status, start_date, end_date, ...}]}`.
+**Returns:** `{meta: {count}, links, data: [{request_id, target_org, status, start_date, end_date, ...}]}`.
 
 **Caveats:**
 - Approved requests have a time window -- check `end_date` against current date.
@@ -936,7 +936,7 @@ Get details of a specific cross-account access request by its ID.
 **Auth:** `x-rh-identity` required
 **Calls:** `GET /api/v1/cross-account-requests/{request_id}/`
 
-**Returns:** `{request_id, target_account, status, start_date, end_date, created, roles, ...}`.
+**Returns:** `{request_id, target_org, status, start_date, end_date, created, roles, ...}`.
 
 ---
 
@@ -986,7 +986,7 @@ Create a cross-account access request for temporary access to another org's reso
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `target_account` | string | _(required)_ | Account number to request access to |
+| `target_org` | string | _(required)_ | Org ID to request access to |
 | `start_date` | string | _(required)_ | Start date (`YYYY-MM-DD`) |
 | `end_date` | string | _(required)_ | End date (`YYYY-MM-DD`) |
 | `roles` | list[string] | _(required)_ | List of role UUIDs |
@@ -1021,7 +1021,7 @@ Update a cross-account access request (full replacement).
 
 **Caveats:**
 - Date format differs from `create_cross_account_request`: this endpoint requires `MM/DD/YYYY`, while create uses `YYYY-MM-DD`. This is an asymmetry in the underlying API serializers.
-- `roles` here takes role display name strings, not UUIDs (unlike create which takes UUIDs). The field name matches `target_org` (not `target_account` as in create).
+- `roles` here takes role display name strings, not UUIDs (unlike create which takes UUIDs).
 
 ---
 

--- a/docs/source/specs/openapi.json
+++ b/docs/source/specs/openapi.json
@@ -3712,10 +3712,6 @@
           "roles"
         ],
         "properties": {
-          "target_account": {
-            "type": "string",
-            "example": "12345"
-          },
           "target_org": {
             "type": "string",
             "example": "12345"
@@ -3857,10 +3853,6 @@
             "format": "uuid",
             "example": "2ad8cac5-336e-44c6-9b16-15ac84224d4b"
           },
-          "target_account": {
-            "type": "string",
-            "example": "12345"
-          },
           "target_org": {
             "type": "string",
             "example": "12345"
@@ -3890,10 +3882,6 @@
             "type": "string",
             "format": "uuid",
             "example": "2ad8cac5-336e-44c6-9b16-15ac84224d4b"
-          },
-          "target_account": {
-            "type": "string",
-            "example": "12345"
           },
           "target_org": {
             "type": "string",

--- a/rbac/api/cross_access/serializer.py
+++ b/rbac/api/cross_access/serializer.py
@@ -31,7 +31,6 @@ class CrossAccountRequestSerializer(serializers.ModelSerializer):
     """Serializer for the cross access request model."""
 
     request_id = serializers.UUIDField(read_only=True)
-    target_account = serializers.CharField(max_length=36, required=False)
     target_org = serializers.CharField(max_length=36)
     user_id = serializers.CharField(max_length=15)
     start_date = serializers.DateTimeField(format="%d %b %Y")
@@ -45,7 +44,6 @@ class CrossAccountRequestSerializer(serializers.ModelSerializer):
         model = CrossAccountRequest
         fields = (
             "request_id",
-            "target_account",
             "target_org",
             "user_id",
             "start_date",
@@ -79,7 +77,6 @@ class CrossAccountRequestDetailSerializer(serializers.ModelSerializer):
     """Serializer for the cross access request model with details."""
 
     request_id = serializers.UUIDField(read_only=True)
-    target_account = serializers.CharField(max_length=36, required=False, allow_null=True, allow_blank=True)
     target_org = serializers.CharField(max_length=36)
     user_id = serializers.CharField(max_length=15)
     start_date = serializers.DateTimeField(format="%m/%d/%Y", input_formats=["%m/%d/%Y"])
@@ -94,7 +91,6 @@ class CrossAccountRequestDetailSerializer(serializers.ModelSerializer):
         model = CrossAccountRequest
         fields = (
             "request_id",
-            "target_account",
             "target_org",
             "user_id",
             "start_date",

--- a/rbac/management/mcp_views.py
+++ b/rbac/management/mcp_views.py
@@ -1875,7 +1875,7 @@ def list_group_principals(
         "list_cross_account_requests(query_by='target_org', status='approved'). "
         "Order by: 'request_id', 'start_date', 'end_date', 'created', 'modified', "
         "'status' (prefix with '-' to reverse). "
-        "Returns: {meta: {count}, links, data: [{request_id, target_account, status, start_date, end_date, ...}]}. "
+        "Returns: {meta: {count}, links, data: [{request_id, target_org, status, start_date, end_date, ...}]}. "
         "Calls: GET /api/v1/cross-account-requests/\n"
         "Caveats:\n"
         "- Cross-account requests are org-to-org, not user-to-user. A TAM requests access to your "
@@ -1921,8 +1921,8 @@ def list_cross_account_requests(
 @register_tool(
     description=(
         "Get details of a specific cross-account access request by its ID, including "
-        "status, start/end dates, target account, and the requested roles. "
-        "Returns: {request_id, target_account, status, start_date, end_date, created, roles, ...}. "
+        "status, start/end dates, target org, and the requested roles. "
+        "Returns: {request_id, target_org, status, start_date, end_date, created, roles, ...}. "
         "Calls: GET /api/v1/cross-account-requests/{request_id}/"
     ),
     requires_auth=True,
@@ -4504,9 +4504,9 @@ def create_workspace(
     description=(
         "Create a cross-account access request. Allows users from one org (e.g. TAMs) "
         "to request temporary access to another org's resources. "
-        "Required: target_account (the account number to request access to), "
+        "Required: target_org (the org ID to request access to), "
         "start_date (YYYY-MM-DD), end_date (YYYY-MM-DD), roles (list of role UUIDs). "
-        "Example: create_cross_account_request(target_account='12345', "
+        "Example: create_cross_account_request(target_org='12345', "
         "start_date='2026-06-01', end_date='2026-06-30', roles=['<role-uuid>']) "
         "Returns: the created request with request_id, status, dates. "
         "Calls: POST /api/v1/cross-account-requests/"
@@ -4517,14 +4517,14 @@ def create_workspace(
 def create_cross_account_request(
     request: HttpRequest,
     *,
-    target_account: str,
+    target_org: str,
     start_date: str,
     end_date: str,
     roles: list[str],
 ) -> str:
     """Create a cross-account request by delegating to CrossAccountRequestViewSet."""
     body: dict[str, Any] = {
-        "target_account": target_account,
+        "target_org": target_org,
         "start_date": start_date,
         "end_date": end_date,
         "roles": roles,

--- a/tests/api/cross_access/fixtures.py
+++ b/tests/api/cross_access/fixtures.py
@@ -75,23 +75,22 @@ class CrossAccountRequestTest(IdentityRequest):
 
         """
             Create cross account requests 1 to 6: request_1 to request_6
-            self.associate_admin_request has user_id 1111111, and account number xxxxxx
+            self.associate_admin_request has user_id 1111111, and org_id = self.org_id
             It would be approver for request_1, request_2, request_5;
             It would be requestor for request_3, request_6
-            |    target_org  | user_id | start_date | end_date  |  status  | roles |
-            |     xxxxxx     | 1111111 |    now     | now+10day | approved |       |
-            |     xxxxxx     | 2222222 |    now     | now+10day | pending  |       |
-            |     123456     | 1111111 |    now     | now+10day | approved |       |
-            |     123456     | 2222222 |    now     | now+10day | pending  |       |
-            |     xxxxxx     | 2222222 |    now     | now+10day | expired  |       |
-            |     123456     | 1111111 |    now     | now_10day | pending  |       |
+            |  target_org     | user_id | start_date | end_date  |  status  | roles |
+            |  self.org_id    | 1111111 |    now     | now+10day | approved |       |
+            |  self.org_id    | 2222222 |    now     | now+10day | pending  |       |
+            |  another_org_id | 1111111 |    now     | now+10day | approved |       |
+            |  self.org_id    | 2222222 |    now     | now+10day | pending  |       |
+            |  self.org_id    | 2222222 |    now     | now+10day | expired  |       |
+            |  another_org_id | 1111111 |    now     | now_10day | pending  |       |
         """
 
         self.another_account = "123456"
         self.another_org_id = "54321"
 
         self.data4create = {
-            "target_account": None,
             "target_org": "054321",
             "start_date": self.format_date(self.ref_time),
             "end_date": self.format_date(self.ref_time + timedelta(90)),
@@ -100,14 +99,13 @@ class CrossAccountRequestTest(IdentityRequest):
 
         public_tenant = Tenant.objects.get(tenant_name="public")
 
-        tenant_for_target_account = Tenant.objects.create(
-            tenant_name=f"acct{self.data4create['target_account']}",
-            account_id=self.data4create["target_account"],
+        tenant_for_target_org = Tenant.objects.create(
+            tenant_name=f"org{self.data4create['target_org']}",
             org_id=self.data4create["target_org"],
         )
-        tenant_for_target_account.ready = True
-        tenant_for_target_account.save()
-        self.fixture.bootstrap_tenant(tenant_for_target_account)
+        tenant_for_target_org.ready = True
+        tenant_for_target_org.save()
+        self.fixture.bootstrap_tenant(tenant_for_target_org)
 
         self.role_1 = self.fixture.new_system_role(name="role_1")
         self.role_2 = self.fixture.new_system_role(name="role_2")
@@ -118,7 +116,6 @@ class CrossAccountRequestTest(IdentityRequest):
         Principal.objects.create(tenant=public_tenant, username="2222222", user_id="2222222")
 
         self.request_1 = CrossAccountRequest.objects.create(
-            target_account=self.account,
             target_org=self.org_id,
             user_id="1111111",
             end_date=self.ref_time + timedelta(10),
@@ -126,42 +123,36 @@ class CrossAccountRequestTest(IdentityRequest):
         )
         self.request_1.roles.add(*(self.role_1, self.role_2))
         self.request_2 = CrossAccountRequest.objects.create(
-            target_account=self.account,
             target_org=self.org_id,
             user_id="2222222",
             end_date=self.ref_time + timedelta(10),
         )
         self.request_2.roles.add(*(self.role_1, self.role_2))
         self.request_3 = CrossAccountRequest.objects.create(
-            target_account=self.another_account,
             target_org=self.another_org_id,
             user_id="1111111",
             end_date=self.ref_time + timedelta(10),
             status="approved",
         )
         self.request_4 = CrossAccountRequest.objects.create(
-            target_account=self.account,
             target_org=self.org_id,
             user_id="2222222",
             end_date=self.ref_time + timedelta(10),
             status="pending",
         )
         self.request_5 = CrossAccountRequest.objects.create(
-            target_account=self.account,
             target_org=self.org_id,
             user_id="2222222",
             end_date=self.ref_time + timedelta(10),
             status="expired",
         )
         self.request_6 = CrossAccountRequest.objects.create(
-            target_account=self.another_account,
             target_org=self.another_org_id,
             user_id="1111111",
             end_date=self.ref_time + timedelta(10),
             status="pending",
         )
         self.not_anemic_request_1 = CrossAccountRequest.objects.create(
-            target_account=self.not_anemic_account,
             target_org=self.not_anemic_org_id,
             user_id="1111111",
             end_date=self.ref_time + timedelta(10),

--- a/tests/api/cross_access/test_model.py
+++ b/tests/api/cross_access/test_model.py
@@ -46,7 +46,6 @@ class CrossAccountRequestModelTests(TestCase):
 
     def test_request_creation_success(self):
         """Test the creation of cross account request."""
-        self.assertEqual(self.request.target_account, None)
         self.assertEqual(self.request.target_org, "654321")
         self.assertEqual(self.request.user_id, "567890")
         self.assertIsNotNone(self.request.start_date)
@@ -69,7 +68,6 @@ class CrossAccountRequestModelTests(TestCase):
         self.assertRaises(
             ValidationError,
             CrossAccountRequest.objects.create,
-            target_account="123456",
             target_org="654321",
             user_id="567890",
             end_date=self.ref_time + timedelta(10),
@@ -85,7 +83,6 @@ class CrossAccountRequestModelTests(TestCase):
         self.assertRaises(
             ValidationError,
             CrossAccountRequest.objects.create,
-            target_account="123456",
             target_org="654321",
             user_id="567890",
             end_date=self.ref_time - timedelta(10),
@@ -99,7 +96,6 @@ class CrossAccountRequestModelTests(TestCase):
             self.assertRaises(
                 IntegrityError,
                 CrossAccountRequest.objects.create,
-                target_account="123456",
                 target_org="654321",
                 user_id="567890",
             )
@@ -108,7 +104,6 @@ class CrossAccountRequestModelTests(TestCase):
         self.assertRaises(
             ValidationError,
             CrossAccountRequest.objects.create,
-            target_account="8888888",
             target_org="7777777",
             user_id="567890",
             end_date=timezone.now() - timedelta(1),
@@ -118,7 +113,7 @@ class CrossAccountRequestModelTests(TestCase):
         """Test the start date and end date can be the same."""
         self.assertEqual(CrossAccountRequest.objects.count(), 1)
         CrossAccountRequest.objects.create(
-            target_account="4321", target_org="1234", user_id="9876", start_date=self.ref_time, end_date=self.ref_time
+            target_org="1234", user_id="9876", start_date=self.ref_time, end_date=self.ref_time
         )
         self.assertEqual(CrossAccountRequest.objects.count(), 2)
 

--- a/tests/api/cross_access/test_util.py
+++ b/tests/api/cross_access/test_util.py
@@ -55,7 +55,6 @@ class CrossAccountRequestUtilTests(CrossAccountRequestTest):
         super().setUp()
 
         self.another_tenant_data = {
-            "target_account": self.another_account,
             "target_org": self.another_org_id,
             "start_date": self.format_date(self.ref_time),
             "end_date": self.format_date(self.ref_time + timedelta(90)),
@@ -63,8 +62,8 @@ class CrossAccountRequestUtilTests(CrossAccountRequestTest):
         }
 
         self.another_tenant = Tenant.objects.create(
-            tenant_name=f"acct{self.another_tenant_data['target_account']}",
-            account_id=self.another_tenant_data["target_account"],
+            tenant_name=f"acct{self.another_account}",
+            account_id=self.another_account,
             org_id=self.another_tenant_data["target_org"],
         )
         self.another_tenant.ready = True
@@ -139,7 +138,6 @@ class CrossAccountRequestUtilTests(CrossAccountRequestTest):
         # Add one of the same roles to another request for the same user and target org and approve
         # but this one expires later
         additional_request = CrossAccountRequest.objects.create(
-            target_account=self.request_4.target_account,
             target_org=self.request_4.target_org,
             user_id="2222222",
             end_date=self.request_4.end_date + timedelta(days=10),
@@ -204,7 +202,6 @@ class CrossAccountRequestUtilTests(CrossAccountRequestTest):
         # Add one of the same roles to another request for the same user and target org and approve
         # but this one expires later
         additional_request = CrossAccountRequest.objects.create(
-            target_account=self.request_4.target_account,
             target_org=self.request_4.target_org,
             user_id="2222222",
             end_date=self.request_4.end_date + timedelta(days=10),

--- a/tests/api/cross_access/test_view.py
+++ b/tests/api/cross_access/test_view.py
@@ -191,7 +191,6 @@ class CrossAccountRequestViewTests(CrossAccountRequestTest):
     def test_list_requests_query_by_user_id_with_combined_filters_success(self):
         """Test listing cross account request based on user id of identity."""
         expired_request = CrossAccountRequest.objects.create(
-            target_account="098765",
             target_org="567890",
             user_id="1111111",
             end_date=self.ref_time + timedelta(10),
@@ -295,8 +294,8 @@ class CrossAccountRequestViewTests(CrossAccountRequestTest):
         response = client.get(f"{URL_LIST}{self.request_1.request_id}/", **self.headers)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertNotIn("target_account", response.data)
         self.assertEqual(response.data.get("email"), "test_user@email.com")
-        self.assertEqual(response.data.get("target_account"), self.account)
         self.assertEqual(len(response.data.get("roles")), 2)
 
     def test_retrieve_request_query_by_account_fail_if_request_in_another_account(self):
@@ -322,9 +321,9 @@ class CrossAccountRequestViewTests(CrossAccountRequestTest):
         )
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertNotIn("target_account", response.data)
         self.assertEqual(response.data.get("email"), None)
         self.assertEqual(response.data.get("user_id"), "1111111")
-        self.assertEqual(response.data.get("target_account"), self.account)
         self.assertEqual(len(response.data.get("roles")), 2)
 
     def test_retrieve_request_query_by_user_id_fail_if_request_by_another_associate(self):
@@ -353,7 +352,8 @@ class CrossAccountRequestViewTests(CrossAccountRequestTest):
                 f"{URL_LIST}?", self.data4create, format="json", **self.associate_non_admin_request.META
             )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self.assertEqual(response.data["target_account"], self.data4create["target_account"])
+        self.assertNotIn("target_account", response.data)
+        self.assertEqual(response.data["target_org"], self.data4create["target_org"])
         self.assertEqual(response.data["status"], "pending")
         self.assertEqual(response.data["start_date"], self.data4create["start_date"])
         self.assertEqual(response.data["end_date"], self.data4create["end_date"])
@@ -378,7 +378,8 @@ class CrossAccountRequestViewTests(CrossAccountRequestTest):
             )
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self.assertEqual(response.data["target_account"], self.data4create["target_account"])
+        self.assertNotIn("target_account", response.data)
+        self.assertEqual(response.data["target_org"], self.data4create["target_org"])
         self.assertEqual(response.data["status"], "pending")
         self.assertEqual(response.data["start_date"], self.data4create["start_date"])
         self.assertEqual(response.data["end_date"], self.data4create["end_date"])
@@ -392,11 +393,21 @@ class CrossAccountRequestViewTests(CrossAccountRequestTest):
             self.data4create["target_org"],
         )
 
+    @patch("management.notifications.notification_handlers.notify")
+    def test_create_requests_ignores_legacy_target_account(self, notify_mock):
+        """Test that target_account in request body is silently ignored while target_org is honored."""
+        payload = {**self.data4create, "target_account": "legacy-value"}
+        client = APIClient()
+        with self.settings(NOTIFICATIONS_ENABLED=True):
+            response = client.post(f"{URL_LIST}?", payload, format="json", **self.associate_non_admin_request.META)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertNotIn("target_account", response.data)
+        self.assertEqual(response.data["target_org"], self.data4create["target_org"])
+
     def test_create_requests_fail_for_no_account(self):
         """Test the creation of cross account request fails when the account doesn't exist."""
 
         cross_account_request_with_missing_account = {
-            "target_account": "9999111",
             "target_org": "9999",
             "start_date": self.format_date(self.ref_time),
             "end_date": self.format_date(self.ref_time + timedelta(90)),
@@ -417,7 +428,6 @@ class CrossAccountRequestViewTests(CrossAccountRequestTest):
 
     def test_create_requests_towards_their_own_account_fail(self):
         """Test the creation of cross account request towards their own account fails."""
-        self.data4create["target_account"] = self.account
         self.data4create["target_org"] = self.org_id
         client = APIClient()
         response = client.post(
@@ -503,7 +513,7 @@ class CrossAccountRequestViewTests(CrossAccountRequestTest):
 
     def test_update_request_denied_for_approver(self):
         """Test updating an entire CAR denied for approver."""
-        self.data4create["target_account"] = self.account
+        self.data4create["target_org"] = self.org_id
         self.data4create["start_date"] = self.format_date(self.ref_time + timedelta(3))
         self.data4create["end_date"] = self.format_date(self.ref_time + timedelta(5))
         self.data4create["roles"] = ["role_8", "role_9"]
@@ -529,7 +539,6 @@ class CrossAccountRequestViewTests(CrossAccountRequestTest):
             "status": "cancelled",
         }
         car_uuid = self.request_1.request_id
-        self.request_1.target_account = self.another_account
         self.request_1.target_org = self.another_org_id
         self.request_1.status = "pending"
         self.request_1.save()
@@ -552,7 +561,6 @@ class CrossAccountRequestViewTests(CrossAccountRequestTest):
             "status": "cancelled",
         }
         car_uuid = self.request_1.request_id
-        self.request_1.target_account = self.another_account
         self.request_1.target_org = self.another_org_id
         self.request_1.status = "pending"
         self.request_1.save()
@@ -572,7 +580,6 @@ class CrossAccountRequestViewTests(CrossAccountRequestTest):
             "status": "cancelled",
         }
         car_uuid = self.request_1.request_id
-        self.request_1.target_account = self.another_account
         self.request_1.target_org = self.another_org_id
         self.request_1.status = "pending"
         self.request_1.save()
@@ -590,7 +597,6 @@ class CrossAccountRequestViewTests(CrossAccountRequestTest):
 
     def test_update_request_success_for_requestor(self):
         """Test updating an entire CAR."""
-        self.data4create["target_account"] = self.another_account
         self.data4create["target_org"] = self.another_org_id
         Tenant.objects.create(
             tenant_name=f"acct{self.another_account}", account_id=self.another_account, org_id=self.another_org_id
@@ -601,7 +607,6 @@ class CrossAccountRequestViewTests(CrossAccountRequestTest):
         self.data4create["status"] = "pending"
 
         car_uuid = self.request_1.request_id
-        self.request_1.target_account = self.another_account
         self.request_1.target_org = self.another_org_id
         self.request_1.status = "pending"
         self.request_1.save()
@@ -620,7 +625,6 @@ class CrossAccountRequestViewTests(CrossAccountRequestTest):
     def test_update_request_success_for_requestor_when_custom_role_with_same_name_exist(self):
         """Test updating an entire CAR."""
         Role.objects.create(name="role_8", system=False, tenant=self.tenant)
-        self.data4create["target_account"] = self.another_account
         self.data4create["target_org"] = self.another_org_id
         Tenant.objects.create(
             tenant_name=f"acct{self.another_account}", account_id=self.another_account, org_id=self.another_org_id
@@ -631,7 +635,6 @@ class CrossAccountRequestViewTests(CrossAccountRequestTest):
         self.data4create["status"] = "pending"
 
         car_uuid = self.request_1.request_id
-        self.request_1.target_account = self.another_account
         self.request_1.target_org = self.another_org_id
         self.request_1.status = "pending"
         self.request_1.save()
@@ -698,7 +701,7 @@ class CrossAccountRequestViewTests(CrossAccountRequestTest):
         update_data = {"start_date": self.format_date(self.ref_time + timedelta(2))}
 
         # request_4's user_id is "2222222", associate_admin_request'user_id is "1111111"
-        # request_4's target_account is "123456", associate_admin_request's account is "xxxxxx"
+        # request_4's target_org is "54321", associate_admin_request's org is self.org_id
         car_uuid = self.request_4.request_id
         url = reverse("v1_api:cross-detail", kwargs={"pk": str(car_uuid)})
 
@@ -841,7 +844,6 @@ class CrossAccountRequestViewTests(CrossAccountRequestTest):
 
     def test_update_bad_date_spec_for_requestor(self):
         """Test that PUT with body fields not matching spec fails."""
-        self.data4create["target_account"] = self.another_account
         self.data4create["target_org"] = self.another_org_id
         Tenant.objects.get_or_create(
             tenant_name=f"acct{self.another_account}", account_id=self.another_account, org_id=self.another_org_id
@@ -849,7 +851,6 @@ class CrossAccountRequestViewTests(CrossAccountRequestTest):
         self.data4create["end_date"] = 12252021
 
         car_uuid = self.request_1.request_id
-        self.request_1.target_account = self.another_account
         self.request_1.target_org = self.another_org_id
         self.request_1.status = "pending"
         self.request_1.save()

--- a/tests/management/access/test_view.py
+++ b/tests/management/access/test_view.py
@@ -543,7 +543,6 @@ class AccessViewTests(IdentityRequest):
         Access.objects.create(role=system_role, permission=assigned_permission, tenant=self.tenant)
 
         cross_account_request = CrossAccountRequest.objects.create(
-            target_account=account_id,
             user_id=user_id,
             target_org=org_id,
             end_date=timezone.now() + timedelta(10),
@@ -588,7 +587,6 @@ class AccessViewTests(IdentityRequest):
         ## This CAR will provide permission: "test:assigned:permission"
         role = self.create_role_and_permission("Test Role one", "test:assigned:permission1", True)
         cross_account_request = CrossAccountRequest.objects.create(
-            target_account=account_id,
             user_id=user_id,
             target_org=org_id,
             end_date=timezone.now() + timedelta(10),
@@ -598,7 +596,6 @@ class AccessViewTests(IdentityRequest):
         ## CAR below will provide permission: "app:*:*"
         role = self.create_role_and_permission("Test Role two", "test:assigned:permission2", True)
         cross_account_request = CrossAccountRequest.objects.create(
-            target_account=account_id,
             user_id=user_id,
             target_org=org_id,
             end_date=timezone.now() + timedelta(20),

--- a/tests/management/group/test_view.py
+++ b/tests/management/group/test_view.py
@@ -7221,7 +7221,6 @@ class GroupReplicationTests(IdentityRequest):
 
         # Now approve a CAR for the tenant and the same role
         request = CrossAccountRequest.objects.create(
-            target_account=self.tenant.account_id,
             target_org=self.tenant.org_id,
             user_id="2222222",
             end_date=timezone.now() + timedelta(10),
@@ -7332,7 +7331,6 @@ class GroupReplicationTests(IdentityRequest):
 
         # Now approve a CAR for the tenant and the same role
         request = CrossAccountRequest.objects.create(
-            target_account=self.tenant.account_id,
             target_org=self.tenant.org_id,
             user_id="2222222",
             end_date=timezone.now() + timedelta(10),

--- a/tests/management/test_mcp_views.py
+++ b/tests/management/test_mcp_views.py
@@ -6030,7 +6030,7 @@ class MCPCrossAccountRequestTests(MCPToolTestMixin, IdentityRequest):
         response = self._call_tool(
             "create_cross_account_request",
             {
-                "target_account": "9999999",
+                "target_org": "9999999",
                 "start_date": "2026-06-01",
                 "end_date": "2026-06-30",
                 "roles": [str(self.role.uuid)],

--- a/tests/migration_tool/tests_migrate.py
+++ b/tests/migration_tool/tests_migrate.py
@@ -165,7 +165,6 @@ class MigrateTests(TestCase):
         # Setup cross account request to migrate
         self.ref_time = timezone.now()
         self.cross_account_request = CrossAccountRequest.objects.create(
-            target_account="098765",
             target_org="7654321",
             user_id="1111111",
             end_date=self.ref_time + timedelta(10),


### PR DESCRIPTION
## Link(s) to Jira
- [RHCLOUD-36475](https://issues.redhat.com/browse/RHCLOUD-36475)

## Description of Intent of Change(s)

The `target_account` field on `CrossAccountRequest` is deprecated. The UI blocker (RHCLOUD-37335) and the "make optional" subtask (RHCLOUD-36474) are both Closed. All business logic already uses `target_org` instead.

This PR removes all code-level references to `target_account`:

- **Serializers**: Removes the field declaration and `Meta.fields` entry from both `CrossAccountRequestSerializer` and `CrossAccountRequestDetailSerializer`. Existing API clients that send `target_account` in request bodies will have it silently ignored (DRF drops unknown fields). Responses no longer include `target_account`.
- **MCP tools**: Updates `create_cross_account_request` to accept `target_org` instead of `target_account`. Updates response field references in list/get tool descriptions.
- **V1 OpenAPI spec**: Removes `target_account` from `CrossAccountRequestCreateIn`, `CrossAccountRequest`, and `CrossAccountRequestWithRoles` schemas.
- **Tests**: Removes `target_account` from all test fixtures, assertions, and request payloads across 8 test files (fixtures, test_view, test_model, test_util, access/test_view, group/test_view, test_mcp_views, tests_migrate).
- **Docs**: Updates MCP.md to reflect the parameter change.

**Intentionally NOT changed**:
- `rbac/api/cross_access/model.py` -- the model field is preserved pending the column removal strategy decision in RHCLOUD-36473.
- No new migration is created.

## Local Testing

```bash
# Run the cross-access tests specifically
pipenv run tox -e py312-fast -- tests.api.cross_access

# Run the full test suite
pipenv run tox -e py312-fast
```

All 3692 tests pass with no regressions.

## Checklist
- [x] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [x] are theses changes covered by unit tests?
- [x] if warranted, are documentation changes accounted for?
- [x] does this require migration changes?
  - [x] No -- model field intentionally preserved (RHCLOUD-36473)
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] API consumers that parse `target_account` from responses will see it missing. All should already be using `target_org`.

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices

[RHCLOUD-36475]: https://redhat.atlassian.net/browse/RHCLOUD-36475?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Remove the deprecated cross-account request target_account API field in favor of target_org across serializers, tools, and tests.

Enhancements:
- Drop target_account from cross-account request serializers so only target_org is exposed by the API.
- Update MCP management tool definitions and helper to use target_org instead of target_account for listing and creating cross-account requests.

Documentation:
- Refresh MCP documentation and OpenAPI specs to describe cross-account requests in terms of target_org and to remove references to target_account.

Tests:
- Adjust cross-account, access, group, MCP, and migration tests and fixtures to stop using target_account and validate behavior solely with target_org.