### PR TITLE
RHCLOUD-46876 - Raise error when v2 role seeding fails for atomic transaction

### DIFF
--- a/rbac/management/role/definer.py
+++ b/rbac/management/role/definer.py
@@ -428,6 +428,7 @@ def _update_or_create_roles(roles, config: _SeedRolesConfig, platform_roles=None
             current_role_ids.add(role.id)
         except Exception as e:
             logger.error(f'Failed to update or create system role: {role_json.get("name")} with error: {e}')
+            raise
     return current_role_ids
 
 

--- a/rbac/management/role/definer.py
+++ b/rbac/management/role/definer.py
@@ -594,7 +594,11 @@ def _create_single_platform_role(access_type, scope, policy_service, public_tena
 
 
 def _seed_v2_role_from_v1(v1_role, display_name, description, public_tenant, platform_roles, resource_service):
-    """Create or update V2 role from V1 role during seeding."""
+    """Create or update V2 role from V1 role during seeding.
+
+    Raises on failure so the caller's transaction rolls back, ensuring V1 and V2 roles
+    are created/updated atomically.
+    """
     try:
         # Check what scopes this role is bound at in V1 tenants to detect scope changes
         # IMPORTANT: Check old scopes BEFORE updating the role or clearing permissions
@@ -647,7 +651,7 @@ def _seed_v2_role_from_v1(v1_role, display_name, description, public_tenant, pla
         return v2_role
     except Exception:
         logger.error("Failed to seed V2 role for %s", display_name, exc_info=True)
-        return None
+        raise
 
 
 def _seed_platform_roles():

--- a/tests/management/role/test_v2_service.py
+++ b/tests/management/role/test_v2_service.py
@@ -53,12 +53,12 @@ class RoleV2ServiceTests(IdentityRequest):
         super().setUp()
         self.service = RoleV2Service(tenant=self.tenant)
 
-        # Create test permissions matching the names used in permission_data throughout tests
-        self.permission1 = Permission.objects.create(permission="inventory:hosts:read", tenant=self.tenant)
-        self.permission2 = Permission.objects.create(permission="inventory:hosts:write", tenant=self.tenant)
-        self.permission3 = Permission.objects.create(permission="cost:reports:read", tenant=self.tenant)
+        # Create test permissions - use unique names to avoid collisions with seed_roles()
+        self.permission1 = Permission.objects.create(permission="test_app:resources:read", tenant=self.tenant)
+        self.permission2 = Permission.objects.create(permission="test_app:resources:write", tenant=self.tenant)
+        self.permission3 = Permission.objects.create(permission="test_app:reports:read", tenant=self.tenant)
 
-        self.permission1_data = {"application": "inventory", "resource_type": "hosts", "operation": "read"}
+        self.permission1_data = {"application": "test_app", "resource_type": "resources", "operation": "read"}
 
     def tearDown(self):
         """Tear down RoleV2Service tests."""
@@ -79,7 +79,7 @@ class RoleV2ServiceTests(IdentityRequest):
     def test_create_role_with_single_permission(self):
         """Test creating a role with a single permission."""
         permission_data = [
-            {"application": "inventory", "resource_type": "hosts", "operation": "read"},
+            {"application": "test_app", "resource_type": "resources", "operation": "read"},
         ]
 
         role = self.service.create(
@@ -100,9 +100,9 @@ class RoleV2ServiceTests(IdentityRequest):
     def test_create_role_with_multiple_permissions(self):
         """Test creating a role with multiple permissions."""
         permission_data = [
-            {"application": "inventory", "resource_type": "hosts", "operation": "read"},
-            {"application": "inventory", "resource_type": "hosts", "operation": "write"},
-            {"application": "cost", "resource_type": "reports", "operation": "read"},
+            {"application": "test_app", "resource_type": "resources", "operation": "read"},
+            {"application": "test_app", "resource_type": "resources", "operation": "write"},
+            {"application": "test_app", "resource_type": "reports", "operation": "read"},
         ]
 
         role = self.service.create(
@@ -120,7 +120,7 @@ class RoleV2ServiceTests(IdentityRequest):
     def test_create_role_with_empty_description_succeeds(self):
         """Test that creating a role with empty description succeeds."""
         permission_data = [
-            {"application": "inventory", "resource_type": "hosts", "operation": "read"},
+            {"application": "test_app", "resource_type": "resources", "operation": "read"},
         ]
 
         role = self.service.create(
@@ -136,7 +136,7 @@ class RoleV2ServiceTests(IdentityRequest):
     def test_create_role_with_whitespace_only_description_succeeds(self):
         """Test that creating a role with whitespace-only description succeeds."""
         permission_data = [
-            {"application": "inventory", "resource_type": "hosts", "operation": "read"},
+            {"application": "test_app", "resource_type": "resources", "operation": "read"},
         ]
 
         role = self.service.create(
@@ -180,7 +180,7 @@ class RoleV2ServiceTests(IdentityRequest):
     def test_create_role_with_missing_name_raises_error(self):
         """Test that creating a role with blank name raises RequiredFieldError."""
         permission_data = [
-            {"application": "inventory", "resource_type": "hosts", "operation": "read"},
+            {"application": "test_app", "resource_type": "resources", "operation": "read"},
         ]
 
         with self.assertRaises(RequiredFieldError) as context:
@@ -197,10 +197,10 @@ class RoleV2ServiceTests(IdentityRequest):
         """Test that creating a role with a duplicate name raises RoleAlreadyExistsError."""
         # Uses permissions created in setUp: inventory:hosts:read and inventory:hosts:write
         permission_data1 = [
-            {"application": "inventory", "resource_type": "hosts", "operation": "read"},
+            {"application": "test_app", "resource_type": "resources", "operation": "read"},
         ]
         permission_data2 = [
-            {"application": "inventory", "resource_type": "hosts", "operation": "write"},
+            {"application": "test_app", "resource_type": "resources", "operation": "write"},
         ]
 
         # Create first role
@@ -364,7 +364,7 @@ class RoleV2ServiceTests(IdentityRequest):
     def test_update_role_with_empty_description_succeeds(self):
         """Test that updating a role with empty description succeeds."""
         permission_data = [
-            {"application": "inventory", "resource_type": "hosts", "operation": "read"},
+            {"application": "test_app", "resource_type": "resources", "operation": "read"},
         ]
 
         role = self.service.create(
@@ -387,7 +387,7 @@ class RoleV2ServiceTests(IdentityRequest):
     def test_update_role_with_empty_permissions_raises_error(self):
         """Test that updating a role with empty permissions raises RequiredFieldError."""
         permission_data = [
-            {"application": "inventory", "resource_type": "hosts", "operation": "read"},
+            {"application": "test_app", "resource_type": "resources", "operation": "read"},
         ]
 
         role = self.service.create(
@@ -418,8 +418,8 @@ class RoleV2ServiceTests(IdentityRequest):
 
         # Create initial role with read and write permissions
         initial_permission_data = [
-            {"application": "inventory", "resource_type": "hosts", "operation": "read"},
-            {"application": "inventory", "resource_type": "hosts", "operation": "write"},
+            {"application": "test_app", "resource_type": "resources", "operation": "read"},
+            {"application": "test_app", "resource_type": "resources", "operation": "write"},
         ]
 
         role = service.create(
@@ -435,8 +435,8 @@ class RoleV2ServiceTests(IdentityRequest):
 
         # Update the role to have different permissions (read and cost:reports:read)
         updated_permission_data = [
-            {"application": "inventory", "resource_type": "hosts", "operation": "read"},
-            {"application": "cost", "resource_type": "reports", "operation": "read"},
+            {"application": "test_app", "resource_type": "resources", "operation": "read"},
+            {"application": "test_app", "resource_type": "reports", "operation": "read"},
         ]
 
         updated_role = service.update(
@@ -461,7 +461,7 @@ class RoleV2ServiceTests(IdentityRequest):
         read_tuples = tuples.find_tuples(
             all_of(
                 resource("rbac", "role", role_uuid),
-                relation("inventory_hosts_read"),
+                relation("test_app_resources_read"),
                 subject("rbac", "principal", "*"),
             )
         )
@@ -471,7 +471,7 @@ class RoleV2ServiceTests(IdentityRequest):
         write_tuples = tuples.find_tuples(
             all_of(
                 resource("rbac", "role", role_uuid),
-                relation("inventory_hosts_write"),
+                relation("test_app_resources_write"),
                 subject("rbac", "principal", "*"),
             )
         )
@@ -481,7 +481,7 @@ class RoleV2ServiceTests(IdentityRequest):
         cost_tuples = tuples.find_tuples(
             all_of(
                 resource("rbac", "role", role_uuid),
-                relation("cost_reports_read"),
+                relation("test_app_reports_read"),
                 subject("rbac", "principal", "*"),
             )
         )
@@ -605,7 +605,7 @@ class RoleV2ServiceTests(IdentityRequest):
                 tuples.count_tuples(
                     all_of(
                         resource("rbac", "role", role_uuid),
-                        relation("inventory_hosts_read"),
+                        relation("test_app_resources_read"),
                         subject("rbac", "principal", "*"),
                     )
                 ),
@@ -660,9 +660,9 @@ class RoleV2ServiceListTests(IdentityRequest):
         super().setUp()
         self.service = RoleV2Service(tenant=self.tenant)
 
-        # Create test permissions
-        self.permission1 = Permission.objects.create(permission="inventory:hosts:read", tenant=self.tenant)
-        self.permission2 = Permission.objects.create(permission="inventory:hosts:write", tenant=self.tenant)
+        # Create test permissions - use unique names to avoid collisions with seed_roles()
+        self.permission1 = Permission.objects.create(permission="test_app:resources:read", tenant=self.tenant)
+        self.permission2 = Permission.objects.create(permission="test_app:resources:write", tenant=self.tenant)
 
         # Create test roles
         self.role1 = RoleV2.objects.create(name="role_one", description="First role", tenant=self.tenant)

--- a/tests/management/role/test_v2_service.py
+++ b/tests/management/role/test_v2_service.py
@@ -53,12 +53,12 @@ class RoleV2ServiceTests(IdentityRequest):
         super().setUp()
         self.service = RoleV2Service(tenant=self.tenant)
 
-        # Create test permissions
-        self.permission1 = Permission.objects.create(permission="inventory:hosts:read", tenant=self.tenant)
-        self.permission2 = Permission.objects.create(permission="inventory:hosts:write", tenant=self.tenant)
-        self.permission3 = Permission.objects.create(permission="cost:reports:read", tenant=self.tenant)
+        # Create test permissions (use unique names to avoid conflicts with seed_roles())
+        self.permission1 = Permission.objects.create(permission="test_app:test_resource:read", tenant=self.tenant)
+        self.permission2 = Permission.objects.create(permission="test_app:test_resource:write", tenant=self.tenant)
+        self.permission3 = Permission.objects.create(permission="test_app:reports:read", tenant=self.tenant)
 
-        self.permission1_data = {"application": "inventory", "resource_type": "hosts", "operation": "read"}
+        self.permission1_data = {"application": "test_app", "resource_type": "test_resource", "operation": "read"}
 
     def tearDown(self):
         """Tear down RoleV2Service tests."""

--- a/tests/management/role/test_v2_service.py
+++ b/tests/management/role/test_v2_service.py
@@ -195,11 +195,12 @@ class RoleV2ServiceTests(IdentityRequest):
 
     def test_create_role_with_duplicate_name_raises_error(self):
         """Test that creating a role with a duplicate name raises RoleAlreadyExistsError."""
+        # Uses permissions created in setUp: inventory:hosts:read and inventory:hosts:write
         permission_data1 = [
-            {"application": "test_app", "resource_type": "test_resource", "operation": "read"},
+            {"application": "inventory", "resource_type": "hosts", "operation": "read"},
         ]
         permission_data2 = [
-            {"application": "test_app", "resource_type": "test_resource", "operation": "write"},
+            {"application": "inventory", "resource_type": "hosts", "operation": "write"},
         ]
 
         # Create first role
@@ -302,6 +303,10 @@ class RoleV2ServiceTests(IdentityRequest):
     @override_settings(REPLICATION_TO_RELATION_ENABLED=True)
     def test_create_role_replicates_permission_tuples(self):
         """Test that creating a role replicates permission tuples to SpiceDB."""
+        # Create test permissions for this test
+        Permission.objects.create(permission="test_app:test_resource:read", tenant=self.tenant)
+        Permission.objects.create(permission="test_app:test_resource:write", tenant=self.tenant)
+
         # Set up in-memory replicator (stub, not mock!)
         tuples = InMemoryTuples()
         replicator = InMemoryRelationReplicator(tuples)

--- a/tests/management/role/test_v2_service.py
+++ b/tests/management/role/test_v2_service.py
@@ -308,8 +308,8 @@ class RoleV2ServiceTests(IdentityRequest):
         service = RoleV2Service(tenant=self.tenant, replicator=replicator)
 
         permission_data = [
-            {"application": "inventory", "resource_type": "hosts", "operation": "read"},
-            {"application": "inventory", "resource_type": "hosts", "operation": "write"},
+            {"application": "test_app", "resource_type": "test_resource", "operation": "read"},
+            {"application": "test_app", "resource_type": "test_resource", "operation": "write"},
         ]
 
         # When: Create a role
@@ -330,7 +330,7 @@ class RoleV2ServiceTests(IdentityRequest):
         read_tuples = tuples.find_tuples(
             all_of(
                 resource("rbac", "role", role_uuid),
-                relation("inventory_hosts_read"),
+                relation("test_app_test_resource_read"),
                 subject("rbac", "principal", "*"),
             )
         )
@@ -340,7 +340,7 @@ class RoleV2ServiceTests(IdentityRequest):
         write_tuples = tuples.find_tuples(
             all_of(
                 resource("rbac", "role", role_uuid),
-                relation("inventory_hosts_write"),
+                relation("test_app_test_resource_write"),
                 subject("rbac", "principal", "*"),
             )
         )

--- a/tests/management/role/test_v2_service.py
+++ b/tests/management/role/test_v2_service.py
@@ -53,12 +53,12 @@ class RoleV2ServiceTests(IdentityRequest):
         super().setUp()
         self.service = RoleV2Service(tenant=self.tenant)
 
-        # Create test permissions (use unique names to avoid conflicts with seed_roles())
-        self.permission1 = Permission.objects.create(permission="test_app:test_resource:read", tenant=self.tenant)
-        self.permission2 = Permission.objects.create(permission="test_app:test_resource:write", tenant=self.tenant)
-        self.permission3 = Permission.objects.create(permission="test_app:reports:read", tenant=self.tenant)
+        # Create test permissions matching the names used in permission_data throughout tests
+        self.permission1 = Permission.objects.create(permission="inventory:hosts:read", tenant=self.tenant)
+        self.permission2 = Permission.objects.create(permission="inventory:hosts:write", tenant=self.tenant)
+        self.permission3 = Permission.objects.create(permission="cost:reports:read", tenant=self.tenant)
 
-        self.permission1_data = {"application": "test_app", "resource_type": "test_resource", "operation": "read"}
+        self.permission1_data = {"application": "inventory", "resource_type": "hosts", "operation": "read"}
 
     def tearDown(self):
         """Tear down RoleV2Service tests."""

--- a/tests/management/role/test_v2_service.py
+++ b/tests/management/role/test_v2_service.py
@@ -275,14 +275,10 @@ class RoleV2ServiceTests(IdentityRequest):
 
     def test_create_role_generates_uuid(self):
         """Test that creating a role auto-generates a UUID."""
-        permission_data = [
-            {"application": "inventory", "resource_type": "hosts", "operation": "read"},
-        ]
-
         role = self.service.create(
             name="UUID Test Role",
             description="Testing UUID generation",
-            permission_data=permission_data,
+            permission_data=[self.permission1_data],
             tenant=self.tenant,
         )
 
@@ -290,14 +286,10 @@ class RoleV2ServiceTests(IdentityRequest):
 
     def test_create_role_sets_type_to_custom(self):
         """Test that created roles are always of type CUSTOM."""
-        permission_data = [
-            {"application": "inventory", "resource_type": "hosts", "operation": "read"},
-        ]
-
         role = self.service.create(
             name="Custom Type Role",
             description="Should be custom",
-            permission_data=permission_data,
+            permission_data=[self.permission1_data],
             tenant=self.tenant,
         )
 

--- a/tests/management/role/test_v2_service.py
+++ b/tests/management/role/test_v2_service.py
@@ -196,10 +196,10 @@ class RoleV2ServiceTests(IdentityRequest):
     def test_create_role_with_duplicate_name_raises_error(self):
         """Test that creating a role with a duplicate name raises RoleAlreadyExistsError."""
         permission_data1 = [
-            {"application": "inventory", "resource_type": "hosts", "operation": "read"},
+            {"application": "test_app", "resource_type": "test_resource", "operation": "read"},
         ]
         permission_data2 = [
-            {"application": "inventory", "resource_type": "hosts", "operation": "write"},
+            {"application": "test_app", "resource_type": "test_resource", "operation": "write"},
         ]
 
         # Create first role

--- a/tests/management/role/test_v2_view.py
+++ b/tests/management/role/test_v2_view.py
@@ -493,7 +493,7 @@ class RoleV2ViewSetTests(IdentityRequest):
         self.permission3 = Permission.objects.create(permission="testapp:hosts:write", tenant=self.tenant)
         self.permission4 = Permission.objects.create(permission="testapp:reports:read", tenant=self.tenant)
 
-        self.permission1_data = {"application": "inventory", "resource_type": "hosts", "operation": "read"}
+        self.permission1_data = {"application": "testapp", "resource_type": "hosts", "operation": "read"}
 
         # Create a role for list tests
         self.role = RoleV2.objects.create(name="test_role", description="Test description", tenant=self.tenant)
@@ -1224,7 +1224,7 @@ class RoleV2ViewSetTests(IdentityRequest):
         data = {
             "name": "Blocked Role",
             "description": "Should be blocked",
-            "permissions": [{"application": "inventory", "resource_type": "hosts", "operation": "read"}],
+            "permissions": [{"application": "testapp", "resource_type": "hosts", "operation": "read"}],
         }
         response = self.client.post(self.url, data, format="json")
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
@@ -1238,7 +1238,7 @@ class RoleV2ViewSetTests(IdentityRequest):
         data = {
             "name": "API Test Role",
             "description": "Created via API",
-            "permissions": [{"application": "inventory", "resource_type": "hosts", "operation": "read"}],
+            "permissions": [{"application": "testapp", "resource_type": "hosts", "operation": "read"}],
         }
 
         response = self.client.post(self.url, data, format="json")
@@ -1250,7 +1250,7 @@ class RoleV2ViewSetTests(IdentityRequest):
         # Verify permissions are returned in response
         self.assertEqual(
             response.data["permissions"],
-            [{"application": "inventory", "resource_type": "hosts", "operation": "read"}],
+            [{"application": "testapp", "resource_type": "hosts", "operation": "read"}],
         )
 
         self._assert_audit_log(action=AuditLog.CREATE, description=f"Created V2 role: {data['name']}")
@@ -1283,8 +1283,8 @@ class RoleV2ViewSetTests(IdentityRequest):
             "name": "Multi Permission API Role",
             "description": "Has multiple permissions",
             "permissions": [
-                {"application": "inventory", "resource_type": "hosts", "operation": "read"},
-                {"application": "inventory", "resource_type": "hosts", "operation": "write"},
+                {"application": "testapp", "resource_type": "hosts", "operation": "read"},
+                {"application": "testapp", "resource_type": "hosts", "operation": "write"},
             ],
         }
 
@@ -1296,8 +1296,8 @@ class RoleV2ViewSetTests(IdentityRequest):
         self.assertCountEqual(
             response.data["permissions"],
             [
-                {"application": "inventory", "resource_type": "hosts", "operation": "read"},
-                {"application": "inventory", "resource_type": "hosts", "operation": "write"},
+                {"application": "testapp", "resource_type": "hosts", "operation": "read"},
+                {"application": "testapp", "resource_type": "hosts", "operation": "write"},
             ],
         )
 
@@ -1309,8 +1309,8 @@ class RoleV2ViewSetTests(IdentityRequest):
             "description": "Testing permission order preservation",
             "permissions": [
                 {"application": "cost", "resource_type": "reports", "operation": "read"},
-                {"application": "inventory", "resource_type": "hosts", "operation": "write"},
-                {"application": "inventory", "resource_type": "hosts", "operation": "read"},
+                {"application": "testapp", "resource_type": "hosts", "operation": "write"},
+                {"application": "testapp", "resource_type": "hosts", "operation": "read"},
             ],
         }
 
@@ -1323,8 +1323,8 @@ class RoleV2ViewSetTests(IdentityRequest):
             response.data["permissions"],
             [
                 {"application": "cost", "resource_type": "reports", "operation": "read"},
-                {"application": "inventory", "resource_type": "hosts", "operation": "write"},
-                {"application": "inventory", "resource_type": "hosts", "operation": "read"},
+                {"application": "testapp", "resource_type": "hosts", "operation": "write"},
+                {"application": "testapp", "resource_type": "hosts", "operation": "read"},
             ],
         )
 
@@ -1332,7 +1332,7 @@ class RoleV2ViewSetTests(IdentityRequest):
         """Test that missing name returns 400."""
         data = {
             "description": "No name",
-            "permissions": [{"application": "inventory", "resource_type": "hosts", "operation": "read"}],
+            "permissions": [{"application": "testapp", "resource_type": "hosts", "operation": "read"}],
         }
 
         response = self.client.post(self.url, data, format="json")
@@ -1395,7 +1395,7 @@ class RoleV2ViewSetTests(IdentityRequest):
         data = {
             "name": "Duplicate API Role",
             "description": "Second role",
-            "permissions": [{"application": "inventory", "resource_type": "hosts", "operation": "read"}],
+            "permissions": [{"application": "testapp", "resource_type": "hosts", "operation": "read"}],
         }
 
         response = self.client.post(self.url, data, format="json")
@@ -1415,7 +1415,7 @@ class RoleV2ViewSetTests(IdentityRequest):
         data = {
             "name": "vulnerability viewer",
             "description": "Custom role with seeded name",
-            "permissions": [{"application": "inventory", "resource_type": "hosts", "operation": "read"}],
+            "permissions": [{"application": "testapp", "resource_type": "hosts", "operation": "read"}],
         }
 
         response = self.client.post(self.url, data, format="json")
@@ -1439,7 +1439,7 @@ class RoleV2ViewSetTests(IdentityRequest):
         data = {
             "name": "PATCH VIEWER",
             "description": "Trying to rename to seeded name",
-            "permissions": [{"application": "inventory", "resource_type": "hosts", "operation": "read"}],
+            "permissions": [{"application": "testapp", "resource_type": "hosts", "operation": "read"}],
         }
 
         response = self.client.put(update_url, data, format="json")
@@ -1500,7 +1500,7 @@ class RoleV2ViewSetTests(IdentityRequest):
         """Test that creating a role without description returns 201 with empty description."""
         data = {
             "name": "No Description Role",
-            "permissions": [{"application": "inventory", "resource_type": "hosts", "operation": "read"}],
+            "permissions": [{"application": "testapp", "resource_type": "hosts", "operation": "read"}],
         }
 
         response = self.client.post(self.url, data, format="json")
@@ -1515,7 +1515,7 @@ class RoleV2ViewSetTests(IdentityRequest):
         data = {
             "name": "Response Format Role",
             "description": "Testing response format",
-            "permissions": [{"application": "inventory", "resource_type": "hosts", "operation": "read"}],
+            "permissions": [{"application": "testapp", "resource_type": "hosts", "operation": "read"}],
         }
 
         response = self.client.post(self.url, data, format="json")
@@ -1532,7 +1532,7 @@ class RoleV2ViewSetTests(IdentityRequest):
         data = {
             "name": "Fields Test Role",
             "description": "Testing fields parameter",
-            "permissions": [{"application": "inventory", "resource_type": "hosts", "operation": "read"}],
+            "permissions": [{"application": "testapp", "resource_type": "hosts", "operation": "read"}],
         }
 
         url = f"{self.url}?fields=id,name,permissions_count"
@@ -1550,7 +1550,7 @@ class RoleV2ViewSetTests(IdentityRequest):
         data = {
             "name": "Invalid Fields Role",
             "description": "Testing invalid fields",
-            "permissions": [{"application": "inventory", "resource_type": "hosts", "operation": "read"}],
+            "permissions": [{"application": "testapp", "resource_type": "hosts", "operation": "read"}],
         }
 
         url = f"{self.url}?fields=id,nonexistent_field"
@@ -1567,7 +1567,7 @@ class RoleV2ViewSetTests(IdentityRequest):
         data = {
             "name": "role_*_admin",
             "description": "Should be rejected",
-            "permissions": [{"application": "inventory", "resource_type": "hosts", "operation": "read"}],
+            "permissions": [{"application": "testapp", "resource_type": "hosts", "operation": "read"}],
         }
 
         response = self.client.post(self.url, data, format="json")
@@ -1613,7 +1613,7 @@ class RoleV2ViewSetTests(IdentityRequest):
         data = {
             "name": "Updated Role",
             "description": "Updated description",
-            "permissions": [{"application": "inventory", "resource_type": "hosts", "operation": "write"}],
+            "permissions": [{"application": "testapp", "resource_type": "hosts", "operation": "write"}],
         }
 
         response = self.client.put(update_url, data, format="json")
@@ -1626,7 +1626,7 @@ class RoleV2ViewSetTests(IdentityRequest):
         # Verify permissions are updated in response
         self.assertEqual(
             response.data["permissions"],
-            [{"application": "inventory", "resource_type": "hosts", "operation": "write"}],
+            [{"application": "testapp", "resource_type": "hosts", "operation": "write"}],
         )
 
         self._assert_audit_log(
@@ -1670,7 +1670,7 @@ class RoleV2ViewSetTests(IdentityRequest):
             "name": "Test Role",
             "description": "Test description",
             "permissions": [
-                {"application": "inventory", "resource_type": "hosts", "operation": "write"},
+                {"application": "testapp", "resource_type": "hosts", "operation": "write"},
                 {"application": "cost", "resource_type": "reports", "operation": "read"},
             ],
         }
@@ -1701,8 +1701,8 @@ class RoleV2ViewSetTests(IdentityRequest):
             "description": "Testing permission order preservation",
             "permissions": [
                 {"application": "cost", "resource_type": "reports", "operation": "read"},
-                {"application": "inventory", "resource_type": "hosts", "operation": "write"},
-                {"application": "inventory", "resource_type": "hosts", "operation": "read"},
+                {"application": "testapp", "resource_type": "hosts", "operation": "write"},
+                {"application": "testapp", "resource_type": "hosts", "operation": "read"},
             ],
         }
 
@@ -1715,8 +1715,8 @@ class RoleV2ViewSetTests(IdentityRequest):
             response.data["permissions"],
             [
                 {"application": "cost", "resource_type": "reports", "operation": "read"},
-                {"application": "inventory", "resource_type": "hosts", "operation": "write"},
-                {"application": "inventory", "resource_type": "hosts", "operation": "read"},
+                {"application": "testapp", "resource_type": "hosts", "operation": "write"},
+                {"application": "testapp", "resource_type": "hosts", "operation": "read"},
             ],
         )
 
@@ -1726,7 +1726,7 @@ class RoleV2ViewSetTests(IdentityRequest):
         data = {
             "name": "Updated Role",
             "description": "Updated description",
-            "permissions": [{"application": "inventory", "resource_type": "hosts", "operation": "read"}],
+            "permissions": [{"application": "testapp", "resource_type": "hosts", "operation": "read"}],
         }
 
         response = self.client.put(update_url, data, format="json")
@@ -1755,7 +1755,7 @@ class RoleV2ViewSetTests(IdentityRequest):
         data = {
             "name": "Role One",
             "description": "Second role",
-            "permissions": [{"application": "inventory", "resource_type": "hosts", "operation": "read"}],
+            "permissions": [{"application": "testapp", "resource_type": "hosts", "operation": "read"}],
         }
 
         response = self.client.put(update_url, data, format="json")
@@ -1806,7 +1806,7 @@ class RoleV2ViewSetTests(IdentityRequest):
         update_url = reverse("v2_management:roles-detail", kwargs={"uuid": str(role.uuid)})
         data = {
             "name": "Test Role",
-            "permissions": [{"application": "inventory", "resource_type": "hosts", "operation": "read"}],
+            "permissions": [{"application": "testapp", "resource_type": "hosts", "operation": "read"}],
         }
 
         response = self.client.put(update_url, data, format="json")
@@ -1832,7 +1832,7 @@ class RoleV2ViewSetTests(IdentityRequest):
         data = {
             "name": "Updated Response Format Role",
             "description": "Updated description",
-            "permissions": [{"application": "inventory", "resource_type": "hosts", "operation": "read"}],
+            "permissions": [{"application": "testapp", "resource_type": "hosts", "operation": "read"}],
         }
 
         response = self.client.put(update_url, data, format="json")
@@ -1857,7 +1857,7 @@ class RoleV2ViewSetTests(IdentityRequest):
         data = {
             "name": "Updated Fields Test Role",
             "description": "Updated description",
-            "permissions": [{"application": "inventory", "resource_type": "hosts", "operation": "read"}],
+            "permissions": [{"application": "testapp", "resource_type": "hosts", "operation": "read"}],
         }
 
         response = self.client.put(url, data, format="json")
@@ -1881,7 +1881,7 @@ class RoleV2ViewSetTests(IdentityRequest):
         data = {
             "name": "Default Fields Role",
             "description": "Test description",
-            "permissions": [{"application": "inventory", "resource_type": "hosts", "operation": "read"}],
+            "permissions": [{"application": "testapp", "resource_type": "hosts", "operation": "read"}],
         }
 
         response = self.client.put(update_url, data, format="json")
@@ -1904,7 +1904,7 @@ class RoleV2ViewSetTests(IdentityRequest):
         data = {
             "name": "Updated*Role",
             "description": "Should be rejected",
-            "permissions": [{"application": "inventory", "resource_type": "hosts", "operation": "read"}],
+            "permissions": [{"application": "testapp", "resource_type": "hosts", "operation": "read"}],
         }
 
         response = self.client.put(update_url, data, format="json")
@@ -1929,7 +1929,7 @@ class RoleV2ViewSetTests(IdentityRequest):
         data = {
             "name": "Attempt to Update Platform Role",
             "description": "This should fail",
-            "permissions": [{"application": "inventory", "resource_type": "hosts", "operation": "read"}],
+            "permissions": [{"application": "testapp", "resource_type": "hosts", "operation": "read"}],
         }
 
         response = self.client.put(update_url, data, format="json")
@@ -1955,7 +1955,7 @@ class RoleV2ViewSetTests(IdentityRequest):
         data = {
             "name": "Attempt to Update Seeded Role",
             "description": "This should fail with 400",
-            "permissions": [{"application": "inventory", "resource_type": "hosts", "operation": "read"}],
+            "permissions": [{"application": "testapp", "resource_type": "hosts", "operation": "read"}],
         }
 
         response = self.client.put(update_url, data, format="json")
@@ -1980,7 +1980,7 @@ class RoleV2ViewSetTests(IdentityRequest):
         data = {
             "name": "Updated Role",
             "description": "Updated description",
-            "permissions": [{"application": "inventory", "resource_type": "hosts", "operation": "read"}],
+            "permissions": [{"application": "testapp", "resource_type": "hosts", "operation": "read"}],
         }
 
         error_cases = [
@@ -2014,7 +2014,7 @@ class RoleV2ViewSetTests(IdentityRequest):
         # We omit the description here, which should be treated as an empty string.
         data = {
             "name": "Description Role",
-            "permissions": [{"application": "inventory", "resource_type": "hosts", "operation": "read"}],
+            "permissions": [{"application": "testapp", "resource_type": "hosts", "operation": "read"}],
         }
 
         response = self.client.put(update_url, data, format="json")
@@ -2035,7 +2035,7 @@ class RoleV2ViewSetTests(IdentityRequest):
         # We omit the description here, which should be treated as an empty string.
         data = {
             "name": "A Better Role",
-            "permissions": [{"application": "inventory", "resource_type": "hosts", "operation": "read"}],
+            "permissions": [{"application": "testapp", "resource_type": "hosts", "operation": "read"}],
         }
 
         response = self.client.put(update_url, data, format="json")
@@ -2062,7 +2062,7 @@ class RoleV2ViewSetTests(IdentityRequest):
             {
                 "name": f"Test Role {str(uuid.uuid4())}",
                 "description": "A role for testing",
-                "permissions": [{"application": "inventory", "resource_type": "hosts", "operation": "read"}],
+                "permissions": [{"application": "testapp", "resource_type": "hosts", "operation": "read"}],
             },
             format="json",
         )

--- a/tests/management/role/test_v2_view.py
+++ b/tests/management/role/test_v2_view.py
@@ -1673,7 +1673,7 @@ class RoleV2ViewSetTests(IdentityRequest):
             "description": "Test description",
             "permissions": [
                 {"application": "testapp", "resource_type": "hosts", "operation": "write"},
-                {"application": "cost", "resource_type": "reports", "operation": "read"},
+                {"application": "testapp", "resource_type": "reports", "operation": "read"},
             ],
         }
 
@@ -1702,7 +1702,7 @@ class RoleV2ViewSetTests(IdentityRequest):
             "name": "Order Test Role",
             "description": "Testing permission order preservation",
             "permissions": [
-                {"application": "cost", "resource_type": "reports", "operation": "read"},
+                {"application": "testapp", "resource_type": "reports", "operation": "read"},
                 {"application": "testapp", "resource_type": "hosts", "operation": "write"},
                 {"application": "testapp", "resource_type": "hosts", "operation": "read"},
             ],
@@ -1716,7 +1716,7 @@ class RoleV2ViewSetTests(IdentityRequest):
         self.assertEqual(
             response.data["permissions"],
             [
-                {"application": "cost", "resource_type": "reports", "operation": "read"},
+                {"application": "testapp", "resource_type": "reports", "operation": "read"},
                 {"application": "testapp", "resource_type": "hosts", "operation": "write"},
                 {"application": "testapp", "resource_type": "hosts", "operation": "read"},
             ],

--- a/tests/management/role/test_v2_view.py
+++ b/tests/management/role/test_v2_view.py
@@ -1581,6 +1581,8 @@ class RoleV2ViewSetTests(IdentityRequest):
     @override_settings(V2_MIGRATION_APP_EXCLUDE_LIST=["cost"])
     def test_create_role_rejects_migration_excluded_application(self):
         """Permissions in V2_MIGRATION_APP_EXCLUDE_LIST cannot be used on create."""
+        # Ensure the permission exists so it can be excluded by the setting
+        Permission.objects.get_or_create(permission="cost:reports:read", defaults={"tenant": self.tenant})
         v2_role_excluded_application_permission_ids_cache.invalidate()
         try:
             data = {

--- a/tests/management/role/test_v2_view.py
+++ b/tests/management/role/test_v2_view.py
@@ -1303,12 +1303,12 @@ class RoleV2ViewSetTests(IdentityRequest):
 
     def test_create_role_preserves_permission_order(self):
         """Test that response permissions are returned in input order."""
-        # Request permissions in specific order (cost first, then inventory)
+        # Request permissions in specific order (reports first, then hosts)
         data = {
             "name": "Order Test Role",
             "description": "Testing permission order preservation",
             "permissions": [
-                {"application": "cost", "resource_type": "reports", "operation": "read"},
+                {"application": "testapp", "resource_type": "reports", "operation": "read"},
                 {"application": "testapp", "resource_type": "hosts", "operation": "write"},
                 {"application": "testapp", "resource_type": "hosts", "operation": "read"},
             ],
@@ -1322,7 +1322,7 @@ class RoleV2ViewSetTests(IdentityRequest):
         self.assertEqual(
             response.data["permissions"],
             [
-                {"application": "cost", "resource_type": "reports", "operation": "read"},
+                {"application": "testapp", "resource_type": "reports", "operation": "read"},
                 {"application": "testapp", "resource_type": "hosts", "operation": "write"},
                 {"application": "testapp", "resource_type": "hosts", "operation": "read"},
             ],

--- a/tests/management/role/test_v2_view.py
+++ b/tests/management/role/test_v2_view.py
@@ -86,17 +86,17 @@ class RoleV2RetrieveViewTest(IdentityRequest):
             )
         )
 
-        # Create permissions
+        # Create permissions (use test-namespaced names to avoid conflicts with seed_roles())
         self.permission1 = Permission.objects.create(
-            permission="inventory:hosts:read",
+            permission="testapp:hosts:read",
             tenant=self.tenant,
         )
         self.permission2 = Permission.objects.create(
-            permission="inventory:hosts:write",
+            permission="testapp:hosts:write",
             tenant=self.tenant,
         )
         self.permission3 = Permission.objects.create(
-            permission="cost:reports:read",
+            permission="testapp:reports:read",
             tenant=self.tenant,
         )
 
@@ -147,9 +147,9 @@ class RoleV2RetrieveViewTest(IdentityRequest):
         # Verify permissions
         self.assertEqual(len(data["permissions"]), 2)
         permission_strings = {f"{p['application']}:{p['resource_type']}:{p['operation']}" for p in data["permissions"]}
-        self.assertEqual(permission_strings, {"inventory:hosts:read", "inventory:hosts:write"})
+        self.assertEqual(permission_strings, {"testapp:hosts:read", "testapp:hosts:write"})
 
-    @override_settings(V2_MIGRATION_APP_EXCLUDE_LIST=["cost"])
+    @override_settings(V2_MIGRATION_APP_EXCLUDE_LIST=["testapp"])
     def test_retrieve_excluded_app_role_returns_404(self):
         """Test that retrieving a role whose permissions are all from an excluded app returns 404."""
         v2_role_excluded_application_permission_ids_cache.invalidate()
@@ -159,7 +159,7 @@ class RoleV2RetrieveViewTest(IdentityRequest):
                 description="Has only excluded-app permissions",
                 tenant=self.tenant,
             )
-            excluded_role.permissions.add(self.permission3)  # cost:reports:read
+            excluded_role.permissions.add(self.permission3)  # testapp:reports:read
 
             url = self._get_role_url(excluded_role.uuid)
             response = self.client.get(url, **self.headers)
@@ -238,9 +238,9 @@ class RoleV2RetrieveViewTest(IdentityRequest):
             self.assertIn("operation", permission)
 
             # Permission strings should be split correctly
-            # inventory:hosts:read -> application=inventory, resource_type=hosts, operation=read
-            if permission["application"] == "inventory":
-                self.assertEqual(permission["resource_type"], "hosts")
+            # testapp:hosts:read -> application=testapp, resource_type=hosts, operation=read
+            if permission["application"] == "testapp":
+                self.assertIn(permission["resource_type"], ["hosts", "reports"])
                 self.assertIn(permission["operation"], ["read", "write"])
 
     def test_retrieve_role_with_no_permissions(self):
@@ -316,10 +316,10 @@ class RoleV2RetrieveViewTest(IdentityRequest):
             tenant=self.tenant,
         )
         # Add permissions in non-alphabetical order
-        # Expected alphabetical order: cost:reports:read, inventory:hosts:read, inventory:hosts:write
-        ordered_role.permissions.add(self.permission2)  # inventory:hosts:write
-        ordered_role.permissions.add(self.permission3)  # cost:reports:read
-        ordered_role.permissions.add(self.permission1)  # inventory:hosts:read
+        # Expected alphabetical order: testapp:hosts:read, testapp:hosts:write, testapp:reports:read
+        ordered_role.permissions.add(self.permission2)  # testapp:hosts:write
+        ordered_role.permissions.add(self.permission3)  # testapp:reports:read
+        ordered_role.permissions.add(self.permission1)  # testapp:hosts:read
 
         url = self._get_role_url(ordered_role.uuid)
         response = self.client.get(url, **self.headers)
@@ -329,7 +329,7 @@ class RoleV2RetrieveViewTest(IdentityRequest):
 
         # Verify permissions are sorted alphabetically
         permission_strings = [f"{p['application']}:{p['resource_type']}:{p['operation']}" for p in data["permissions"]]
-        self.assertEqual(permission_strings, ["cost:reports:read", "inventory:hosts:read", "inventory:hosts:write"])
+        self.assertEqual(permission_strings, ["testapp:hosts:read", "testapp:hosts:write", "testapp:reports:read"])
 
         ordered_role.delete()
 
@@ -417,9 +417,9 @@ class RoleV2RetrieveViewTest(IdentityRequest):
             "name": "Consistency Test Role",
             "description": "Testing create/retrieve consistency",
             "permissions": [
-                {"application": "inventory", "resource_type": "hosts", "operation": "write"},
-                {"application": "cost", "resource_type": "reports", "operation": "read"},
-                {"application": "inventory", "resource_type": "hosts", "operation": "read"},
+                {"application": "testapp", "resource_type": "hosts", "operation": "write"},
+                {"application": "testapp", "resource_type": "reports", "operation": "read"},
+                {"application": "testapp", "resource_type": "hosts", "operation": "read"},
             ],
         }
 
@@ -434,7 +434,7 @@ class RoleV2RetrieveViewTest(IdentityRequest):
         create_permissions = [
             f"{p['application']}:{p['resource_type']}:{p['operation']}" for p in create_response.data["permissions"]
         ]
-        self.assertEqual(create_permissions, ["inventory:hosts:write", "cost:reports:read", "inventory:hosts:read"])
+        self.assertEqual(create_permissions, ["testapp:hosts:write", "testapp:reports:read", "testapp:hosts:read"])
 
         # Retrieve the same role
         retrieve_url = reverse("v2_management:roles-detail", kwargs={"uuid": role_id})
@@ -445,7 +445,7 @@ class RoleV2RetrieveViewTest(IdentityRequest):
         retrieve_permissions = [
             f"{p['application']}:{p['resource_type']}:{p['operation']}" for p in retrieve_response.data["permissions"]
         ]
-        self.assertEqual(retrieve_permissions, ["cost:reports:read", "inventory:hosts:read", "inventory:hosts:write"])
+        self.assertEqual(retrieve_permissions, ["testapp:hosts:read", "testapp:hosts:write", "testapp:reports:read"])
 
         # Both should have same permission set, just different order
         self.assertEqual(set(create_permissions), set(retrieve_permissions))
@@ -487,11 +487,11 @@ class RoleV2ViewSetTests(IdentityRequest):
         self.list_url = f"{self.url}?resource_type=workspace"
         self.delete_url = reverse("v2_management:roles-bulk-destroy")
 
-        # Create test permissions
+        # Create test permissions (use test-namespaced names to avoid conflicts with seed_roles())
         self.permission1 = Permission.objects.create(permission="test:resource:read", tenant=self.tenant)
-        self.permission2 = Permission.objects.create(permission="inventory:hosts:read", tenant=self.tenant)
-        self.permission3 = Permission.objects.create(permission="inventory:hosts:write", tenant=self.tenant)
-        self.permission4 = Permission.objects.create(permission="cost:reports:read", tenant=self.tenant)
+        self.permission2 = Permission.objects.create(permission="testapp:hosts:read", tenant=self.tenant)
+        self.permission3 = Permission.objects.create(permission="testapp:hosts:write", tenant=self.tenant)
+        self.permission4 = Permission.objects.create(permission="testapp:reports:read", tenant=self.tenant)
 
         self.permission1_data = {"application": "inventory", "resource_type": "hosts", "operation": "read"}
 
@@ -843,7 +843,7 @@ class RoleV2ViewSetTests(IdentityRequest):
         role_without_perm = RoleV2.objects.create(name="no_match_role", tenant=self.tenant)
         role_without_perm.permissions.add(self.permission4)
 
-        url = f"{self.list_url}&permission=inventory:hosts:read"
+        url = f"{self.list_url}&permission=testapp:hosts:read"
         response = self.client.get(url, **self.headers)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -859,7 +859,7 @@ class RoleV2ViewSetTests(IdentityRequest):
         role_b = RoleV2.objects.create(name="cost_reader", tenant=self.tenant)
         role_b.permissions.add(self.permission4)
 
-        url = f"{self.list_url}&permission=inventory:hosts:read,cost:reports:read"
+        url = f"{self.list_url}&permission=testapp:hosts:read,testapp:reports:read"
         response = self.client.get(url, **self.headers)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -880,7 +880,7 @@ class RoleV2ViewSetTests(IdentityRequest):
         role = RoleV2.objects.create(name="multi_perm_role", tenant=self.tenant)
         role.permissions.add(self.permission2, self.permission3)
 
-        url = f"{self.list_url}&permission=inventory:hosts:read,inventory:hosts:write"
+        url = f"{self.list_url}&permission=testapp:hosts:read,testapp:hosts:write"
         response = self.client.get(url, **self.headers)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)


### PR DESCRIPTION
## Link(s) to Jira
https://redhat.atlassian.net/browse/RHCLOUD-46876

## Description of Intent of Change(s)
  - Fix V2 role seeding to raise exceptions instead of silently returning None, ensuring V1 and V2 roles are created
  atomically
  - When _seed_v2_role_from_v1 fails, the exception now propagates to _make_role's @atomic_with_retry decorator which
  retries up to 3 times and rolls back on permanent failure
  - Prevents inconsistent state where V1 system roles exist without corresponding SeededRoleV2 records

## Local Testing
How can the feature be exercised?
How can the bug be exploited and fix confirmed?
Is any special local setup required?

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
