### PR TITLE
RHCLOUD-40442: Fix default workspace replication job

### DIFF
--- a/deploy/rbac-clowdapp.yml
+++ b/deploy/rbac-clowdapp.yml
@@ -1283,7 +1283,7 @@ objects:
           image: ${IMAGE}:${IMAGE_TAG}
           command:
             - /opt/rbac/rbac/manage.py
-            - replicate-default-workspaces
+            - replicate_default_workspaces
             - "--all"
           resources:
             limits:


### PR DESCRIPTION
## Link(s) to Jira
[RHCLOUD-40442](https://redhat.atlassian.net/browse/RHCLOUD-40442)

## Description of Intent of Change(s)
Fix command name in default workspace replication job.

[RHCLOUD-40442]: https://redhat.atlassian.net/browse/RHCLOUD-40442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Bug Fixes:
- Correct the command invoked in the default workspace replication job so the replication task runs successfully.