### PR TITLE
[RHCLOUD-49129] Requires with_ancestry to list root/default workspaces for UI

### DIFF
--- a/docs/source/specs/typespec/main.tsp
+++ b/docs/source/specs/typespec/main.tsp
@@ -551,7 +551,7 @@ namespace Workspaces {
         @example("-created")
         @query order_by?: string = "name";
 
-        @doc("Include ancestor and fallback workspaces (root, default, ungrouped) in the response. Set to true for tree navigation. Defaults to false, returning only workspaces the user has explicit access to.")
+        @doc("When true, list responses include ancestor workspaces for tree navigation and fallback workspaces (root, default, ungrouped) when the user has no explicit access. When false (default), only workspaces with explicit Inventory permission are returned.")
         @example(false)
         @query with_ancestry?: boolean = false;
     ): WorkspaceListResponse | Problems.CommonProblems;

--- a/docs/source/specs/typespec/main.tsp
+++ b/docs/source/specs/typespec/main.tsp
@@ -550,6 +550,10 @@ namespace Workspaces {
         @doc("Sort by specified field(s), prefix with '-' for descending order. Allowed fields: name, created, modified, type.")
         @example("-created")
         @query order_by?: string = "name";
+
+        @doc("Include ancestor and fallback workspaces (root, default, ungrouped) in the response. Set to true for tree navigation. Defaults to false, returning only workspaces the user has explicit access to.")
+        @example(false)
+        @query with_ancestry?: boolean = false;
     ): WorkspaceListResponse | Problems.CommonProblems;
 
     @doc("Create workspace in tenant")

--- a/docs/source/specs/v2/openapi.json
+++ b/docs/source/specs/v2/openapi.json
@@ -1686,7 +1686,7 @@
             "name": "with_ancestry",
             "in": "query",
             "required": false,
-            "description": "Include ancestor and fallback workspaces (root, default, ungrouped) in the response. Set to true for tree navigation. Defaults to false, returning only workspaces the user has explicit access to.",
+            "description": "When true, list responses include ancestor workspaces for tree navigation and fallback workspaces (root, default, ungrouped) when the user has no explicit access. When false (default), only workspaces with explicit Inventory permission are returned.",
             "schema": {
               "type": "boolean",
               "default": false

--- a/docs/source/specs/v2/openapi.json
+++ b/docs/source/specs/v2/openapi.json
@@ -1681,6 +1681,17 @@
               "default": "name"
             },
             "explode": false
+          },
+          {
+            "name": "with_ancestry",
+            "in": "query",
+            "required": false,
+            "description": "Include ancestor and fallback workspaces (root, default, ungrouped) in the response. Set to true for tree navigation. Defaults to false, returning only workspaces the user has explicit access to.",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            },
+            "explode": false
           }
         ],
         "responses": {

--- a/docs/source/specs/v2/openapi.yaml
+++ b/docs/source/specs/v2/openapi.yaml
@@ -1069,7 +1069,7 @@ paths:
         - name: with_ancestry
           in: query
           required: false
-          description: Include ancestor and fallback workspaces (root, default, ungrouped) in the response. Set to true for tree navigation. Defaults to false, returning only workspaces the user has explicit access to.
+          description: When true, list responses include ancestor workspaces for tree navigation and fallback workspaces (root, default, ungrouped) when the user has no explicit access. When false (default), only workspaces with explicit Inventory permission are returned.
           schema:
             type: boolean
             default: false

--- a/docs/source/specs/v2/openapi.yaml
+++ b/docs/source/specs/v2/openapi.yaml
@@ -1066,6 +1066,14 @@ paths:
             type: string
             default: name
           explode: false
+        - name: with_ancestry
+          in: query
+          required: false
+          description: Include ancestor and fallback workspaces (root, default, ungrouped) in the response. Set to true for tree navigation. Defaults to false, returning only workspaces the user has explicit access to.
+          schema:
+            type: boolean
+            default: false
+          explode: false
       responses:
         '200':
           description: The request has succeeded.

--- a/rbac/management/permissions/workspace_access.py
+++ b/rbac/management/permissions/workspace_access.py
@@ -167,9 +167,9 @@ class WorkspaceAccessPermission(permissions.BasePermission):
 
         # For list/detail operations, allow request to proceed
         # FilterBackend handles access filtering via queryset
-        # For list: users with no real workspace access get fallback workspaces
-        # (root, default, ungrouped) via FilterBackend instead of 403
-        # This ensures 404 for both non-existing and inaccessible workspaces
+        # For list with with_ancestry=true: users get fallback workspaces (root, default, ungrouped)
+        # For list with with_ancestry=false: FilterBackend raises 403 if user has no access
+        # For detail: 404 for both non-existing and inaccessible workspaces
         return True
 
     def _has_permission_v1(self, request, view, ws_id) -> bool:

--- a/rbac/management/workspace/filters.py
+++ b/rbac/management/workspace/filters.py
@@ -76,8 +76,9 @@ class WorkspaceAccessFilterBackend(filters.BaseFilterBackend):
         # Call is_user_allowed_v2 - handles both list and detail cases
         # Side effect: when workspace_id is None (list actions), is_user_allowed_v2 sets
         # request.permission_tuples with accessible workspace IDs, used for filtering below
+        with_ancestry = getattr(request, "with_ancestry", False) if workspace_id is None else False
         try:
-            has_access = is_user_allowed_v2(request, relation, workspace_id)
+            has_access = is_user_allowed_v2(request, relation, workspace_id, with_ancestry=with_ancestry)
         except Exception as e:
             logger.exception(
                 "Exception in is_user_allowed_v2: user=%s, org_id=%s, workspace_id=%s, relation=%s, error=%s",

--- a/rbac/management/workspace/filters.py
+++ b/rbac/management/workspace/filters.py
@@ -22,6 +22,7 @@ from feature_flags import FEATURE_FLAGS
 from management.workspace.utils import permission_from_request
 from management.workspace.utils.access import is_user_allowed_v2
 from rest_framework import filters
+from rest_framework.exceptions import PermissionDenied
 
 logger = logging.getLogger(__name__)
 
@@ -96,6 +97,8 @@ class WorkspaceAccessFilterBackend(filters.BaseFilterBackend):
 
         # For list actions: check access decision first, then filter by permission_tuples
         if not has_access:
+            if not with_ancestry:
+                raise PermissionDenied("You do not have permission to perform this action.")
             return queryset.none()
 
         # If permission_tuples is set, filter by those IDs

--- a/rbac/management/workspace/serializer.py
+++ b/rbac/management/workspace/serializer.py
@@ -37,11 +37,6 @@ class WorkspaceListInputSerializer(serializers.Serializer):
     GET /v2/workspaces/
     """
 
-    with_ancestry = serializers.BooleanField(
-        required=False,
-        default=False,
-        help_text="Include ancestor and fallback workspaces (root, default, ungrouped) in the response.",
-    )
     type = serializers.CharField(required=False, allow_blank=True, help_text="Filter by workspace type")
     name = serializers.CharField(
         required=False,
@@ -53,6 +48,11 @@ class WorkspaceListInputSerializer(serializers.Serializer):
     )
     parent_id = serializers.CharField(required=False, allow_blank=True, help_text="Filter by parent workspace ID")
     ids = serializers.CharField(required=False, allow_blank=True, help_text="Filter by comma-separated workspace IDs")
+    with_ancestry = serializers.BooleanField(
+        required=False,
+        default=False,
+        help_text="Include ancestor and fallback workspaces (root, default, ungrouped) in the response.",
+    )
 
     def to_internal_value(self, data):
         """Reject NUL bytes in query parameters."""

--- a/rbac/management/workspace/serializer.py
+++ b/rbac/management/workspace/serializer.py
@@ -37,6 +37,11 @@ class WorkspaceListInputSerializer(serializers.Serializer):
     GET /v2/workspaces/
     """
 
+    with_ancestry = serializers.BooleanField(
+        required=False,
+        default=False,
+        help_text="Include ancestor and fallback workspaces (root, default, ungrouped) in the response.",
+    )
     type = serializers.CharField(required=False, allow_blank=True, help_text="Filter by workspace type")
     name = serializers.CharField(
         required=False,

--- a/rbac/management/workspace/utils/access.py
+++ b/rbac/management/workspace/utils/access.py
@@ -225,7 +225,7 @@ def is_user_allowed_v1(request, required_operation, target_workspace):
     return any(valid_perm_tuple in tuple_set for valid_perm_tuple in valid_perm_tuples)
 
 
-def is_user_allowed_v2(request, required_operation, target_workspace):
+def is_user_allowed_v2(request, required_operation, target_workspace, with_ancestry=False):
     """
     Check if the user is allowed to perform the required permission on the target workspace using Inventory API.
 
@@ -235,6 +235,10 @@ def is_user_allowed_v2(request, required_operation, target_workspace):
         request: The HTTP request object
         required_operation: The operation/relation to check (view, create, edit, move, delete)
         target_workspace: The workspace ID to check, or None for list operations
+        with_ancestry: For list operations only. When True, include ancestor workspaces for
+            tree navigation and fallback workspaces (root, default, ungrouped) when the user
+            has no explicit access. When False, return only workspaces with explicit Inventory
+            permission.
 
     Returns:
         bool: True if the user has permission, False otherwise
@@ -357,10 +361,7 @@ def is_user_allowed_v2(request, required_operation, target_workspace):
             # Convert to set of UUIDs for proper filtering
             accessible_workspace_ids = set(accessible_workspace_ids)
 
-            with_ancestry = getattr(request, "with_ancestry", False)
-
             if accessible_workspace_ids:
-                # Get workspace objects for accessible IDs
                 with record_timing(timings, "db_filter_accessible_workspaces"):
                     accessible_workspaces = Workspace.objects.filter(
                         id__in=accessible_workspace_ids, tenant=request.tenant
@@ -368,8 +369,7 @@ def is_user_allowed_v2(request, required_operation, target_workspace):
 
                 if not accessible_workspaces.exists():
                     # Inventory can return workspace ids that are not present in RBAC for this tenant
-                    # (replication lag, stale tuples, cross-env mismatch). Treat like no workspace access
-                    # so the list API still returns root/default/ungrouped like users with no permissions.
+                    # (replication lag, stale tuples, cross-env mismatch). Treat like no workspace access.
                     logger.info(
                         "StreamedListObjects returned %s workspace id(s) but none exist for this tenant; "
                         "using fallback workspaces",
@@ -381,11 +381,9 @@ def is_user_allowed_v2(request, required_operation, target_workspace):
                     else:
                         accessible_workspace_ids = set()
                 else:
-                    # Keep only ids that exist for this tenant; drop stale Inventory-only ids
                     accessible_workspace_ids = {str(wid) for wid in accessible_workspaces.values_list("id", flat=True)}
 
                     if with_ancestry:
-                        # Add ancestors from the top-level workspace(s) for tree navigation
                         with record_timing(timings, "filter_top_level_workspaces"):
                             top_level_workspaces = filter_top_level_workspaces(accessible_workspaces)
 
@@ -393,11 +391,9 @@ def is_user_allowed_v2(request, required_operation, target_workspace):
                             for workspace in top_level_workspaces:
                                 ancestor_ids = {str(ancestor.id) for ancestor in workspace.ancestors()}
                                 accessible_workspace_ids.update(ancestor_ids)
-            else:
-                if with_ancestry:
-                    # Attach root, default, and ungrouped workspaces for basic structure visibility
-                    with record_timing(timings, "get_fallback_workspace_ids"):
-                        accessible_workspace_ids = get_fallback_workspace_ids(request.tenant)
+            elif with_ancestry:
+                with record_timing(timings, "get_fallback_workspace_ids"):
+                    accessible_workspace_ids = get_fallback_workspace_ids(request.tenant)
 
             # Store permission tuples for later filtering
             request.permission_tuples = [(None, ws_id) for ws_id in accessible_workspace_ids]

--- a/rbac/management/workspace/utils/access.py
+++ b/rbac/management/workspace/utils/access.py
@@ -357,11 +357,9 @@ def is_user_allowed_v2(request, required_operation, target_workspace):
             # Convert to set of UUIDs for proper filtering
             accessible_workspace_ids = set(accessible_workspace_ids)
 
-            if accessible_workspace_ids:
-                # User has actual workspace permissions (not just fallbacks)
-                request.has_real_workspace_access = True
+            with_ancestry = getattr(request, "with_ancestry", False)
 
-                # Add ancestors only from the top-level workspace(s) in accessible workspaces (for ancestry needs)
+            if accessible_workspace_ids:
                 # Get workspace objects for accessible IDs
                 with record_timing(timings, "db_filter_accessible_workspaces"):
                     accessible_workspaces = Workspace.objects.filter(
@@ -377,29 +375,29 @@ def is_user_allowed_v2(request, required_operation, target_workspace):
                         "using fallback workspaces",
                         len(accessible_workspace_ids),
                     )
-                    request.has_real_workspace_access = False
-                    with record_timing(timings, "get_fallback_workspace_ids"):
-                        accessible_workspace_ids = get_fallback_workspace_ids(request.tenant)
+                    if with_ancestry:
+                        with record_timing(timings, "get_fallback_workspace_ids"):
+                            accessible_workspace_ids = get_fallback_workspace_ids(request.tenant)
+                    else:
+                        accessible_workspace_ids = set()
                 else:
                     # Keep only ids that exist for this tenant; drop stale Inventory-only ids
                     accessible_workspace_ids = {str(wid) for wid in accessible_workspaces.values_list("id", flat=True)}
 
-                    # Find the top-level workspace(s) - those that are not children of any other accessible workspace
-                    with record_timing(timings, "filter_top_level_workspaces"):
-                        top_level_workspaces = filter_top_level_workspaces(accessible_workspaces)
+                    if with_ancestry:
+                        # Add ancestors from the top-level workspace(s) for tree navigation
+                        with record_timing(timings, "filter_top_level_workspaces"):
+                            top_level_workspaces = filter_top_level_workspaces(accessible_workspaces)
 
-                    with record_timing(timings, "add_ancestor_ids"):
-                        for workspace in top_level_workspaces:
-                            # Add ancestors directly for this top-level workspace
-                            ancestor_ids = {str(ancestor.id) for ancestor in workspace.ancestors()}
-                            accessible_workspace_ids.update(ancestor_ids)
+                        with record_timing(timings, "add_ancestor_ids"):
+                            for workspace in top_level_workspaces:
+                                ancestor_ids = {str(ancestor.id) for ancestor in workspace.ancestors()}
+                                accessible_workspace_ids.update(ancestor_ids)
             else:
-                # User has no actual workspace permissions, only fallback access
-                request.has_real_workspace_access = False
-
-                # If no accessible workspaces, attach at least root, default, and ungrouped workspaces
-                with record_timing(timings, "get_fallback_workspace_ids"):
-                    accessible_workspace_ids = get_fallback_workspace_ids(request.tenant)
+                if with_ancestry:
+                    # Attach root, default, and ungrouped workspaces for basic structure visibility
+                    with record_timing(timings, "get_fallback_workspace_ids"):
+                        accessible_workspace_ids = get_fallback_workspace_ids(request.tenant)
 
             # Store permission tuples for later filtering
             request.permission_tuples = [(None, ws_id) for ws_id in accessible_workspace_ids]

--- a/rbac/management/workspace/utils/access.py
+++ b/rbac/management/workspace/utils/access.py
@@ -395,7 +395,10 @@ def is_user_allowed_v2(request, required_operation, target_workspace, with_ances
                 with record_timing(timings, "get_fallback_workspace_ids"):
                     accessible_workspace_ids = get_fallback_workspace_ids(request.tenant)
 
-            # Store permission tuples for later filtering
+            # Store permission tuples for later filtering.
+            # Note: the contents depend on with_ancestry — with_ancestry=true includes
+            # ancestor and fallback IDs, while false includes only explicitly granted IDs.
+            # Do not cache or reuse these tuples across requests with different with_ancestry values.
             request.permission_tuples = [(None, ws_id) for ws_id in accessible_workspace_ids]
 
             result = bool(accessible_workspace_ids)

--- a/rbac/management/workspace/view.py
+++ b/rbac/management/workspace/view.py
@@ -194,6 +194,8 @@ class WorkspaceViewSet(WorkspaceObjectAccessMixin, BaseV2ViewSet):
         input_serializer.is_valid(raise_exception=True)
         validated_params = input_serializer.validated_data
 
+        request.with_ancestry = validated_params.get("with_ancestry", False)
+
         queryset = self.filter_queryset(self.get_queryset())
         queryset = self._service.list(queryset, validated_params)
 

--- a/rbac/management/workspace/view.py
+++ b/rbac/management/workspace/view.py
@@ -194,6 +194,8 @@ class WorkspaceViewSet(WorkspaceObjectAccessMixin, BaseV2ViewSet):
         input_serializer.is_valid(raise_exception=True)
         validated_params = input_serializer.validated_data
 
+        # Bridge query param to access layer; read by WorkspaceAccessFilterBackend and
+        # passed explicitly to is_user_allowed_v2(with_ancestry=...).
         request.with_ancestry = validated_params.get("with_ancestry", False)
 
         queryset = self.filter_queryset(self.get_queryset())

--- a/tests/management/workspace/test_filters.py
+++ b/tests/management/workspace/test_filters.py
@@ -373,7 +373,7 @@ class WorkspaceFilterBackendIntegrationTests(TransactionIdentityRequest):
         return_value=True,
     )
     def test_list_returns_fallback_workspaces_when_no_real_access(self, mock_flag, mock_channel):
-        """Test that list returns 200 with fallback workspaces when user has no real workspace access in V2 mode."""
+        """with_ancestry=true returns fallback workspaces when user has no real workspace access."""
         mock_stub = MagicMock()
         mock_channel.return_value.__enter__.return_value = MagicMock()
 
@@ -406,7 +406,7 @@ class WorkspaceFilterBackendIntegrationTests(TransactionIdentityRequest):
         return_value=True,
     )
     def test_v2_list_non_admin_without_inventory_access_includes_root_and_default(self, mock_flag, mock_channel):
-        """Users with no workspace relations in Inventory still list root and default (and ungrouped) workspaces."""
+        """with_ancestry=true: users with no Inventory access still list root, default, and ungrouped."""
         mock_stub = MagicMock()
         mock_channel.return_value.__enter__.return_value = MagicMock()
         mock_stub.StreamedListObjects.return_value = iter([])
@@ -432,7 +432,7 @@ class WorkspaceFilterBackendIntegrationTests(TransactionIdentityRequest):
         return_value=True,
     )
     def test_list_returns_fallback_when_inventory_ids_missing_in_rbac_db(self, mock_flag, mock_channel):
-        """Inventory IDs with no matching Workspace row for this tenant fall back to root/default/ungrouped."""
+        """with_ancestry=true: stale Inventory IDs fall back to root/default/ungrouped."""
         mock_stub = MagicMock()
         mock_channel.return_value.__enter__.return_value = MagicMock()
         orphan_id = uuid4()
@@ -461,6 +461,61 @@ class WorkspaceFilterBackendIntegrationTests(TransactionIdentityRequest):
         "feature_flags.FEATURE_FLAGS.is_workspace_access_check_v2_enabled",
         return_value=True,
     )
+    def test_list_stale_inventory_ids_returns_empty_without_ancestry(self, mock_flag, mock_channel):
+        """with_ancestry=false: stale Inventory IDs return empty, not fallback."""
+        mock_stub = MagicMock()
+        mock_channel.return_value.__enter__.return_value = MagicMock()
+        orphan_id = uuid4()
+        mock_stub.StreamedListObjects.side_effect = lambda *args, **kwargs: iter(
+            self._create_mock_workspace_responses([orphan_id])
+        )
+
+        with patch(
+            "kessel.inventory.v1beta2.inventory_service_pb2_grpc.KesselInventoryServiceStub",
+            return_value=mock_stub,
+        ):
+            request_context = self._create_request_context(self.customer_data, self.user_data, is_org_admin=False)
+            headers = request_context["request"].META
+            url = reverse("v2_management:workspace-list")
+            response = APIClient().get(f"{url}?with_ancestry=false", format="json", **headers)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["data"], [])
+        self.assertEqual(response.data["meta"]["count"], 0)
+
+    @patch("management.inventory_client.create_client_channel_inventory")
+    @patch(
+        "feature_flags.FEATURE_FLAGS.is_workspace_access_check_v2_enabled",
+        return_value=True,
+    )
+    def test_list_defaults_to_without_ancestry_when_param_omitted(self, mock_flag, mock_channel):
+        """Omitting with_ancestry defaults to false: only explicitly accessible workspaces returned."""
+        mock_stub = MagicMock()
+        mock_channel.return_value.__enter__.return_value = MagicMock()
+        mock_stub.StreamedListObjects.side_effect = lambda *args, **kwargs: iter(
+            self._create_mock_workspace_responses([self.standard_workspace.id])
+        )
+
+        with patch(
+            "kessel.inventory.v1beta2.inventory_service_pb2_grpc.KesselInventoryServiceStub",
+            return_value=mock_stub,
+        ):
+            request_context = self._create_request_context(self.customer_data, self.user_data, is_org_admin=False)
+            headers = request_context["request"].META
+            url = reverse("v2_management:workspace-list")
+            response = APIClient().get(url, format="json", **headers)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn("meta", response.data)
+        self.assertIn("data", response.data)
+        returned_ids = {str(ws["id"]) for ws in response.data["data"]}
+        self.assertEqual(returned_ids, {str(self.standard_workspace.id)})
+
+    @patch("management.inventory_client.create_client_channel_inventory")
+    @patch(
+        "feature_flags.FEATURE_FLAGS.is_workspace_access_check_v2_enabled",
+        return_value=True,
+    )
     def test_list_without_ancestry_returns_only_explicitly_accessible(self, mock_flag, mock_channel):
         """with_ancestry=false returns only workspaces Inventory explicitly granted, no ancestors."""
         mock_stub = MagicMock()
@@ -479,11 +534,10 @@ class WorkspaceFilterBackendIntegrationTests(TransactionIdentityRequest):
             response = APIClient().get(f"{url}?with_ancestry=false", format="json", **headers)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn("meta", response.data)
+        self.assertIn("data", response.data)
         returned_ids = {str(ws["id"]) for ws in response.data["data"]}
-        self.assertIn(str(self.standard_workspace.id), returned_ids)
-        self.assertNotIn(str(self.root_workspace.id), returned_ids)
-        self.assertNotIn(str(self.default_workspace.id), returned_ids)
-        self.assertNotIn(str(self.ungrouped_workspace.id), returned_ids)
+        self.assertEqual(returned_ids, {str(self.standard_workspace.id)})
 
     @patch("management.inventory_client.create_client_channel_inventory")
     @patch(
@@ -506,7 +560,9 @@ class WorkspaceFilterBackendIntegrationTests(TransactionIdentityRequest):
             response = APIClient().get(f"{url}?with_ancestry=false", format="json", **headers)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(len(response.data["data"]), 0)
+        self.assertIn("meta", response.data)
+        self.assertEqual(response.data["data"], [])
+        self.assertEqual(response.data["meta"]["count"], 0)
 
     @patch(
         "feature_flags.FEATURE_FLAGS.is_workspace_access_check_v2_enabled",

--- a/tests/management/workspace/test_filters.py
+++ b/tests/management/workspace/test_filters.py
@@ -389,7 +389,7 @@ class WorkspaceFilterBackendIntegrationTests(TransactionIdentityRequest):
 
             url = reverse("v2_management:workspace-list")
             client = APIClient()
-            response = client.get(url, format="json", **headers)
+            response = client.get(f"{url}?with_ancestry=true", format="json", **headers)
 
             # Should return 200 with fallback workspaces (root, default, ungrouped)
             self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -417,7 +417,8 @@ class WorkspaceFilterBackendIntegrationTests(TransactionIdentityRequest):
         ):
             request_context = self._create_request_context(self.customer_data, self.user_data, is_org_admin=False)
             headers = request_context["request"].META
-            response = APIClient().get(reverse("v2_management:workspace-list"), format="json", **headers)
+            url = reverse("v2_management:workspace-list")
+            response = APIClient().get(f"{url}?with_ancestry=true", format="json", **headers)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         types_by_id = {str(row["id"]): row["type"] for row in response.data["data"]}
@@ -445,7 +446,8 @@ class WorkspaceFilterBackendIntegrationTests(TransactionIdentityRequest):
         ):
             request_context = self._create_request_context(self.customer_data, self.user_data, is_org_admin=False)
             headers = request_context["request"].META
-            response = APIClient().get(reverse("v2_management:workspace-list"), format="json", **headers)
+            url = reverse("v2_management:workspace-list")
+            response = APIClient().get(f"{url}?with_ancestry=true", format="json", **headers)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         returned_ids = {str(ws["id"]) for ws in response.data["data"]}
@@ -453,6 +455,58 @@ class WorkspaceFilterBackendIntegrationTests(TransactionIdentityRequest):
         self.assertIn(str(self.default_workspace.id), returned_ids)
         self.assertIn(str(self.ungrouped_workspace.id), returned_ids)
         self.assertNotIn(str(orphan_id), returned_ids)
+
+    @patch("management.inventory_client.create_client_channel_inventory")
+    @patch(
+        "feature_flags.FEATURE_FLAGS.is_workspace_access_check_v2_enabled",
+        return_value=True,
+    )
+    def test_list_without_ancestry_returns_only_explicitly_accessible(self, mock_flag, mock_channel):
+        """with_ancestry=false returns only workspaces Inventory explicitly granted, no ancestors."""
+        mock_stub = MagicMock()
+        mock_channel.return_value.__enter__.return_value = MagicMock()
+        mock_stub.StreamedListObjects.side_effect = lambda *args, **kwargs: iter(
+            self._create_mock_workspace_responses([self.standard_workspace.id])
+        )
+
+        with patch(
+            "kessel.inventory.v1beta2.inventory_service_pb2_grpc.KesselInventoryServiceStub",
+            return_value=mock_stub,
+        ):
+            request_context = self._create_request_context(self.customer_data, self.user_data, is_org_admin=False)
+            headers = request_context["request"].META
+            url = reverse("v2_management:workspace-list")
+            response = APIClient().get(f"{url}?with_ancestry=false", format="json", **headers)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        returned_ids = {str(ws["id"]) for ws in response.data["data"]}
+        self.assertIn(str(self.standard_workspace.id), returned_ids)
+        self.assertNotIn(str(self.root_workspace.id), returned_ids)
+        self.assertNotIn(str(self.default_workspace.id), returned_ids)
+        self.assertNotIn(str(self.ungrouped_workspace.id), returned_ids)
+
+    @patch("management.inventory_client.create_client_channel_inventory")
+    @patch(
+        "feature_flags.FEATURE_FLAGS.is_workspace_access_check_v2_enabled",
+        return_value=True,
+    )
+    def test_list_without_ancestry_returns_empty_when_no_access(self, mock_flag, mock_channel):
+        """with_ancestry=false returns empty list (not fallback) when user has no access."""
+        mock_stub = MagicMock()
+        mock_channel.return_value.__enter__.return_value = MagicMock()
+        mock_stub.StreamedListObjects.return_value = iter([])
+
+        with patch(
+            "kessel.inventory.v1beta2.inventory_service_pb2_grpc.KesselInventoryServiceStub",
+            return_value=mock_stub,
+        ):
+            request_context = self._create_request_context(self.customer_data, self.user_data, is_org_admin=False)
+            headers = request_context["request"].META
+            url = reverse("v2_management:workspace-list")
+            response = APIClient().get(f"{url}?with_ancestry=false", format="json", **headers)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data["data"]), 0)
 
     @patch(
         "feature_flags.FEATURE_FLAGS.is_workspace_access_check_v2_enabled",

--- a/tests/management/workspace/test_filters.py
+++ b/tests/management/workspace/test_filters.py
@@ -67,7 +67,7 @@ class WorkspaceAccessFilterBackendUnitTests(TransactionTestCase):
         mock_flags.is_workspace_access_check_v2_enabled.return_value = True
 
         # Mock is_user_allowed_v2 to set permission_tuples on request
-        def set_permission_tuples(req, relation, target_workspace):
+        def set_permission_tuples(req, relation, target_workspace, with_ancestry=False):
             req.permission_tuples = [(None, "ws-1"), (None, "ws-2")]
             return True
 
@@ -86,7 +86,7 @@ class WorkspaceAccessFilterBackendUnitTests(TransactionTestCase):
         self.assertIsNone(call_args[0][2])  # target_workspace should be None
 
         # Should filter queryset by accessible IDs
-        queryset.filter.assert_called()
+        queryset.filter.assert_called_once_with(id__in={"ws-1", "ws-2"})
 
     @patch("management.workspace.filters.is_user_allowed_v2")
     @patch("management.workspace.filters.FEATURE_FLAGS")
@@ -461,8 +461,8 @@ class WorkspaceFilterBackendIntegrationTests(TransactionIdentityRequest):
         "feature_flags.FEATURE_FLAGS.is_workspace_access_check_v2_enabled",
         return_value=True,
     )
-    def test_list_stale_inventory_ids_returns_empty_without_ancestry(self, mock_flag, mock_channel):
-        """with_ancestry=false: stale Inventory IDs return empty, not fallback."""
+    def test_list_stale_inventory_ids_returns_403_without_ancestry(self, mock_flag, mock_channel):
+        """with_ancestry=false: stale Inventory IDs return 403, not fallback."""
         mock_stub = MagicMock()
         mock_channel.return_value.__enter__.return_value = MagicMock()
         orphan_id = uuid4()
@@ -479,9 +479,7 @@ class WorkspaceFilterBackendIntegrationTests(TransactionIdentityRequest):
             url = reverse("v2_management:workspace-list")
             response = APIClient().get(f"{url}?with_ancestry=false", format="json", **headers)
 
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data["data"], [])
-        self.assertEqual(response.data["meta"]["count"], 0)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @patch("management.inventory_client.create_client_channel_inventory")
     @patch(
@@ -544,8 +542,8 @@ class WorkspaceFilterBackendIntegrationTests(TransactionIdentityRequest):
         "feature_flags.FEATURE_FLAGS.is_workspace_access_check_v2_enabled",
         return_value=True,
     )
-    def test_list_without_ancestry_returns_empty_when_no_access(self, mock_flag, mock_channel):
-        """with_ancestry=false returns empty list (not fallback) when user has no access."""
+    def test_list_without_ancestry_returns_403_when_no_access(self, mock_flag, mock_channel):
+        """with_ancestry=false returns 403 when user has no workspace access."""
         mock_stub = MagicMock()
         mock_channel.return_value.__enter__.return_value = MagicMock()
         mock_stub.StreamedListObjects.return_value = iter([])
@@ -559,10 +557,40 @@ class WorkspaceFilterBackendIntegrationTests(TransactionIdentityRequest):
             url = reverse("v2_management:workspace-list")
             response = APIClient().get(f"{url}?with_ancestry=false", format="json", **headers)
 
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    @patch("management.inventory_client.create_client_channel_inventory")
+    @patch(
+        "feature_flags.FEATURE_FLAGS.is_workspace_access_check_v2_enabled",
+        return_value=True,
+    )
+    def test_list_with_ancestry_excludes_sibling_workspaces(self, mock_flag, mock_channel):
+        """with_ancestry=true includes ancestors but not sibling workspaces the user lacks access to."""
+        sibling_workspace = self.service.create(
+            {"name": "Sibling Workspace", "description": "Sibling", "parent_id": self.default_workspace.id},
+            self.tenant,
+        )
+        mock_stub = MagicMock()
+        mock_channel.return_value.__enter__.return_value = MagicMock()
+        mock_stub.StreamedListObjects.side_effect = lambda *args, **kwargs: iter(
+            self._create_mock_workspace_responses([self.standard_workspace.id])
+        )
+
+        with patch(
+            "kessel.inventory.v1beta2.inventory_service_pb2_grpc.KesselInventoryServiceStub",
+            return_value=mock_stub,
+        ):
+            request_context = self._create_request_context(self.customer_data, self.user_data, is_org_admin=False)
+            headers = request_context["request"].META
+            url = reverse("v2_management:workspace-list")
+            response = APIClient().get(f"{url}?with_ancestry=true", format="json", **headers)
+
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertIn("meta", response.data)
-        self.assertEqual(response.data["data"], [])
-        self.assertEqual(response.data["meta"]["count"], 0)
+        returned_ids = {str(ws["id"]) for ws in response.data["data"]}
+        self.assertIn(str(self.standard_workspace.id), returned_ids)
+        self.assertIn(str(self.default_workspace.id), returned_ids)
+        self.assertIn(str(self.root_workspace.id), returned_ids)
+        self.assertNotIn(str(sibling_workspace.id), returned_ids)
 
     @patch(
         "feature_flags.FEATURE_FLAGS.is_workspace_access_check_v2_enabled",

--- a/tests/management/workspace/test_serializer.py
+++ b/tests/management/workspace/test_serializer.py
@@ -326,3 +326,29 @@ class WorkspaceListInputSerializerTest(TestCase):
         s = WorkspaceListInputSerializer(data={"ids": "abc\x00def"})
         self.assertFalse(s.is_valid())
         self.assertIn("ids", s.errors)
+
+    # --- with_ancestry ---
+
+    def test_with_ancestry_omitted_defaults_to_false(self):
+        """Test that omitting with_ancestry defaults to false."""
+        s = WorkspaceListInputSerializer(data={})
+        self.assertTrue(s.is_valid(), s.errors)
+        self.assertFalse(s.validated_data["with_ancestry"])
+
+    def test_with_ancestry_true_string(self):
+        """Test that with_ancestry=true is accepted."""
+        s = WorkspaceListInputSerializer(data={"with_ancestry": "true"})
+        self.assertTrue(s.is_valid(), s.errors)
+        self.assertTrue(s.validated_data["with_ancestry"])
+
+    def test_with_ancestry_false_string(self):
+        """Test that with_ancestry=false is accepted."""
+        s = WorkspaceListInputSerializer(data={"with_ancestry": "false"})
+        self.assertTrue(s.is_valid(), s.errors)
+        self.assertFalse(s.validated_data["with_ancestry"])
+
+    def test_with_ancestry_invalid_value(self):
+        """Test that invalid with_ancestry values are rejected."""
+        s = WorkspaceListInputSerializer(data={"with_ancestry": "maybe"})
+        self.assertFalse(s.is_valid())
+        self.assertIn("with_ancestry", s.errors)

--- a/tests/management/workspace/test_workspace_inventory_access.py
+++ b/tests/management/workspace/test_workspace_inventory_access.py
@@ -2455,8 +2455,8 @@ class WorkspaceInventoryAccessV2Tests(TransactionIdentityRequest):
         "feature_flags.FEATURE_FLAGS.is_workspace_access_check_v2_enabled",
         return_value=True,
     )
-    def test_workspace_list_type_standard_returns_empty_without_real_access(self, mock_flag, mock_channel):
-        """Test that type=standard returns 200 with empty list when user has no real workspace access in V2 mode."""
+    def test_workspace_list_type_standard_returns_403_without_real_access(self, mock_flag, mock_channel):
+        """Test that type=standard returns 403 when user has no real workspace access and with_ancestry is false."""
         # Mock Inventory API to return empty list (no accessible workspaces)
         mock_stub = MagicMock()
         mock_channel.return_value.__enter__.return_value = MagicMock()
@@ -2475,13 +2475,10 @@ class WorkspaceInventoryAccessV2Tests(TransactionIdentityRequest):
             url = reverse("v2_management:workspace-list")
             client = APIClient()
 
-            # Query with type=standard - should return 200 with empty data
-            # (fallback workspaces are root/default/ungrouped, none are type=standard)
+            # Without with_ancestry, fallback workspaces are not applied
             response = client.get(f"{url}?type=standard", format="json", **headers)
 
-            self.assertEqual(response.status_code, status.HTTP_200_OK)
-            self.assertIn("data", response.data)
-            self.assertEqual(len(response.data["data"]), 0)
+            self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @patch("management.inventory_client.create_client_channel_inventory")
     @patch(
@@ -2619,8 +2616,8 @@ class WorkspaceInventoryAccessV2Tests(TransactionIdentityRequest):
         "feature_flags.FEATURE_FLAGS.is_workspace_access_check_v2_enabled",
         return_value=True,
     )
-    def test_workspace_list_no_type_returns_fallback_without_real_access(self, mock_flag, mock_channel):
-        """Test that default list (no type filter) returns fallback workspaces when user has no real workspace access."""
+    def test_workspace_list_no_type_returns_403_without_real_access(self, mock_flag, mock_channel):
+        """Test that default list (no type filter) returns 403 when user has no real workspace access."""
         # Mock Inventory API to return empty list (no accessible workspaces)
         mock_stub = MagicMock()
         mock_channel.return_value.__enter__.return_value = MagicMock()
@@ -2639,13 +2636,10 @@ class WorkspaceInventoryAccessV2Tests(TransactionIdentityRequest):
             url = reverse("v2_management:workspace-list")
             client = APIClient()
 
-            # Query without type filter - should return 200 with fallback workspaces
+            # Omitting with_ancestry defaults to false; no Inventory access returns 403
             response = client.get(url, format="json", **headers)
 
-            # Default type filter is 'standard', so fallback workspaces (root, default, ungrouped)
-            # are filtered out, resulting in empty data
-            self.assertEqual(response.status_code, status.HTTP_200_OK)
-            self.assertIn("data", response.data)
+            self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @patch("management.inventory_client.create_client_channel_inventory")
     @patch(

--- a/tests/management/workspace/test_workspace_inventory_access.py
+++ b/tests/management/workspace/test_workspace_inventory_access.py
@@ -736,7 +736,7 @@ class WorkspaceInventoryAccessV2Tests(TransactionIdentityRequest):
 
             url = reverse("v2_management:workspace-list")
             client = APIClient()
-            response = client.get(url, format="json", **headers)
+            response = client.get(f"{url}?with_ancestry=true", format="json", **headers)
 
             # Should return 200 with fallback workspaces (root, default, ungrouped)
             self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -1211,7 +1211,7 @@ class WorkspaceInventoryAccessV2Tests(TransactionIdentityRequest):
 
             url = reverse("v2_management:workspace-list")
             client = APIClient()
-            response = client.get(url, format="json", **headers)
+            response = client.get(f"{url}?with_ancestry=true", format="json", **headers)
 
             # Should return 200 with fallback workspaces (root, default, ungrouped)
             self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -1321,7 +1321,7 @@ class WorkspaceInventoryAccessV2Tests(TransactionIdentityRequest):
 
             url = reverse("v2_management:workspace-list")
             client = APIClient()
-            response = client.get(url, format="json", **headers)
+            response = client.get(f"{url}?with_ancestry=true", format="json", **headers)
 
             # Should have access to the workspace and all its ancestors
             self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -1367,7 +1367,7 @@ class WorkspaceInventoryAccessV2Tests(TransactionIdentityRequest):
 
             url = reverse("v2_management:workspace-list")
             client = APIClient()
-            response = client.get(url, format="json", **headers)
+            response = client.get(f"{url}?with_ancestry=true", format="json", **headers)
 
             # Should return 200 with fallback workspaces (root, default, ungrouped)
             self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -2476,8 +2476,8 @@ class WorkspaceInventoryAccessV2Tests(TransactionIdentityRequest):
             url = reverse("v2_management:workspace-list")
             client = APIClient()
 
-            # Query with type=all - should return 200 with fallback workspaces
-            response = client.get(f"{url}?type=all", format="json", **headers)
+            # Query with type=all and with_ancestry - should return 200 with fallback workspaces
+            response = client.get(f"{url}?type=all&with_ancestry=true", format="json", **headers)
 
             self.assertEqual(response.status_code, status.HTTP_200_OK)
             self.assertIn("data", response.data)
@@ -2640,8 +2640,8 @@ class WorkspaceInventoryAccessV2Tests(TransactionIdentityRequest):
             url = reverse("v2_management:workspace-list")
             client = APIClient()
 
-            # Query with type=root - should return root workspace from fallback
-            response = client.get(f"{url}?type=root", format="json", **headers)
+            # Query with type=root and with_ancestry - should return root workspace from fallback
+            response = client.get(f"{url}?type=root&with_ancestry=true", format="json", **headers)
 
             self.assertEqual(response.status_code, status.HTTP_200_OK)
             self.assertIn("data", response.data)
@@ -2674,8 +2674,8 @@ class WorkspaceInventoryAccessV2Tests(TransactionIdentityRequest):
             url = reverse("v2_management:workspace-list")
             client = APIClient()
 
-            # Query with type=default - should return default workspace from fallback
-            response = client.get(f"{url}?type=default", format="json", **headers)
+            # Query with type=default and with_ancestry - should return default workspace from fallback
+            response = client.get(f"{url}?type=default&with_ancestry=true", format="json", **headers)
 
             self.assertEqual(response.status_code, status.HTTP_200_OK)
             self.assertIn("data", response.data)

--- a/tests/management/workspace/test_workspace_inventory_access.py
+++ b/tests/management/workspace/test_workspace_inventory_access.py
@@ -1340,6 +1340,38 @@ class WorkspaceInventoryAccessV2Tests(TransactionIdentityRequest):
         "feature_flags.FEATURE_FLAGS.is_workspace_access_check_v2_enabled",
         return_value=True,
     )
+    def test_workspace_list_excludes_ancestors_when_with_ancestry_false(self, mock_flag, mock_channel):
+        """with_ancestry=false returns only the accessible workspace, not its ancestors."""
+        mock_stub = MagicMock()
+        mock_channel.return_value.__enter__.return_value = MagicMock()
+        mock_responses = self._create_mock_workspace_responses([self.standard_sub_workspace.id])
+        mock_stub.StreamedListObjects.side_effect = lambda *args, **kwargs: iter(mock_responses)
+
+        with patch(
+            "kessel.inventory.v1beta2.inventory_service_pb2_grpc.KesselInventoryServiceStub",
+            return_value=mock_stub,
+        ):
+            request_context = self._create_request_context(self.customer_data, self.user_data, is_org_admin=False)
+            headers = request_context["request"].META
+            self._setup_access_for_principal(
+                self.user_data["username"],
+                "inventory:groups:read",
+                workspace_id=str(self.standard_sub_workspace.id),
+                platform_default=False,
+            )
+
+            url = reverse("v2_management:workspace-list")
+            response = APIClient().get(f"{url}?with_ancestry=false", format="json", **headers)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        returned_ids = {str(ws["id"]) for ws in response.data["data"]}
+        self.assertEqual(returned_ids, {str(self.standard_sub_workspace.id)})
+
+    @patch("management.inventory_client.create_client_channel_inventory")
+    @patch(
+        "feature_flags.FEATURE_FLAGS.is_workspace_access_check_v2_enabled",
+        return_value=True,
+    )
     def test_workspace_list_returns_fallback_workspaces_when_no_access(self, mock_flag, mock_channel):
         """Test that workspace list returns fallback workspaces when user has no real workspace access in V2 mode."""
         # Mock Inventory API to return empty list (no accessible workspaces)


### PR DESCRIPTION
## Link(s) to Jira
- https://redhat.atlassian.net/browse/RHCLOUD-49129

## Description of Intent of Change(s)
Requires with_ancestry to list root/default workspaces for UI, this would reduce the confusion on the HBI side that a user without permission but can see default workspace

Breaking change: The default behavior changes from "always include fallback workspaces" to "only explicitly accessible workspaces." 

## Local Testing
Unit tests

## Checklist
- [x] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [x] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
