### PR TITLE
docs: update test commands to use tox -r to match CI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,30 +34,33 @@ insights-rbac is a Django REST Framework microservice providing Role-Based Acces
 
 ### Testing
 
-Django's test runner requires **dotted module paths**, not file paths. If `tox` is not on PATH, use `pipenv run tox`.
+Django's test runner requires **dotted module paths**, not file paths. Use `tox -r` to match CI (Tekton pipeline).
 
 ```bash
-# Run all tests (with coverage)
-pipenv run tox -e py312
+# Run all environments (lint + tests + mypy), same as CI
+tox -r
+
+# Run all tests with coverage
+tox -r -e py312
 
 # Run all tests without coverage (faster)
-pipenv run tox -e py312-fast
+tox -r -e py312-fast
 
 # Run a specific test module
-pipenv run tox -e py312-fast -- tests.management.workspace.test_view
+tox -r -e py312-fast -- tests.management.workspace.test_view
 
 # Run a specific test class
-pipenv run tox -e py312-fast -- tests.management.workspace.test_view.WorkspaceTestsList
+tox -r -e py312-fast -- tests.management.workspace.test_view.WorkspaceTestsList
 
 # Run a single test method
-pipenv run tox -e py312-fast -- tests.management.workspace.test_view.WorkspaceTestsList.test_workspace_list_unfiltered
+tox -r -e py312-fast -- tests.management.workspace.test_view.WorkspaceTestsList.test_workspace_list_unfiltered
 ```
 
 ### Linting and Formatting
 
 ```bash
-pipenv run tox -e lint                             # flake8 + black --check
-pipenv run black -t py312 -l 119 rbac tests        # auto-format
+tox -r -e lint                                     # flake8 + black --check
+black -t py312 -l 119 rbac tests                   # auto-format
 ```
 
 ### Local Development
@@ -98,7 +101,7 @@ The `.pre-commit-config.yaml` enforces:
 - django-upgrade (target 5.2)
 - openapi-spec-validator
 
-Run manually: `pipenv run pre-commit run --all-files`
+Run manually: `pre-commit run --all-files`
 
 ## Key Conventions
 

--- a/docs/testing-guidelines.md
+++ b/docs/testing-guidelines.md
@@ -4,25 +4,28 @@ Rules and patterns for writing tests in insights-rbac. This is a reference for c
 
 ## Running Tests
 
-Django's test runner requires **dotted module paths**, not file paths.
+Django's test runner requires **dotted module paths**, not file paths. Use `tox -r` to match CI (Tekton pipeline).
 
 ```bash
+# Run all environments (lint + tests + mypy), same as CI
+tox -r
+
 # All tests without coverage (fast feedback loop)
-pipenv run tox -e py312-fast
+tox -r -e py312-fast
 
 # All tests with coverage
-pipenv run tox -e py312
+tox -r -e py312
 
 # Specific module / class / method
-pipenv run tox -e py312-fast -- tests.management.workspace.test_view
-pipenv run tox -e py312-fast -- tests.management.workspace.test_view.WorkspaceTestsList
-pipenv run tox -e py312-fast -- tests.management.workspace.test_view.WorkspaceTestsList.test_workspace_list_unfiltered
+tox -r -e py312-fast -- tests.management.workspace.test_view
+tox -r -e py312-fast -- tests.management.workspace.test_view.WorkspaceTestsList
+tox -r -e py312-fast -- tests.management.workspace.test_view.WorkspaceTestsList.test_workspace_list_unfiltered
 
 # Profile slowest tests
-pipenv run tox -e py312-profile
+tox -r -e py312-profile
 
 # Lint + format check
-pipenv run tox -e lint
+tox -r -e lint
 ```
 
 Both `py312` and `py312-fast` run with `--failfast`. The `py312` env uses `--parallel 4` (4 workers) and collects branch coverage (omits migrations). The `py312-fast` env uses `--parallel` (auto worker count) and skips coverage.


### PR DESCRIPTION
## Summary
- Replace `pipenv run tox` with `tox -r` in AGENTS.md and docs/testing-guidelines.md to match how the Tekton pipeline actually runs tests
- Add `tox -r` (all environments) as the first example since that is what CI executes
- Also update linting and pre-commit commands to drop the `pipenv run` wrapper

## Motivation

The Tekton pull-request pipeline (`.tekton/insights-rbac-pull-request.yaml`) runs `pip install tox && tox -r`. The AI docs were using `pipenv run tox` which is inconsistent with CI and can lead to confusion.

## Test plan
- [ ] Verify `tox -r` runs successfully locally
- [ ] Confirm documentation renders correctly on GitHub

## Summary by Sourcery

Align testing documentation and examples with the CI pipeline by standardizing on direct tox usage with environment recreation.

Documentation:
- Update AGENTS.md and testing-guidelines.md to recommend running tests and linting with `tox -r` to mirror CI behavior and remove `pipenv run` wrappers.
- Refresh examples for running tests, linting, formatting, and pre-commit hooks to use direct tox, black, and pre-commit commands.