### PR TITLE
[RHCLOUD-47926] V2 system role update/delete returns 400 instead of 404

### DIFF
--- a/rbac/management/role/v2_view.py
+++ b/rbac/management/role/v2_view.py
@@ -65,7 +65,7 @@ class RoleV2ViewSet(AtomicOperationsMixin, BaseV2ViewSet):
     DEFAULT_CREATE_UPDATE_FIELDS = {"id", "name", "description", "permissions", "last_modified"}
 
     def get_queryset(self):
-        """Return assignable roles for the requesting tenant. Restricts writes to custom roles."""
+        """Return assignable roles for the requesting tenant. Restricts creates to custom roles."""
         if self.action == "retrieve":
             fields = RoleV2Service.DEFAULT_RETRIEVE_FIELDS
         else:
@@ -74,6 +74,8 @@ class RoleV2ViewSet(AtomicOperationsMixin, BaseV2ViewSet):
 
         if self.action in ("list", "retrieve"):
             return base_qs.excluding_out_of_scope_v2_roles()
+        if self.action in ("update", "bulk_destroy"):
+            return base_qs
         return base_qs.filter(type=RoleV2.Types.CUSTOM)
 
     def get_serializer_context(self):
@@ -165,6 +167,9 @@ class RoleV2ViewSet(AtomicOperationsMixin, BaseV2ViewSet):
         with atomic_block():
             instance = self.get_object()
 
+            if instance.type != RoleV2.Types.CUSTOM:
+                raise ValidationError({"uuid": "System roles may not be updated."})
+
             audit_log = AuditLog()
             audit_log.log_edit(request=request, resource=AuditLog.ROLE_V2, object=instance)
 
@@ -202,6 +207,27 @@ class RoleV2ViewSet(AtomicOperationsMixin, BaseV2ViewSet):
 
         ids = set(serializer.validated_data["ids"])
 
+        if ids:
+            non_custom = (
+                RoleV2.objects.for_tenant(request.tenant)
+                .assignable()
+                .filter(uuid__in=ids)
+                .exclude(type=RoleV2.Types.CUSTOM)
+            )
+            if non_custom.exists():
+                return Response(
+                    v2response_error_from_errors(
+                        errors=[
+                            {
+                                "detail": "System roles may not be deleted.",
+                                "status": status.HTTP_400_BAD_REQUEST,
+                                "source": "ids",
+                            }
+                        ],
+                    ),
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+
         try:
             removed_roles = service.bulk_delete(ids, from_tenant=self.request.tenant)
 
@@ -216,12 +242,18 @@ class RoleV2ViewSet(AtomicOperationsMixin, BaseV2ViewSet):
                 status=status.HTTP_404_NOT_FOUND,
             )
         except CustomRoleRequiredError as e:
-            # This should be impossible. We constrain deletions to be from the user's tenant. Non-custom roles should
-            # only exist in the public tenant, and there shouldn't be any users in the public tenant. Thus,
-            # we will never find any non-custom roles to try to delete.
             return Response(
-                {"title": "An internal error occurred.", "detail": str(e)},
-                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                v2response_error_from_errors(
+                    errors=[
+                        {
+                            "detail": str(e),
+                            "status": status.HTTP_400_BAD_REQUEST,
+                            "source": "ids",
+                        }
+                    ],
+                    exc=e,
+                ),
+                status=status.HTTP_400_BAD_REQUEST,
             )
 
         # We don't allow a revert here because sending a notification in the middle could fail. This would make it

--- a/tests/management/role/test_v2_view.py
+++ b/tests/management/role/test_v2_view.py
@@ -1934,12 +1934,36 @@ class RoleV2ViewSetTests(IdentityRequest):
 
         response = self.client.put(update_url, data, format="json")
 
-        # Platform roles are filtered out in get_queryset() for update action
+        # Platform roles are filtered out by assignable() so they're invisible (404)
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
         self.assertEqual(response["Content-Type"], "application/problem+json")
         self.assertEqual(response.data["status"], 404)
         self.assertIn("title", response.data)
         self.assertIn("detail", response.data)
+
+    def test_update_seeded_role_returns_400(self):
+        """Test that attempting to update a seeded role returns 400, not 404."""
+        public_tenant, _ = Tenant.objects.get_or_create(tenant_name="public")
+        seeded_role = SeededRoleV2.objects.create(
+            name="Seeded Role For Update Test",
+            description="A seeded role",
+            tenant=public_tenant,
+        )
+        seeded_role.permissions.add(self.permission1)
+
+        update_url = reverse("v2_management:roles-detail", kwargs={"uuid": str(seeded_role.uuid)})
+        data = {
+            "name": "Attempt to Update Seeded Role",
+            "description": "This should fail with 400",
+            "permissions": [{"application": "inventory", "resource_type": "hosts", "operation": "read"}],
+        }
+
+        response = self.client.put(update_url, data, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response["Content-Type"], "application/problem+json")
+        self.assertEqual(response.data["status"], 400)
+        self.assertIn("System roles may not be updated", str(response.data))
 
     # --- Problem RFC format on errors ---
 
@@ -2134,7 +2158,7 @@ class RoleV2ViewSetTests(IdentityRequest):
         self.assertTrue(RoleV2.objects.filter(pk=role.pk).exists())
 
     def test_delete_seeded(self):
-        """Test that deleting a seeded role fails with status 404."""
+        """Test that deleting a seeded role fails with status 400, not 404."""
         seed_roles()
 
         seeded_role = SeededRoleV2.objects.first()
@@ -2142,7 +2166,23 @@ class RoleV2ViewSetTests(IdentityRequest):
 
         response = self._request_delete({"ids": [str(seeded_role.uuid)]})
 
-        self._assert_delete_not_found(response, [seeded_role.uuid])
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("System roles may not be deleted", str(response.data))
+        self.assertTrue(RoleV2.objects.filter(pk=seeded_role.pk).exists())
+
+    def test_delete_mix_of_custom_and_seeded_returns_400(self):
+        """Test that bulk-deleting a mix of custom + seeded roles returns 400 and deletes nothing."""
+        seed_roles()
+        seeded_role = SeededRoleV2.objects.first()
+        self.assertIsNotNone(seeded_role)
+
+        custom_role = self._create_role()
+
+        response = self._request_delete({"ids": [custom_role["id"], str(seeded_role.uuid)]})
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("System roles may not be deleted", str(response.data))
+        self.assertTrue(RoleV2.objects.filter(uuid=custom_role["id"]).exists())
         self.assertTrue(RoleV2.objects.filter(pk=seeded_role.pk).exists())
 
     def test_delete_missing_ids(self):


### PR DESCRIPTION
## Link(s) to Jira
- [RHCLOUD-47926](https://issues.redhat.com/browse/RHCLOUD-47926)

## Note
Replaces #2932 and #3012. The branch kept falling behind master and could not be updated due to the repository's verified-signature rule conflicting with unsigned commits on master. This is a fresh branch from current master with the same cherry-picked commits. Previously approved by @astrozzc in #2932.

## Description of Intent of Change(s)

The V2 role API returned 404 when attempting to update or delete a system (seeded) role. This was misleading -- the role exists and is visible in list/retrieve, but `get_queryset()` filtered to `type=CUSTOM` for all write actions, making seeded roles invisible to DRF's `get_object()` before validation could run.

**Changes:**
- **`get_queryset()`**: Only widen the queryset for `update` and `bulk_destroy` actions (explicit allowlist per review feedback). All other write actions default to `type=CUSTOM`.
- **`perform_atomic_update`**: After `get_object()`, validates that the role is CUSTOM. Non-custom roles get a 400 with "System roles may not be updated."
- **`_perform_bulk_destroy`**: Pre-checks requested IDs for non-custom assignable roles before calling the service. Returns 400 with "System roles may not be deleted." Also changed the `CustomRoleRequiredError` fallback handler from 500 to 400 with proper Problem JSON format.

**Before:** PUT on seeded role -> 404. Bulk delete of seeded role -> 404.
**After:** PUT on seeded role -> 400 "System roles may not be updated." Bulk delete of seeded role -> 400 "System roles may not be deleted."

## Checklist
- [x] are theses changes covered by unit tests?

## Secure Coding Practices Checklist
- [x] Input Validation
- [x] Access Control
- [x] Error Handling and Logging
- [x] General Coding Practices

[RHCLOUD-47926]: https://redhat.atlassian.net/browse/RHCLOUD-47926?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ