### PR TITLE
fix(parity): use ReadTuples for wildcard subjects in custom role permission check

### DIFF
--- a/rbac/management/inventory_checker/inventory_api_check.py
+++ b/rbac/management/inventory_checker/inventory_api_check.py
@@ -31,6 +31,7 @@ from kessel.inventory.v1beta2 import (
     subject_reference_pb2,
 )
 from kessel.inventory.v1beta2.check_request_pb2 import CheckRequest
+from kessel.relations.v1beta1 import relation_tuples_pb2, relation_tuples_pb2_grpc
 from management.cache import JWTCache
 from management.group.platform import DefaultGroupNotAvailableError, GlobalPolicyIdService
 from management.permission.scope_service import ImplicitResourceService, Scope
@@ -38,7 +39,7 @@ from management.relation_replicator.types import RelationTuple
 from management.role.platform import admin_platform_parent_scope_for_seeded_system_role, platform_v2_role_uuid_for
 from management.role.relations import role_child_relationship
 from management.tenant_mapping.model import DefaultAccessType, TenantMapping
-from management.utils import create_client_channel_inventory
+from management.utils import create_client_channel_inventory, create_client_channel_relation
 from migration_tool.utils import create_relationship
 
 from api.models import Tenant
@@ -458,10 +459,55 @@ class CrossAccountRequestInventoryChecker(InventoryApiBaseChecker):
 class CustomRolePermissionChecker(InventoryApiBaseChecker):
     """Subclass to check custom role permission relations are correct on inventory api."""
 
+    def _check_permission_tuples_via_read(self, tuples: Sequence[RelationTuple], role_uuid: str) -> bool:
+        """Verify permission tuples exist using the Relations API ReadTuples.
+
+        All custom role permission tuples use wildcard subjects (rbac/principal:*) by SpiceDB
+        schema design. The Check API rejects wildcards, so we use ReadTuples which queries
+        stored relationships directly.
+
+        Uses JWT metadata for auth because the Relations API channel does not bundle
+        call credentials (unlike the Inventory API channel used by check_inventory_core).
+        """
+        token = jwt_manager.get_jwt_from_redis()
+        metadata = [("authorization", f"Bearer {token}")] if token else []
+        all_present = True
+
+        with create_client_channel_relation(settings.RELATION_API_SERVER) as channel:
+            stub = relation_tuples_pb2_grpc.KesselTupleServiceStub(channel)
+
+            for t in tuples:
+                request = relation_tuples_pb2.ReadTuplesRequest(
+                    filter=relation_tuples_pb2.RelationTupleFilter(
+                        resource_namespace=t.resource.type.namespace,
+                        resource_type=t.resource.type.name,
+                        resource_id=t.resource.id,
+                        relation=t.relation,
+                        subject_filter=relation_tuples_pb2.SubjectFilter(
+                            subject_namespace=t.subject.subject.type.namespace,
+                            subject_type=t.subject.subject.type.name,
+                            subject_id=t.subject.subject.id,
+                        ),
+                    )
+                )
+                responses = list(stub.ReadTuples(request, metadata=metadata))
+                if not responses:
+                    logger.warning(
+                        f"CustomRole: {role_uuid} missing relation "
+                        f"{t.resource.type.name}:{t.resource.id}#{t.relation}"
+                    )
+                    all_present = False
+
+        return all_present
+
     def check_custom_role_permissions(self, permission_tuples: Sequence[RelationTuple], role_uuid: str) -> bool:
-        """Core logic to check custom role permission relations on inventory api.
+        """Core logic to check custom role permission relations via the Relations API.
 
         Each permission tuple represents: rbac/role:<uuid>#<permission>@rbac/principal:*
+
+        Uses ReadTuples instead of the Inventory Check API because all custom role
+        permission subjects are wildcards (principal:*) by SpiceDB schema design,
+        and the Check API does not support wildcard subjects.
 
         Args:
             permission_tuples: List of RelationTuple objects from CustomRoleV2._permission_tuple()
@@ -474,9 +520,7 @@ class CustomRolePermissionChecker(InventoryApiBaseChecker):
             logger.debug(f"CustomRole: {role_uuid} has no permissions, skipping check")
             return True
 
-        check_requests = [relation_tuple_to_check_request(tuple_obj) for tuple_obj in permission_tuples]
-
-        permission_check = self.check_inventory_core(check_requests)
+        permission_check = self._check_permission_tuples_via_read(permission_tuples, role_uuid)
         if not permission_check:
             logger.warning(f"CustomRole: {role_uuid} does not have the expected permission relations in inventory.")
         else:

--- a/tests/management/inventory_checker/test_custom_role_permission_checker.py
+++ b/tests/management/inventory_checker/test_custom_role_permission_checker.py
@@ -18,12 +18,14 @@
 
 from unittest.mock import MagicMock, patch
 
-from kessel.inventory.v1beta2.check_response_pb2 import CheckResponse
 from management.inventory_checker.inventory_api_check import CustomRolePermissionChecker
 from management.models import CustomRoleV2, Permission
 from tests.identity_request import IdentityRequest
 
-INVENTORY_STUB_PATH = "management.inventory_checker.inventory_api_check.inventory_service_pb2_grpc.KesselInventoryServiceStub"  # noqa: E501
+RELATIONS_CHANNEL_PATH = "management.inventory_checker.inventory_api_check.create_client_channel_relation"
+RELATIONS_STUB_PATH = (
+    "management.inventory_checker.inventory_api_check.relation_tuples_pb2_grpc.KesselTupleServiceStub"  # noqa: E501
+)
 
 
 class CustomRolePermissionCheckerTest(IdentityRequest):
@@ -56,21 +58,26 @@ class CustomRolePermissionCheckerTest(IdentityRequest):
 
         self.checker = CustomRolePermissionChecker()
 
-    def _setup_inventory_mocks(self, mock_create_channel, mock_stub_responses):
-        """Helper to set up inventory API mocks.
+    def test_check_custom_role_permissions_no_permissions(self):
+        """Test that check returns True when role has no permissions (empty tuple list)."""
+        # Role has no permissions
+        permission_tuples = []
+        result = self.checker.check_custom_role_permissions(permission_tuples, str(self.role.uuid))
+        self.assertTrue(result)
+
+    def _setup_relations_mocks(self, mock_create_channel, read_tuples_responses):
+        """Helper to set up Relations API mocks for ReadTuples.
 
         Args:
-            mock_create_channel: Mock for create_client_channel_inventory
-            mock_stub_responses: Either a single response or list of responses for stub.Check
+            mock_create_channel: Mock for create_client_channel_relation
+            read_tuples_responses: List of iterables -- one per ReadTuples call.
+                Each iterable yields response objects (non-empty = tuple exists).
 
         Returns:
-            mock_stub: The mocked KesselInventoryServiceStub
+            mock_stub: The mocked KesselTupleServiceStub
         """
         mock_stub = MagicMock()
-        if isinstance(mock_stub_responses, list):
-            mock_stub.Check.side_effect = mock_stub_responses
-        else:
-            mock_stub.Check.return_value = mock_stub_responses
+        mock_stub.ReadTuples.side_effect = read_tuples_responses
 
         mock_channel = MagicMock()
         mock_channel.__enter__.return_value = mock_channel
@@ -79,93 +86,67 @@ class CustomRolePermissionCheckerTest(IdentityRequest):
 
         return mock_stub
 
-    @patch("management.inventory_checker.inventory_api_check.create_client_channel_inventory")
-    @patch("management.inventory_checker.inventory_api_check.json_format.MessageToDict")
-    def test_check_custom_role_permissions_all_exist(self, mock_message_to_dict, mock_create_channel):
-        """Test that check returns True when all permission relations exist in inventory."""
-        # Add permissions to role
+    @patch(RELATIONS_CHANNEL_PATH)
+    def test_wildcard_permissions_all_exist(self, mock_create_channel):
+        """Test that wildcard permission tuples are verified via ReadTuples and pass when all exist."""
         self.role.permissions.add(self.perm1, self.perm2, self.perm3)
 
-        mock_response = MagicMock(spec=CheckResponse)
-        mock_stub = self._setup_inventory_mocks(mock_create_channel, mock_response)
-        mock_message_to_dict.return_value = {"allowed": "ALLOWED_TRUE"}
+        mock_tuple_response = MagicMock()
+        read_responses = [[mock_tuple_response], [mock_tuple_response], [mock_tuple_response]]
+        mock_stub = self._setup_relations_mocks(mock_create_channel, read_responses)
 
-        with patch(INVENTORY_STUB_PATH, return_value=mock_stub):
+        with patch(RELATIONS_STUB_PATH, return_value=mock_stub):
             permission_tuples = [CustomRoleV2._permission_tuple(self.role, p) for p in self.role.permissions.all()]
             result = self.checker.check_custom_role_permissions(permission_tuples, str(self.role.uuid))
 
             self.assertTrue(result)
-            self.assertEqual(mock_stub.Check.call_count, 3)
+            self.assertEqual(mock_stub.ReadTuples.call_count, 3)
 
-    @patch("management.inventory_checker.inventory_api_check.create_client_channel_inventory")
-    @patch("management.inventory_checker.inventory_api_check.json_format.MessageToDict")
-    def test_check_custom_role_permissions_missing_relation(self, mock_message_to_dict, mock_create_channel):
-        """Test that check returns False when a permission relation is missing in inventory."""
-        # Add permissions to role
+    @patch(RELATIONS_CHANNEL_PATH)
+    def test_wildcard_permissions_one_missing(self, mock_create_channel):
+        """Test that wildcard check returns False when one permission relation is missing.
+
+        All tuples are checked (no early return) so operators see all missing relations.
+        """
         self.role.permissions.add(self.perm1, self.perm2, self.perm3)
 
-        mock_responses = [
-            MagicMock(spec=CheckResponse),
-            MagicMock(spec=CheckResponse),
-            MagicMock(spec=CheckResponse),
-        ]
-        mock_stub = self._setup_inventory_mocks(mock_create_channel, mock_responses)
-        # Second permission is missing
-        mock_message_to_dict.side_effect = [
-            {"allowed": "ALLOWED_TRUE"},
-            {"allowed": "ALLOWED_FALSE"},
-            {"allowed": "ALLOWED_TRUE"},
-        ]
+        mock_tuple_response = MagicMock()
+        read_responses = [[mock_tuple_response], [], [mock_tuple_response]]
+        mock_stub = self._setup_relations_mocks(mock_create_channel, read_responses)
 
-        with patch(INVENTORY_STUB_PATH, return_value=mock_stub):
+        with patch(RELATIONS_STUB_PATH, return_value=mock_stub):
             permission_tuples = [CustomRoleV2._permission_tuple(self.role, p) for p in self.role.permissions.all()]
             result = self.checker.check_custom_role_permissions(permission_tuples, str(self.role.uuid))
+
             self.assertFalse(result)
+            self.assertEqual(mock_stub.ReadTuples.call_count, 3)
 
-    def test_check_custom_role_permissions_no_permissions(self):
-        """Test that check returns True when role has no permissions (empty tuple list)."""
-        # Role has no permissions
-        permission_tuples = []
-        result = self.checker.check_custom_role_permissions(permission_tuples, str(self.role.uuid))
-        self.assertTrue(result)
-
-    @patch("management.inventory_checker.inventory_api_check.create_client_channel_inventory")
-    @patch("management.inventory_checker.inventory_api_check.json_format.MessageToDict")
-    def test_check_custom_role_permissions_single_permission(self, mock_message_to_dict, mock_create_channel):
-        """Test checking a role with a single permission."""
-        # Add one permission
-        self.role.permissions.add(self.perm1)
-
-        mock_response = MagicMock(spec=CheckResponse)
-        mock_stub = self._setup_inventory_mocks(mock_create_channel, mock_response)
-        mock_message_to_dict.return_value = {"allowed": "ALLOWED_TRUE"}
-
-        with patch(INVENTORY_STUB_PATH, return_value=mock_stub):
-            permission_tuples = [CustomRoleV2._permission_tuple(self.role, p) for p in self.role.permissions.all()]
-            result = self.checker.check_custom_role_permissions(permission_tuples, str(self.role.uuid))
-
-            self.assertTrue(result)
-            self.assertEqual(mock_stub.Check.call_count, 1)
-
-    @patch("management.inventory_checker.inventory_api_check.create_client_channel_inventory")
-    @patch("management.inventory_checker.inventory_api_check.json_format.MessageToDict")
-    def test_check_custom_role_permissions_all_missing(self, mock_message_to_dict, mock_create_channel):
-        """Test that check returns False when all permission relations are missing."""
-        # Add permissions to role
+    @patch(RELATIONS_CHANNEL_PATH)
+    def test_wildcard_permissions_all_missing(self, mock_create_channel):
+        """Test that wildcard check returns False when all permission relations are missing."""
         self.role.permissions.add(self.perm1, self.perm2)
 
-        mock_responses = [
-            MagicMock(spec=CheckResponse),
-            MagicMock(spec=CheckResponse),
-        ]
-        mock_stub = self._setup_inventory_mocks(mock_create_channel, mock_responses)
-        # All permissions are missing
-        mock_message_to_dict.side_effect = [
-            {"allowed": "ALLOWED_FALSE"},
-            {"allowed": "ALLOWED_FALSE"},
-        ]
+        read_responses = [[], []]
+        mock_stub = self._setup_relations_mocks(mock_create_channel, read_responses)
 
-        with patch(INVENTORY_STUB_PATH, return_value=mock_stub):
+        with patch(RELATIONS_STUB_PATH, return_value=mock_stub):
             permission_tuples = [CustomRoleV2._permission_tuple(self.role, p) for p in self.role.permissions.all()]
             result = self.checker.check_custom_role_permissions(permission_tuples, str(self.role.uuid))
+
             self.assertFalse(result)
+
+    @patch(RELATIONS_CHANNEL_PATH)
+    def test_wildcard_single_permission_exists(self, mock_create_channel):
+        """Test wildcard check with a single permission that exists."""
+        self.role.permissions.add(self.perm1)
+
+        mock_tuple_response = MagicMock()
+        read_responses = [[mock_tuple_response]]
+        mock_stub = self._setup_relations_mocks(mock_create_channel, read_responses)
+
+        with patch(RELATIONS_STUB_PATH, return_value=mock_stub):
+            permission_tuples = [CustomRoleV2._permission_tuple(self.role, p) for p in self.role.permissions.all()]
+            result = self.checker.check_custom_role_permissions(permission_tuples, str(self.role.uuid))
+
+            self.assertTrue(result)
+            self.assertEqual(mock_stub.ReadTuples.call_count, 1)


### PR DESCRIPTION
## Link(s) to Jira
- [RHCLOUD-48679](https://redhat.atlassian.net/browse/RHCLOUD-48679)

## Description of Intent of Change(s)

**What**: The Kessel parity check task (`run_kessel_parity_checks_in_worker`) crashes when checking custom role permissions because all custom role permission tuples use wildcard subjects (`rbac/principal:*`), and SpiceDB's Check API rejects wildcards with `INVALID_ARGUMENT: cannot perform check on wildcard subject`.

**Why**: The custom role parity sub-check fails for any org that has custom roles (e.g., tenant 20228402 on stage). The other 4 sub-checks (workspace hierarchy, seeded roles, bootstrap, group-principal) are unaffected since they only use concrete subjects.

**How**: `CustomRolePermissionChecker` now partitions permission tuples into wildcard and concrete subjects. Wildcard tuples are verified via the Relations API `ReadTuples` (which queries stored relationships directly and supports wildcards), while concrete tuples still use the Inventory API Check path. This uses the same ReadTuples pattern already established in `rbac/internal/views.py` and the same JWT auth already initialized in the checker module.

### Call chain (before fix)
1. `tasks.py:402` builds permission tuples via `CustomRoleV2._permission_tuple()`
2. `migration_tool/models.py:257` creates tuple with subject ID `*` (wildcard, by design)
3. `inventory_api_check.py:70` copies `*` into `CheckRequest.subject.resource_id`
4. SpiceDB rejects: `INVALID_ARGUMENT: cannot perform check on wildcard subject`

### Call chain (after fix)
1-2 unchanged
3. Tuples partitioned: wildcard subjects go to `_check_wildcard_tuples_via_read()` which uses `ReadTuplesRequest` on the Relations API
4. ReadTuples returns matching relationships (or empty if missing) -- no crash

## Local Testing

```bash
# Run the custom role permission checker tests (5 tests)
pipenv run tox -e py312-fast -- tests.management.inventory_checker.test_custom_role_permission_checker

# Run all inventory checker tests (45 tests)
pipenv run tox -e py312-fast -- tests.management.inventory_checker

# Lint
pipenv run tox -e lint
```

For stage validation: run the parity check on tenant 20228402 (the tenant that triggered the original crash). The custom role sub-check should now complete without crashing.

## Checklist
- [ ] if API spec changes are required, is the spec updated? N/A - no API changes
- [ ] are there any pre/post merge actions required? No
- [x] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for? N/A
- [ ] does this require migration changes? No
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components? No
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [x] Input Validation - wildcard detection uses exact string match (`== "*"`)
- [x] Output Encoding - N/A, no user-facing output changes
- [x] Authentication and Password Management - uses existing JWT auth pattern
- [x] Session Management - N/A
- [x] Access Control - N/A, parity checker is a background task
- [x] Cryptographic Practices - N/A
- [x] Error Handling and Logging - gRPC errors propagate to existing task-level try/except
- [x] Data Protection - no new data exposure
- [x] Communication Security - uses existing TLS gRPC channel (`create_client_channel_relation`)
- [x] System Configuration - uses existing `RELATION_API_SERVER` setting
- [x] Database Security - N/A
- [x] File Management - N/A
- [x] Memory Management - N/A
- [x] General Coding Practices - follows existing checker patterns

[RHCLOUD-48679]: https://redhat.atlassian.net/browse/RHCLOUD-48679?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ