### PR TITLE
[RHCLOUD-48827] fix(dr): add early Kafka prerequisite checks in DR reconcile task

### DIFF
--- a/deploy/rbac-clowdapp.yml
+++ b/deploy/rbac-clowdapp.yml
@@ -213,6 +213,10 @@ objects:
             value: ${DR_RELATIONS_RECONCILE_ENABLED}
           - name: DR_WORKSPACE_RECONCILE_ENABLED
             value: ${DR_WORKSPACE_RECONCILE_ENABLED}
+          - name: RBAC_KAFKA_CONSUMER_TOPIC
+            value: ${RBAC_KAFKA_CONSUMER_TOPIC}
+          - name: DR_KAFKA_CONSUMER_GROUP_ID
+            value: ${DR_KAFKA_CONSUMER_GROUP_ID}
           - name: CELERY_WORKER_CONCURRENCY
             value: ${CELERY_WORKER_CONCURRENCY}
           - name: NOTIFICATIONS_TOPIC
@@ -1726,6 +1730,9 @@ parameters:
 - description: Enable disaster recovery workspace recovery endpoint and Celery task
   name: DR_WORKSPACE_RECONCILE_ENABLED
   value: 'False'
+- description: Kafka consumer group ID for DR reconciliation reader
+  name: DR_KAFKA_CONSUMER_GROUP_ID
+  value: 'rbac-dr-consumer-group'
 - name: EXTERNAL_SYNC_TOPIC
   value: 'platform.rbac.sync'
 - name: EXTERNAL_CHROME_TOPIC

--- a/rbac/management/tasks.py
+++ b/rbac/management/tasks.py
@@ -666,6 +666,12 @@ def run_disaster_recovery_reconcile(
     if not getattr(settings, "DR_RELATIONS_RECONCILE_ENABLED", False):
         return {"message": "Disaster recovery reconciliation is disabled"}
 
+    if not getattr(settings, "KAFKA_ENABLED", False):
+        return {"message": "Disaster recovery reconciliation requires Kafka (KAFKA_ENABLED=False)"}
+
+    if not getattr(settings, "RBAC_KAFKA_CONSUMER_TOPIC", None):
+        return {"message": "Disaster recovery reconciliation requires RBAC_KAFKA_CONSUMER_TOPIC to be configured"}
+
     try:
         from management.disaster_recovery.service import reconcile
 

--- a/tests/internal/test_dr_views.py
+++ b/tests/internal/test_dr_views.py
@@ -172,5 +172,11 @@ class DisasterRecoveryTaskFeatureFlagTest(TestCase):
         from management.tasks import run_disaster_recovery_reconcile
 
         result = run_disaster_recovery_reconcile(restore_timestamp_ms=1000000, buffer_seconds=300)
-        self.assertEqual(result["status"], "failed")
-        self.assertIn("error", result)
+        self.assertIn("KAFKA_ENABLED", result["message"])
+
+    @override_settings(DR_RELATIONS_RECONCILE_ENABLED=True, KAFKA_ENABLED=True, RBAC_KAFKA_CONSUMER_TOPIC=None)
+    def test_task_enabled_but_topic_not_configured(self):
+        from management.tasks import run_disaster_recovery_reconcile
+
+        result = run_disaster_recovery_reconcile(restore_timestamp_ms=1000000, buffer_seconds=300)
+        self.assertIn("RBAC_KAFKA_CONSUMER_TOPIC", result["message"])


### PR DESCRIPTION
## Summary
- Add early guard checks for `KAFKA_ENABLED` and `RBAC_KAFKA_CONSUMER_TOPIC` in `run_disaster_recovery_reconcile` Celery task
- Returns clean message dict instead of raising `DisasterRecoveryError` exception when Kafka prerequisites are missing
- Eliminates noisy stack traces in worker logs for what is a configuration issue, not a runtime error

## Test plan
- [x] Existing test `test_task_enabled_but_kafka_disabled` updated to match new early-return behavior
- [x] New test `test_task_enabled_but_topic_not_configured` added for missing topic guard
- [x] All 12 DR view tests passing (`tox -r -e py312-fast -- tests.internal.test_dr_views`)