### PR TITLE
[RHCLOUD-35383] Add v2_role FK, indexes, and unique constraint to BindingMapping

### DIFF
--- a/rbac/management/group/relation_api_dual_write_subject_handler.py
+++ b/rbac/management/group/relation_api_dual_write_subject_handler.py
@@ -228,7 +228,8 @@ class RelationApiDualWriteSubjectHandler:
             resource,
             **subject,
         )
-        mapping = BindingMapping.for_role_binding(binding, system_role)
+        v2_role = SeededRoleV2.objects.filter(uuid=system_role.uuid).first()
+        mapping = BindingMapping.for_role_binding(binding, system_role, v2_role=v2_role)
         self.relations_to_add.extend(mapping.as_tuples())
         return mapping
 

--- a/rbac/management/migrations/0089_bindingmapping_v2_role_and_indexes.py
+++ b/rbac/management/migrations/0089_bindingmapping_v2_role_and_indexes.py
@@ -1,0 +1,37 @@
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("management", "0088_auditlog_source"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="bindingmapping",
+            name="v2_role",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="binding_mappings",
+                to="management.rolev2",
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="bindingmapping",
+            index=models.Index(
+                fields=["role", "resource_type_namespace", "resource_type_name", "resource_id"],
+                name="bm_role_resource_idx",
+            ),
+        ),
+        migrations.AddConstraint(
+            model_name="bindingmapping",
+            constraint=models.UniqueConstraint(
+                fields=["v2_role", "resource_type_namespace", "resource_type_name", "resource_id"],
+                name="unique_bindingmapping_v2role_resource",
+            ),
+        ),
+    ]

--- a/rbac/management/migrations/0090_backfill_bindingmapping_v2_role.py
+++ b/rbac/management/migrations/0090_backfill_bindingmapping_v2_role.py
@@ -1,0 +1,56 @@
+import itertools
+
+from django.db import migrations, transaction
+
+
+def backfill_v2_role(apps, schema_editor):
+    """Backfill v2_role FK from mappings JSON field."""
+    BindingMapping = apps.get_model("management", "BindingMapping")
+    RoleV2 = apps.get_model("management", "RoleV2")
+
+    needed_uuids = set(
+        BindingMapping.objects.filter(v2_role__isnull=True)
+        .exclude(mappings__role__id=None)
+        .values_list("mappings__role__id", flat=True)
+        .distinct()
+    )
+
+    v2_role_lookup = {str(r.uuid): r.pk for r in RoleV2.objects.filter(uuid__in=needed_uuids).only("id", "uuid")}
+
+    unprocessed_pks = BindingMapping.objects.filter(v2_role__isnull=True).values_list("pk", flat=True).iterator()
+
+    for pk_chunk in itertools.batched(unprocessed_pks, 1000):
+        with transaction.atomic():
+            rows = BindingMapping.objects.filter(pk__in=pk_chunk, v2_role__isnull=True).select_for_update()
+
+            batch = []
+            for bm in rows:
+                role_data = bm.mappings.get("role")
+                if not role_data or "id" not in role_data:
+                    continue
+
+                role_uuid = str(role_data["id"])
+                v2_role_pk = v2_role_lookup.get(role_uuid)
+                if v2_role_pk is None:
+                    v2 = RoleV2.objects.filter(uuid=role_uuid).values_list("pk", flat=True).first()
+                    if v2 is None:
+                        continue
+                    v2_role_pk = v2
+                    v2_role_lookup[role_uuid] = v2_role_pk
+
+                bm.v2_role_id = v2_role_pk
+                batch.append(bm)
+
+            if batch:
+                BindingMapping.objects.bulk_update(batch, ["v2_role_id"])
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("management", "0089_bindingmapping_v2_role_and_indexes"),
+    ]
+
+    operations = [
+        migrations.RunPython(backfill_v2_role, migrations.RunPython.noop),
+    ]

--- a/rbac/management/role/model.py
+++ b/rbac/management/role/model.py
@@ -18,7 +18,7 @@
 """Model for role management."""
 
 import logging
-from typing import Optional, Union
+from typing import Optional, TYPE_CHECKING, Union
 from uuid import uuid4
 
 from django.conf import settings
@@ -40,6 +40,9 @@ from migration_tool.models import (
 )
 
 from api.models import FilterQuerySet, TenantAwareModel
+
+if TYPE_CHECKING:
+    from management.role.v2_model import RoleV2
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
@@ -153,9 +156,30 @@ class BindingMapping(models.Model):
     # JSON encoding of migration_tool.models.V2rolebinding
     mappings = models.JSONField(default=dict)
     role = models.ForeignKey(Role, on_delete=models.CASCADE, related_name="binding_mappings")
+    v2_role = models.ForeignKey(
+        "management.RoleV2",
+        null=True,
+        blank=True,
+        on_delete=models.SET_NULL,
+        related_name="binding_mappings",
+    )
     resource_type_namespace = models.CharField(max_length=256, null=False)
     resource_type_name = models.CharField(max_length=256, null=False)
     resource_id = models.CharField(max_length=256, null=False)
+
+    class Meta:
+        indexes = [
+            models.Index(
+                fields=["role", "resource_type_namespace", "resource_type_name", "resource_id"],
+                name="bm_role_resource_idx",
+            ),
+        ]
+        constraints = [
+            models.UniqueConstraint(
+                fields=["v2_role", "resource_type_namespace", "resource_type_name", "resource_id"],
+                name="unique_bindingmapping_v2role_resource",
+            ),
+        ]
 
     def save(self, *args, **kwargs):
         """Validate and save this BindingMapping."""
@@ -167,7 +191,7 @@ class BindingMapping(models.Model):
         super().save(*args, **kwargs)
 
     @classmethod
-    def for_role_binding(cls, role_binding: V2rolebinding, v1_role: Union[Role, str]):
+    def for_role_binding(cls, role_binding: V2rolebinding, v1_role: Union[Role, str], v2_role: Optional["RoleV2"]):
         """Create a new BindingMapping for a V2rolebinding."""
         mappings = role_binding.as_minimal_dict()
         resource = role_binding.resource
@@ -180,6 +204,7 @@ class BindingMapping(models.Model):
         return cls(
             mappings=mappings,
             **role_arg,
+            v2_role=v2_role,
             resource_type_namespace=resource_type_namespace,
             resource_type_name=resource_type_name,
             resource_id=resource_id,

--- a/rbac/migration_tool/sharedSystemRolesReplicatedRoleBindings.py
+++ b/rbac/migration_tool/sharedSystemRolesReplicatedRoleBindings.py
@@ -301,6 +301,7 @@ def _get_or_create_binding(
         existing_mapping.update_mappings_from_role_binding(
             role_binding.as_migration_value(force_group_uuids=group_uuids)
         )
+        existing_mapping.v2_role = v2_role
 
         return existing_mapping, role_binding
     else:
@@ -315,6 +316,7 @@ def _get_or_create_binding(
         new_mapping = BindingMapping.for_role_binding(
             role_binding=role_binding.as_migration_value(force_group_uuids=group_uuids),
             v1_role=v1_role,
+            v2_role=v2_role,
         )
 
         return new_mapping, role_binding

--- a/tests/internal/test_utils.py
+++ b/tests/internal/test_utils.py
@@ -805,6 +805,7 @@ class RemoveOrphanBindingMappingsTest(DualWriteTestCase):
                 users={},
             ),
             role,
+            v2_role=None,
         )
 
         for tuple in binding.as_tuples():

--- a/tests/internal/test_views.py
+++ b/tests/internal/test_views.py
@@ -1000,7 +1000,7 @@ class InternalViewsetTests(BaseInternalViewsetTests):
             **self.request.META,
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        binding_attrs.update({"id": binding_mapping.id, "role": self.role.id})
+        binding_attrs.update({"id": binding_mapping.id, "role": self.role.id, "v2_role": None})
         self.assertEqual(json.loads(response.content.decode()), [binding_attrs])
 
     @patch("management.relation_replicator.outbox_replicator.OutboxReplicator.replicate")

--- a/tests/management/role/test_dual_write.py
+++ b/tests/management/role/test_dual_write.py
@@ -550,6 +550,8 @@ class DualWriteTestCase(TestCase):
         )
 
         self.assertIn(group_id, mapping.mappings["groups"])
+        self.assertIsNotNone(mapping.v2_role, "BindingMapping should have v2_role set during dual-write")
+        self.assertEqual(str(mapping.v2_role.uuid), v2_role_id)
 
         binding = RoleBinding.objects.get(
             resource_type=target.resource_type[1],

--- a/tests/management/role/test_model.py
+++ b/tests/management/role/test_model.py
@@ -20,6 +20,7 @@ from django.db import IntegrityError, transaction
 
 from api.cross_access.model import CrossAccountRequest
 from management.models import BindingMapping, ExtRoleRelation, ExtTenant, Role
+from management.role.v2_model import RoleV2
 from tests.identity_request import IdentityRequest
 from migration_tool.models import (
     V2role,
@@ -120,7 +121,7 @@ class BindingMappingTests(IdentityRequest):
         self.v2rolebinding = V2rolebinding(
             id="v2rolebinding", role=self.v2role, resource=self.resource, groups=frozenset(), users={}
         )
-        self.binding_mapping = BindingMapping.for_role_binding(self.v2rolebinding, self.role)
+        self.binding_mapping = BindingMapping.for_role_binding(self.v2rolebinding, self.role, v2_role=None)
         self.user_id_1 = "user1"
         self.user_id_2 = "user2"
         self.cars = CrossAccountRequest.objects.bulk_create(
@@ -313,3 +314,80 @@ class BindingMappingTests(IdentityRequest):
         role_binding = self.binding_mapping.get_role_binding()
         self.assertIn("group1", role_binding.groups)
         self.assertEqual(len(role_binding.groups), 2)
+
+    def test_unique_constraint_prevents_duplicate_v2_role_resource(self):
+        """Test that two BindingMappings with same v2_role + resource are rejected."""
+        v2_role = RoleV2.objects.create(name="test-v2-role", tenant=self.tenant)
+
+        BindingMapping.objects.create(
+            mappings=self.binding_mapping.mappings,
+            role=self.role,
+            v2_role=v2_role,
+            resource_type_namespace="ns",
+            resource_type_name="type",
+            resource_id="rid",
+        )
+
+        with self.assertRaises(IntegrityError):
+            with transaction.atomic():
+                BindingMapping.objects.create(
+                    mappings=self.binding_mapping.mappings,
+                    role=self.role,
+                    v2_role=v2_role,
+                    resource_type_namespace="ns",
+                    resource_type_name="type",
+                    resource_id="rid",
+                )
+
+    def test_null_v2_role_does_not_conflict(self):
+        """Test that multiple BindingMappings with NULL v2_role are allowed."""
+        BindingMapping.objects.create(
+            mappings=self.binding_mapping.mappings,
+            role=self.role,
+            v2_role=None,
+            resource_type_namespace="ns",
+            resource_type_name="type",
+            resource_id="rid",
+        )
+        BindingMapping.objects.create(
+            mappings=self.binding_mapping.mappings,
+            role=self.role,
+            v2_role=None,
+            resource_type_namespace="ns",
+            resource_type_name="type",
+            resource_id="rid",
+        )
+        self.assertEqual(
+            BindingMapping.objects.filter(
+                v2_role__isnull=True, resource_type_namespace="ns", resource_type_name="type", resource_id="rid"
+            ).count(),
+            2,
+        )
+
+    def test_set_null_on_delete_v2_role(self):
+        """Test that deleting a RoleV2 sets v2_role to NULL on BindingMapping."""
+        v2_role = RoleV2.objects.create(name="set-null-test", tenant=self.tenant)
+        bm = BindingMapping.objects.create(
+            mappings=self.binding_mapping.mappings,
+            role=self.role,
+            v2_role=v2_role,
+            resource_type_namespace="ns",
+            resource_type_name="type",
+            resource_id="rid",
+        )
+        bm_pk = bm.pk
+        v2_role.delete()
+        bm.refresh_from_db()
+        self.assertTrue(BindingMapping.objects.filter(pk=bm_pk).exists())
+        self.assertIsNone(bm.v2_role)
+
+    def test_for_role_binding_with_v2_role(self):
+        """Test that for_role_binding accepts and sets v2_role."""
+        v2_role = RoleV2.objects.create(name="factory-test", tenant=self.tenant)
+        mapping = BindingMapping.for_role_binding(self.v2rolebinding, self.role, v2_role=v2_role)
+        self.assertEqual(mapping.v2_role, v2_role)
+
+    def test_for_role_binding_without_v2_role(self):
+        """Test that for_role_binding still works without v2_role."""
+        mapping = BindingMapping.for_role_binding(self.v2rolebinding, self.role, v2_role=None)
+        self.assertIsNone(mapping.v2_role)

--- a/tests/util/v2_local_invariants.py
+++ b/tests/util/v2_local_invariants.py
@@ -28,6 +28,14 @@ def _assert_binding_mapping_consistent(test: TestCase, binding: RoleBinding, map
     test.assertEqual(binding.resource_id, mapping.resource_id)
     test.assertEqual(str(binding.role.uuid), mapping.mappings["role"]["id"])
 
+    test.assertIsNotNone(mapping.v2_role, f"BindingMapping {mapping.id} should have v2_role set")
+    test.assertEqual(mapping.v2_role_id, binding.role_id, "v2_role FK should match RoleBinding's role")
+    test.assertEqual(
+        str(mapping.v2_role.uuid),
+        mapping.mappings["role"]["id"],
+        "v2_role UUID should match mappings JSON role id",
+    )
+
     v1_groups = set(mapping.mappings["groups"])
     v2_groups = set(str(g.uuid) for g in binding.bound_groups())
 
@@ -67,7 +75,8 @@ def _assert_role_mappings_consistent(test: TestCase, role: CustomRoleV2, mapping
 
 def _assert_v1_v2_system_roles_locally_consistent(test: TestCase):
     binding_mappings_by_uuid = {
-        str(m.mappings["id"]): m for m in BindingMapping.objects.filter(role__system=True).prefetch_related("role")
+        str(m.mappings["id"]): m
+        for m in BindingMapping.objects.filter(role__system=True).prefetch_related("role").select_related("v2_role")
     }
 
     role_bindings_by_uuid = {str(b.uuid): b for b in RoleBinding.objects.filter(role__type=RoleV2.Types.SEEDED)}
@@ -81,7 +90,8 @@ def _assert_v1_v2_system_roles_locally_consistent(test: TestCase):
 
 def _assert_v1_v2_custom_roles_locally_consistent(test: TestCase):
     binding_mappings_by_uuid = {
-        str(m.mappings["id"]): m for m in BindingMapping.objects.filter(role__system=False).prefetch_related("role")
+        str(m.mappings["id"]): m
+        for m in BindingMapping.objects.filter(role__system=False).prefetch_related("role").select_related("v2_role")
     }
 
     role_bindings_by_uuid = {str(b.uuid): b for b in RoleBinding.objects.filter(role__type=RoleV2.Types.CUSTOM)}


### PR DESCRIPTION
## Link(s) to Jira
- [RHCLOUD-35383](https://redhat.atlassian.net/browse/RHCLOUD-35383)

## Description of Intent of Change(s)

**WHAT:** Add a ForeignKey from BindingMapping to RoleV2, compound indexes, and a unique constraint to prevent duplicate binding mappings.

**WHY:** BindingMapping currently stores the V2 role ID buried inside a JSON field (`mappings["role"]["id"]`) and has zero indexes or constraints. This causes inefficient lookups, no database-level prevention of duplicate bindings, and required a complex locking workaround in the dual-write handler to prevent concurrent duplicate creation.

**HOW:**
- Add nullable `v2_role` ForeignKey to BindingMapping pointing to RoleV2 (SET_NULL on delete)
- Add compound index on `(role, resource_type_namespace, resource_type_name, resource_id)` for V1 role queries used in the locking code and workspace service
- Add unique constraint on `(v2_role, resource_type_namespace, resource_type_name, resource_id)` to prevent duplicate bindings per V2 role and resource (merged into schema migration since PostgreSQL excludes NULLs from unique constraints)
- Data migration backfills `v2_role` from `mappings["role"]["id"]` using `values_list` for UUID collection, `itertools.batched` for chunking, `transaction.atomic()` + `select_for_update()` per batch for safe locking, and fallback individual lookups for race condition handling
- Make `v2_role` a required parameter on `for_role_binding()` factory method (callers must explicitly pass it, even if `None`)
- Update `sharedSystemRolesReplicatedRoleBindings` caller to pass `v2_role`
- Update dual-write handler to look up `SeededRoleV2` by UUID for system roles

Two migrations: schema (add field + index + unique constraint) -> data (backfill with batched locking).

SET_NULL is used instead of CASCADE to preserve BindingMappings when a RoleV2 is deleted. The V1 `role` FK already handles cleanup via CASCADE when a V1 role is deleted. SET_NULL allows lazy V2 role re-creation from existing mappings (used by the dual-write handler's custom role migration path). Long-term target is PROTECT (tracked as follow-up).

**Out of scope (follow-up):**
- Switching `on_delete` from SET_NULL to PROTECT (after lazy migration path is removed)
- Making `v2_role` field non-nullable (after backfill completes across all tenants)
- Removing the resource-level locking workaround in `relation_api_dual_write_subject_handler.py`
- Replacing `mappings["role"]["id"]` JSON lookups with `v2_role` FK queries

**Note:** Replaces PR #2906 (closed due to GitHub signed-commits ruleset conflict during rebase).

## Local Testing
- `pipenv run tox -e lint` -- passes
- `pipenv run tox -e py312-fast` -- all 3795 tests pass
- Migrations applied and verified against local PostgreSQL

## Checklist
- [ ] if API spec changes are required, is the spec updated? N/A
- [ ] are there any pre/post merge actions required? No
- [x] are these changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for? N/A
- [x] does this require migration changes?
  - [x] if yes, are they backwards compatible? Yes -- new nullable FK, additive index and constraint
- [ ] is there known, direct impact to dependent teams/components? No

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices

[RHCLOUD-35383]: https://redhat.atlassian.net/browse/RHCLOUD-35383?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Add a nullable RoleV2 foreign key and supporting constraints to BindingMapping, backfill it from existing JSON data, and update callers and tests accordingly.

New Features:
- Introduce a nullable v2_role foreign key on BindingMapping linking to RoleV2.
- Enforce a unique BindingMapping per v2_role and resource via a database unique constraint.

Enhancements:
- Add a compound index on BindingMapping for role and resource fields to improve lookup performance.
- Extend BindingMapping.for_role_binding to accept an explicit v2_role parameter and propagate it to created mappings.
- Update dual-write and migration tooling to populate and maintain the new v2_role relationship.

Tests:
- Add tests covering the v2_role unique constraint behavior, NULL handling, on-delete SET_NULL semantics, and the updated for_role_binding factory.
- Adjust existing tests and helpers to pass the new v2_role argument and validate its presence in API responses.