### PR TITLE
chore(deps): consolidate 5 npm dependency updates

### DIFF
--- a/docs/source/specs/typespec/package.json
+++ b/docs/source/specs/typespec/package.json
@@ -6,17 +6,17 @@
     "node": ">=20.0.0"
   },
   "peerDependencies": {
-    "@typespec/compiler": "^1.12.0"
+    "@typespec/compiler": "1.13.0"
   },
   "devDependencies": {
-    "@typespec/compiler": "^1.12.0"
+    "@typespec/compiler": "1.13.0"
   },
   "private": true,
   "dependencies": {
-    "@typespec/http": "^1.12.0",
-    "@typespec/json-schema": "^1.12.0",
+    "@typespec/http": "1.13.0",
+    "@typespec/json-schema": "1.13.0",
     "@typespec/openapi3": "^1.11.0",
-    "@typespec/rest": "^0.82.0",
-    "@typespec/versioning": "^0.82.0"
+    "@typespec/rest": "^0.83.0",
+    "@typespec/versioning": "^0.83.0"
   }
 }


### PR DESCRIPTION
## Summary

Consolidates 5 npm dependency update PRs from `red-hat-konflux[bot]` into a single PR for easier review.

## Consolidated PRs

- #3038: Update dependency @typespec/versioning to ^0.83.0
- #3036: Update dependency @typespec/rest to ^0.83.0
- #3029: Update dependency @typespec/json-schema to v1.13.0
- #3028: Update dependency @typespec/http to v1.13.0
- #3027: chore(deps): update dependency @typespec/compiler to v1.13.0

## Why consolidate?

- Reduces CI/CD load from multiple small PRs
- Easier to review related dependency updates together
- Single merge commit instead of many

## Testing

- [ ] CI passes
- [ ] No breaking changes from dependency updates
