### PR TITLE
fix(dr): skip bootstrap_tenant events in DR reconciliation

### DIFF
--- a/rbac/management/disaster_recovery/service.py
+++ b/rbac/management/disaster_recovery/service.py
@@ -7,11 +7,14 @@ from management.disaster_recovery.corrective_writer import (
     generate_corrective_actions,
     write_corrective_events,
 )
-from management.disaster_recovery.kafka_reader import read_events_in_window
+from management.disaster_recovery.kafka_reader import ParsedReplicationEvent, read_events_in_window
 from management.disaster_recovery.resource_checker import check_resources_exist
 from management.relation_replicator.outbox_replicator import OutboxReplicator
+from management.relation_replicator.relation_replicator import ReplicationEventType
 
 logger = logging.getLogger(__name__)
+
+_BOOTSTRAP_EVENT_TYPES = frozenset({ReplicationEventType.BOOTSTRAP_TENANT, ReplicationEventType.BULK_BOOTSTRAP_TENANT})
 
 
 def reconcile(
@@ -46,9 +49,9 @@ def reconcile(
         buffer_seconds,
     )
 
-    events = read_events_in_window(start_timestamp_ms, end_timestamp_ms)
+    all_events = read_events_in_window(start_timestamp_ms, end_timestamp_ms)
 
-    if not events:
+    if not all_events:
         logger.info("No events found in the time window, nothing to reconcile")
         return {
             "status": "completed",
@@ -58,16 +61,40 @@ def reconcile(
             "corrective_adds": 0,
             "corrective_removes": 0,
             "skipped": 0,
+            "skipped_bootstrap_events": 0,
             "errors": 0,
             "duration_seconds": round(time.monotonic() - start, 3),
         }
+
+    events, skipped_bootstrap = _partition_bootstrap_events(all_events)
 
     all_tuples = []
     for event in events:
         all_tuples.extend(event.relations_to_add)
         all_tuples.extend(event.relations_to_remove)
 
-    logger.info("Read %d events with %d total tuples", len(events), len(all_tuples))
+    logger.info(
+        "Read %d events with %d total tuples (%d bootstrap events skipped)",
+        len(events),
+        len(all_tuples),
+        skipped_bootstrap,
+    )
+
+    if not events:
+        elapsed = round(time.monotonic() - start, 3)
+        logger.info("All %d events in the window were bootstrap events, nothing to reconcile", skipped_bootstrap)
+        return {
+            "status": "completed",
+            "time_window": {"start_ms": start_timestamp_ms, "end_ms": end_timestamp_ms},
+            "events_read": len(all_events),
+            "tuples_processed": 0,
+            "corrective_adds": 0,
+            "corrective_removes": 0,
+            "skipped": 0,
+            "skipped_bootstrap_events": skipped_bootstrap,
+            "errors": 0,
+            "duration_seconds": elapsed,
+        }
 
     existence_map = check_resources_exist(all_tuples)
     actions = generate_corrective_actions(events, existence_map)
@@ -102,22 +129,25 @@ def reconcile(
         result = {
             "status": "dry_run",
             "time_window": {"start_ms": start_timestamp_ms, "end_ms": end_timestamp_ms},
-            "events_read": len(events),
+            "events_read": len(all_events),
             "tuples_processed": len(all_tuples),
             "corrective_adds": len(adds),
             "corrective_removes": len(removes),
             "skipped": len(skips),
+            "skipped_bootstrap_events": skipped_bootstrap,
             "errors": 0,
             "actions": action_details,
             "duration_seconds": elapsed,
         }
         logger.info(
-            "DR reconciliation DRY RUN: events=%d tuples=%d would_add=%d would_remove=%d skipped=%d (%.3fs)",
+            "DR reconciliation DRY RUN: events=%d tuples=%d would_add=%d would_remove=%d skipped=%d "
+            "bootstrap_skipped=%d (%.3fs)",
             len(events),
             len(all_tuples),
             len(adds),
             len(removes),
             len(skips),
+            skipped_bootstrap,
             elapsed,
         )
         return result
@@ -132,21 +162,55 @@ def reconcile(
     result = {
         "status": "completed",
         "time_window": {"start_ms": start_timestamp_ms, "end_ms": end_timestamp_ms},
-        "events_read": len(events),
+        "events_read": len(all_events),
         "tuples_processed": len(all_tuples),
+        "skipped_bootstrap_events": skipped_bootstrap,
         "duration_seconds": elapsed,
     }
     result.update(write_result)
 
     logger.info(
-        "DR reconciliation completed: events=%d tuples=%d adds=%d removes=%d skipped=%d errors=%d (%.3fs)",
+        "DR reconciliation completed: events=%d tuples=%d adds=%d removes=%d skipped=%d "
+        "bootstrap_skipped=%d errors=%d (%.3fs)",
         result["events_read"],
         result["tuples_processed"],
         result["corrective_adds"],
         result["corrective_removes"],
         result["skipped"],
+        skipped_bootstrap,
         result["errors"],
         elapsed,
     )
 
     return result
+
+
+def _partition_bootstrap_events(
+    events: list[ParsedReplicationEvent],
+) -> tuple[list[ParsedReplicationEvent], int]:
+    """Separate bootstrap tenant events from events that need reconciliation.
+
+    Bootstrap events create virtual resources (groups, role bindings) stored
+    only in TenantMapping, not as Django model instances. Per-resource existence
+    checking would incorrectly flag them as missing. These events are atomic:
+    the tenant is either fully bootstrapped or not present at all.
+    """
+    non_bootstrap = []
+    skipped = 0
+
+    for event in events:
+        if event.event_type in _BOOTSTRAP_EVENT_TYPES:
+            skipped += 1
+            bootstrap_tuples = len(event.relations_to_add) + len(event.relations_to_remove)
+            logger.info(
+                "Skipping bootstrap event (type=%s, org_id=%s, offset=%d, partition=%d, tuples=%d)",
+                event.event_type,
+                event.org_id,
+                event.offset,
+                event.partition,
+                bootstrap_tuples,
+            )
+        else:
+            non_bootstrap.append(event)
+
+    return non_bootstrap, skipped

--- a/tests/management/disaster_recovery/test_service.py
+++ b/tests/management/disaster_recovery/test_service.py
@@ -7,7 +7,7 @@ from django.test import TestCase
 
 from api.models import Tenant
 from management.disaster_recovery.kafka_reader import ParsedReplicationEvent
-from management.disaster_recovery.service import reconcile
+from management.disaster_recovery.service import _partition_bootstrap_events, reconcile
 from management.relation_replicator.outbox_replicator import InMemoryLog, OutboxReplicator
 from management.relation_replicator.relation_replicator import ReplicationEventType
 from management.relation_replicator.types import (
@@ -248,3 +248,193 @@ class ReconcileServiceTest(TestCase):
         self.assertEqual(action["source_partition"], 1)
         self.assertEqual(action["source_offset"], 42)
         self.assertIn(fake_id, action["tuple"])
+
+
+class PartitionBootstrapEventsTest(TestCase):
+    """Tests for _partition_bootstrap_events."""
+
+    def _make_event(self, event_type, offset=0):
+        return ParsedReplicationEvent(
+            offset=offset,
+            partition=0,
+            timestamp_ms=1000,
+            event_type=event_type,
+            org_id="test-org",
+            relations_to_add=[_make_tuple()],
+            relations_to_remove=[],
+        )
+
+    def test_bootstrap_tenant_filtered_out(self):
+        events = [self._make_event("bootstrap_tenant")]
+        non_bootstrap, skipped = _partition_bootstrap_events(events)
+        self.assertEqual(non_bootstrap, [])
+        self.assertEqual(skipped, 1)
+
+    def test_bulk_bootstrap_tenant_filtered_out(self):
+        events = [self._make_event("bulk_bootstrap_tenant")]
+        non_bootstrap, skipped = _partition_bootstrap_events(events)
+        self.assertEqual(non_bootstrap, [])
+        self.assertEqual(skipped, 1)
+
+    def test_non_bootstrap_events_kept(self):
+        events = [
+            self._make_event("create_workspace"),
+            self._make_event("add_principal_to_group"),
+        ]
+        non_bootstrap, skipped = _partition_bootstrap_events(events)
+        self.assertEqual(len(non_bootstrap), 2)
+        self.assertEqual(skipped, 0)
+
+    def test_mixed_events_partitioned(self):
+        events = [
+            self._make_event("create_workspace", offset=1),
+            self._make_event("bootstrap_tenant", offset=2),
+            self._make_event("add_principal_to_group", offset=3),
+            self._make_event("bulk_bootstrap_tenant", offset=4),
+        ]
+        non_bootstrap, skipped = _partition_bootstrap_events(events)
+        self.assertEqual(len(non_bootstrap), 2)
+        self.assertEqual(skipped, 2)
+        self.assertEqual([e.offset for e in non_bootstrap], [1, 3])
+
+    def test_empty_events(self):
+        non_bootstrap, skipped = _partition_bootstrap_events([])
+        self.assertEqual(non_bootstrap, [])
+        self.assertEqual(skipped, 0)
+
+
+class ReconcileBootstrapSkipTest(TestCase):
+    """Integration tests for bootstrap event skipping in reconcile."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.tenant = Tenant.objects.create(
+            tenant_name="test-dr-bootstrap",
+            account_id="bootstrap-account",
+            org_id="bootstrap-org",
+            ready=True,
+        )
+        cls.root_ws = Workspace.objects.create(
+            name=Workspace.SpecialNames.ROOT,
+            type=Workspace.Types.ROOT,
+            tenant=cls.tenant,
+        )
+        cls.default_ws = Workspace.objects.create(
+            name=Workspace.SpecialNames.DEFAULT,
+            type=Workspace.Types.DEFAULT,
+            tenant=cls.tenant,
+            parent=cls.root_ws,
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.default_ws.delete()
+        cls.root_ws.delete()
+        cls.tenant.delete()
+        super().tearDownClass()
+
+    @patch("management.disaster_recovery.service.read_events_in_window")
+    def test_bootstrap_only_window_returns_no_corrective_actions(self, mock_read):
+        """Window with only bootstrap events produces zero corrective actions."""
+        group_uuid = str(uuid4())
+        rb_uuid = str(uuid4())
+
+        mock_read.return_value = [
+            ParsedReplicationEvent(
+                offset=100,
+                partition=0,
+                timestamp_ms=1000,
+                event_type="bootstrap_tenant",
+                org_id="some-org",
+                relations_to_add=[
+                    _make_tuple("group", group_uuid),
+                    _make_tuple("role_binding", rb_uuid),
+                ],
+                relations_to_remove=[],
+            )
+        ]
+
+        log = InMemoryLog()
+        replicator = OutboxReplicator(log=log)
+
+        result = reconcile(
+            restore_timestamp_ms=1000000,
+            buffer_seconds=300,
+            replicator=replicator,
+        )
+
+        self.assertEqual(result["status"], "completed")
+        self.assertEqual(result["corrective_adds"], 0)
+        self.assertEqual(result["corrective_removes"], 0)
+        self.assertEqual(result["skipped_bootstrap_events"], 1)
+        self.assertEqual(result["events_read"], 1)
+        self.assertEqual(result["tuples_processed"], 0)
+        self.assertEqual(len(log), 0)
+
+    @patch("management.disaster_recovery.service.read_events_in_window")
+    def test_mixed_bootstrap_and_regular_events(self, mock_read):
+        """Bootstrap events are skipped while regular events are processed normally."""
+        fake_ws_id = str(uuid4())
+
+        mock_read.return_value = [
+            ParsedReplicationEvent(
+                offset=100,
+                partition=0,
+                timestamp_ms=1000,
+                event_type="bootstrap_tenant",
+                org_id="some-org",
+                relations_to_add=[_make_tuple("group", str(uuid4()))],
+                relations_to_remove=[],
+            ),
+            ParsedReplicationEvent(
+                offset=101,
+                partition=0,
+                timestamp_ms=1001,
+                event_type="create_workspace",
+                relations_to_add=[_make_tuple("workspace", fake_ws_id)],
+                relations_to_remove=[],
+            ),
+        ]
+
+        log = InMemoryLog()
+        replicator = OutboxReplicator(log=log)
+
+        result = reconcile(
+            restore_timestamp_ms=1000000,
+            buffer_seconds=300,
+            replicator=replicator,
+        )
+
+        self.assertEqual(result["skipped_bootstrap_events"], 1)
+        self.assertEqual(result["events_read"], 2)
+        self.assertEqual(result["corrective_removes"], 1)
+        self.assertEqual(len(log), 1)
+
+    @patch("management.disaster_recovery.service.read_events_in_window")
+    def test_dry_run_reports_skipped_bootstrap(self, mock_read):
+        mock_read.return_value = [
+            ParsedReplicationEvent(
+                offset=100,
+                partition=0,
+                timestamp_ms=1000,
+                event_type="bulk_bootstrap_tenant",
+                org_id="some-org",
+                relations_to_add=[_make_tuple("group", str(uuid4()))],
+                relations_to_remove=[],
+            ),
+        ]
+
+        log = InMemoryLog()
+        replicator = OutboxReplicator(log=log)
+
+        result = reconcile(
+            restore_timestamp_ms=1000000,
+            buffer_seconds=300,
+            replicator=replicator,
+            dry_run=True,
+        )
+
+        self.assertEqual(result["status"], "completed")
+        self.assertEqual(result["skipped_bootstrap_events"], 1)
+        self.assertEqual(len(log), 0)


### PR DESCRIPTION
## Summary

**Alternative to #3108** — instead of enriching the resource checker with TenantMapping fallback queries, skip bootstrap_tenant events entirely during DR reconciliation.

- Filter out `bootstrap_tenant` and `bulk_bootstrap_tenant` events before the existence check / truth table
- Bootstrap events are atomic: the tenant is either fully bootstrapped (all relations valid) or not present at all — per-resource existence checking is the wrong abstraction for these events
- Report `skipped_bootstrap_events` count in the reconciliation summary for observability

## Root Cause

During `bootstrap_tenant`, `TenantMapping` is created with auto-generated UUIDs for default groups and role bindings. Relation tuples are emitted referencing these UUIDs, but **no actual `Group` or `RoleBinding` Django model objects are created**. The DR reconciler's `check_resources_exist` queries only model tables, so it reports these resources as non-existent, triggering `relations_to_add + not exists → REMOVE` — which would delete valid relations from SpiceDB.

## Approach comparison

| | PR #3108 (TenantMapping fallback) | This PR (skip bootstrap) |
|---|---|---|
| **Approach** | Enrich existence check to also query TenantMapping UUID fields | Filter out bootstrap events before truth table |
| **Precision** | Handles edge case where tenant was deleted after bootstrap | Treats bootstrap as all-or-nothing |
| **Complexity** | Adds TenantMapping coupling to resource_checker | Simpler — one filter in service.py |
| **Files changed** | resource_checker.py + tests | service.py + tests |

## Test plan

- [x] New `PartitionBootstrapEventsTest` (5 unit tests): filtering logic for bootstrap/non-bootstrap events
- [x] New `ReconcileBootstrapSkipTest` (3 integration tests):
  - Bootstrap-only window produces zero corrective actions
  - Mixed bootstrap + regular events: bootstrap skipped, regular processed normally
  - Dry run reports skipped bootstrap count
- [x] All 53 DR tests pass
- [x] Pre-commit hooks pass (flake8, black, trailing whitespace)