### PR TITLE
fix: temp patch for kernel-headers CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,9 @@ RUN INSTALL_PKGS="python3.12 python3.12-devel glibc-langpack-en libpq-devel gcc 
     microdnf --nodocs -y upgrade && \
     microdnf -y --setopt=tsflags=nodocs --setopt=install_weak_deps=0 install $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
+    # Temp fix: CVE-2026-46243, CVE-2026-31613, CVE-2026-31786 (RHSA-2026:24381)
+    # Remove after base image includes kernel >= 5.14.0-687.13.1.el9_8
+    microdnf -y update kernel-headers && \
     microdnf -y clean all --enablerepo='*'
 
 # PIPENV_DEV is set to true in the docker-compose allowing

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,8 +46,8 @@ RUN INSTALL_PKGS="python3.12 python3.12-devel glibc-langpack-en libpq-devel gcc 
     microdnf -y --setopt=tsflags=nodocs --setopt=install_weak_deps=0 install $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     # Temp fix: CVE-2026-46243, CVE-2026-31613, CVE-2026-31786 (RHSA-2026:24381)
-    # Remove after base image includes kernel >= 5.14.0-687.13.1.el9_8
-    microdnf -y update kernel-headers && \
+    # Remove after base image includes kernel-headers >= 5.14.0-687.13.1.el9_8
+    microdnf -y install kernel-headers-5.14.0-687.13.1.el9_8 && \
     microdnf -y clean all --enablerepo='*'
 
 # PIPENV_DEV is set to true in the docker-compose allowing


### PR DESCRIPTION
Explicitly update kernel-headers to pull fixed version (5.14.0-687.13.1.el9_8) from RHEL repos until a patched ubi9/ubi-minimal base image is released.

CVEs addressed:
- CVE-2026-46243 (High 7.8) - CIFS privilege escalation
- CVE-2026-31613 (Medium 7.1) - SMB client OOB read
- CVE-2026-31786 (Medium 7.1) - Xen hypervisor buffer overflow

Advisory: RHSA-2026:24381
Remove this workaround after base image >= 9.8-XXXXXXXXXX (post 2026-06-08)

## Link(s) to Jira
-

## Description of Intent of Change(s)
The what, why and how.

## Local Testing
How can the feature be exercised?
How can the bug be exploited and fix confirmed?
Is any special local setup required?

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
