### PR TITLE
RHCLOUD-48590: Handle multiple scopes in CARs

### DIFF
--- a/rbac/api/cross_access/relation_api_dual_write_cross_access_handler.py
+++ b/rbac/api/cross_access/relation_api_dual_write_cross_access_handler.py
@@ -168,18 +168,19 @@ class RelationApiDualWriteCrossAccessHandler(RelationApiDualWriteSubjectHandler)
         source_key = self._source_key()
 
         for role in roles:
-            self._update_mapping_for_system_role(
-                role,
-                scope=(self._resource_service.scope_for_role(role)),
-                update_mapping=add_principal_to_binding,
-                create_default_mapping_for_system_role=(
-                    lambda resource: self._create_default_mapping_for_system_role(
-                        system_role=role,
-                        resource=resource,
-                        users={str(source_key): user_id},
-                    )
-                ),
-            )
+            for scope in self._resource_service.binding_scopes_for_role(role):
+                self._update_mapping_for_system_role(
+                    role,
+                    scope=scope,
+                    update_mapping=add_principal_to_binding,
+                    create_default_mapping_for_system_role=(
+                        lambda resource: self._create_default_mapping_for_system_role(
+                            system_role=role,
+                            resource=resource,
+                            users={str(source_key): user_id},
+                        )
+                    ),
+                )
 
     @atomic
     def _add_car_roles_v2(self, roles: set[Role]):
@@ -191,7 +192,8 @@ class RelationApiDualWriteCrossAccessHandler(RelationApiDualWriteSubjectHandler)
         principal = Principal.objects.get(user_id=self._user_id())
 
         for role in roles:
-            v1_roles_by_scope.setdefault(self._resource_service.scope_for_role(role), set()).add(role)
+            for scope in self._resource_service.binding_scopes_for_role(role):
+                v1_roles_by_scope.setdefault(scope, set()).add(role)
 
         for scope, v1_roles in v1_roles_by_scope.items():
             resource = scope_resources.resource_for(scope)

--- a/rbac/management/inventory_checker/inventory_api_check.py
+++ b/rbac/management/inventory_checker/inventory_api_check.py
@@ -36,7 +36,7 @@ from management.cache import JWTCache
 from management.group.platform import DefaultGroupNotAvailableError, GlobalPolicyIdService
 from management.permission.scope_service import ImplicitResourceService, Scope
 from management.relation_replicator.types import RelationTuple
-from management.role.platform import admin_platform_parent_scope_for_seeded_system_role, platform_v2_role_uuid_for
+from management.role.platform import admin_platform_parent_scopes_for_seeded_system_role, platform_v2_role_uuid_for
 from management.role.relations import role_child_relationship
 from management.tenant_mapping.model import DefaultAccessType, TenantMapping
 from management.utils import create_client_channel_inventory, create_client_channel_relation
@@ -553,24 +553,28 @@ def generate_seeded_role_hierarchy_tuples(
 
     if implicit_resource_service is None:
         implicit_resource_service = ImplicitResourceService.from_settings()
-    scope = implicit_resource_service.scope_for_role(v1_role)
+
+    binding_scopes = set(implicit_resource_service.binding_scopes_for_role(v1_role))
+    admin_scopes = set(admin_platform_parent_scopes_for_seeded_system_role(v1_role.name, binding_scopes))
+
     policy_service = GlobalPolicyIdService.shared()
     tuples = []
 
     if v1_role.admin_default:
-        try:
-            admin_scope = admin_platform_parent_scope_for_seeded_system_role(v1_role.name, scope, apply_override=True)
-            parent_uuid = platform_v2_role_uuid_for(DefaultAccessType.ADMIN, admin_scope, policy_service)
-            tuples.append(role_child_relationship(parent_uuid, seeded_role.uuid))
-        except DefaultGroupNotAvailableError:
-            logger.warning(f"Default admin group not available for seeded role {seeded_role.uuid}")
+        for scope in admin_scopes:
+            try:
+                parent_uuid = platform_v2_role_uuid_for(DefaultAccessType.ADMIN, scope, policy_service)
+                tuples.append(role_child_relationship(parent_uuid, seeded_role.uuid))
+            except DefaultGroupNotAvailableError:
+                logger.warning(f"Default admin group not available for seeded role {seeded_role.uuid}")
 
     if v1_role.platform_default:
-        try:
-            parent_uuid = platform_v2_role_uuid_for(DefaultAccessType.USER, scope, policy_service)
-            tuples.append(role_child_relationship(parent_uuid, seeded_role.uuid))
-        except DefaultGroupNotAvailableError:
-            logger.warning(f"Default platform group not available for seeded role {seeded_role.uuid}")
+        for scope in binding_scopes:
+            try:
+                parent_uuid = platform_v2_role_uuid_for(DefaultAccessType.USER, scope, policy_service)
+                tuples.append(role_child_relationship(parent_uuid, seeded_role.uuid))
+            except DefaultGroupNotAvailableError:
+                logger.warning(f"Default platform group not available for seeded role {seeded_role.uuid}")
 
     return tuples
 

--- a/rbac/management/permission/scope_service.py
+++ b/rbac/management/permission/scope_service.py
@@ -326,11 +326,6 @@ class ImplicitResourceService:
             default=Scope.DEFAULT,
         )
 
-    def scope_for_role(self, role: Role) -> Scope:
-        """Return the implicit scope for a role based on its permissions."""
-        # TODO: this may need to eventually take into account resource definitions for custom roles.
-        return self.highest_scope_for_permissions(a.permission.permission for a in role.access.all())
-
     def binding_scopes_for_role(self, role: Role) -> list["Scope"]:
         """Return the scopes at which bindings should be created for this role.
 
@@ -338,6 +333,7 @@ class ImplicitResourceService:
         remaining workspace scopes are merged to the highest among them.
         ROOT+DEFAULT without TENANT collapses to ROOT (workspace parent inheritance).
         """
+        # TODO: this may need to eventually take into account resource definitions for custom roles.
         return binding_scopes_for_permissions((a.permission.permission for a in role.access.all()), self)
 
     def v2_bound_resource_for_permission(

--- a/rbac/management/role/definer.py
+++ b/rbac/management/role/definer.py
@@ -37,7 +37,7 @@ from management.permission.scope_service import ImplicitResourceService, Scope
 from management.relation_replicator.relation_replicator import ReplicationEventType
 from management.role.model import Access, ExtRoleRelation, ExtTenant, ResourceDefinition, Role, RoleScopeState
 from management.role.platform import (
-    admin_platform_parent_scope_for_seeded_system_role,
+    admin_platform_parent_scopes_for_seeded_system_role,
     platform_v2_role_uuid_for,
 )
 from management.role.relation_api_dual_write_handler import (
@@ -387,11 +387,8 @@ def _seed_v2_role_from_v1(v1_role, display_name, description, public_tenant, pla
                 logger.info("Added %s as child of platform role %s", display_name, platform_role.name)
 
         if v1_role.admin_default:
-            for scope in binding_scopes:
-                admin_scope = admin_platform_parent_scope_for_seeded_system_role(
-                    v1_role.name, scope, apply_override=True
-                )
-                admin_platform_role = platform_roles[(DefaultAccessType.ADMIN, admin_scope)]
+            for scope in admin_platform_parent_scopes_for_seeded_system_role(v1_role.name, binding_scopes):
+                admin_platform_role = platform_roles[(DefaultAccessType.ADMIN, scope)]
                 admin_platform_role.children.add(v2_role)
                 logger.info("Added %s as child of admin platform role %s", display_name, admin_platform_role.name)
 

--- a/rbac/management/role/platform.py
+++ b/rbac/management/role/platform.py
@@ -16,7 +16,7 @@
 #
 """Contains utilities for handling platform roles."""
 
-from typing import Callable
+from typing import Callable, Iterable
 from uuid import UUID
 
 from django.conf import settings
@@ -34,18 +34,19 @@ ADMIN_DEFAULT_SEEDED_ROLES_FORCE_ROOT_SCOPE = frozenset(
 )
 
 
-def admin_platform_parent_scope_for_seeded_system_role(
-    role_name: str, permission_derived_scope: Scope, *, apply_override: bool
-) -> Scope:
+def admin_platform_parent_scopes_for_seeded_system_role(
+    role_name: str, permission_derived_scopes: Iterable[Scope]
+) -> set[Scope]:
     """
     Return the scope of the admin platform role that should be the parent of this admin_default seeded role.
 
     Call only for roles with ``admin_default=True``. When apply_override is False (e.g. when generating
     tuples to strip all historical variants), the caller's scope is used as-is.
     """
-    if apply_override and role_name in ADMIN_DEFAULT_SEEDED_ROLES_FORCE_ROOT_SCOPE:
-        return Scope.ROOT
-    return permission_derived_scope
+    if role_name in ADMIN_DEFAULT_SEEDED_ROLES_FORCE_ROOT_SCOPE:
+        return {Scope.ROOT}
+
+    return set(permission_derived_scopes)
 
 
 _uuid_fns: dict[DefaultAccessType, dict[Scope, Callable[[GlobalPolicyIdService], UUID]]] = {

--- a/rbac/management/role/relation_api_dual_write_handler.py
+++ b/rbac/management/role/relation_api_dual_write_handler.py
@@ -182,7 +182,6 @@ class SeedingRelationApiDualWriteHandler(BaseRelationApiDualWriteHandler):
                 except DefaultGroupNotAvailableError:
                     # Default groups may not exist yet during seeding, skip parent relationship
                     logging.warning(f"Default groups may not exist yet during seeding for admin scope {scope}")
-                    pass
 
         if role.platform_default:
             for scope in binding_scopes:
@@ -198,7 +197,6 @@ class SeedingRelationApiDualWriteHandler(BaseRelationApiDualWriteHandler):
                 except DefaultGroupNotAvailableError:
                     # Default groups may not exist yet during seeding, skip parent relationship
                     logging.warning(f"Default groups may not exist yet during seeding for platform scope {scope}")
-                    pass
 
         return create_relations
 

--- a/rbac/management/role/relation_api_dual_write_handler.py
+++ b/rbac/management/role/relation_api_dual_write_handler.py
@@ -28,14 +28,17 @@ from management.models import Workspace
 from management.permission.scope_service import ImplicitResourceService, Scope, bound_model_for_scope
 from management.relation_replicator.noop_replicator import NoopReplicator
 from management.relation_replicator.outbox_replicator import OutboxReplicator
-from management.relation_replicator.relation_replicator import DualWriteException, PartitionKey
-from management.relation_replicator.relation_replicator import RelationReplicator
-from management.relation_replicator.relation_replicator import ReplicationEvent
-from management.relation_replicator.relation_replicator import ReplicationEventType
+from management.relation_replicator.relation_replicator import (
+    DualWriteException,
+    PartitionKey,
+    RelationReplicator,
+    ReplicationEvent,
+    ReplicationEventType,
+)
 from management.relation_replicator.types import RelationTuple
 from management.role.model import BindingMapping, Role
 from management.role.platform import (
-    admin_platform_parent_scope_for_seeded_system_role,
+    admin_platform_parent_scopes_for_seeded_system_role,
     platform_v2_role_uuid_for,
 )
 from management.role.relations import (
@@ -55,7 +58,6 @@ from migration_tool.sharedSystemRolesReplicatedRoleBindings import (
     with_workspace_scope_inheritance,
 )
 from migration_tool.utils import create_relationship
-
 
 from api.models import Tenant
 
@@ -112,7 +114,7 @@ class SeedingRelationApiDualWriteHandler(BaseRelationApiDualWriteHandler):
         """Generate & store role's current relations."""
         if not self.replication_enabled():
             return
-        self._current_role_relations = self._generate_relations_for_role(list_all_possible_scopes_for_removal=True)
+        self._current_role_relations = self._generate_relations_for_role(for_removal=True)
 
     def replicate_update_system_role(self):
         """Replicate update of system role."""
@@ -146,51 +148,61 @@ class SeedingRelationApiDualWriteHandler(BaseRelationApiDualWriteHandler):
         self._replicate(
             ReplicationEventType.DELETE_SYSTEM_ROLE,
             self._create_metadata_from_role(),
-            self._generate_relations_for_role(list_all_possible_scopes_for_removal=True),
+            self._generate_relations_for_role(for_removal=True),
             [],
         )
 
-    def _check_create_admin_platform_relation(self, role, role_scope, *, apply_seeded_admin_scope_override: bool):
-        """Check system role and create admin and platform system role parent-child relationship."""
-        create_relations = []
-        if role.admin_default:
-            try:
-                admin_scope = admin_platform_parent_scope_for_seeded_system_role(
-                    role.name,
-                    role_scope,
-                    apply_override=apply_seeded_admin_scope_override,
-                )
-                parent_uuid = platform_v2_role_uuid_for(
-                    DefaultAccessType.ADMIN,
-                    admin_scope,
-                    GlobalPolicyIdService.shared(),
-                )
+    def _check_create_admin_platform_relation(self, role, *, for_removal: bool):
+        """
+        Check system role and create admin and platform system role parent-child relationship.
 
-                create_parent_child_relationship = role_child_relationship(parent_uuid, self.role.uuid)
-                create_relations.append(create_parent_child_relationship)
-            except DefaultGroupNotAvailableError:
-                # Default groups may not exist yet during seeding, skip parent relationship
-                logging.warning(f"Default groups may not exist yet during seeding for admin scope {role_scope}")
-                pass
+        Set for_removal to True when computing relations to remove; this will ensure that parent relations for all
+        scopes are removed (regardless of the role's current scopes).
+        """
+        if for_removal:
+            binding_scopes = set(Scope)
+            admin_scopes = binding_scopes
+        else:
+            binding_scopes = set(self.implicit_resource_service.binding_scopes_for_role(role))
+            admin_scopes = set(admin_platform_parent_scopes_for_seeded_system_role(role.name, binding_scopes))
+
+        create_relations = []
+
+        if role.admin_default:
+            for scope in admin_scopes:
+                try:
+                    parent_uuid = platform_v2_role_uuid_for(
+                        DefaultAccessType.ADMIN,
+                        scope,
+                        GlobalPolicyIdService.shared(),
+                    )
+
+                    create_parent_child_relationship = role_child_relationship(parent_uuid, self.role.uuid)
+                    create_relations.append(create_parent_child_relationship)
+                except DefaultGroupNotAvailableError:
+                    # Default groups may not exist yet during seeding, skip parent relationship
+                    logging.warning(f"Default groups may not exist yet during seeding for admin scope {scope}")
+                    pass
 
         if role.platform_default:
-            try:
-                parent_uuid = platform_v2_role_uuid_for(
-                    DefaultAccessType.USER,
-                    role_scope,
-                    GlobalPolicyIdService.shared(),
-                )
+            for scope in binding_scopes:
+                try:
+                    parent_uuid = platform_v2_role_uuid_for(
+                        DefaultAccessType.USER,
+                        scope,
+                        GlobalPolicyIdService.shared(),
+                    )
 
-                create_parent_child_relationship = role_child_relationship(parent_uuid, self.role.uuid)
-                create_relations.append(create_parent_child_relationship)
-            except DefaultGroupNotAvailableError:
-                # Default groups may not exist yet during seeding, skip parent relationship
-                logging.warning(f"Default groups may not exist yet during seeding for platform scope {role_scope}")
-                pass
+                    create_parent_child_relationship = role_child_relationship(parent_uuid, self.role.uuid)
+                    create_relations.append(create_parent_child_relationship)
+                except DefaultGroupNotAvailableError:
+                    # Default groups may not exist yet during seeding, skip parent relationship
+                    logging.warning(f"Default groups may not exist yet during seeding for platform scope {scope}")
+                    pass
 
         return create_relations
 
-    def _generate_relations_for_role(self, list_all_possible_scopes_for_removal=False) -> list[RelationTuple]:
+    def _generate_relations_for_role(self, for_removal=False) -> list[RelationTuple]:
         """Generate system role permissions."""
         relations = []
         # Gather v1 and v2 permissions for the role
@@ -201,22 +213,8 @@ class SeedingRelationApiDualWriteHandler(BaseRelationApiDualWriteHandler):
             v2_perm = v1_perm_to_v2_perm(v1_perm)
             v2_permissions.append(v2_perm)
 
-            # When deleting, generate relationships for all possible scopes
-        if list_all_possible_scopes_for_removal is True:
-            for scope in Scope:
-                relations.extend(
-                    self._check_create_admin_platform_relation(
-                        self.role, scope, apply_seeded_admin_scope_override=False
-                    )
-                )
-        else:
-            binding_scopes = self.implicit_resource_service.binding_scopes_for_role(self.role)
-            for scope in binding_scopes:
-                relations.extend(
-                    self._check_create_admin_platform_relation(
-                        self.role, scope, apply_seeded_admin_scope_override=True
-                    )
-                )
+        # When deleting, generate relationships for all possible scopes
+        relations.extend(self._check_create_admin_platform_relation(self.role, for_removal=for_removal))
 
         for permission in v2_permissions:
             relations.append(

--- a/tests/internal/test_migrate_binding_scope_api.py
+++ b/tests/internal/test_migrate_binding_scope_api.py
@@ -16,47 +16,45 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """
 
 import uuid
-from api.cross_access.model import CrossAccountRequest
-from unittest.mock import patch, Mock
+from unittest.mock import Mock, patch
+
 from django.contrib.auth.models import User as DjangoUser
 from django.test import TestCase, override_settings
 from management.group.definer import add_roles, clone_default_group_in_public_schema, seed_group
 from management.group.model import Group
 from management.group.platform import GlobalPolicyIdService
 from management.group.relation_api_dual_write_group_handler import RelationApiDualWriteGroupHandler
-from management.models import BindingMapping, Workspace, Access, Permission
+from management.models import Access, BindingMapping, Permission, Workspace
 from management.permission.scope_service import ImplicitResourceService, Scope
 from management.policy.model import Policy
-from management.role.model import ResourceDefinition
 from management.relation_replicator.outbox_replicator import OutboxReplicator
 from management.relation_replicator.relation_replicator import ReplicationEventType
 from management.role.definer import seed_roles
-from management.role.model import Role
+from management.role.model import ResourceDefinition, Role
 from management.role.v2_model import CustomRoleV2, RoleV2, SeededRoleV2
 from management.role.v2_service import RoleV2Service
 from management.role_binding.model import RoleBinding
 from management.tenant_mapping.v2_activation import ensure_v2_write_activated
 from management.tenant_service.v2 import V2TenantBootstrapService
 from migration_tool.in_memory_tuples import (
-    InMemoryTuples,
     InMemoryRelationReplicator,
+    InMemoryTuples,
     all_of,
-    resource,
     relation,
+    resource,
     subject,
     subject_id,
     subject_type,
 )
 from migration_tool.migrate_binding_scope import (
+    car_source,
+    custom_role_source,
+    migrate_all_role_bindings,
     migrate_custom_role_bindings,
     migrate_system_role_bindings_for_group,
-    migrate_all_role_bindings,
-    car_source,
     system_role_source,
-    custom_role_source,
 )
 from migration_tool.utils import create_relationship
-from api.models import Tenant
 from tests.management.group.test_view import find_relation_in_list
 from tests.management.role.test_dual_write import DualWriteTestCase, RbacFixture
 from tests.util import (
@@ -64,7 +62,10 @@ from tests.util import (
     assert_v1_v2_tuples_fully_consistent,
     assert_v2_tuples_consistent,
 )
-from tests.v2_util import seed_v2_role_from_v1, bootstrap_tenant_for_v2_test
+from tests.v2_util import bootstrap_tenant_for_v2_test, seed_v2_role_from_v1
+
+from api.cross_access.model import CrossAccountRequest
+from api.models import Tenant
 
 
 @override_settings(ATOMIC_RETRY_DISABLED=True)
@@ -301,10 +302,12 @@ class BindingScopeMigrationTupleVerificationTest(TestCase):
 
         # Verify scope logic worked correctly (create fresh service with current settings)
         service = ImplicitResourceService.from_settings()
-        actual_scope = service.scope_for_role(role)
+        actual_scopes = service.binding_scopes_for_role(role)
 
         # Verify scope was correctly determined as ROOT
-        self.assertEqual(actual_scope, Scope.ROOT, f"Handler should determine ROOT scope for rbac:* permissions")
+        self.assertCountEqual(
+            actual_scopes, {Scope.ROOT}, f"Handler should determine ROOT scope for rbac:* permissions"
+        )
 
         # Verify binding is at root workspace
         self.assertEqual(final_binding.resource_type_name, "workspace")
@@ -1188,29 +1191,19 @@ class ComprehensiveBootstrapMigrationTest(DualWriteTestCase):
         - Verifies all bindings are migrated to correct scopes
         - Verifies tuples are correctly updated
         """
-
-        # Helper function to swap scopes for simulating historical incorrect bindings
-        def wrong_scope_for_role(role):
-            """Return wrong scope for test roles to simulate incorrect historical bindings."""
-            if hasattr(role, "uuid"):
-                if role.uuid == non_platform_default_role.uuid:
-                    return Scope.DEFAULT  # Wrong! Should be ROOT
-                elif role.uuid == platform_default_role.uuid:
-                    return Scope.ROOT  # Wrong! Should be DEFAULT
-            return service.scope_for_role(role)  # Use correct scope for other roles
-
         # Redirect all OutboxReplicator.replicate() calls to our InMemoryRelationReplicator
         mock_replicate.side_effect = InMemoryRelationReplicator(self.tuples).replicate
 
         # Step 1: Create system roles using fixture helpers
-        # Get a platform default system role with DEFAULT scope (not rbac:*:* which would be ROOT scope)
-        service = ImplicitResourceService.from_settings()
-        platform_default_role = None
-        for role in Role.objects.filter(system=True, platform_default=True):
-            if service.scope_for_role(role) == Scope.DEFAULT:
-                platform_default_role = role
-                break
+
+        # Get a platform default system role. This should have DEFAULT scope (since no approval permissions are
+        # assigned root/tenant scope).
+        platform_default_role = Role.objects.filter(name="Approval Approver", system=True).first()
+
         self.assertIsNotNone(platform_default_role, "Should have a platform default system role with DEFAULT scope")
+        self.assertTrue(platform_default_role.platform_default)
+        self.assertFalse(platform_default_role.admin_default)
+        self.assertTrue(all(a.permission.application == "approval" for a in platform_default_role.access.all()))
 
         # Create non-platform default system role with ROOT scope (rbac:*:* matches ROOT_SCOPE_PERMISSIONS)
         non_platform_default_role = self.given_v1_system_role(
@@ -1235,18 +1228,8 @@ class ComprehensiveBootstrapMigrationTest(DualWriteTestCase):
         self.switch_tenant(self.tenant3)
         custom_group_t3, _ = self.fixture.new_group(name="Custom Admins", tenant=self.tenant3)
 
-        # Step 5: Simulate incorrect binding state by using wrong scope configuration
-        # Use a mock resource service that returns wrong scopes to simulate historical incorrect bindings
-        mock_wrong_scope_service = Mock(spec=ImplicitResourceService)
-        mock_wrong_scope_service.scope_for_role = Mock(side_effect=wrong_scope_for_role)
-        mock_wrong_scope_service.binding_scopes_for_role = Mock(side_effect=lambda role: [wrong_scope_for_role(role)])
-
-        # Temporarily patch ImplicitResourceService.from_settings to return wrong scopes when creating bindings
-        with patch(
-            "management.group.relation_api_dual_write_group_handler.ImplicitResourceService.from_settings",
-            return_value=mock_wrong_scope_service,
-        ):
-            # Add roles with wrong scope configuration - this will create bindings at wrong scopes
+        # Assign the two roles in the incorrect scopes.
+        with self.settings(ROOT_SCOPE_PERMISSIONS="approval:*:*"):
             add_roles(custom_group_t3, [platform_default_role.uuid, non_platform_default_role.uuid], self.tenant3)
 
         # Verify non-platform role is at DEFAULT workspace (wrong)
@@ -1273,26 +1256,28 @@ class ComprehensiveBootstrapMigrationTest(DualWriteTestCase):
         service = ImplicitResourceService.from_settings()
 
         for binding in BindingMapping.objects.all():
-            expected_scope = service.scope_for_role(binding.role)
+            expected_scopes = set(service.binding_scopes_for_role(binding.role))
             binding_id = binding.mappings["id"]
 
             if binding.resource_type_name == "workspace":
                 workspace = Workspace.objects.get(id=binding.resource_id)
 
-                if expected_scope == Scope.ROOT:
+                if expected_scopes == {Scope.ROOT}:
                     self.assertEqual(
                         workspace.type,
                         Workspace.Types.ROOT,
                         f"Binding {binding.id} for role '{binding.role.name}' (ROOT scope) "
                         f"should be at root workspace, got {workspace.type}",
                     )
-                elif expected_scope == Scope.DEFAULT:
+                elif expected_scopes == {Scope.DEFAULT}:
                     self.assertEqual(
                         workspace.type,
                         Workspace.Types.DEFAULT,
                         f"Binding {binding.id} for role '{binding.role.name}' (DEFAULT scope) "
                         f"should be at default workspace, got {workspace.type}",
                     )
+                else:
+                    self.fail(f"Unexpected binding scopes: {expected_scopes}")
 
                 # Verify complete workspace->binding tuple exists
                 complete_ws_binding_tuples = self.tuples.find_tuples(

--- a/tests/management/permission/test_scope_service.py
+++ b/tests/management/permission/test_scope_service.py
@@ -18,10 +18,10 @@
 Tests for permission scope functionality.
 """
 
-from django.test import TestCase, override_settings
+from collections.abc import Iterable
 from typing import Tuple
 
-from api.models import Tenant
+from django.test import TestCase, override_settings
 from management.models import Permission, Role
 from management.permission.scope_service import (
     ImplicitResourceService,
@@ -29,6 +29,8 @@ from management.permission.scope_service import (
     Scope,
     scopes_for_resource_type,
 )
+
+from api.models import Tenant
 from .test_model import INVALID_PERMISSIONS_V1
 
 DEFAULT_APPS = [
@@ -674,8 +676,8 @@ class RoleTests(TestCase):
             permission="tenant:resource:verb",
         )
 
-    def _assert_role_scope(self, scope: Scope):
-        self.assertEqual(scope, self.service.scope_for_role(self.role))
+    def _assert_role_scopes(self, scopes: Iterable[Scope]):
+        self.assertCountEqual(scopes, self.service.binding_scopes_for_role(self.role))
 
     def _create_access(self, permission: Permission, attribute_filter: dict = None):
         access = self.role.access.create(tenant=self.public_tenant, permission=permission)
@@ -685,25 +687,31 @@ class RoleTests(TestCase):
 
     def test_empty(self):
         """Test that the correct scope is returned for a role with no permissions."""
-        self._assert_role_scope(Scope.DEFAULT)
+        self._assert_role_scopes({Scope.DEFAULT})
 
     def test_default_scope(self):
-        """Test that the correct scope is returned for a role with a default-scope permissions."""
+        """Test that the correct scope is returned for a role with only a default-scope permissions."""
         self._create_access(self.default_permission)
-        self._assert_role_scope(Scope.DEFAULT)
+        self._assert_role_scopes({Scope.DEFAULT})
 
     def test_root_scope(self):
-        """Test that the correct scope is returned for a role with a root-scope permission."""
+        """Test that the correct scope is returned for a role with root- and default-scope permissions."""
         self._create_access(self.default_permission)
         self._create_access(self.root_permission)
-        self._assert_role_scope(Scope.ROOT)
+        self._assert_role_scopes({Scope.ROOT})
 
-    def test_tenant_scope(self):
-        """Test that the correct scope is returned for a role with a tenant-scope permission."""
+    def test_tenant_default_scope(self):
+        """Test that the correct scopes are returned for a role with tenant-scope and default-scope permissions."""
+        self._create_access(self.default_permission)
+        self._create_access(self.tenant_permission)
+        self._assert_role_scopes({Scope.TENANT, Scope.DEFAULT})
+
+    def test_tenant_root_scope(self):
+        """Test that the correct scopes are returned for a role with tenant-scope and root-scope permissions."""
         self._create_access(self.default_permission)
         self._create_access(self.root_permission)
         self._create_access(self.tenant_permission)
-        self._assert_role_scope(Scope.TENANT)
+        self._assert_role_scopes({Scope.TENANT, Scope.ROOT})
 
     def test_resource_definition(self):
         """Test that resource definitions do not affect the scope of a role."""
@@ -711,7 +719,7 @@ class RoleTests(TestCase):
             self.root_permission, attribute_filter={"key": "service", "operation": "equal", "value": "something"}
         )
 
-        self._assert_role_scope(Scope.ROOT)
+        self._assert_role_scopes({Scope.ROOT})
 
 
 class ExplicitlyScopedTest(TestCase):

--- a/tests/management/role/test_definer.py
+++ b/tests/management/role/test_definer.py
@@ -38,7 +38,7 @@ from management.relation_replicator.relation_replicator import ReplicationEvent,
 from management.role.definer import _seed_platform_roles, seed_permissions, seed_roles
 from management.role.platform import (
     ADMIN_DEFAULT_SEEDED_ROLES_FORCE_ROOT_SCOPE,
-    admin_platform_parent_scope_for_seeded_system_role,
+    admin_platform_parent_scopes_for_seeded_system_role,
     platform_v2_role_uuid_for,
 )
 from management.role.relation_api_dual_write_handler import (
@@ -867,30 +867,17 @@ class RoleDefinerTests(IdentityRequest):
         """Test that all roles in ADMIN_DEFAULT_SEEDED_ROLES_FORCE_ROOT_SCOPE are overridden to ROOT."""
         for role_name in ADMIN_DEFAULT_SEEDED_ROLES_FORCE_ROOT_SCOPE:
             for derived_scope in Scope:
-                result = admin_platform_parent_scope_for_seeded_system_role(
-                    role_name, derived_scope, apply_override=True
-                )
+                result = admin_platform_parent_scopes_for_seeded_system_role(role_name, {derived_scope})
                 self.assertEqual(
                     result,
-                    Scope.ROOT,
+                    {Scope.ROOT},
                     f"{role_name!r} with derived scope {derived_scope.name} should be forced to ROOT",
                 )
 
-    def test_admin_default_force_root_does_not_apply_without_override(self):
-        """Test that the ROOT override is skipped when apply_override=False."""
-        for role_name in ADMIN_DEFAULT_SEEDED_ROLES_FORCE_ROOT_SCOPE:
-            for derived_scope in Scope:
-                result = admin_platform_parent_scope_for_seeded_system_role(
-                    role_name, derived_scope, apply_override=False
-                )
-                self.assertEqual(result, derived_scope)
-
     def test_admin_default_force_root_does_not_apply_to_other_roles(self):
         """Test that ordinary admin_default roles are NOT forced to ROOT."""
-        result = admin_platform_parent_scope_for_seeded_system_role(
-            "Some Other Role", Scope.DEFAULT, apply_override=True
-        )
-        self.assertEqual(result, Scope.DEFAULT)
+        result = admin_platform_parent_scopes_for_seeded_system_role("Some Other Role", {Scope.DEFAULT})
+        self.assertEqual(result, {Scope.DEFAULT})
 
 
 @override_settings(ATOMIC_RETRY_DISABLED=True)

--- a/tests/management/role/test_dual_write.py
+++ b/tests/management/role/test_dual_write.py
@@ -2914,12 +2914,18 @@ class DualWriteCrossAccountReqeustTestCase(DualWriteTestCase):
 
         with self.settings(ROOT_SCOPE_PERMISSIONS="", TENANT_SCOPE_PERMISSIONS="app:resource:verb"):
             car = self.given_car(self.user_id, [system_role])
+
             self._expect_user_tenant_count(1, system_role)
+            self._expect_user_root_count(0, system_role)
+            self._expect_user_default_count(0, system_role)
 
         # Expiring the CAR should remove the role binding even if the role's scope has changed in the interim.
         with self.settings(ROOT_SCOPE_PERMISSIONS="", TENANT_SCOPE_PERMISSIONS=""):
             self.given_car_expired(car)
+
+            self._expect_user_tenant_count(0, system_role)
             self._expect_user_root_count(0, system_role)
+            self._expect_user_default_count(0, system_role)
 
     def test_scope_removal(self):
         self._do_test_scope_removal()

--- a/tests/management/role/test_dual_write.py
+++ b/tests/management/role/test_dual_write.py
@@ -17,13 +17,13 @@
 """Test tuple changes for RBAC operations."""
 
 from datetime import timedelta
+from typing import Callable, Iterable, Optional, Tuple
+from unittest.mock import patch
 
-from django.utils import timezone
-from typing import Callable, Optional, Tuple, Iterable
-from django.test import TestCase, override_settings
-from django.db.models import Q
 from django.conf import settings
-
+from django.db.models import Q
+from django.test import TestCase, override_settings
+from django.utils import timezone
 from management.group.definer import seed_group, set_system_flag_before_update
 from management.group.model import Group
 from management.group.platform import GlobalPolicyIdService
@@ -56,11 +56,10 @@ from management.role.relation_api_dual_write_handler import (
 from management.role.v2_model import CustomRoleV2, RoleV2, SeededRoleV2
 from management.role_binding.model import RoleBinding, RoleBindingPrincipal
 from management.role_binding.service import RoleBindingService
-from management.tenant_mapping.model import TenantMapping, DefaultAccessType
+from management.tenant_mapping.model import DefaultAccessType, TenantMapping
 from management.tenant_mapping.v2_activation import ensure_v2_write_activated
-from management.tenant_service.tenant_service import BootstrappedTenant
+from management.tenant_service.tenant_service import BootstrappedTenant, TenantBootstrapService
 from management.tenant_service.v2 import V2TenantBootstrapService
-from management.tenant_service.tenant_service import TenantBootstrapService
 from migration_tool.in_memory_tuples import (
     InMemoryRelationReplicator,
     InMemoryTuples,
@@ -73,7 +72,10 @@ from migration_tool.in_memory_tuples import (
     subject,
     subject_type,
 )
+from migration_tool.models import V2boundresource
 from migration_tool.utils import create_relationship
+from tests.util import assert_v1_v2_locally_consistent, assert_v1_v2_tuples_fully_consistent
+from tests.v2_util import bootstrap_tenant_for_v2_test, seed_v2_role_from_v1
 
 from api.cross_access.model import CrossAccountRequest
 from api.cross_access.relation_api_dual_write_cross_access_handler import (
@@ -81,11 +83,6 @@ from api.cross_access.relation_api_dual_write_cross_access_handler import (
 )
 from api.cross_access.util import create_cross_principal
 from api.models import Tenant, User
-from unittest.mock import patch
-
-from migration_tool.models import V2boundresource
-from tests.util import assert_v1_v2_locally_consistent, assert_v1_v2_tuples_fully_consistent
-from tests.v2_util import seed_v2_role_from_v1, bootstrap_tenant_for_v2_test
 
 
 @override_settings(REPLICATION_TO_RELATION_ENABLED=True)
@@ -2908,6 +2905,21 @@ class DualWriteCrossAccountReqeustTestCase(DualWriteTestCase):
     def test_v2_scope_assignment(self):
         ensure_v2_write_activated(self.tenant)
         self._do_test_scope_assignment()
+
+    @override_settings(ROOT_SCOPE_PERMISSIONS="inventory:*:*", TENANT_SCOPE_PERMISSIONS="rbac:*:*")
+    def _do_test_binding_multiple_scopes(self):
+        system_role = self.given_v1_system_role("test", permissions=["rbac:resource:verb", "inventory:resource:verb"])
+        car = self.given_car(self.user_id, [system_role])
+
+        self._expect_user_root_count(1, system_role)
+        self._expect_user_tenant_count(1, system_role)
+
+    def test_binding_multiple_scopes(self):
+        self._do_test_binding_multiple_scopes()
+
+    def test_v2_binding_multiple_scopes(self):
+        ensure_v2_write_activated(self.tenant)
+        self._do_test_binding_multiple_scopes()
 
     def _do_test_scope_removal(self):
         system_role = self.given_v1_system_role("test", permissions=["app:resource:verb"])


### PR DESCRIPTION
## Link(s) to Jira
[RHCLOUD-48590](https://redhat.atlassian.net/browse/RHCLOUD-48590)

## Description of Intent of Change(s)
We currently still do the old behavior of binding only to a role's highest scope for CARs; update this to consider all scopes.

This also cleans up the notion of a scope elsewhere in the codebase (in admin-default role handling) and removes the now-meaningless `scope_for_role`. This should help prevent any similar issues recurring in the future.

This PR might be best reviewed commit-by-commit.

[RHCLOUD-48590]: https://redhat.atlassian.net/browse/RHCLOUD-48590?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ