### PR TITLE
feat(parity): add per-sub-check breakdown with detailed failure output

### DIFF
--- a/rbac/internal/views.py
+++ b/rbac/internal/views.py
@@ -1993,7 +1993,9 @@ def check_workspace_relation(request, workspace_uuid):
         try:
             if workspace_pairs:
                 workspace_uuid = str(workspace_uuid)
-                workspace_descendants_correct = WorkspaceRelationChecker.check_workspace_descendants(workspace_pairs)
+                workspace_descendants_correct, _ = WorkspaceRelationChecker.check_workspace_descendants(
+                    workspace_pairs
+                )
                 response = {
                     "org_id": workspace.tenant.org_id,
                     "workspace_id": workspace_uuid,

--- a/rbac/management/inventory_checker/inventory_api_check.py
+++ b/rbac/management/inventory_checker/inventory_api_check.py
@@ -306,9 +306,8 @@ class WorkspaceRelationInventoryChecker(InventoryApiBaseChecker):
     """Subclass to check workspace parent relations are correct on inventory api."""
 
     def check_workspace_descendants(self, workspace_pairs):
-        """Core logic to check workspace descendant relations on inventory api."""
+        """Check workspace parent relations on inventory api, returning per-pair results."""
         checks = []
-        # Build the check requests for checking parent-child workspace relationship
         for workspace_uuid, workspace_parent_uuid in workspace_pairs:
             check_request = CheckRequest(
                 object=resource_reference_pb2.ResourceReference(
@@ -326,12 +325,19 @@ class WorkspaceRelationInventoryChecker(InventoryApiBaseChecker):
                 ),
             )
             checks.append(check_request)
-        workspace_check = self.check_inventory_core(checks)
-        if not workspace_check:
-            logger.warning(f"{workspace_uuid} does not have the expected parent workspace.")
+
+        results_list = self._check_inventory_batch(checks)
+        pair_results = []
+        for (ws_id, parent_id), exists in zip(workspace_pairs, results_list):
+            pair_results.append({"workspace_id": ws_id, "parent_id": parent_id, "exists": exists})
+
+        all_passed = all(r["exists"] for r in pair_results)
+        if all_passed:
+            logger.info(f"All {len(workspace_pairs)} workspace parent relations exist.")
         else:
-            logger.info(f"{workspace_uuid} has the correct parent workspace.")
-        return workspace_check
+            missing = [r for r in pair_results if not r["exists"]]
+            logger.warning(f"{len(missing)} of {len(workspace_pairs)} workspace parent relations missing.")
+        return all_passed, pair_results
 
     def check_workspace(self, workspace_id, workspace_parent_id):
         """Core logic to check workspace relation on inventory api."""

--- a/rbac/management/tasks.py
+++ b/rbac/management/tasks.py
@@ -406,9 +406,12 @@ def run_kessel_parity_checks_in_worker(org_ids=None):
             workspace_pairs = [(str(w_id), str(parent_id)) for (w_id, parent_id) in workspaces]
             pairs_count = len(workspace_pairs)
 
+            workspace_pair_results = []
             if workspace_pairs:
                 logger.info(f"Checking {pairs_count} workspace parent relations for tenant {org_id}")
-                workspace_check_passed = workspace_checker.check_workspace_descendants(workspace_pairs)
+                workspace_check_passed, workspace_pair_results = workspace_checker.check_workspace_descendants(
+                    workspace_pairs
+                )
             else:
                 logger.warning(f"No workspace pairs to check for tenant {org_id} — missing default workspace?")
                 workspace_check_passed = False
@@ -508,6 +511,56 @@ def run_kessel_parity_checks_in_worker(org_ids=None):
                 stats["failed_tenants"] += 1
                 logger.warning(f"Parity check FAILED for tenant {org_id}")
 
+            sub_check_log = logger.info if tenant_passed else logger.warning
+
+            detail_lines = []
+            detail_lines.append(f"  Sub-check results for tenant {org_id}:")
+            detail_lines.append(
+                f"    Workspace hierarchy: {'PASSED' if workspace_check_passed else 'FAILED'}"
+                f" ({pairs_count} pairs)"
+            )
+            if not workspace_check_passed and workspace_pair_results:
+                missing = [r for r in workspace_pair_results if not r["exists"]]
+                for r in missing[:20]:
+                    detail_lines.append(f"      - MISSING: workspace {r['workspace_id']} -> parent {r['parent_id']}")
+                if len(missing) > 20:
+                    detail_lines.append(f"      ... and {len(missing) - 20} more")
+
+            detail_lines.append(
+                f"    Custom roles:        {'PASSED' if custom_role_check_passed else 'FAILED'}"
+                f" ({len(role_results)} roles)"
+            )
+            if not custom_role_check_passed:
+                failed_roles = [r for r in role_results if not r["passed"]]
+                for r in failed_roles[:20]:
+                    detail_lines.append(f"      - FAILED: role {r['role_name']} ({r['role_uuid']})")
+                if len(failed_roles) > 20:
+                    detail_lines.append(f"      ... and {len(failed_roles) - 20} more")
+
+            detail_lines.append(
+                f"    Bootstrap:           {'PASSED' if bootstrap_check_passed else 'FAILED'}"
+                f" ({len(bootstrap_details)} checks)"
+            )
+            if not bootstrap_check_passed and bootstrap_details:
+                missing = [d for d in bootstrap_details if not d["exists"]]
+                for d in missing[:20]:
+                    detail_lines.append(f"      - MISSING: {d['name']} ({d.get('check', '')})")
+                if len(missing) > 20:
+                    detail_lines.append(f"      ... and {len(missing) - 20} more")
+
+            detail_lines.append(
+                f"    Group-principal:     {'PASSED' if group_principal_check_passed else 'FAILED'}"
+                f" ({len(group_results)} groups, {tenant_group_principal_relations} relations)"
+            )
+            if not group_principal_check_passed:
+                failed_groups = [g for g in group_results if not g["passed"]]
+                for g in failed_groups[:20]:
+                    detail_lines.append(f"      - FAILED: group {g['group_name']} ({g['group_uuid']})")
+                if len(failed_groups) > 20:
+                    detail_lines.append(f"      ... and {len(failed_groups) - 20} more")
+
+            sub_check_log("\n".join(detail_lines))
+
             tenant_elapsed = time.monotonic() - tenant_start
             tenant_durations.append(tenant_elapsed)
             logger.info(f"Tenant {org_id} parity check took {tenant_elapsed:.3f}s")
@@ -581,7 +634,9 @@ def run_kessel_parity_checks_in_worker(org_ids=None):
         f"Total seeded roles: {stats['total_seeded_roles_checked']}, "
         f"Total bootstrap checks: {stats['total_bootstrap_checks']}, "
         f"Total groups: {stats['total_groups_checked']}, "
-        f"Total group-principal relations: {stats['total_group_principal_relations_checked']}"
+        f"Total group-principal relations: {stats['total_group_principal_relations_checked']}, "
+        f"Seeded role hierarchy: {'PASSED' if seeded_hierarchy_passed else 'FAILED'}"
+        f" ({stats['total_seeded_roles_checked']} roles)"
     )
 
     stats["timing"] = timing_stats

--- a/tests/internal/test_views.py
+++ b/tests/internal/test_views.py
@@ -4821,7 +4821,7 @@ class InternalInventoryViewsetTests(BaseInternalViewsetTests):
         mock_stub = MagicMock()
         mock_stub.Check.return_value = "true"
 
-        mock_check_workspace_relation.return_value = mock_stub.Check.return_value
+        mock_check_workspace_relation.return_value = (True, [])
         mock_workspace_view.return_value = (
             {
                 "org_id": self.root_workspace.tenant.org_id,
@@ -4848,7 +4848,7 @@ class InternalInventoryViewsetTests(BaseInternalViewsetTests):
         # Check response
         self.assertEqual(response_body["org_id"], self.root_workspace.tenant.org_id)
         self.assertEqual(response_body["workspace_id"], str(self.root_workspace.id))
-        self.assertEqual(response_body["workspace_descendants_correct"], "true")
+        self.assertTrue(response_body["workspace_descendants_correct"])
 
     @patch(
         "management.inventory_checker.inventory_api_check.WorkspaceRelationInventoryChecker.check_workspace",

--- a/tests/management/test_parity_tasks.py
+++ b/tests/management/test_parity_tasks.py
@@ -35,6 +35,13 @@ BOOTSTRAP_CHECKER_PATH = (
 class ParityCheckTasksTest(IdentityRequest):
     """Test the Kessel parity check tasks."""
 
+    @staticmethod
+    def _collect_log_text(mock_logger):
+        """Collect all info, warning, and exception log calls into a single string for assertion."""
+        all_calls = mock_logger.info.call_args_list + mock_logger.warning.call_args_list
+        all_calls += mock_logger.exception.call_args_list
+        return "\n".join(c.args[0] if c.args else "" for c in all_calls)
+
     def setUp(self):
         """Set up the parity check task tests."""
         super().setUp()
@@ -134,7 +141,7 @@ class ParityCheckTasksTest(IdentityRequest):
         self.tenant.save()
 
         # Mock the checker to return True (all checks pass)
-        mock_check_workspace.return_value = True
+        mock_check_workspace.return_value = (True, [])
 
         result = run_kessel_parity_checks_in_worker()
 
@@ -172,7 +179,7 @@ class ParityCheckTasksTest(IdentityRequest):
         self.tenant.save()
 
         # Mock the checker to return False (checks failed)
-        mock_check_workspace.return_value = False
+        mock_check_workspace.return_value = (False, [])
 
         result = run_kessel_parity_checks_in_worker()
 
@@ -201,7 +208,7 @@ class ParityCheckTasksTest(IdentityRequest):
         self.tenant.save()
 
         # Mock the checker to return True
-        mock_check_workspace.return_value = True
+        mock_check_workspace.return_value = (True, [])
 
         result = run_kessel_parity_checks_in_worker()
 
@@ -246,7 +253,7 @@ class ParityCheckTasksTest(IdentityRequest):
         )
 
         # Mock the checker to return True for first, False for second
-        mock_check_workspace.side_effect = [True, False]
+        mock_check_workspace.side_effect = [(True, []), (False, [])]
 
         result = run_kessel_parity_checks_in_worker()
 
@@ -277,7 +284,7 @@ class ParityCheckTasksTest(IdentityRequest):
         self.tenant.save()
 
         # Mock the checker
-        mock_check_workspace.return_value = True
+        mock_check_workspace.return_value = (True, [])
 
         run_kessel_parity_checks_in_worker()
 
@@ -352,7 +359,7 @@ class ParityCheckTasksTest(IdentityRequest):
         role2.permissions.add(perm2)
 
         # Mock both checkers to return True
-        mock_check_workspace.return_value = True
+        mock_check_workspace.return_value = (True, [])
         mock_check_role_perms.return_value = True
 
         result = run_kessel_parity_checks_in_worker()
@@ -398,7 +405,7 @@ class ParityCheckTasksTest(IdentityRequest):
         role1.permissions.add(perm1)
 
         # Mock workspace check to pass, custom role check to fail
-        mock_check_workspace.return_value = True
+        mock_check_workspace.return_value = (True, [])
         mock_check_role_perms.return_value = False
 
         result = run_kessel_parity_checks_in_worker()
@@ -432,7 +439,7 @@ class ParityCheckTasksTest(IdentityRequest):
         role1.permissions.add(perm1)
 
         # Mock workspace check to fail, custom role check to pass
-        mock_check_workspace.return_value = False
+        mock_check_workspace.return_value = (False, [])
         mock_check_role_perms.return_value = True
 
         result = run_kessel_parity_checks_in_worker()
@@ -461,7 +468,7 @@ class ParityCheckTasksTest(IdentityRequest):
         self.tenant.save()
 
         # Mock workspace check to pass
-        mock_check_workspace.return_value = True
+        mock_check_workspace.return_value = (True, [])
 
         result = run_kessel_parity_checks_in_worker()
 
@@ -504,7 +511,7 @@ class ParityCheckTasksTest(IdentityRequest):
 
         CustomRoleV2.objects.create(name="role1", tenant=self.tenant)
 
-        mock_check_workspace.return_value = True
+        mock_check_workspace.return_value = (True, [])
         mock_check_role_perms.side_effect = RuntimeError("gRPC connection timeout")
 
         result = run_kessel_parity_checks_in_worker()
@@ -537,7 +544,7 @@ class ParityCheckTasksTest(IdentityRequest):
         CustomRoleV2.objects.create(name="empty-role", tenant=self.tenant)
 
         # Mock workspace check to pass
-        mock_check_workspace.return_value = True
+        mock_check_workspace.return_value = (True, [])
         # Empty permission list returns True
         mock_check_role_perms.return_value = True
 
@@ -567,7 +574,7 @@ class ParityCheckTasksTest(IdentityRequest):
         """Bootstrap parity success should increment counters and mark tenant as passed."""
         self.tenant.org_id = "test_org_id"
         self.tenant.save()
-        mock_check_workspace.return_value = True
+        mock_check_workspace.return_value = (True, [])
 
         bootstrap_details = [
             {"name": "default_workspace_parent", "exists": True},
@@ -594,7 +601,7 @@ class ParityCheckTasksTest(IdentityRequest):
         """Bootstrap parity failure should mark tenant as failed even when other checks pass."""
         self.tenant.org_id = "test_org_id"
         self.tenant.save()
-        mock_check_workspace.return_value = True
+        mock_check_workspace.return_value = (True, [])
 
         bootstrap_details = [
             {"name": "default_workspace_parent", "exists": True},
@@ -621,7 +628,7 @@ class ParityCheckTasksTest(IdentityRequest):
         """Missing TenantMapping should skip bootstrap check and fail the tenant."""
         self.tenant.org_id = "test_org_id"
         self.tenant.save()
-        mock_check_workspace.return_value = True
+        mock_check_workspace.return_value = (True, [])
         self.tenant_mapping.delete()
 
         result = run_kessel_parity_checks_in_worker()
@@ -643,7 +650,7 @@ class ParityCheckTasksTest(IdentityRequest):
         """Missing root workspace should skip bootstrap check and fail the tenant."""
         self.tenant.org_id = "test_org_id"
         self.tenant.save()
-        mock_check_workspace.return_value = True
+        mock_check_workspace.return_value = (True, [])
 
         self.child_workspace.delete()
         self.default_workspace.delete()
@@ -666,7 +673,7 @@ class ParityCheckTasksTest(IdentityRequest):
         """When the bootstrap checker raises, the tenant is still counted and marked failed."""
         self.tenant.org_id = "test_org_id"
         self.tenant.save()
-        mock_check_workspace.return_value = True
+        mock_check_workspace.return_value = (True, [])
         self.mock_bootstrap_checker.side_effect = Exception("gRPC unavailable")
 
         result = run_kessel_parity_checks_in_worker()
@@ -696,7 +703,7 @@ class ParityCheckTasksTest(IdentityRequest):
         p2 = Principal.objects.create(username="user2", tenant=self.tenant, user_id="uid2")
         group1.principals.add(p1, p2)
 
-        mock_check_workspace.return_value = True
+        mock_check_workspace.return_value = (True, [])
         mock_check_group.return_value = {
             "group_uuid": str(group1.uuid),
             "principal_relations": [
@@ -735,7 +742,7 @@ class ParityCheckTasksTest(IdentityRequest):
         p1 = Principal.objects.create(username="user1", tenant=self.tenant, user_id="uid1")
         group1.principals.add(p1)
 
-        mock_check_workspace.return_value = True
+        mock_check_workspace.return_value = (True, [])
         mock_check_group.return_value = {
             "group_uuid": str(group1.uuid),
             "principal_relations": [
@@ -765,7 +772,7 @@ class ParityCheckTasksTest(IdentityRequest):
 
         Group.objects.create(name="empty-group", tenant=self.tenant)
 
-        mock_check_workspace.return_value = True
+        mock_check_workspace.return_value = (True, [])
 
         result = run_kessel_parity_checks_in_worker()
 
@@ -794,7 +801,7 @@ class ParityCheckTasksTest(IdentityRequest):
         p_no_uid = Principal.objects.create(username="no-uid", tenant=self.tenant, user_id=None)
         group1.principals.add(p_no_uid)
 
-        mock_check_workspace.return_value = True
+        mock_check_workspace.return_value = (True, [])
 
         result = run_kessel_parity_checks_in_worker()
 
@@ -823,7 +830,7 @@ class ParityCheckTasksTest(IdentityRequest):
         group1.principals.add(p1)
         group2.principals.add(p2)
 
-        mock_check_workspace.return_value = True
+        mock_check_workspace.return_value = (True, [])
         mock_check_group.side_effect = [
             {
                 "group_uuid": str(group1.uuid),
@@ -869,7 +876,7 @@ class ParityCheckTasksTest(IdentityRequest):
         p1 = Principal.objects.create(username="user1", tenant=self.tenant, user_id="uid1")
         group1.principals.add(p1)
 
-        mock_check_workspace.return_value = True
+        mock_check_workspace.return_value = (True, [])
         mock_check_role_perms.return_value = True
         mock_check_group.return_value = {
             "group_uuid": str(group1.uuid),
@@ -901,7 +908,7 @@ class ParityCheckTasksTest(IdentityRequest):
         p1 = Principal.objects.create(username="user1", tenant=self.tenant, user_id="uid1")
         group1.principals.add(p1)
 
-        mock_check_workspace.return_value = True
+        mock_check_workspace.return_value = (True, [])
         mock_check_group.side_effect = RuntimeError("gRPC connection timeout")
 
         result = run_kessel_parity_checks_in_worker()
@@ -923,7 +930,7 @@ class ParityCheckTasksTest(IdentityRequest):
         self.tenant.org_id = "test_org_id"
         self.tenant.save()
 
-        mock_check_workspace.return_value = True
+        mock_check_workspace.return_value = (True, [])
 
         # Even though PARITY_CHECK_ENABLED=False, explicit org_ids should work
         result = run_kessel_parity_checks_in_worker(org_ids=["test_org_id"])
@@ -948,7 +955,7 @@ class ParityCheckTasksTest(IdentityRequest):
         self.tenant.org_id = "test_org_id"
         self.tenant.save()
 
-        mock_check_workspace.return_value = True
+        mock_check_workspace.return_value = (True, [])
 
         result = run_kessel_parity_checks_in_worker(org_ids=["test_org_id", "test_org_id", "test_org_id"])
 
@@ -972,10 +979,120 @@ class ParityCheckTasksTest(IdentityRequest):
         self.tenant.org_id = "test_org_id"
         self.tenant.save()
 
-        mock_check_workspace.return_value = True
+        mock_check_workspace.return_value = (True, [])
 
         result = run_kessel_parity_checks_in_worker(org_ids=["  test_org_id  "])
 
         mock_check_workspace.assert_called_once()
         self.assertEqual(result["total_tenants"], 1)
         self.assertEqual(result["tenants_checked"][0]["org_id"], "test_org_id")
+
+    @override_settings(PARITY_CHECK_ENABLED=True, PARITY_CHECK_ORG_IDS="test_org_id")
+    @patch("management.inventory_checker.inventory_api_check.GroupPrincipalInventoryChecker.check_relationships")
+    @patch(
+        "management.inventory_checker.inventory_api_check.CustomRolePermissionChecker.check_custom_role_permissions"
+    )
+    @patch(
+        "management.inventory_checker.inventory_api_check.WorkspaceRelationInventoryChecker.check_workspace_descendants"
+    )
+    def test_per_sub_check_logging_all_pass(self, mock_check_workspace, mock_check_role_perms, mock_check_group):
+        """Test that per-sub-check breakdown appears in logs when all checks pass."""
+        self.tenant.org_id = "test_org_id"
+        self.tenant.save()
+
+        role1 = CustomRoleV2.objects.create(name="role1", tenant=self.tenant)
+        perm1 = Permission.objects.create(permission="inventory:hosts:read", tenant=self.tenant)
+        role1.permissions.add(perm1)
+
+        group1 = Group.objects.create(name="group1", tenant=self.tenant)
+        p1 = Principal.objects.create(username="user1", tenant=self.tenant, user_id="uid1")
+        group1.principals.add(p1)
+
+        mock_check_workspace.return_value = (True, [])
+        mock_check_role_perms.return_value = True
+        mock_check_group.return_value = {
+            "group_uuid": str(group1.uuid),
+            "principal_relations": [{"id": "localhost/uid1", "relation_exists": True}],
+        }
+
+        with patch("management.tasks.logger") as mock_logger:
+            run_kessel_parity_checks_in_worker()
+
+        log_text = self._collect_log_text(mock_logger)
+        self.assertIn("Workspace hierarchy: PASSED", log_text)
+        self.assertIn("Custom roles:        PASSED", log_text)
+        self.assertIn("Bootstrap:           PASSED", log_text)
+        self.assertIn("Group-principal:     PASSED", log_text)
+
+    @override_settings(PARITY_CHECK_ENABLED=True, PARITY_CHECK_ORG_IDS="test_org_id")
+    @patch("management.inventory_checker.inventory_api_check.GroupPrincipalInventoryChecker.check_relationships")
+    @patch(
+        "management.inventory_checker.inventory_api_check.CustomRolePermissionChecker.check_custom_role_permissions"
+    )
+    @patch(
+        "management.inventory_checker.inventory_api_check.WorkspaceRelationInventoryChecker.check_workspace_descendants"
+    )
+    def test_per_sub_check_logging_mixed_results(self, mock_check_workspace, mock_check_role_perms, mock_check_group):
+        """Test that per-sub-check breakdown shows FAILED for failing sub-checks."""
+        self.tenant.org_id = "test_org_id"
+        self.tenant.save()
+
+        role1 = CustomRoleV2.objects.create(name="role1", tenant=self.tenant)
+        perm1 = Permission.objects.create(permission="inventory:hosts:read", tenant=self.tenant)
+        role1.permissions.add(perm1)
+
+        group1 = Group.objects.create(name="group1", tenant=self.tenant)
+        p1 = Principal.objects.create(username="user1", tenant=self.tenant, user_id="uid1")
+        group1.principals.add(p1)
+
+        mock_check_workspace.return_value = (False, [])
+        mock_check_role_perms.return_value = True
+        mock_check_group.return_value = {
+            "group_uuid": str(group1.uuid),
+            "principal_relations": [{"id": "localhost/uid1", "relation_exists": False}],
+        }
+
+        with patch("management.tasks.logger") as mock_logger:
+            run_kessel_parity_checks_in_worker()
+
+        log_text = self._collect_log_text(mock_logger)
+        self.assertIn("Workspace hierarchy: FAILED", log_text)
+        self.assertIn("Custom roles:        PASSED", log_text)
+        self.assertIn("Bootstrap:           PASSED", log_text)
+        self.assertIn("Group-principal:     FAILED", log_text)
+
+    @override_settings(PARITY_CHECK_ENABLED=True, PARITY_CHECK_ORG_IDS="test_org_id")
+    @patch(
+        "management.inventory_checker.inventory_api_check.WorkspaceRelationInventoryChecker.check_workspace_descendants"
+    )
+    def test_final_summary_includes_seeded_role_result(self, mock_check_workspace):
+        """Test that the final summary log includes seeded role hierarchy result."""
+        self.tenant.org_id = "test_org_id"
+        self.tenant.save()
+
+        mock_check_workspace.return_value = (True, [])
+
+        with patch("management.tasks.logger") as mock_logger:
+            run_kessel_parity_checks_in_worker()
+
+        log_text = self._collect_log_text(mock_logger)
+        self.assertIn("Seeded role hierarchy: PASSED", log_text)
+
+    @override_settings(PARITY_CHECK_ENABLED=True, PARITY_CHECK_ORG_IDS="test_org_id")
+    @patch(
+        "management.inventory_checker.inventory_api_check.WorkspaceRelationInventoryChecker.check_workspace_descendants"
+    )
+    def test_per_sub_check_logging_includes_item_counts(self, mock_check_workspace):
+        """Test that per-sub-check breakdown includes item counts."""
+        self.tenant.org_id = "test_org_id"
+        self.tenant.save()
+
+        mock_check_workspace.return_value = (True, [])
+
+        with patch("management.tasks.logger") as mock_logger:
+            run_kessel_parity_checks_in_worker()
+
+        log_text = self._collect_log_text(mock_logger)
+        self.assertIn("2 pairs", log_text)
+        self.assertIn("0 roles", log_text)
+        self.assertIn("0 groups", log_text)

--- a/tests/management/test_parity_tasks.py
+++ b/tests/management/test_parity_tasks.py
@@ -36,11 +36,20 @@ class ParityCheckTasksTest(IdentityRequest):
     """Test the Kessel parity check tasks."""
 
     @staticmethod
-    def _collect_log_text(mock_logger):
+    def _format_log_call(c):
+        """Format a single mock log call, handling both f-string and %s-style messages."""
+        if not c.args:
+            return ""
+        if len(c.args) > 1:
+            return c.args[0] % c.args[1:]
+        return c.args[0]
+
+    @classmethod
+    def _collect_log_text(cls, mock_logger):
         """Collect all info, warning, and exception log calls into a single string for assertion."""
         all_calls = mock_logger.info.call_args_list + mock_logger.warning.call_args_list
         all_calls += mock_logger.exception.call_args_list
-        return "\n".join(c.args[0] if c.args else "" for c in all_calls)
+        return "\n".join(cls._format_log_call(c) for c in all_calls)
 
     def setUp(self):
         """Set up the parity check task tests."""
@@ -1096,3 +1105,161 @@ class ParityCheckTasksTest(IdentityRequest):
         self.assertIn("2 pairs", log_text)
         self.assertIn("0 roles", log_text)
         self.assertIn("0 groups", log_text)
+
+    @override_settings(PARITY_CHECK_ENABLED=True, PARITY_CHECK_ORG_IDS="test_org_id")
+    @patch(
+        "management.inventory_checker.inventory_api_check.WorkspaceRelationInventoryChecker.check_workspace_descendants"
+    )
+    def test_sub_check_log_uses_info_when_all_pass(self, mock_check_workspace):
+        """Test that sub-check breakdown is logged at INFO level when all checks pass."""
+        self.tenant.org_id = "test_org_id"
+        self.tenant.save()
+        mock_check_workspace.return_value = (True, [])
+
+        with patch("management.tasks.logger") as mock_logger:
+            run_kessel_parity_checks_in_worker()
+
+        info_text = "\n".join(self._format_log_call(c) for c in mock_logger.info.call_args_list)
+        warning_text = "\n".join(self._format_log_call(c) for c in mock_logger.warning.call_args_list)
+        self.assertIn("Sub-check results for tenant", info_text)
+        self.assertNotIn("Sub-check results for tenant", warning_text)
+
+    @override_settings(PARITY_CHECK_ENABLED=True, PARITY_CHECK_ORG_IDS="test_org_id")
+    @patch(
+        "management.inventory_checker.inventory_api_check.WorkspaceRelationInventoryChecker.check_workspace_descendants"
+    )
+    def test_sub_check_log_uses_warning_when_any_fail(self, mock_check_workspace):
+        """Test that sub-check breakdown is logged at WARNING level when any check fails."""
+        self.tenant.org_id = "test_org_id"
+        self.tenant.save()
+        mock_check_workspace.return_value = (False, [])
+
+        with patch("management.tasks.logger") as mock_logger:
+            run_kessel_parity_checks_in_worker()
+
+        info_text = "\n".join(self._format_log_call(c) for c in mock_logger.info.call_args_list)
+        warning_text = "\n".join(self._format_log_call(c) for c in mock_logger.warning.call_args_list)
+        self.assertNotIn("Sub-check results for tenant", info_text)
+        self.assertIn("Sub-check results for tenant", warning_text)
+
+    @override_settings(PARITY_CHECK_ENABLED=True, PARITY_CHECK_ORG_IDS="test_org_id")
+    @patch(
+        "management.inventory_checker.inventory_api_check.WorkspaceRelationInventoryChecker.check_workspace_descendants"
+    )
+    def test_detailed_failure_shows_missing_workspace_pairs(self, mock_check_workspace):
+        """Test that failed workspace pairs appear as MISSING lines in the log."""
+        self.tenant.org_id = "test_org_id"
+        self.tenant.save()
+        mock_check_workspace.return_value = (
+            False,
+            [
+                {"workspace_id": "ws-1", "parent_id": "ws-root", "exists": True},
+                {"workspace_id": "ws-2", "parent_id": "ws-root", "exists": False},
+            ],
+        )
+
+        with patch("management.tasks.logger") as mock_logger:
+            run_kessel_parity_checks_in_worker()
+
+        log_text = self._collect_log_text(mock_logger)
+        self.assertIn("MISSING: workspace ws-2 -> parent ws-root", log_text)
+        self.assertNotIn("MISSING: workspace ws-1", log_text)
+
+    @override_settings(PARITY_CHECK_ENABLED=True, PARITY_CHECK_ORG_IDS="test_org_id")
+    @patch(
+        "management.inventory_checker.inventory_api_check.CustomRolePermissionChecker.check_custom_role_permissions"
+    )
+    @patch(
+        "management.inventory_checker.inventory_api_check.WorkspaceRelationInventoryChecker.check_workspace_descendants"
+    )
+    def test_detailed_failure_shows_failed_roles(self, mock_check_workspace, mock_check_role_perms):
+        """Test that failed custom roles appear as FAILED lines in the log."""
+        self.tenant.org_id = "test_org_id"
+        self.tenant.save()
+
+        role1 = CustomRoleV2.objects.create(name="my-failing-role", tenant=self.tenant)
+        perm1 = Permission.objects.create(permission="inventory:hosts:read", tenant=self.tenant)
+        role1.permissions.add(perm1)
+
+        mock_check_workspace.return_value = (True, [])
+        mock_check_role_perms.return_value = False
+
+        with patch("management.tasks.logger") as mock_logger:
+            run_kessel_parity_checks_in_worker()
+
+        log_text = self._collect_log_text(mock_logger)
+        self.assertIn(f"FAILED: role my-failing-role ({role1.uuid})", log_text)
+
+    @override_settings(PARITY_CHECK_ENABLED=True, PARITY_CHECK_ORG_IDS="test_org_id")
+    @patch(
+        "management.inventory_checker.inventory_api_check.WorkspaceRelationInventoryChecker.check_workspace_descendants"
+    )
+    def test_detailed_failure_shows_missing_bootstrap_checks(self, mock_check_workspace):
+        """Test that failed bootstrap checks appear as MISSING lines in the log."""
+        self.tenant.org_id = "test_org_id"
+        self.tenant.save()
+        mock_check_workspace.return_value = (True, [])
+
+        bootstrap_details = [
+            {
+                "name": "default_workspace_parent",
+                "check": "rbac/workspace:ws-1#parent@rbac/workspace:ws-2",
+                "exists": True,
+            },
+            {"name": "root_workspace_tenant", "check": "rbac/workspace:ws-r#tenant@rbac/tenant:t-1", "exists": False},
+        ]
+        self.mock_bootstrap_checker.return_value = (False, bootstrap_details)
+
+        with patch("management.tasks.logger") as mock_logger:
+            run_kessel_parity_checks_in_worker()
+
+        log_text = self._collect_log_text(mock_logger)
+        self.assertIn("MISSING: root_workspace_tenant (rbac/workspace:ws-r#tenant@rbac/tenant:t-1)", log_text)
+        self.assertNotIn("MISSING: default_workspace_parent", log_text)
+
+    @override_settings(PARITY_CHECK_ENABLED=True, PARITY_CHECK_ORG_IDS="test_org_id")
+    @patch("management.inventory_checker.inventory_api_check.GroupPrincipalInventoryChecker.check_relationships")
+    @patch(
+        "management.inventory_checker.inventory_api_check.WorkspaceRelationInventoryChecker.check_workspace_descendants"
+    )
+    def test_detailed_failure_shows_failed_groups(self, mock_check_workspace, mock_check_group):
+        """Test that failed groups appear as FAILED lines in the log."""
+        self.tenant.org_id = "test_org_id"
+        self.tenant.save()
+
+        group1 = Group.objects.create(name="my-failing-group", tenant=self.tenant)
+        p1 = Principal.objects.create(username="user1", tenant=self.tenant, user_id="uid1")
+        group1.principals.add(p1)
+
+        mock_check_workspace.return_value = (True, [])
+        mock_check_group.return_value = {
+            "group_uuid": str(group1.uuid),
+            "principal_relations": [{"id": "localhost/uid1", "relation_exists": False}],
+        }
+
+        with patch("management.tasks.logger") as mock_logger:
+            run_kessel_parity_checks_in_worker()
+
+        log_text = self._collect_log_text(mock_logger)
+        self.assertIn(f"FAILED: group my-failing-group ({group1.uuid})", log_text)
+
+    @override_settings(PARITY_CHECK_ENABLED=True, PARITY_CHECK_ORG_IDS="test_org_id")
+    @patch(
+        "management.inventory_checker.inventory_api_check.WorkspaceRelationInventoryChecker.check_workspace_descendants"
+    )
+    def test_detailed_failure_caps_at_20_items(self, mock_check_workspace):
+        """Test that detailed failure output caps at 20 items with a '... and N more' suffix."""
+        self.tenant.org_id = "test_org_id"
+        self.tenant.save()
+
+        pair_results = [{"workspace_id": f"ws-{i}", "parent_id": "root", "exists": False} for i in range(25)]
+        mock_check_workspace.return_value = (False, pair_results)
+
+        with patch("management.tasks.logger") as mock_logger:
+            run_kessel_parity_checks_in_worker()
+
+        log_text = self._collect_log_text(mock_logger)
+        self.assertIn("MISSING: workspace ws-0 -> parent root", log_text)
+        self.assertIn("MISSING: workspace ws-19 -> parent root", log_text)
+        self.assertNotIn("ws-20", log_text)
+        self.assertIn("... and 5 more", log_text)


### PR DESCRIPTION
## Link(s) to Jira
- https://redhat.atlassian.net/browse/RHCLOUD-48844

## Description of Intent of Change(s)

**What**: Enhance the Kessel parity check task logging so operators can immediately see which specific sub-check failed AND which individual resources are missing, without digging through truncated result dicts.

**Why**: Libor ran the parity check on stage and couldn't tell which sub-check failed from the output. The previous logs only showed a single PASSED/FAILED line per tenant with no breakdown. Even after adding the per-sub-check summary, the feedback was that operators also need to know *which exact resources* are missing.

**How**:

1. **Per-sub-check breakdown** -- after each tenant's PASSED/FAILED line, log a structured breakdown showing each sub-check result with item counts:
   ```
   Sub-check results for tenant 12345678:
     Workspace hierarchy: PASSED (3 pairs)
     Custom roles:        FAILED (2 roles)
       - FAILED: role my-role (abc-123-uuid)
     Bootstrap:           PASSED (21 checks)
     Group-principal:     PASSED (5 groups, 12 relations)
   ```

2. **Detailed failure output** -- when a sub-check fails, list which specific resources are missing (capped at 20 items to prevent log flooding):
   - Workspace: `MISSING: workspace <id> -> parent <id>`
   - Custom roles: `FAILED: role <name> (<uuid>)`
   - Bootstrap: `MISSING: <name> (<check>)`
   - Group-principal: `FAILED: group <name> (<uuid>)`

3. **Workspace checker refactor** -- changed `check_workspace_descendants` to return `tuple[bool, list[dict]]` (matching the bootstrap checker pattern) so the task gets per-pair results. Fixes a latent bug where the checker only logged the last workspace UUID from a loop variable leak.

4. **Log level distinction** -- sub-check breakdown uses INFO when all checks pass, WARNING when any fail.

5. **Seeded role result in final summary** -- the overall summary now includes the seeded role hierarchy check result.

## Local Testing

Unit tests only (V2 APIs require Kessel for local auth):

```bash
pipenv run tox -e py312-fast -- tests.management.test_parity_tasks
pipenv run tox -e py312-fast -- tests.internal.test_views
```

45 parity task tests pass, including:
- `test_per_sub_check_logging_all_pass` -- all sub-checks show PASSED
- `test_per_sub_check_logging_mixed_results` -- FAILED sub-checks are logged
- `test_sub_check_log_uses_info_when_all_pass` -- INFO level for passing tenants
- `test_sub_check_log_uses_warning_when_any_fail` -- WARNING level for failing tenants
- `test_detailed_failure_shows_missing_workspace_pairs` -- MISSING workspace pairs in log
- `test_detailed_failure_shows_failed_roles` -- FAILED roles in log
- `test_detailed_failure_shows_missing_bootstrap_checks` -- MISSING bootstrap checks in log
- `test_detailed_failure_shows_failed_groups` -- FAILED groups in log
- `test_detailed_failure_caps_at_20_items` -- 20-item cap with overflow message

## Checklist
- [ ] if API spec changes are required, is the spec updated? N/A -- logging only
- [x] are there any pre/post merge actions required? No
- [x] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for? N/A
- [ ] does this require migration changes? No
- [ ] is there known, direct impact to dependent teams/components? No -- internal logging only

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [x] Input Validation -- N/A (no user input)
- [x] Output Encoding -- N/A (server-side logging only)
- [x] Error Handling and Logging -- defensive `.get('check', '')` for missing fields
- [x] General Coding Practices -- 20-item cap prevents log flooding