### PR TITLE
RHCLOUD-48456: Don't lock tenants during scope migration

### DIFF
--- a/rbac/migration_tool/migrate_binding_scope.py
+++ b/rbac/migration_tool/migrate_binding_scope.py
@@ -54,7 +54,9 @@ def migrate_custom_role_bindings(raw_role: Role, replicator: RelationReplicator)
 
     Returns: Number of bindings migrated (1 if migrated, 0 if no change)
     """
-    role: Optional[Role] = Role.objects.select_for_update().select_related("tenant").filter(pk=raw_role.pk).first()
+    role: Optional[Role] = (
+        Role.objects.select_for_update(of=["self"]).select_related("tenant").filter(pk=raw_role.pk).first()
+    )
 
     if role is None:
         logger.warning(f"Role vanished before it could be migrated: pk={raw_role.pk!r}")
@@ -101,7 +103,9 @@ def migrate_system_role_bindings_for_group(raw_group: Group, replicator: Relatio
 
     Returns: Number of bindings cleaned up
     """
-    group: Optional[Group] = Group.objects.select_for_update().select_related("tenant").filter(pk=raw_group.pk).first()
+    group: Optional[Group] = (
+        Group.objects.select_for_update(of=["self"]).select_related("tenant").filter(pk=raw_group.pk).first()
+    )
 
     if group is None:
         logger.warning(f"Group vanished before it could be migrated: pk={raw_group.pk!r}")


### PR DESCRIPTION
## Link(s) to Jira
[RHCLOUD-48456](https://redhat.atlassian.net/browse/RHCLOUD-48456)

## Description of Intent of Change(s)
Seems to be causing issues with the Kafka consumer trying to update the tenant.

[RHCLOUD-48456]: https://redhat.atlassian.net/browse/RHCLOUD-48456?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Restrict row-level locking during role and group scope migration to avoid locking tenant records.

Bug Fixes:
- Update role migration queries to lock only the role row instead of associated tenant records.
- Update group migration queries to lock only the group row instead of associated tenant records.