### PR TITLE
feat: add DR_RECONCILE_ENABLED parameter to ClowdApp template

### DIFF
--- a/deploy/rbac-clowdapp.yml
+++ b/deploy/rbac-clowdapp.yml
@@ -209,6 +209,8 @@ objects:
             value: ${NOTIFICATIONS_RH_ENABLED}
           - name: KAFKA_ENABLED
             value: ${KAFKA_ENABLED}
+          - name: DR_RECONCILE_ENABLED
+            value: ${DR_RECONCILE_ENABLED}
           - name: NOTIFICATIONS_TOPIC
             value: ${NOTIFICATIONS_TOPIC}
           - name: EXTERNAL_SYNC_TOPIC
@@ -533,6 +535,8 @@ objects:
             value: ${NOTIFICATIONS_RH_ENABLED}
           - name: KAFKA_ENABLED
             value: ${KAFKA_ENABLED}
+          - name: DR_RECONCILE_ENABLED
+            value: ${DR_RECONCILE_ENABLED}
           - name: NOTIFICATIONS_TOPIC
             value: ${NOTIFICATIONS_TOPIC}
           - name: EXTERNAL_SYNC_TOPIC
@@ -1630,6 +1634,9 @@ parameters:
   value: 'platform.notifications.ingress'
 - description: Enable kafka
   name: KAFKA_ENABLED
+  value: 'False'
+- description: Enable disaster recovery reconciliation endpoint and Celery task
+  name: DR_RECONCILE_ENABLED
   value: 'False'
 - name: EXTERNAL_SYNC_TOPIC
   value: 'platform.rbac.sync'


### PR DESCRIPTION
## Summary
- Add `DR_RECONCILE_ENABLED` env var to the `service` and `worker-service` deployments in `deploy/rbac-clowdapp.yml`
- Add parameter definition (default `False`) so it can be set via bonfire: `bonfire deploy rbac -p rbac/DR_RECONCILE_ENABLED=True`
- The DR reconciliation endpoint (`_private/api/disaster_recovery/reconcile/`) and Celery task both check this setting — without it in the ClowdApp template, there's no way to enable DR on ephemeral clusters

## Test plan
- [ ] Deploy with `bonfire deploy rbac -p rbac/DR_RECONCILE_ENABLED=True`
- [ ] Verify `DR_RECONCILE_ENABLED=True` is set on service and worker pods
- [ ] Verify the DR reconciliation endpoint returns 200 (not 403)

## Summary by Sourcery

Add configuration for enabling disaster recovery reconciliation via ClowdApp parameters and propagate it to service deployments.

New Features:
- Expose DR_RECONCILE_ENABLED environment variable in the service deployment.
- Expose DR_RECONCILE_ENABLED environment variable in the worker-service deployment.
- Introduce DR_RECONCILE_ENABLED ClowdApp parameter with a default value of False.