### PR TITLE
[RHCLOUD-48456] Update locking strategy for rbac consumer

### DIFF
--- a/rbac/core/kafka_consumer.py
+++ b/rbac/core/kafka_consumer.py
@@ -17,6 +17,7 @@
 
 """RBAC Kafka consumer for processing Debezium and replication messages."""
 
+import enum
 import json
 import logging
 import random
@@ -28,7 +29,7 @@ from typing import Any, Dict, List, Optional
 
 import grpc
 from django.conf import settings
-from django.db import connection
+from django.db import OperationalError, connection, transaction
 from google.protobuf import json_format
 from internal.migration_coordination import notify_migration_batch_completion
 from kafka import KafkaConsumer, TopicPartition
@@ -143,6 +144,12 @@ replication_event_latency = Histogram(
     "End-to-end latency from event creation to successful processing in seconds",
     ["event_type"],
     buckets=(0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0, 120.0, 300.0),
+)
+
+consistency_token_save_total = Counter(
+    "rbac_kafka_consumer_consistency_token_save_total",
+    "Consistency token save attempts and outcomes",
+    ["status"],  # success, lock_timeout, error
 )
 
 
@@ -722,6 +729,57 @@ def _send_pg_notify_best_effort(channel: str, payload: str, description: str) ->
         logger.info("Sent NOTIFY on channel '%s' (%s)", channel, description)
     except Exception as e:
         logger.error("Failed NOTIFY on channel '%s' (%s): %s", channel, description, e)
+
+
+_CONSISTENCY_TOKEN_LOCK_TIMEOUT_MS = 2_000
+
+
+class _TokenSaveStatus(enum.Enum):
+    SUCCESS = "success"
+    LOCK_TIMEOUT = "lock_timeout"
+    ERROR = "error"
+
+
+def _save_consistency_token_best_effort(org_id: str, token: str, aggregateid: str) -> None:
+    """Persist the latest relations consistency token on the tenant row.
+
+    This is a best-effort operation: if the row is locked by a long-running
+    transaction (e.g. migrate_binding_scope, bootstrap_tenants), we fail fast
+    with a short lock_timeout instead of blocking for the session-wide 60s.
+    A future message for the same org will overwrite the token anyway, so
+    skipping one save is harmless.
+    """
+    token_save_status = _TokenSaveStatus.SUCCESS
+    try:
+        with transaction.atomic():
+            with connection.cursor() as cursor:
+                cursor.execute("SET LOCAL lock_timeout = %s", [f"{_CONSISTENCY_TOKEN_LOCK_TIMEOUT_MS}ms"])
+            rows = Tenant.objects.filter(org_id=org_id).update(relations_consistency_token=token)
+        if rows == 0:
+            logger.warning("Tenant not found for org_id: %s. Unable to save consistency token.", org_id)
+    except OperationalError as e:
+        error_str = str(e).lower()
+        is_lock_timeout = (
+            "lock timeout" in error_str
+            or "lock_timeout" in error_str
+            or "canceling statement due to lock" in error_str
+        )
+        if is_lock_timeout:
+            token_save_status = _TokenSaveStatus.LOCK_TIMEOUT
+            logger.warning(
+                "Consistency token save skipped (lock contention) for org_id=%s, "
+                "aggregateid=%s. A later message will update the token.",
+                org_id,
+                aggregateid,
+            )
+        else:
+            token_save_status = _TokenSaveStatus.ERROR
+            logger.error("Consistency token save failed for org_id=%s: %s", org_id, e)
+    except Exception as e:
+        token_save_status = _TokenSaveStatus.ERROR
+        logger.error("Consistency token save failed for org_id=%s: %s", org_id, e)
+    finally:
+        consistency_token_save_total.labels(status=token_save_status.value).inc()
 
 
 class RBACKafkaConsumer:
@@ -1344,14 +1402,7 @@ class RBACKafkaConsumer:
             )
 
             if token and org_id:
-                try:
-                    tenant = Tenant.objects.get(org_id=org_id)
-                    tenant.relations_consistency_token = token
-                    tenant.save()
-                except Tenant.DoesNotExist:
-                    logger.warning(
-                        f"Tenant not found for org_id: {org_id}. " f"Unable to save consistency token: {token}"
-                    )
+                _save_consistency_token_best_effort(org_id, token, debezium_msg.aggregateid)
             else:
                 logger.warning(
                     f"No consistency token in either write or delete response - "

--- a/tests/core/test_kafka_consumer.py
+++ b/tests/core/test_kafka_consumer.py
@@ -49,7 +49,10 @@ from core.kafka_consumer import (
     RBACKafkaConsumer,
     ReplicationMessage,
     RetryConfig,
+    _save_consistency_token_best_effort,
+    consistency_token_save_total,
 )
+from django.db import OperationalError
 from django.test import TestCase
 from django.test.utils import override_settings
 from internal.migration_coordination import MigrationNotifyCoordination
@@ -640,14 +643,9 @@ class RBACKafkaConsumerTests(TestCase):
     @patch("core.kafka_consumer.json_format.ParseDict")
     @patch("core.kafka_consumer.relations_api_replication.write_relationships")
     @patch("core.kafka_consumer.relations_api_replication.delete_relationships")
-    @patch("core.kafka_consumer.Tenant.objects.get")
-    def test_process_relations_message_success(self, mock_tenant_get, mock_delete, mock_write, mock_parse_dict):
+    @patch("core.kafka_consumer._save_consistency_token_best_effort")
+    def test_process_relations_message_success(self, mock_save_token, mock_delete, mock_write, mock_parse_dict):
         """Test successful relations message processing."""
-        # Mock tenant lookup
-        mock_tenant = Mock()
-        mock_tenant.org_id = "12345"
-        mock_tenant_get.return_value = mock_tenant
-
         # Mock protobuf conversion
         mock_relationship_pb = Mock()
         mock_parse_dict.return_value = mock_relationship_pb
@@ -692,7 +690,7 @@ class RBACKafkaConsumerTests(TestCase):
         result = consumer._process_relations_message(debezium_msg, 0, 0)
 
         self.assertTrue(result)
-        mock_tenant_get.assert_called_once_with(org_id="12345")
+        mock_save_token.assert_called_once_with("12345", "test-token-123", "test-id-123")
         mock_write.assert_called_once()
         mock_delete.assert_called_once()
 
@@ -716,9 +714,9 @@ class RBACKafkaConsumerTests(TestCase):
     @patch("core.kafka_consumer.json_format.ParseDict")
     @patch("core.kafka_consumer.relations_api_replication.write_relationships")
     @patch("core.kafka_consumer.relations_api_replication.delete_relationships")
-    @patch("core.kafka_consumer.Tenant.objects.get")
+    @patch("core.kafka_consumer._save_consistency_token_best_effort")
     def test_process_relations_message_remove_legacy_root_parent_sends_notify(
-        self, mock_tenant_get, mock_delete, mock_write, mock_parse_dict, mock_conn_cursor, mock_coordination
+        self, mock_save_token, mock_delete, mock_write, mock_parse_dict, mock_conn_cursor, mock_coordination
     ):
         """Consumer NOTIFYs after remove_root_parent_tenant_relationships batch replication."""
         from management.relation_replicator.relation_replicator import ReplicationEventType
@@ -727,7 +725,6 @@ class RBACKafkaConsumerTests(TestCase):
             channel="test_legacy_ch",
             log_label="test_remove_legacy",
         )
-        mock_tenant_get.return_value = Mock(org_id="12345")
         mock_parse_dict.return_value = Mock()
         mock_write.return_value = Mock(consistency_token=Mock(token="tok"))
         mock_delete.return_value = Mock(consistency_token=Mock(token=None))
@@ -774,9 +771,9 @@ class RBACKafkaConsumerTests(TestCase):
     @patch("core.kafka_consumer.json_format.ParseDict")
     @patch("core.kafka_consumer.relations_api_replication.write_relationships")
     @patch("core.kafka_consumer.relations_api_replication.delete_relationships")
-    @patch("core.kafka_consumer.Tenant.objects.get")
+    @patch("core.kafka_consumer._save_consistency_token_best_effort")
     def test_process_relations_message_migrate_binding_scope_sends_notify(
-        self, mock_tenant_get, mock_delete, mock_write, mock_parse_dict, mock_conn_cursor, mock_coordination
+        self, mock_save_token, mock_delete, mock_write, mock_parse_dict, mock_conn_cursor, mock_coordination
     ):
         """Consumer NOTIFYs after migrate_binding_scope batch replication."""
         from management.relation_replicator.relation_replicator import ReplicationEventType
@@ -785,7 +782,6 @@ class RBACKafkaConsumerTests(TestCase):
             channel="test_migrate_binding_scope_ch",
             log_label="test_migrate_binding_scope",
         )
-        mock_tenant_get.return_value = Mock(org_id="12345")
         mock_parse_dict.return_value = Mock()
         mock_write.return_value = Mock(consistency_token=Mock(token="tok"))
         mock_delete.return_value = Mock(consistency_token=Mock(token=None))
@@ -2003,3 +1999,83 @@ class FencingTokenErrorHandlingTests(TestCase):
         # Should re-raise the gRPC error (not RuntimeError)
         with self.assertRaises(grpc.RpcError):
             self.consumer._process_relations_message(debezium_msg, 0, 0)
+
+
+class SaveConsistencyTokenBestEffortTests(TestCase):
+    """Tests for _save_consistency_token_best_effort."""
+
+    @patch("core.kafka_consumer.Tenant.objects")
+    @patch("core.kafka_consumer.connection.cursor")
+    def test_success(self, mock_cursor_ctx, mock_tenant_objects):
+        """Token is saved via UPDATE and success metric incremented."""
+        mock_cursor = Mock()
+        mock_cm = Mock()
+        mock_cm.__enter__ = Mock(return_value=mock_cursor)
+        mock_cm.__exit__ = Mock(return_value=False)
+        mock_cursor_ctx.return_value = mock_cm
+
+        mock_qs = Mock()
+        mock_qs.update.return_value = 1
+        mock_tenant_objects.filter.return_value = mock_qs
+
+        before = consistency_token_save_total.labels(status="success")._value.get()
+        _save_consistency_token_best_effort("org123", "token-abc", "agg-1")
+
+        mock_tenant_objects.filter.assert_called_once_with(org_id="org123")
+        mock_qs.update.assert_called_once_with(relations_consistency_token="token-abc")
+        after = consistency_token_save_total.labels(status="success")._value.get()
+        self.assertEqual(after - before, 1)
+
+    @patch("core.kafka_consumer.Tenant.objects")
+    @patch("core.kafka_consumer.connection.cursor")
+    def test_lock_timeout_does_not_raise(self, mock_cursor_ctx, mock_tenant_objects):
+        """OperationalError with lock timeout is swallowed and metric recorded."""
+        mock_cursor = Mock()
+        mock_cm = Mock()
+        mock_cm.__enter__ = Mock(return_value=mock_cursor)
+        mock_cm.__exit__ = Mock(return_value=False)
+        mock_cursor_ctx.return_value = mock_cm
+
+        mock_qs = Mock()
+        mock_qs.update.side_effect = OperationalError("canceling statement due to lock timeout")
+        mock_tenant_objects.filter.return_value = mock_qs
+
+        before = consistency_token_save_total.labels(status="lock_timeout")._value.get()
+        _save_consistency_token_best_effort("org123", "token-abc", "agg-1")
+        after = consistency_token_save_total.labels(status="lock_timeout")._value.get()
+        self.assertEqual(after - before, 1)
+
+    @patch("core.kafka_consumer.Tenant.objects")
+    @patch("core.kafka_consumer.connection.cursor")
+    def test_other_operational_error_does_not_raise(self, mock_cursor_ctx, mock_tenant_objects):
+        """Non-lock OperationalError is caught and recorded as error."""
+        mock_cursor = Mock()
+        mock_cm = Mock()
+        mock_cm.__enter__ = Mock(return_value=mock_cursor)
+        mock_cm.__exit__ = Mock(return_value=False)
+        mock_cursor_ctx.return_value = mock_cm
+
+        mock_qs = Mock()
+        mock_qs.update.side_effect = OperationalError("connection reset by peer")
+        mock_tenant_objects.filter.return_value = mock_qs
+
+        before = consistency_token_save_total.labels(status="error")._value.get()
+        _save_consistency_token_best_effort("org123", "token-abc", "agg-1")
+        after = consistency_token_save_total.labels(status="error")._value.get()
+        self.assertEqual(after - before, 1)
+
+    @patch("core.kafka_consumer.Tenant.objects")
+    @patch("core.kafka_consumer.connection.cursor")
+    def test_tenant_not_found(self, mock_cursor_ctx, mock_tenant_objects):
+        """Zero rows updated logs a warning but does not raise."""
+        mock_cursor = Mock()
+        mock_cm = Mock()
+        mock_cm.__enter__ = Mock(return_value=mock_cursor)
+        mock_cm.__exit__ = Mock(return_value=False)
+        mock_cursor_ctx.return_value = mock_cm
+
+        mock_qs = Mock()
+        mock_qs.update.return_value = 0
+        mock_tenant_objects.filter.return_value = mock_qs
+
+        _save_consistency_token_best_effort("org-missing", "token-abc", "agg-1")


### PR DESCRIPTION
## Link(s) to Jira
- https://redhat.atlassian.net/browse/RHCLOUD-48456

## Description of Intent of Change(s)
The tenant consistency token is taking too long waiting for lock expiration with retry. Reducing the wait time so that it does not block the consumer processing other events.
Consistency token update failure resulting stale consistency token is more acceptable than blocking the consumer.

## Local Testing
Unit tests

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
