### PR TITLE
[RHCLOUD-48180] Allow non uuid as resource_id

### DIFF
--- a/docs/source/specs/typespec/main.tsp
+++ b/docs/source/specs/typespec/main.tsp
@@ -1392,8 +1392,11 @@ namespace Roles {
         @doc("Filter roles by the resource type (e.g. 'tenant', 'workspace'). When omitted, returns roles from all scopes.")
         @query resource_type?: string;
 
-        @doc("Filter by resource ID. Requires resource_type to be specified.")
+        @doc("Filter by resource ID. For workspace: UUID. For tenant: tenant resource ID (format: {domain}/{org_id}). Requires resource_type unless resource.tenant.org_id is provided.")
         @query resource_id?: string;
+
+        @doc("Org ID of the tenant resource to filter by. Cannot be combined with resource_id. When provided, resource_type is implicitly 'tenant'.")
+        @query("resource.tenant.org_id") resource_tenant_org_id?: string;
 
         @doc("Control which fields are included in the response to optimize payload size.")
         @query fields?: FieldMask = "id,name,description,last_modified";

--- a/docs/source/specs/v2/openapi.json
+++ b/docs/source/specs/v2/openapi.json
@@ -1098,7 +1098,17 @@
             "name": "resource_id",
             "in": "query",
             "required": false,
-            "description": "Filter by resource ID. Requires resource_type to be specified.",
+            "description": "Filter by resource ID. For workspace: UUID. For tenant: tenant resource ID (format: {domain}/{org_id}). Requires resource_type unless resource.tenant.org_id is provided.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          },
+          {
+            "name": "resource.tenant.org_id",
+            "in": "query",
+            "required": false,
+            "description": "Org ID of the tenant resource to filter by. Cannot be combined with resource_id. When provided, resource_type is implicitly 'tenant'.",
             "schema": {
               "type": "string"
             },

--- a/docs/source/specs/v2/openapi.yaml
+++ b/docs/source/specs/v2/openapi.yaml
@@ -698,7 +698,14 @@ paths:
         - name: resource_id
           in: query
           required: false
-          description: Filter by resource ID. Requires resource_type to be specified.
+          description: 'Filter by resource ID. For workspace: UUID. For tenant: tenant resource ID (format: {domain}/{org_id}). Requires resource_type unless resource.tenant.org_id is provided.'
+          schema:
+            type: string
+          explode: false
+        - name: resource.tenant.org_id
+          in: query
+          required: false
+          description: Org ID of the tenant resource to filter by. Cannot be combined with resource_id. When provided, resource_type is implicitly 'tenant'.
           schema:
             type: string
           explode: false

--- a/rbac/management/dotted_query_param_mixin.py
+++ b/rbac/management/dotted_query_param_mixin.py
@@ -1,0 +1,41 @@
+#
+# Copyright 2026 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""Mixin for v2 query-parameter serializers with dotted keys."""
+
+from typing import ClassVar
+
+
+class DottedQueryParamSerializerMixin:
+    """Remap dotted query param keys and strip NUL bytes before field validation.
+
+    Subclasses set ``DOTTED_PARAM_MAP`` to map API query names (e.g.
+    ``resource.tenant.org_id``) to serializer field names (e.g.
+    ``resource_tenant_org_id``).
+    """
+
+    DOTTED_PARAM_MAP: ClassVar[dict[str, str]] = {}
+
+    def to_internal_value(self, data):
+        """Remap dotted query param keys and sanitize NUL bytes."""
+        remapped = {key: data[key] for key in data}
+        for dotted, underscored in self.DOTTED_PARAM_MAP.items():
+            if dotted in remapped:
+                remapped[underscored] = remapped.pop(dotted)
+        sanitized = {
+            key: value.replace("\x00", "") if isinstance(value, str) else value for key, value in remapped.items()
+        }
+        return super().to_internal_value(sanitized)

--- a/rbac/management/role/v2_serializer.py
+++ b/rbac/management/role/v2_serializer.py
@@ -32,6 +32,11 @@ from management.utils import FieldSelection, FieldSelectionValidationError, UUID
 from rest_framework import serializers
 
 
+def _normalize_blank_or_none(value: str | None) -> str | None:
+    """Return None for empty/blank values, pass through otherwise."""
+    return (value and value.strip()) or None
+
+
 class PermissionSerializer(serializers.Serializer):
     """Serializer for permission data."""
 
@@ -155,6 +160,10 @@ def validate_fields_parameter(value: str, default_fields: set, strict: bool = Fa
 class RoleV2ListSerializer(serializers.Serializer):
     """Input serializer for RoleV2 list query parameters."""
 
+    DOTTED_PARAM_MAP = {
+        "resource.tenant.org_id": "resource_tenant_org_id",
+    }
+
     name = serializers.CharField(
         required=False,
         allow_blank=True,
@@ -171,14 +180,26 @@ class RoleV2ListSerializer(serializers.Serializer):
         required=False, allow_blank=True, help_text="Filter roles by the resource type they are scoped to"
     )
     resource_id = serializers.CharField(
-        required=False, allow_blank=True, help_text="Resource ID (requires resource_type)"
+        required=False,
+        allow_blank=True,
+        max_length=256,
+        help_text="Resource ID (requires resource_type unless resource.tenant.org_id is provided)",
+    )
+    resource_tenant_org_id = serializers.CharField(
+        required=False,
+        allow_blank=True,
+        help_text="Org ID of the tenant resource to filter by",
     )
     fields = serializers.CharField(required=False, default="", allow_blank=True, help_text="Control included fields")
 
     def to_internal_value(self, data):
-        """Sanitize input data by stripping NUL bytes before field validation."""
+        """Remap dotted query param keys and sanitize NUL bytes before field validation."""
+        remapped = {key: data[key] for key in data}
+        for dotted, underscored in self.DOTTED_PARAM_MAP.items():
+            if dotted in remapped:
+                remapped[underscored] = remapped.pop(dotted)
         sanitized = {
-            key: value.replace("\x00", "") if isinstance(value, str) else value for key, value in data.items()
+            key: value.replace("\x00", "") if isinstance(value, str) else value for key, value in remapped.items()
         }
         return super().to_internal_value(sanitized)
 
@@ -194,21 +215,34 @@ class RoleV2ListSerializer(serializers.Serializer):
         """Parse, validate, and resolve fields parameter into a set of field names."""
         return validate_fields_parameter(value, RoleV2Service.DEFAULT_LIST_FIELDS)
 
-    def validate_resource_id(self, value):
-        """Return a UUID (or None if omitted/blank) for workspace resource filtering."""
-        if value in (None, ""):
-            return None
-        try:
-            return uuid.UUID(str(value).strip())
-        except ValueError as e:
-            raise serializers.ValidationError(_("Enter a valid UUID.")) from e
+    validate_resource_id = staticmethod(_normalize_blank_or_none)
+    validate_resource_type = staticmethod(_normalize_blank_or_none)
+    validate_resource_tenant_org_id = staticmethod(_normalize_blank_or_none)
 
     def validate(self, data):
-        """Cross-field validation: resource_id requires resource_type."""
-        if data.get("resource_id") and not data.get("resource_type"):
+        """Cross-field validation for resource filters (aligned with role bindings)."""
+        resource_tenant_org_id = data.get("resource_tenant_org_id")
+        resource_id = data.get("resource_id")
+        resource_type = data.get("resource_type")
+
+        if resource_tenant_org_id:
+            if resource_id:
+                raise serializers.ValidationError("resource.tenant.org_id cannot be combined with resource_id.")
+            if resource_type and resource_type != "tenant":
+                raise serializers.ValidationError(
+                    "resource_type must be 'tenant' when resource.tenant.org_id is provided."
+                )
+        elif resource_id and not resource_type:
             raise serializers.ValidationError(
                 {"resource_id": "resource_type is required when resource_id is provided."}
             )
+
+        if resource_type == "workspace" and resource_id:
+            try:
+                data["resource_id"] = str(uuid.UUID(str(resource_id).strip()))
+            except ValueError as e:
+                raise serializers.ValidationError({"resource_id": _("Enter a valid UUID.")}) from e
+
         return data
 
 

--- a/rbac/management/role/v2_serializer.py
+++ b/rbac/management/role/v2_serializer.py
@@ -19,6 +19,7 @@
 import uuid
 
 from django.utils.translation import gettext as _
+from management.dotted_query_param_mixin import DottedQueryParamSerializerMixin
 from management.exceptions import RequiredFieldError
 from management.role.v2_exceptions import (
     InvalidRolePermissionsError,
@@ -28,13 +29,8 @@ from management.role.v2_exceptions import (
 )
 from management.role.v2_model import RoleV2
 from management.role.v2_service import RoleV2Service
-from management.utils import FieldSelection, FieldSelectionValidationError, UUIDStringField
+from management.utils import FieldSelection, FieldSelectionValidationError, UUIDStringField, normalize_blank_or_none
 from rest_framework import serializers
-
-
-def _normalize_blank_or_none(value: str | None) -> str | None:
-    """Return None for empty/blank values, pass through otherwise."""
-    return (value and value.strip()) or None
 
 
 class PermissionSerializer(serializers.Serializer):
@@ -157,7 +153,7 @@ def validate_fields_parameter(value: str, default_fields: set, strict: bool = Fa
     return resolved or default_fields
 
 
-class RoleV2ListSerializer(serializers.Serializer):
+class RoleV2ListSerializer(DottedQueryParamSerializerMixin, serializers.Serializer):
     """Input serializer for RoleV2 list query parameters."""
 
     DOTTED_PARAM_MAP = {
@@ -192,17 +188,6 @@ class RoleV2ListSerializer(serializers.Serializer):
     )
     fields = serializers.CharField(required=False, default="", allow_blank=True, help_text="Control included fields")
 
-    def to_internal_value(self, data):
-        """Remap dotted query param keys and sanitize NUL bytes before field validation."""
-        remapped = {key: data[key] for key in data}
-        for dotted, underscored in self.DOTTED_PARAM_MAP.items():
-            if dotted in remapped:
-                remapped[underscored] = remapped.pop(dotted)
-        sanitized = {
-            key: value.replace("\x00", "") if isinstance(value, str) else value for key, value in remapped.items()
-        }
-        return super().to_internal_value(sanitized)
-
     def validate_name(self, value: str | None) -> str | None:
         """Return None for empty values."""
         return value or None
@@ -215,9 +200,9 @@ class RoleV2ListSerializer(serializers.Serializer):
         """Parse, validate, and resolve fields parameter into a set of field names."""
         return validate_fields_parameter(value, RoleV2Service.DEFAULT_LIST_FIELDS)
 
-    validate_resource_id = staticmethod(_normalize_blank_or_none)
-    validate_resource_type = staticmethod(_normalize_blank_or_none)
-    validate_resource_tenant_org_id = staticmethod(_normalize_blank_or_none)
+    validate_resource_id = staticmethod(normalize_blank_or_none)
+    validate_resource_type = staticmethod(normalize_blank_or_none)
+    validate_resource_tenant_org_id = staticmethod(normalize_blank_or_none)
 
     def validate(self, data):
         """Cross-field validation for resource filters (aligned with role bindings)."""
@@ -227,10 +212,12 @@ class RoleV2ListSerializer(serializers.Serializer):
 
         if resource_tenant_org_id:
             if resource_id:
-                raise serializers.ValidationError("resource.tenant.org_id cannot be combined with resource_id.")
+                raise serializers.ValidationError(
+                    {"resource_tenant_org_id": "resource.tenant.org_id cannot be combined with resource_id."}
+                )
             if resource_type and resource_type != "tenant":
                 raise serializers.ValidationError(
-                    "resource_type must be 'tenant' when resource.tenant.org_id is provided."
+                    {"resource_type": "resource_type must be 'tenant' when resource.tenant.org_id is provided."}
                 )
         elif resource_id and not resource_type:
             raise serializers.ValidationError(

--- a/rbac/management/role/v2_service.py
+++ b/rbac/management/role/v2_service.py
@@ -286,7 +286,7 @@ class RoleV2Service:
         return queryset
 
     def _filter_by_resource_type(
-        self, queryset: QuerySet, resource_type: str, resource_id: Optional[uuid.UUID] = None
+        self, queryset: QuerySet, resource_type: str, resource_id: Optional[str] = None
     ) -> QuerySet:
         """Filter roles to those whose highest permission scope maps to resource_type.
 

--- a/rbac/management/role/v2_view.py
+++ b/rbac/management/role/v2_view.py
@@ -34,6 +34,7 @@ from management.role.v2_serializer import (
     validate_fields_parameter,
 )
 from management.role.v2_service import RoleV2Service
+from management.role_binding.serializer import resolve_resource_identifiers
 from management.utils import v2response_error_from_errors
 from management.v2_mixins import AtomicOperationsMixin
 from rest_framework import status
@@ -111,6 +112,10 @@ class RoleV2ViewSet(AtomicOperationsMixin, BaseV2ViewSet):
         input_serializer = RoleV2ListSerializer(data=request.query_params, context={"request": request})
         input_serializer.is_valid(raise_exception=True)
         validated_params = input_serializer.validated_data
+
+        if validated_params.get("resource_tenant_org_id"):
+            resource_type, resource_id = resolve_resource_identifiers(validated_params)
+            validated_params = {**validated_params, "resource_id": resource_id, "resource_type": resource_type}
 
         service = RoleV2Service(tenant=request.tenant)
         queryset = service.list(validated_params)

--- a/rbac/management/role/v2_view.py
+++ b/rbac/management/role/v2_view.py
@@ -115,7 +115,11 @@ class RoleV2ViewSet(AtomicOperationsMixin, BaseV2ViewSet):
 
         if validated_params.get("resource_tenant_org_id"):
             resource_type, resource_id = resolve_resource_identifiers(validated_params)
-            validated_params = {**validated_params, "resource_id": resource_id, "resource_type": resource_type}
+            validated_params = {
+                **{k: v for k, v in validated_params.items() if k != "resource_tenant_org_id"},
+                "resource_id": resource_id,
+                "resource_type": resource_type,
+            }
 
         service = RoleV2Service(tenant=request.tenant)
         queryset = service.list(validated_params)

--- a/rbac/management/role_binding/serializer.py
+++ b/rbac/management/role_binding/serializer.py
@@ -24,6 +24,7 @@ This module contains:
 import uuid
 from typing import Optional
 
+from management.dotted_query_param_mixin import DottedQueryParamSerializerMixin
 from management.models import Group
 from management.principal.model import Principal
 from management.role.v2_model import RoleV2
@@ -31,7 +32,7 @@ from management.role.v2_serializer import RoleIdSerializer
 from management.role_binding.model import RoleBinding
 from management.role_binding.service import CreateBindingRequest, ExcludeSources, RoleBindingService
 from management.subject import SubjectType
-from management.utils import FieldSelection, FieldSelectionValidationError
+from management.utils import FieldSelection, FieldSelectionValidationError, normalize_blank_or_none
 from rest_framework import serializers
 
 from api.models import Tenant
@@ -63,11 +64,6 @@ class RoleBindingBySubjectFieldSelection(FieldSelection):
         "resource": {"id", "name", "type"},
         "sources": {"id", "name", "type"},
     }
-
-
-def _normalize_blank_or_none(value: str | None) -> str | None:
-    """Return None for empty/blank values, pass through otherwise."""
-    return (value and value.strip()) or None
 
 
 def _normalize_uuid_or_none(value: str | None) -> uuid.UUID | None:
@@ -127,21 +123,8 @@ def resolve_resource_identifiers(params: dict) -> tuple[str, str]:
     return resource_type, resource_id
 
 
-class RoleBindingInputSerializerMixin:
+class RoleBindingInputSerializerMixin(DottedQueryParamSerializerMixin):
     """Shared validation methods for role binding input serializers."""
-
-    DOTTED_PARAM_MAP: dict[str, str] = {}
-
-    def to_internal_value(self, data):
-        """Remap dotted query param keys and sanitize NUL bytes."""
-        remapped = {key: data[key] for key in data}
-        for dotted, underscored in self.DOTTED_PARAM_MAP.items():
-            if dotted in remapped:
-                remapped[underscored] = remapped.pop(dotted)
-        sanitized = {
-            key: value.replace("\x00", "") if isinstance(value, str) else value for key, value in remapped.items()
-        }
-        return super().to_internal_value(sanitized)
 
     def validate_fields(self, value):
         """Parse and validate fields parameter into RoleBindingFieldSelection object."""
@@ -214,13 +197,13 @@ class RoleBindingListInputSerializer(RoleBindingInputSerializerMixin, serializer
         """Return None for empty values, validate UUID format otherwise."""
         return _normalize_uuid_or_none(value)
 
-    validate_resource_id = staticmethod(_normalize_blank_or_none)
-    validate_resource_type = staticmethod(_normalize_blank_or_none)
-    validate_resource_tenant_org_id = staticmethod(_normalize_blank_or_none)
-    validate_subject_type = staticmethod(_normalize_blank_or_none)
-    validate_granted_subject_type = staticmethod(_normalize_blank_or_none)
-    validate_granted_subject_id = staticmethod(_normalize_blank_or_none)
-    validate_granted_subject_principal_user_id = staticmethod(_normalize_blank_or_none)
+    validate_resource_id = staticmethod(normalize_blank_or_none)
+    validate_resource_type = staticmethod(normalize_blank_or_none)
+    validate_resource_tenant_org_id = staticmethod(normalize_blank_or_none)
+    validate_subject_type = staticmethod(normalize_blank_or_none)
+    validate_granted_subject_type = staticmethod(normalize_blank_or_none)
+    validate_granted_subject_id = staticmethod(normalize_blank_or_none)
+    validate_granted_subject_principal_user_id = staticmethod(normalize_blank_or_none)
 
     def validate_exclude_sources(self, value):
         """Map empty string to the default (none = show all)."""
@@ -333,11 +316,11 @@ class RoleBindingInputSerializer(RoleBindingInputSerializerMixin, serializers.Se
         help_text="Exclude bindings: 'none' (default) shows all, 'indirect' hides inherited, 'direct' hides direct",
     )
 
-    validate_resource_id = staticmethod(_normalize_blank_or_none)
-    validate_resource_type = staticmethod(_normalize_blank_or_none)
-    validate_resource_tenant_org_id = staticmethod(_normalize_blank_or_none)
-    validate_subject_type = staticmethod(_normalize_blank_or_none)
-    validate_subject_id = staticmethod(_normalize_blank_or_none)
+    validate_resource_id = staticmethod(normalize_blank_or_none)
+    validate_resource_type = staticmethod(normalize_blank_or_none)
+    validate_resource_tenant_org_id = staticmethod(normalize_blank_or_none)
+    validate_subject_type = staticmethod(normalize_blank_or_none)
+    validate_subject_id = staticmethod(normalize_blank_or_none)
 
     def validate(self, attrs):
         """Cross-field validation for resource params."""
@@ -1130,9 +1113,9 @@ class UpdateRoleBindingRequestSerializer(RoleBindingInputSerializerMixin, serial
     # Request body
     roles = RoleIdSerializer(many=True, required=True, help_text="Roles to assign")
 
-    validate_resource_id = staticmethod(_normalize_blank_or_none)
-    validate_resource_type = staticmethod(_normalize_blank_or_none)
-    validate_resource_tenant_org_id = staticmethod(_normalize_blank_or_none)
+    validate_resource_id = staticmethod(normalize_blank_or_none)
+    validate_resource_type = staticmethod(normalize_blank_or_none)
+    validate_resource_tenant_org_id = staticmethod(normalize_blank_or_none)
 
     def validate_fields(self, value):
         """Parse and validate fields parameter using by-subject selection."""

--- a/rbac/management/utils.py
+++ b/rbac/management/utils.py
@@ -569,6 +569,11 @@ def clean_query_param(value, param_name):
     return value
 
 
+def normalize_blank_or_none(value: str | None) -> str | None:
+    """Return None for empty/blank strings, pass through otherwise."""
+    return (value and value.strip()) or None
+
+
 def validate_uuid(uuid, key="UUID Validation"):
     """Verify UUID provided is valid."""
     try:

--- a/tests/management/role/test_v2_serializer.py
+++ b/tests/management/role/test_v2_serializer.py
@@ -22,6 +22,7 @@ from django.db.models import Count
 from django.test import override_settings
 from rest_framework import serializers
 
+from api.models import Tenant
 from management.models import Permission
 from management.role.v2_model import CustomRoleV2, RoleV2
 from management.role.v2_serializer import (
@@ -371,18 +372,37 @@ class RoleV2ListSerializerTests(IdentityRequest):
         self.assertTrue(serializer.is_valid(), serializer.errors)
         self.assertEqual(serializer.validated_data["fields"], set(RoleV2ResponseSerializer.Meta.fields))
 
-    def test_valid_resource_id_as_uuid(self):
-        """resource_id is parsed to uuid.UUID when valid."""
+    def test_valid_resource_id_as_uuid_for_workspace(self):
+        """resource_id is normalized to a UUID string when resource_type is workspace."""
         uid = "550e8400-e29b-41d4-a716-446655440000"
         serializer = RoleV2ListSerializer(data={"resource_type": "workspace", "resource_id": uid})
         self.assertTrue(serializer.is_valid(), serializer.errors)
-        self.assertEqual(str(serializer.validated_data["resource_id"]), uid)
+        self.assertEqual(serializer.validated_data["resource_id"], uid)
 
-    def test_invalid_resource_id_returns_error(self):
-        """Non-UUID resource_id is rejected."""
+    def test_invalid_resource_id_returns_error_for_workspace(self):
+        """Non-UUID resource_id is rejected when resource_type is workspace."""
         serializer = RoleV2ListSerializer(data={"resource_type": "workspace", "resource_id": "not-a-uuid"})
         self.assertFalse(serializer.is_valid())
         self.assertIn("resource_id", serializer.errors)
+
+    def test_tenant_resource_id_accepted(self):
+        """Tenant resource IDs (domain/org_id) are accepted when resource_type is tenant."""
+        tenant_resource_id = Tenant.org_id_to_tenant_resource_id("20228402")
+        serializer = RoleV2ListSerializer(
+            data={"resource_type": "tenant", "resource_id": tenant_resource_id},
+        )
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        self.assertEqual(serializer.validated_data["resource_id"], tenant_resource_id)
+
+    def test_resource_tenant_org_id_cannot_combine_with_resource_id(self):
+        """resource.tenant.org_id and resource_id are mutually exclusive."""
+        serializer = RoleV2ListSerializer(
+            data={
+                "resource_tenant_org_id": "20228402",
+                "resource_id": Tenant.org_id_to_tenant_resource_id("20228402"),
+            },
+        )
+        self.assertFalse(serializer.is_valid())
 
 
 @override_settings(ATOMIC_RETRY_DISABLED=True)

--- a/tests/management/role/test_v2_serializer.py
+++ b/tests/management/role/test_v2_serializer.py
@@ -403,6 +403,7 @@ class RoleV2ListSerializerTests(IdentityRequest):
             },
         )
         self.assertFalse(serializer.is_valid())
+        self.assertIn("resource_tenant_org_id", serializer.errors)
 
 
 @override_settings(ATOMIC_RETRY_DISABLED=True)

--- a/tests/management/role/test_v2_view.py
+++ b/tests/management/role/test_v2_view.py
@@ -19,6 +19,7 @@
 import uuid
 from collections.abc import Iterable
 from importlib import reload
+from urllib.parse import urlencode
 from unittest.mock import ANY, patch
 
 from django.conf import settings
@@ -1039,11 +1040,69 @@ class RoleV2ViewSetTests(IdentityRequest):
         self.assertIn("test_role", names)
         self.assertNotIn("root_scoped", names)
 
-    def test_list_roles_resource_id_invalid_uuid_returns_400(self):
-        """Invalid resource_id is rejected before listing."""
+    def test_list_roles_resource_id_invalid_uuid_returns_400_for_workspace(self):
+        """Invalid resource_id is rejected for workspace before listing."""
         url = f"{self.url}?resource_type=workspace&resource_id=not-a-uuid"
         response = self.client.get(url, **self.headers)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    @patch(CACHE_PATCH_TARGET, _scope_cache(tenant_perms="tenant_app:*:*"))
+    def test_list_roles_tenant_resource_id_accepted(self):
+        """Tenant resource_id (domain/org_id) is accepted for resource_type=tenant."""
+        tenant_perm = Permission.objects.create(permission="tenant_app:res:read", tenant=self.tenant)
+        tenant_role = RoleV2.objects.create(name="tenant_role", description="Tenant", tenant=self.tenant)
+        tenant_role.permissions.add(tenant_perm)
+
+        tenant_resource_id = self.tenant.tenant_resource_id()
+        url = f"{self.url}?{urlencode({'resource_type': 'tenant', 'resource_id': tenant_resource_id})}"
+        response = self.client.get(url, **self.headers)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        names = {r["name"] for r in response.data["data"]}
+        self.assertIn("tenant_role", names)
+
+    @patch(
+        CACHE_PATCH_TARGET,
+        _scope_cache(tenant_perms="tenant_app:*:*", default_perms="inventory:hosts:read"),
+    )
+    def test_list_roles_resource_type_tenant_includes_custom_tenant_scoped_role(self):
+        """resource_type=tenant returns custom roles whose highest scope is tenant."""
+        tenant_perm = Permission.objects.create(permission="tenant_app:res:read", tenant=self.tenant)
+        custom_tenant_role = CustomRoleV2.objects.create(
+            name="custom_tenant_role",
+            description="Custom tenant scoped",
+            tenant=self.tenant,
+        )
+        custom_tenant_role.permissions.add(tenant_perm)
+
+        custom_workspace_role = CustomRoleV2.objects.create(
+            name="custom_workspace_role",
+            description="Custom workspace scoped",
+            tenant=self.tenant,
+        )
+        custom_workspace_role.permissions.add(self.permission2)
+
+        url = f"{self.url}?resource_type=tenant"
+        response = self.client.get(url, **self.headers)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        names = {r["name"] for r in response.data["data"]}
+        self.assertIn("custom_tenant_role", names)
+        self.assertNotIn("custom_workspace_role", names)
+
+    @patch(CACHE_PATCH_TARGET, _scope_cache(tenant_perms="tenant_app:*:*"))
+    def test_list_roles_resource_tenant_org_id_accepted(self):
+        """resource.tenant.org_id resolves to tenant resource_id like role bindings."""
+        tenant_perm = Permission.objects.create(permission="tenant_app:res:read", tenant=self.tenant)
+        tenant_role = RoleV2.objects.create(name="tenant_role", description="Tenant", tenant=self.tenant)
+        tenant_role.permissions.add(tenant_perm)
+
+        url = f"{self.url}?resource.tenant.org_id={self.tenant.org_id}"
+        response = self.client.get(url, **self.headers)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        names = {r["name"] for r in response.data["data"]}
+        self.assertIn("tenant_role", names)
 
     @patch(CACHE_PATCH_TARGET, _scope_cache())
     def test_list_roles_resource_id_unknown_workspace_returns_empty(self):


### PR DESCRIPTION
## Link(s) to Jira
- https://redhat.atlassian.net/browse/RHCLOUD-48180

## Description of Intent of Change(s)
V2 Role listing when resource_type is tenant, allow non uuid

## Local Testing
Unit tests

## Checklist
- [x] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Allow tenant-scoped role listing to accept non-UUID tenant resource identifiers and align query parameter handling with role binding semantics.

New Features:
- Support tenant resource IDs (domain/org_id format) as resource_id values when resource_type is tenant in the V2 role listing API.
- Introduce the resource.tenant.org_id query parameter to resolve tenant resource identifiers without requiring an explicit resource_type.

Enhancements:
- Relax resource_id validation to be UUID-only only for workspace-scoped queries while treating other resource IDs as opaque strings.
- Normalize and remap dotted query parameters (such as resource.tenant.org_id) in the RoleV2 list serializer, and route them through resolve_resource_identifiers in the view.
- Update OpenAPI and Typespec documentation to describe tenant resource ID formats and the new resource.tenant.org_id query parameter.

Tests:
- Extend role V2 serializer and view tests to cover tenant resource_id acceptance, resource.tenant.org_id handling, and workspace-specific UUID validation.