### PR TITLE
[RHCLOUD-48478] Lock roles during assignment and seeding

### DIFF
--- a/rbac/api/cross_access/relation_api_dual_write_cross_access_handler.py
+++ b/rbac/api/cross_access/relation_api_dual_write_cross_access_handler.py
@@ -158,8 +158,9 @@ class RelationApiDualWriteCrossAccessHandler(RelationApiDualWriteSubjectHandler)
             skip_scope_validation=True,
         )
 
-    def _add_car_roles_v1(self, roles: set[Role]):
+    def _add_car_roles_v1(self, roles: Iterable[Role]):
         self._expect_v1_tenant()
+        roles = self._with_system_roles_for_share(roles)
 
         def add_principal_to_binding(mapping: BindingMapping):
             self.relations_to_add.append(mapping.assign_user_to_bindings(user_id, source_key))
@@ -191,6 +192,8 @@ class RelationApiDualWriteCrossAccessHandler(RelationApiDualWriteSubjectHandler)
 
         principal = Principal.objects.get(user_id=self._user_id())
 
+        # We do not need to lock the roles here, since we're in a SERIALIZABLE transaction (and so is seeding each
+        # role).
         for role in roles:
             for scope in self._resource_service.binding_scopes_for_role(role):
                 v1_roles_by_scope.setdefault(scope, set()).add(role)
@@ -245,6 +248,8 @@ class RelationApiDualWriteCrossAccessHandler(RelationApiDualWriteSubjectHandler)
             if removal is not None:
                 self.relations_to_remove.append(removal)
 
+        # We don't need to lock the roles, since we will handle any possible scope (without actually looking at the
+        # roles).
         for role in roles:
             for scope in Scope:
                 self._update_mapping_for_system_role(
@@ -263,6 +268,8 @@ class RelationApiDualWriteCrossAccessHandler(RelationApiDualWriteSubjectHandler)
 
         v2_roles_to_remove: set[SeededRoleV2] = SeededRoleV2.for_v1_roles(roles)
 
+        # We don't need to lock the roles, since we will handle any possible scope (without actually looking at the
+        # roles).
         for scope in Scope:
             resource = scope_resources.resource_for(scope)
 

--- a/rbac/management/group/relation_api_dual_write_group_handler.py
+++ b/rbac/management/group/relation_api_dual_write_group_handler.py
@@ -195,13 +195,12 @@ class RelationApiDualWriteGroupHandler(RelationApiDualWriteSubjectHandler):
             if to_add:
                 self.relations_to_add.append(to_add)
 
-        # Go through current roles
-        # For each binding
-        # Remove all of this subject
-        # Replicate this removal
-        # Add back subject
-        # Replicate this addition
-        for role in roles:
+        # Go through current roles, and, for each binding:
+        # * Remove all of this subject
+        # * Replicate this removal
+        # * Add back subject
+        # * Replicate this addition
+        for role in self._with_system_roles_for_share(roles):
             # When a role has mixed scopes including TENANT, create bindings at each scope
             # so that workspace-scoped permissions are not lost.
             binding_scopes = self._resource_service.binding_scopes_for_role(role)
@@ -262,6 +261,9 @@ class RelationApiDualWriteGroupHandler(RelationApiDualWriteSubjectHandler):
         # so we always have to check at least the default workspace and the correct resource.
         #
         # In order to handle all these cases, we always attempt to remove the role from all scopes.
+        #
+        # As a consequence of this, we also do not have to lock any system roles here: we don't actually look at
+        # the role's permissions in determining where to remove it.
         for scope in Scope:
             self._update_mapping_for_role(
                 role,

--- a/rbac/management/group/relation_api_dual_write_subject_handler.py
+++ b/rbac/management/group/relation_api_dual_write_subject_handler.py
@@ -18,7 +18,7 @@
 """Class to handle Dual Write API related operations."""
 
 import logging
-from typing import Callable, Optional
+from typing import Callable, Iterable, Optional
 from uuid import uuid4
 
 from django.conf import settings
@@ -478,3 +478,46 @@ class RelationApiDualWriteSubjectHandler:
 
         role_handler.prepare_for_update()
         role_handler.replicate_new_or_updated_role(role)
+
+    @staticmethod
+    def _with_system_roles_for_share(roles: Iterable[Role]) -> list[Role]:
+        """
+        Return the provided roles, with all system roles reloaded and locked FOR SHARE.
+
+        Principally, this ensures that the role will not be changed by seeding while this lock is held (since seeding
+        locks the role FOR UPDATE).
+
+        It is expected that the call has already locked all provided custom roles FOR UPDATE.
+        """
+        roles = set(roles)
+
+        custom: list[Role] = list()
+        system: list[Role] = list()
+
+        for role in roles:
+            if role.system:
+                system.append(role)
+            else:
+                custom.append(role)
+
+        if len(system) > 0:
+            id_params = ", ".join(["%s"] * len(system))
+
+            locked_system = list(
+                Role.objects.raw(
+                    f"SELECT * FROM management_role WHERE system = TRUE AND id IN ({id_params}) FOR SHARE",
+                    [r.id for r in system],
+                )
+            )
+        else:
+            locked_system = []
+
+        final_roles = custom + locked_system
+
+        requested_ids = {r.id for r in roles}
+        final_ids = {r.id for r in final_roles}
+
+        if final_ids != requested_ids:
+            raise RuntimeError(f"Could not find roles with the following IDs: {requested_ids - final_ids}")
+
+        return final_roles

--- a/rbac/management/group/relation_api_dual_write_subject_handler.py
+++ b/rbac/management/group/relation_api_dual_write_subject_handler.py
@@ -487,6 +487,9 @@ class RelationApiDualWriteSubjectHandler:
         Principally, this ensures that the role will not be changed by seeding while this lock is held (since seeding
         locks the role FOR UPDATE).
 
+        This should be used before any role (un)assignment operation, unless the operation doesn't actually depend on
+        the state of the role. (For instance, certain unassignment operations only care about the role's UUID.)
+
         It is expected that the call has already locked all provided custom roles FOR UPDATE.
         """
         roles = set(roles)

--- a/rbac/management/role/definer.py
+++ b/rbac/management/role/definer.py
@@ -105,7 +105,20 @@ def _make_role(data, config: _SeedRolesConfig, platform_roles=None, resource_ser
         platform_default=data.get("platform_default", False),
         admin_default=data.get("admin_default", False),
     )
-    role, created = Role.objects.get_or_create(name=name, defaults=defaults, tenant=public_tenant)
+
+    # Taking a lock on the role prevents it from being assigned during seeding (since the dual-write handlers lock it
+    # FOR SHARE). Doing this ensures that, once seeding the role has finished, all further assignments will see the
+    # new permissions (and thus use them to compute the relevant scopes).
+    #
+    # This doesn't technically ensure that other processes will use the new scopes in all situations; if the scopes have
+    # changed due to a change in the *settings*, rather than the permissions, then a process with the old settings
+    # will continue using the old scope. We don't have a good way to fix that here. (The obvious ideas for how to fix
+    # it would be using scopes stored in the database during assignment and storing the latest scope settings
+    # themselves in the database. Alternatively, we could just be sure to manually migrate the relevant roles every
+    # time the settings change.)
+    #
+    # TODO: fix the above
+    role, created = Role.objects.select_for_update().get_or_create(name=name, defaults=defaults, tenant=public_tenant)
     updated = False
 
     dual_write_handler = SeedingRelationApiDualWriteHandler(role)

--- a/rbac/management/role/definer.py
+++ b/rbac/management/role/definer.py
@@ -182,15 +182,15 @@ def _update_or_create_roles(roles, config: _SeedRolesConfig, platform_roles=None
     exist without their corresponding V2 SeededRoleV2 records.
     """
     current_roles: list[Role] = list()
-    # Sort roles by name to ensure consistent lock ordering and prevent deadlocks
-    sorted_roles = sorted(roles, key=lambda r: r.get("name", ""))
-    for role_json in sorted_roles:
+
+    for role_json in roles:
         try:
             role = _make_role(role_json, config, platform_roles, resource_service)
             current_roles.append(role)
         except Exception as e:
             logger.error(f'Failed to update or create system role: {role_json.get("name")} with error: {e}')
             raise
+
     return current_roles
 
 


### PR DESCRIPTION
## Link(s) to Jira
[RHCLOUD-48478](https://redhat.atlassian.net/browse/RHCLOUD-48478)

## Description of Intent of Change(s)
Lock system roles `FOR UPDATE` during seeding and `FOR SHARE` during assignment. This ensures that, once seeding has finished, any further assignments will use the new permissions to compute the scope.

(As described in the comment in `definer.py`, this doesn't handle cases where the scope settings have changed, but it's still an improvement.)

~~Do not merge until #3058 is merged, since otherwise we will potentially be holding locks on system roles while updating their binding scope (which can take a while).~~

[RHCLOUD-48478]: https://redhat.atlassian.net/browse/RHCLOUD-48478?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved consistency when assigning, removing, and resetting roles across access and group relationships.
  - Strengthened handling of system roles during concurrent updates to prevent conflicting changes.
  - Improved role creation and updates during setup, reducing the risk of duplicate or inconsistent role data.

- **Refactor**
  - Role processing now supports broader collections and preserves the supplied processing order.
  - Added safeguards to detect missing roles during relationship updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->