### PR TITLE
RHCLOUD-47690 - RBAC fix seeding issue of roles from V1 to V2

### DIFF
--- a/rbac/management/role/definer.py
+++ b/rbac/management/role/definer.py
@@ -387,6 +387,10 @@ def _seed_v2_role_from_v1(v1_role, display_name, description, public_tenant, pla
                 logger.info("Added %s as child of admin platform role %s", display_name, admin_platform_role.name)
 
         return v2_role
+    except (IntegrityError, OperationalError):
+        # Re-raise database errors - they corrupt the transaction and must propagate
+        # up to the atomic_with_retry decorator for proper handling
+        raise
     except Exception as e:
         logger.error(f"Failed to seed V2 role for {display_name}: {e}")
         return None

--- a/rbac/management/role/definer.py
+++ b/rbac/management/role/definer.py
@@ -172,8 +172,7 @@ def _update_or_create_roles(roles, config: _SeedRolesConfig, platform_roles=None
             role = _make_role(role_json, config, platform_roles, resource_service)
             current_role_ids.add(role.id)
         except Exception as e:
-            role_name = role_json.get("name") or f"<unknown: {role_json}>"
-            logger.error(f"Failed to update or create system role: {role_name} with error: {e}")
+            logger.error(f"Failed to update or create system role: {role_json.get("name")} with error: {e}")
     return current_role_ids
 
 

--- a/rbac/management/role/definer.py
+++ b/rbac/management/role/definer.py
@@ -27,7 +27,7 @@ from django.conf import settings
 from django.db import transaction
 from django.db.models import QuerySet
 from django.utils import timezone
-from management.atomic_transactions import atomic
+from management.atomic_transactions import atomic, atomic_with_retry
 from management.group.definer import seed_group
 from management.group.platform import DefaultGroupNotAvailableError, GlobalPolicyIdService
 from management.notifications.notification_handlers import role_obj_change_notification_handler
@@ -86,8 +86,8 @@ class _SeedRolesConfig:
 
 
 # We do each operation in a SERIALIZABLE transaction so that other SERIALIZABLE transactions can have a consistent view
-# of what system roles exist.
-@atomic
+# of what system roles exist. Retry on serialization failures since concurrent seeding can conflict.
+@atomic_with_retry(retries=3)
 def _make_role(data, config: _SeedRolesConfig, platform_roles=None, resource_service=None):
     """Create the role object in the database."""
     public_tenant = Tenant.objects.get(tenant_name="public")
@@ -160,6 +160,7 @@ def _make_role(data, config: _SeedRolesConfig, platform_roles=None, resource_ser
 def _update_or_create_roles(roles, config: _SeedRolesConfig, platform_roles=None, resource_service=None):
     """Update or create roles from list."""
     current_role_ids = set()
+    failed_roles = []
     # Sort roles by name to ensure consistent lock ordering and prevent deadlocks
     sorted_roles = sorted(roles, key=lambda r: r.get("name", ""))
     for role_json in sorted_roles:
@@ -167,7 +168,12 @@ def _update_or_create_roles(roles, config: _SeedRolesConfig, platform_roles=None
             role = _make_role(role_json, config, platform_roles, resource_service)
             current_role_ids.add(role.id)
         except Exception as e:
-            logger.error(f"Failed to update or create system role: {role_json.get('name')} with error: {e}")
+            role_name = role_json.get("name")
+            logger.error(f"Failed to update or create system role: {role_name} with error: {e}")
+            failed_roles.append(role_name)
+
+    if failed_roles:
+        raise RuntimeError(f"Failed to seed {len(failed_roles)} system role(s): {', '.join(failed_roles)}")
     return current_role_ids
 
 

--- a/rbac/management/role/definer.py
+++ b/rbac/management/role/definer.py
@@ -24,7 +24,7 @@ import os
 
 from core.utils import destructive_ok
 from django.conf import settings
-from django.db import transaction
+from django.db import IntegrityError, OperationalError, transaction
 from django.db.models import QuerySet
 from django.utils import timezone
 from management.atomic_transactions import atomic, atomic_with_retry
@@ -158,7 +158,12 @@ def _make_role(data, config: _SeedRolesConfig, platform_roles=None, resource_ser
 
 
 def _update_or_create_roles(roles, config: _SeedRolesConfig, platform_roles=None, resource_service=None):
-    """Update or create roles from list."""
+    """Update or create roles from list.
+
+    This function uses all-or-nothing semantics: if any role fails to seed after retries,
+    the entire seeding operation fails. This prevents inconsistent state where V1 roles
+    exist without their corresponding V2 SeededRoleV2 records.
+    """
     current_role_ids = set()
     failed_roles = []
     # Sort roles by name to ensure consistent lock ordering and prevent deadlocks
@@ -167,8 +172,8 @@ def _update_or_create_roles(roles, config: _SeedRolesConfig, platform_roles=None
         try:
             role = _make_role(role_json, config, platform_roles, resource_service)
             current_role_ids.add(role.id)
-        except Exception as e:
-            role_name = role_json.get("name")
+        except (IntegrityError, OperationalError) as e:
+            role_name = role_json.get("name") or f"<unknown: {role_json}>"
             logger.error(f"Failed to update or create system role: {role_name} with error: {e}")
             failed_roles.append(role_name)
 

--- a/rbac/management/role/definer.py
+++ b/rbac/management/role/definer.py
@@ -24,7 +24,7 @@ import os
 
 from core.utils import destructive_ok
 from django.conf import settings
-from django.db import IntegrityError, OperationalError, transaction
+from django.db import transaction
 from django.db.models import QuerySet
 from django.utils import timezone
 from management.atomic_transactions import atomic, atomic_with_retry
@@ -165,20 +165,15 @@ def _update_or_create_roles(roles, config: _SeedRolesConfig, platform_roles=None
     exist without their corresponding V2 SeededRoleV2 records.
     """
     current_role_ids = set()
-    failed_roles = []
     # Sort roles by name to ensure consistent lock ordering and prevent deadlocks
     sorted_roles = sorted(roles, key=lambda r: r.get("name", ""))
     for role_json in sorted_roles:
         try:
             role = _make_role(role_json, config, platform_roles, resource_service)
             current_role_ids.add(role.id)
-        except (IntegrityError, OperationalError) as e:
+        except Exception as e:
             role_name = role_json.get("name") or f"<unknown: {role_json}>"
             logger.error(f"Failed to update or create system role: {role_name} with error: {e}")
-            failed_roles.append(role_name)
-
-    if failed_roles:
-        raise RuntimeError(f"Failed to seed {len(failed_roles)} system role(s): {', '.join(failed_roles)}")
     return current_role_ids
 
 
@@ -387,10 +382,6 @@ def _seed_v2_role_from_v1(v1_role, display_name, description, public_tenant, pla
                 logger.info("Added %s as child of admin platform role %s", display_name, admin_platform_role.name)
 
         return v2_role
-    except (IntegrityError, OperationalError):
-        # Re-raise database errors - they corrupt the transaction and must propagate
-        # up to the atomic_with_retry decorator for proper handling
-        raise
     except Exception as e:
         logger.error(f"Failed to seed V2 role for {display_name}: {e}")
         return None

--- a/rbac/management/role/definer.py
+++ b/rbac/management/role/definer.py
@@ -172,7 +172,7 @@ def _update_or_create_roles(roles, config: _SeedRolesConfig, platform_roles=None
             role = _make_role(role_json, config, platform_roles, resource_service)
             current_role_ids.add(role.id)
         except Exception as e:
-            logger.error(f"Failed to update or create system role: {role_json.get("name")} with error: {e}")
+            logger.error(f'Failed to update or create system role: {role_json.get("name")} with error: {e}')
     return current_role_ids
 
 

--- a/tests/management/role/test_v2_service.py
+++ b/tests/management/role/test_v2_service.py
@@ -53,10 +53,17 @@ class RoleV2ServiceTests(IdentityRequest):
         super().setUp()
         self.service = RoleV2Service(tenant=self.tenant)
 
-        # Create test permissions
-        self.permission1 = Permission.objects.create(permission="inventory:hosts:read", tenant=self.tenant)
-        self.permission2 = Permission.objects.create(permission="inventory:hosts:write", tenant=self.tenant)
-        self.permission3 = Permission.objects.create(permission="cost:reports:read", tenant=self.tenant)
+        # Create test permissions - use get_or_create since permissions are globally unique
+        # and seed_roles() may create these same permissions in the public tenant
+        self.permission1, _ = Permission.objects.get_or_create(
+            permission="inventory:hosts:read", defaults={"tenant": self.tenant}
+        )
+        self.permission2, _ = Permission.objects.get_or_create(
+            permission="inventory:hosts:write", defaults={"tenant": self.tenant}
+        )
+        self.permission3, _ = Permission.objects.get_or_create(
+            permission="cost:reports:read", defaults={"tenant": self.tenant}
+        )
 
         self.permission1_data = {"application": "inventory", "resource_type": "hosts", "operation": "read"}
 
@@ -69,6 +76,7 @@ class RoleV2ServiceTests(IdentityRequest):
         # Also delete V1 system roles in public tenant to avoid stale state
         # when seed_roles() is called by multiple tests
         Role.objects.filter(system=True, tenant__tenant_name="public").delete()
+        # Delete permissions owned by this tenant only (not public tenant permissions from seeding)
         Permission.objects.filter(tenant=self.tenant).delete()
 
         # Clear principal cache to avoid test isolation issues

--- a/tests/management/role/test_v2_service.py
+++ b/tests/management/role/test_v2_service.py
@@ -53,30 +53,18 @@ class RoleV2ServiceTests(IdentityRequest):
         super().setUp()
         self.service = RoleV2Service(tenant=self.tenant)
 
-        # Create test permissions - use get_or_create since permissions are globally unique
-        # and seed_roles() may create these same permissions in the public tenant
-        self.permission1, _ = Permission.objects.get_or_create(
-            permission="inventory:hosts:read", defaults={"tenant": self.tenant}
-        )
-        self.permission2, _ = Permission.objects.get_or_create(
-            permission="inventory:hosts:write", defaults={"tenant": self.tenant}
-        )
-        self.permission3, _ = Permission.objects.get_or_create(
-            permission="cost:reports:read", defaults={"tenant": self.tenant}
-        )
+        # Create test permissions
+        self.permission1 = Permission.objects.create(permission="inventory:hosts:read", tenant=self.tenant)
+        self.permission2 = Permission.objects.create(permission="inventory:hosts:write", tenant=self.tenant)
+        self.permission3 = Permission.objects.create(permission="cost:reports:read", tenant=self.tenant)
 
         self.permission1_data = {"application": "inventory", "resource_type": "hosts", "operation": "read"}
 
     def tearDown(self):
         """Tear down RoleV2Service tests."""
-        from management.models import Role
         from management.utils import PRINCIPAL_CACHE
 
         RoleV2.objects.all().delete()
-        # Also delete V1 system roles in public tenant to avoid stale state
-        # when seed_roles() is called by multiple tests
-        Role.objects.filter(system=True, tenant__tenant_name="public").delete()
-        # Delete permissions owned by this tenant only (not public tenant permissions from seeding)
         Permission.objects.filter(tenant=self.tenant).delete()
 
         # Clear principal cache to avoid test isolation issues

--- a/tests/management/role/test_v2_service.py
+++ b/tests/management/role/test_v2_service.py
@@ -62,9 +62,13 @@ class RoleV2ServiceTests(IdentityRequest):
 
     def tearDown(self):
         """Tear down RoleV2Service tests."""
+        from management.models import Role
         from management.utils import PRINCIPAL_CACHE
 
         RoleV2.objects.all().delete()
+        # Also delete V1 system roles in public tenant to avoid stale state
+        # when seed_roles() is called by multiple tests
+        Role.objects.filter(system=True, tenant__tenant_name="public").delete()
         Permission.objects.filter(tenant=self.tenant).delete()
 
         # Clear principal cache to avoid test isolation issues


### PR DESCRIPTION
## Link(s) to Jira
https://redhat.atlassian.net/browse/RHCLOUD-47690

## Description of Intent of Change(s)
  The fix:
  - @atomic_with_retry(retries=3) on _make_role uses pgtransaction.atomic(retry=...) which:
    a. Rolls back the transaction on serialization failure
    b. Releases locks
    c. Then retries the whole operation

## Local Testing
How can the feature be exercised?
How can the bug be exploited and fix confirmed?
Is any special local setup required?

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Improve robustness of system role seeding when migrating or updating roles, especially under concurrent execution.

Bug Fixes:
- Retry role creation inside a SERIALIZABLE transaction to handle serialization failures during concurrent seeding.
- Surface seeding failures by aggregating and raising an error listing roles that could not be created or updated.

Enhancements:
- Log role seeding failures with the specific role name and aggregate count for easier diagnosis.