### PR TITLE
[RHCLOUD-48809] replace V2 API setup with Django ORM data creation

### DIFF
--- a/docs/ephemeral-dr-toolkit.md
+++ b/docs/ephemeral-dr-toolkit.md
@@ -237,7 +237,7 @@ PARITY_STEP=cleanup ./scripts/ephemeral/rbac-parity-toolkit.sh --check
 
 ## State File
 
-The toolkit persists state between phases in `~/.cache/rbac-dr-state.env` (plain key=value format). This allows running phases independently:
+The toolkit persists state between phases in `/tmp/rbac-parity-state.env` (plain key=value format). This allows running phases independently:
 
 ```bash
 # Run setup, then come back later for simulate

--- a/docs/ephemeral-dr-toolkit.md
+++ b/docs/ephemeral-dr-toolkit.md
@@ -235,7 +235,7 @@ PARITY_STEP=cleanup ./scripts/ephemeral/rbac-parity-toolkit.sh --check
 | `PARITY_FAST` | `false` | Skip waits and auto-confirm |
 | `PARITY_MINIMAL` | `false` | Minimal test data (1 of each resource) |
 
-## DR Toolkit State File
+## State File
 
 The toolkit persists state between phases in `~/.cache/rbac-dr-state.env` (plain key=value format). This allows running phases independently:
 

--- a/rbac/internal/migrations/migrate_role_scope.py
+++ b/rbac/internal/migrations/migrate_role_scope.py
@@ -60,8 +60,8 @@ def _check_migration(
     This should be run in the same SERIALIZABLE transaction as the actual migration (otherwise, the results of the
     check will be out of date).
     """
-    # We do not need to lock to prevent updates from concurrent seeding, since both this and seeding are in
-    # SERIALIZABLE transactions.
+    # Re-fetch the role to operate on its current state. When this function runs inside
+    # the SERIALIZABLE atomic_block(), this refetch is the authoritative concurrency check.
     role = Role.objects.filter(pk=role.pk).first()
 
     if role is None:
@@ -155,6 +155,17 @@ def migrate_role_scope_if_changed(v1_role: Role, replicator: Optional[RelationRe
 
     if replicator is None:
         replicator = OutboxReplicator()
+
+    # Early exit optimization outside the transaction. The authoritative concurrency
+    # check happens inside atomic_block() below via _check_migration().
+    v1_role = Role.objects.filter(pk=v1_role.pk).first()
+
+    if v1_role is None:
+        logger.info("System role concurrently deleted; not updating binding scopes.")
+        return
+
+    if not v1_role.system:
+        raise ValueError(f"Expected system role, but got pk={v1_role.pk!r}")
 
     resource_service = ImplicitResourceService.from_settings()
 

--- a/scripts/ephemeral/parity_data_setup.py
+++ b/scripts/ephemeral/parity_data_setup.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python
+"""Parity toolkit data setup/cleanup via Django ORM.
+
+Runs on the RBAC service pod via ``oc exec``. Bypasses V2 API permission
+checks by using the service layer directly, while still producing
+Debezium outbox writes for Kessel replication.
+
+Usage (from oc exec)::
+
+    python parity_data_setup.py setup --org-id=12345 --run-tag=abc123 [--minimal]
+    python parity_data_setup.py cleanup --org-id=12345 \\
+        --workspace-ids=uuid1,uuid2 --role-uuid=uuid3 --group-ids=uuid4,uuid5
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from api.models import Tenant as TenantType
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "rbac.settings")
+
+import django  # noqa: E402
+
+django.setup()
+
+from api.models import Tenant  # noqa: E402
+from management.group.model import Group  # noqa: E402
+from management.group.relation_api_dual_write_group_handler import RelationApiDualWriteGroupHandler  # noqa: E402
+from management.principal.model import Principal  # noqa: E402
+from management.relation_replicator.outbox_replicator import OutboxReplicator  # noqa: E402
+from management.relation_replicator.relation_replicator import ReplicationEventType  # noqa: E402
+from management.role.v2_service import RoleV2Service  # noqa: E402
+from management.role_binding.service import CreateBindingRequest, RoleBindingService  # noqa: E402
+from management.workspace.service import WorkspaceService  # noqa: E402
+
+logger = logging.getLogger(__name__)
+
+
+def get_tenant(org_id: str) -> TenantType:
+    """Look up tenant by org_id."""
+    try:
+        return Tenant.objects.get(org_id=org_id)
+    except Tenant.DoesNotExist:
+        print(json.dumps({"error": f"Tenant not found for org_id={org_id}"}))
+        sys.exit(1)
+
+
+def setup(org_id: str, run_tag: str, minimal: bool) -> None:
+    """Create test data covering all 5 parity sub-checks."""
+    tenant = get_tenant(org_id)
+    replicator = OutboxReplicator()
+    result = {}
+
+    # 1. Workspaces
+    ws_count = 1 if minimal else 2
+    ws_service = WorkspaceService(replicator=replicator)
+    workspace_ids = []
+    for i in range(1, ws_count + 1):
+        ws = ws_service.create(
+            validated_data={"name": f"parity-ws-{i}-{run_tag}"},
+            request_tenant=tenant,
+        )
+        workspace_ids.append(str(ws.id))
+    result["workspace_ids"] = workspace_ids
+
+    # 2. Custom role with permissions
+    role_service = RoleV2Service(tenant=tenant, replicator=replicator)
+    if minimal:
+        perms = [{"application": "inventory", "resource_type": "hosts", "verb": "read"}]
+    else:
+        perms = [
+            {"application": "inventory", "resource_type": "hosts", "verb": "read"},
+            {"application": "inventory", "resource_type": "groups", "verb": "write"},
+        ]
+    role = role_service.create(
+        name=f"parity-role-{run_tag}",
+        description=f"Parity check test role ({run_tag})",
+        permission_data=perms,
+        tenant=tenant,
+    )
+    result["role_uuid"] = str(role.uuid)
+    result["role_perm_count"] = len(perms)
+
+    # 3. Groups with principal
+    group_count = 1 if minimal else 2
+    principal, _ = Principal.objects.get_or_create(
+        username="jdoe",
+        tenant=tenant,
+        defaults={"type": Principal.Types.USER},
+    )
+    result["test_username"] = principal.username
+
+    group_ids = []
+    for i in range(1, group_count + 1):
+        group = Group.objects.create(
+            name=f"parity-group-{i}-{run_tag}",
+            tenant=tenant,
+        )
+        group.principals.add(principal)
+        handler = RelationApiDualWriteGroupHandler(
+            group,
+            ReplicationEventType.ADD_PRINCIPALS_TO_GROUP,
+            replicator=replicator,
+        )
+        handler.replicate_new_principals([principal])
+        group_ids.append(str(group.uuid))
+    result["group_ids"] = group_ids
+
+    # 4. Role bindings (tie role + group + workspace)
+    rb_service = RoleBindingService(tenant=tenant, replicator=replicator)
+    binding_requests = [
+        CreateBindingRequest(
+            role_id=str(role.uuid),
+            resource_type="workspace",
+            resource_id=ws_id,
+            subject_type="group",
+            subject_id=group_ids[0],
+        )
+        for ws_id in workspace_ids
+    ]
+    rb_service.batch_create(binding_requests)
+    result["binding_count"] = len(binding_requests)
+
+    print(json.dumps(result))
+
+
+def cleanup(org_id: str, workspace_ids: list[str], role_uuid: str, group_ids: list[str]) -> None:
+    """Remove test data in FK-safe order.
+
+    Uses direct ORM deletes (no service layer) because this runs on ephemeral
+    clusters that are destroyed after testing. Outbox events are not produced,
+    so Kessel relations will be orphaned. For persistent environments, use the
+    service-layer teardown methods instead.
+    """
+    tenant = get_tenant(org_id)
+    cleaned = 0
+
+    from management.role.v2_model import CustomRoleV2
+    from management.role_binding.model import RoleBinding
+    from management.workspace.model import Workspace
+
+    # 1. Role bindings (must go first due to FK constraints)
+    if role_uuid:
+        deleted, _ = RoleBinding.objects.filter(
+            role__uuid=role_uuid,
+            tenant=tenant,
+        ).delete()
+        cleaned += deleted
+
+    # 2. Workspaces
+    if workspace_ids:
+        deleted, _ = Workspace.objects.filter(
+            id__in=workspace_ids,
+            tenant=tenant,
+        ).delete()
+        cleaned += deleted
+
+    # 3. Role (permissions cascade via M2M through table)
+    if role_uuid:
+        deleted, _ = CustomRoleV2.objects.filter(
+            uuid=role_uuid,
+            tenant=tenant,
+        ).delete()
+        cleaned += deleted
+
+    # 4. Groups (M2M principals cleared automatically on group delete)
+    if group_ids:
+        deleted, _ = Group.objects.filter(
+            uuid__in=group_ids,
+            tenant=tenant,
+        ).delete()
+        cleaned += deleted
+
+    print(json.dumps({"cleaned": cleaned}))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Parity toolkit data setup/cleanup")
+    parser.add_argument("mode", choices=["setup", "cleanup"])
+    parser.add_argument("--org-id", required=True)
+    parser.add_argument("--run-tag", default="")
+    parser.add_argument("--minimal", action="store_true")
+    parser.add_argument("--workspace-ids", default="")
+    parser.add_argument("--role-uuid", default="")
+    parser.add_argument("--group-ids", default="")
+
+    args = parser.parse_args()
+
+    if args.mode == "setup":
+        if not args.run_tag:
+            print(json.dumps({"error": "--run-tag is required for setup mode"}))
+            sys.exit(1)
+        setup(args.org_id, args.run_tag, args.minimal)
+    elif args.mode == "cleanup":
+        ws_ids = [x for x in args.workspace_ids.split(",") if x]
+        g_ids = [x for x in args.group_ids.split(",") if x]
+        cleanup(args.org_id, ws_ids, args.role_uuid, g_ids)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ephemeral/rbac-parity-toolkit.sh
+++ b/scripts/ephemeral/rbac-parity-toolkit.sh
@@ -31,14 +31,17 @@ set -euo pipefail
 
 EPHEMERAL_NAMESPACE=$(oc project -q 2>/dev/null || true)
 BENTO_BASIC_AUTH_CONSOLE_DOT_USERNAME=jdoe
+EPHEMERAL_PASSWORD=$(oc get secret "env-${EPHEMERAL_NAMESPACE:-none}-keycloak" -o json 2>/dev/null \
+  | jq -r '.data.defaultPassword // empty' | base64 -d 2>/dev/null || true)
 EPHEMERAL_HOST_NAME=$(oc get frontendenvironment "env-${EPHEMERAL_NAMESPACE:-none}" -o json 2>/dev/null \
   | jq -r '.spec.hostname // empty' 2>/dev/null || true)
+BENTO_URL=https://${EPHEMERAL_HOST_NAME}
 
 # ── Config (overridable via env) ──────────────────────────────────────────────
 
 RBAC_SERVICE_POD_LABEL="${RBAC_SERVICE_POD_LABEL:-pod=rbac-service}"
 RBAC_WORKER_POD_LABEL="${RBAC_WORKER_POD_LABEL:-pod=rbac-worker-service}"
-RBAC_DB_POD_LABEL="${RBAC_DB_POD_LABEL:-pod=rbac-db}"
+RBAC_DB_POD_LABEL="${RBAC_DB_POD_LABEL:-app=rbac,service=db}"
 
 PARITY_ORG_ID="${PARITY_ORG_ID:-}"
 PARITY_FAST="${PARITY_FAST:-false}"
@@ -74,6 +77,10 @@ state_save() {
 
 state_load() {
   if [[ -f "${PARITY_STATE_FILE}" ]]; then
+    if grep -qvE '^[A-Z_]+=.*$|^$' "${PARITY_STATE_FILE}" 2>/dev/null; then
+      err "State file contains invalid entries -- refusing to load: ${PARITY_STATE_FILE}"
+      return 1
+    fi
     # shellcheck disable=SC1090
     source "${PARITY_STATE_FILE}"
   fi
@@ -189,6 +196,12 @@ _db_creds() {
 _db_query() {
   PGPASSWORD="${_db_password}" oc exec "${_db_pod}" -- \
     psql -U "${_db_user}" -d "${_db_name}" -t -A -c "$1" 2>/dev/null | tr -d '\r'
+}
+
+_db_query_parameterized() {
+  local var_binding="$1" sql="$2"
+  PGPASSWORD="${_db_password}" oc exec "${_db_pod}" -- \
+    psql -U "${_db_user}" -d "${_db_name}" -v "${var_binding}" -t -A -c "${sql}" 2>/dev/null | tr -d '\r'
 }
 
 # ── Internal API helper ──────────────────────────────────────────────────────
@@ -615,8 +628,8 @@ phase_break() {
 
   # First remove any role bindings referencing this workspace.
   local rb_deleted
-  rb_deleted=$(_db_query "DELETE FROM management_rolebinding
-    WHERE resource_id = '${target_ws_id}'
+  rb_deleted=$(_db_query_parameterized "ws_id=${target_ws_id}" "DELETE FROM management_rolebinding
+    WHERE resource_id = :'ws_id'
     RETURNING uuid;")
   if [[ -n "${rb_deleted}" ]]; then
     info "  Removed role bindings referencing workspace: ${rb_deleted}"
@@ -624,8 +637,8 @@ phase_break() {
 
   # Delete the workspace itself.
   local ws_deleted
-  ws_deleted=$(_db_query "DELETE FROM management_workspace
-    WHERE id = '${target_ws_id}'
+  ws_deleted=$(_db_query_parameterized "ws_id=${target_ws_id}" "DELETE FROM management_workspace
+    WHERE id = :'ws_id'
     RETURNING id, name;")
 
   if [[ -n "${ws_deleted}" ]]; then

--- a/scripts/ephemeral/rbac-parity-toolkit.sh
+++ b/scripts/ephemeral/rbac-parity-toolkit.sh
@@ -414,7 +414,7 @@ phase_setup() {
   echo ""
   echo -e "${BOLD}=== Phase: SETUP ===${NC}"
   echo ""
-  echo "  Creating test data to exercise all parity sub-checks."
+  echo "  Creating test data via Django ORM (bypasses V2 API permission checks)."
   echo "  Run tag: ${run_tag}"
   echo ""
 
@@ -425,145 +425,69 @@ phase_setup() {
 
   state_save PARITY_RUN_TAG "${run_tag}"
 
-  # ── 1. Workspaces (exercises workspace hierarchy check) ──────────────────
-  echo ""
-  echo -e "${BOLD}--- Creating workspaces ---${NC}"
-  echo ""
-
-  local ws_count=2
-  [[ "${PARITY_MINIMAL}" == "true" ]] && ws_count=1
-
-  local ws_ids=()
-  for i in $(seq 1 "${ws_count}"); do
-    local ws_name="parity-ws-${i}-${run_tag}"
-    local ws_resp
-    ws_resp=$(exec_api_curl POST "/api/rbac/v2/workspaces/" \
-      -H "Content-Type: application/json" \
-      -d "{\"name\": \"${ws_name}\"}") || return 1
-    local ws_id
-    ws_id=$(echo "${ws_resp}" | jq -r '.id')
-    ws_ids+=("${ws_id}")
-    good "Created workspace: ${ws_name} (${ws_id})"
-  done
-
-  local ws_ids_csv
-  ws_ids_csv=$(IFS=,; echo "${ws_ids[*]}")
-  state_save PARITY_WORKSPACE_IDS "${ws_ids_csv}"
-
-  # ── 2. Custom role with permissions (exercises custom role check) ────────
-  echo ""
-  echo -e "${BOLD}--- Creating custom role ---${NC}"
-  echo ""
-
-  local role_name="parity-role-${run_tag}"
-  local perms_json perm_count
-  if [[ "${PARITY_MINIMAL}" == "true" ]]; then
-    perm_count=1
-    perms_json='[{"application":"inventory","resource_type":"hosts","operation":"read"}]'
-  else
-    perm_count=2
-    perms_json='[{"application":"inventory","resource_type":"hosts","operation":"read"},{"application":"inventory","resource_type":"groups","operation":"write"}]'
-  fi
-
-  local role_body
-  role_body=$(jq -nc \
-    --arg name "${role_name}" \
-    --argjson perms "${perms_json}" \
-    '{name: $name, permissions: $perms}')
-
-  local role_resp
-  role_resp=$(exec_api_curl POST "/api/rbac/v2/roles/" \
-    -H "Content-Type: application/json" \
-    -d "${role_body}") || return 1
-  local role_uuid
-  role_uuid=$(echo "${role_resp}" | jq -r '.id')
-  state_save PARITY_ROLE_UUID "${role_uuid}"
-  good "Created role: ${role_name} (${role_uuid}) with ${perm_count} permission(s)"
-
-  # ── 3. Group with principal (exercises group-principal check) ─────────────
-  echo ""
-  echo -e "${BOLD}--- Creating group with principal ---${NC}"
-  echo ""
-
-  # Find an existing principal to add.
-  local test_username
-  test_username=$(exec_api_curl GET "/api/rbac/v1/principals/?limit=1&type=user" \
-    2>/dev/null | jq -r '.data[0].username // empty' 2>/dev/null)
-  if [[ -z "${test_username}" ]]; then
-    test_username="${BENTO_BASIC_AUTH_CONSOLE_DOT_USERNAME}"
-  fi
-  state_save PARITY_TEST_USERNAME "${test_username}"
-  info "Using principal: ${test_username}"
-
-  local group_count=2
-  [[ "${PARITY_MINIMAL}" == "true" ]] && group_count=1
-
-  local group_ids=()
-  for i in $(seq 1 "${group_count}"); do
-    local group_name="parity-group-${i}-${run_tag}"
-    local g_resp
-    g_resp=$(exec_api_curl POST "/api/rbac/v1/groups/" \
-      -H "Content-Type: application/json" \
-      -d "{\"name\": \"${group_name}\"}") || return 1
-    local group_uuid
-    group_uuid=$(echo "${g_resp}" | jq -r '.uuid')
-    group_ids+=("${group_uuid}")
-    good "Created group: ${group_name} (${group_uuid})"
-
-    # Add principal to the group.
-    if exec_api_curl POST "/api/rbac/v1/groups/${group_uuid}/principals/" \
-      -H "Content-Type: application/json" \
-      -d "{\"principals\": [{\"username\": \"${test_username}\"}]}" >/dev/null 2>&1; then
-      good "  Added principal '${test_username}' to group"
-    else
-      warn "  Failed to add principal"
-    fi
-  done
-
-  local group_ids_csv
-  group_ids_csv=$(IFS=,; echo "${group_ids[*]}")
-  state_save PARITY_GROUP_IDS "${group_ids_csv}"
-
-  # ── 4. Role binding (ties role+group+workspace together) ─────────────────
-  echo ""
-  echo -e "${BOLD}--- Creating role bindings ---${NC}"
-  echo ""
-
-  local rb_requests=""
-  for ws_id in "${ws_ids[@]}"; do
-    [[ -n "${rb_requests}" ]] && rb_requests="${rb_requests},"
-    rb_requests="${rb_requests}{\"resource\":{\"id\":\"${ws_id}\",\"type\":\"workspace\"},\"subject\":{\"id\":\"${group_ids[0]}\",\"type\":\"group\"},\"role\":{\"id\":\"${role_uuid}\"}}"
-  done
-
-  local rb_ok=false
-  for attempt in 1 2 3; do
-    exec_api_curl POST "/api/rbac/v2/role-bindings:batchCreate/" \
-      -H "Content-Type: application/json" \
-      -d "{\"requests\": [${rb_requests}]}" >/dev/null 2>&1 && { rb_ok=true; break; }
-    warn "Role binding batch create attempt ${attempt}/3 failed, retrying in 5s..."
-    sleep 5
-  done
-
-  if [[ "${rb_ok}" != "true" ]]; then
-    err "Failed to create role bindings after 3 attempts"
+  local svc_pod
+  svc_pod=$(get_pod_by_label "${RBAC_SERVICE_POD_LABEL}")
+  if [[ -z "${svc_pod}" ]]; then
+    err "No running RBAC service pod found"
     return 1
   fi
-  good "Created ${#ws_ids[@]} role binding(s)"
 
-  # ── 5. Bootstrap + seeded roles (already exist from bootstrap/seeds) ─────
-  echo ""
-  info "Bootstrap and seeded role data already exist from tenant bootstrap."
-  info "No additional setup needed for those sub-checks."
+  local script_dir
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  info "Copying parity_data_setup.py to pod ${svc_pod}..."
+  oc cp "${script_dir}/parity_data_setup.py" "${svc_pod}:/tmp/parity_data_setup.py" || {
+    err "Failed to copy setup script to pod"
+    return 1
+  }
 
-  # ── Summary ──────────────────────────────────────────────────────────────
+  local setup_cmd="cd /opt/rbac/rbac && DJANGO_SETTINGS_MODULE=rbac.settings /opt/rbac/.venv/bin/python /tmp/parity_data_setup.py setup --org-id=${PARITY_ORG_ID} --run-tag=${run_tag}"
+  [[ "${PARITY_MINIMAL}" == "true" ]] && setup_cmd="${setup_cmd} --minimal"
+
+  info "Running ORM-based data setup on pod..."
+  local raw_output
+  raw_output=$(oc exec "${svc_pod}" -- sh -c "${setup_cmd}" 2>&1)
+
+  local setup_output
+  setup_output=$(echo "${raw_output}" | grep -v '^Defaulted' | tail -1)
+
+  local setup_error
+  setup_error=$(echo "${setup_output}" | jq -r '.error // empty' 2>/dev/null)
+  if [[ -n "${setup_error}" ]]; then
+    err "Setup script failed: ${setup_error}"
+    err "Full output: ${raw_output}"
+    return 1
+  fi
+
+  local ws_ids_csv role_uuid group_ids_csv test_username binding_count role_perm_count
+  ws_ids_csv=$(echo "${setup_output}" | jq -r '.workspace_ids | join(",")')
+  role_uuid=$(echo "${setup_output}" | jq -r '.role_uuid')
+  group_ids_csv=$(echo "${setup_output}" | jq -r '.group_ids | join(",")')
+  test_username=$(echo "${setup_output}" | jq -r '.test_username')
+  binding_count=$(echo "${setup_output}" | jq -r '.binding_count')
+  role_perm_count=$(echo "${setup_output}" | jq -r '.role_perm_count')
+
+  if [[ -z "${ws_ids_csv}" || "${ws_ids_csv}" == "null" ]]; then
+    err "Setup script returned no workspace IDs"
+    err "Output: ${raw_output}"
+    return 1
+  fi
+
+  state_save PARITY_WORKSPACE_IDS "${ws_ids_csv}"
+  state_save PARITY_ROLE_UUID "${role_uuid}"
+  state_save PARITY_GROUP_IDS "${group_ids_csv}"
+  state_save PARITY_TEST_USERNAME "${test_username}"
+
+  local ws_count group_count
+  ws_count=$(echo "${ws_ids_csv}" | tr ',' '\n' | wc -l | tr -d ' ')
+  group_count=$(echo "${group_ids_csv}" | tr ',' '\n' | wc -l | tr -d ' ')
+
   echo ""
   echo -e "${BOLD}=== Setup Summary ===${NC}"
   echo ""
-  echo "  Org ID:      ${PARITY_ORG_ID}"
-  echo "  Workspaces:  ${ws_count} created (${ws_ids_csv})"
-  echo "  Role:        ${role_name} (${role_uuid})"
-  echo "  Groups:      ${group_count} with principal '${test_username}'"
-  echo "  Bindings:    ${#ws_ids[@]} (role -> group -> workspace)"
+  good "Workspaces:  ${ws_count} created (${ws_ids_csv})"
+  good "Role:        parity-role-${run_tag} (${role_uuid}) with ${role_perm_count} permission(s)"
+  good "Groups:      ${group_count} with principal '${test_username}'"
+  good "Bindings:    ${binding_count} (role -> group -> workspace)"
   echo "  Bootstrap:   pre-existing"
   echo "  Seeded roles: pre-existing"
   echo ""
@@ -841,62 +765,44 @@ phase_cleanup() {
   echo ""
 
   state_load
-  _db_creds || return 1
 
-  local cleaned=0
+  local svc_pod
+  svc_pod=$(get_pod_by_label "${RBAC_SERVICE_POD_LABEL}")
+  if [[ -z "${svc_pod}" ]]; then
+    err "No running RBAC service pod found"
+    return 1
+  fi
 
-  # Delete role bindings first (FK constraints).
+  local script_dir
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  oc cp "${script_dir}/parity_data_setup.py" "${svc_pod}:/tmp/parity_data_setup.py" 2>/dev/null || true
+
+  local cleanup_cmd="cd /opt/rbac/rbac && DJANGO_SETTINGS_MODULE=rbac.settings /opt/rbac/.venv/bin/python /tmp/parity_data_setup.py cleanup --org-id=${PARITY_ORG_ID:-}"
+
+  local ws_ids="${PARITY_WORKSPACE_IDS:-}"
   local role_uuid="${PARITY_ROLE_UUID:-}"
-  if [[ -n "${role_uuid}" ]]; then
-    info "Removing role bindings for role ${role_uuid}..."
-    _db_query "DELETE FROM management_rolebinding
-      WHERE role_id = (SELECT id FROM management_rolev2 WHERE uuid='${role_uuid}');" >/dev/null 2>&1 || true
-    cleaned=$((cleaned + 1))
+  local group_ids="${PARITY_GROUP_IDS:-}"
+
+  [[ -n "${ws_ids}" ]] && cleanup_cmd="${cleanup_cmd} --workspace-ids=${ws_ids}"
+  [[ -n "${role_uuid}" ]] && cleanup_cmd="${cleanup_cmd} --role-uuid=${role_uuid}"
+  [[ -n "${group_ids}" ]] && cleanup_cmd="${cleanup_cmd} --group-ids=${group_ids}"
+
+  if [[ -z "${ws_ids}" && -z "${role_uuid}" && -z "${group_ids}" ]]; then
+    info "No resources to clean up (state file empty or missing)."
+    rm -f "${PARITY_STATE_FILE}"
+    return 0
   fi
 
-  # Delete workspaces.
-  local ws_ids_csv="${PARITY_WORKSPACE_IDS:-}"
-  if [[ -n "${ws_ids_csv}" ]]; then
-    info "Removing test workspaces..."
-    IFS=',' read -ra ws_ids <<< "${ws_ids_csv}"
-    for ws_id in "${ws_ids[@]}"; do
-      _db_query "DELETE FROM management_workspace WHERE id = '${ws_id}';" >/dev/null 2>&1 || true
-      good "  Deleted workspace ${ws_id}"
-    done
-    cleaned=$((cleaned + ${#ws_ids[@]}))
-  fi
+  info "Running ORM-based cleanup on pod..."
+  local raw_output
+  raw_output=$(oc exec "${svc_pod}" -- sh -c "${cleanup_cmd}" 2>&1)
 
-  # Delete the role.
-  if [[ -n "${role_uuid}" ]]; then
-    info "Removing test role..."
-    # Delete role permissions first, then the role itself.
-    local role_pk
-    role_pk=$(_db_query "SELECT id FROM management_rolev2 WHERE uuid='${role_uuid}';" 2>/dev/null)
-    if [[ -n "${role_pk}" ]]; then
-      _db_query "DELETE FROM management_rolev2_permissions WHERE rolev2_id = ${role_pk};" >/dev/null 2>&1 || true
-      _db_query "DELETE FROM management_rolev2 WHERE id = ${role_pk};" >/dev/null 2>&1 || true
-      good "  Deleted role ${role_uuid}"
-      cleaned=$((cleaned + 1))
-    fi
-  fi
+  local cleanup_output
+  cleanup_output=$(echo "${raw_output}" | grep -v '^Defaulted' | tail -1)
 
-  # Delete groups.
-  local group_ids_csv="${PARITY_GROUP_IDS:-}"
-  if [[ -n "${group_ids_csv}" ]]; then
-    info "Removing test groups..."
-    IFS=',' read -ra group_ids <<< "${group_ids_csv}"
-    for gid in "${group_ids[@]}"; do
-      # Remove principals from group first.
-      _db_query "DELETE FROM management_group_principals WHERE group_id = (SELECT id FROM management_group WHERE uuid='${gid}');" >/dev/null 2>&1 || true
-      # Remove policies referencing this group.
-      _db_query "DELETE FROM management_policy_group WHERE group_id = (SELECT id FROM management_group WHERE uuid='${gid}');" >/dev/null 2>&1 || true
-      _db_query "DELETE FROM management_group WHERE uuid = '${gid}';" >/dev/null 2>&1 || true
-      good "  Deleted group ${gid}"
-    done
-    cleaned=$((cleaned + ${#group_ids[@]}))
-  fi
+  local cleaned
+  cleaned=$(echo "${cleanup_output}" | jq -r '.cleaned // 0' 2>/dev/null)
 
-  # Clear state file.
   rm -f "${PARITY_STATE_FILE}"
 
   echo ""

--- a/scripts/ephemeral/rbac-parity-toolkit.sh
+++ b/scripts/ephemeral/rbac-parity-toolkit.sh
@@ -81,8 +81,11 @@ state_load() {
       err "State file contains invalid entries -- refusing to load: ${PARITY_STATE_FILE}"
       return 1
     fi
-    # shellcheck disable=SC1090
-    source "${PARITY_STATE_FILE}"
+    while IFS='=' read -r key value; do
+      [[ -z "${key}" ]] && continue
+      printf -v "${key}" '%s' "${value}"
+      export "${key}"
+    done < "${PARITY_STATE_FILE}"
   fi
 }
 

--- a/tests/internal/migrations/test_migrate_role_scope.py
+++ b/tests/internal/migrations/test_migrate_role_scope.py
@@ -101,3 +101,22 @@ class MigrateRoleScopeTest(DualWriteTestCase):
     def test_no_migrate_without_replication(self):
         self._do_migrate()
         self.assertFalse(RoleScopeState.objects.filter(role=self.role).exists())
+
+    def test_no_migrate_deleted_role(self):
+        """Early exit when role is concurrently deleted."""
+        role_pk = self.role.pk
+        self.role.delete()
+
+        from management.role.model import Role
+
+        deleted_role = Role(pk=role_pk)
+        migrate_role_scope_if_changed(deleted_role, InMemoryRelationReplicator(self.tuples))
+        self.assertFalse(RoleScopeState.objects.filter(role_id=role_pk).exists())
+
+    def test_raises_for_non_system_role(self):
+        """ValueError when a non-system role is passed."""
+        self.role.system = False
+        self.role.save()
+
+        with self.assertRaises(ValueError):
+            self._do_migrate()


### PR DESCRIPTION
## Summary

- Replace API-based data creation in parity toolkit setup phase with Django ORM operations that bypass Kessel permission checks on ephemeral clusters
- Add ephemeral cluster DR toolkit and parity check scripts for operational tooling
- Fix AttributeError crash in `migrate_role_scope_if_changed` when role is concurrently deleted

## JIRA

[RHCLOUD-48809](https://issues.redhat.com/browse/RHCLOUD-48809)

## Test plan

- [ ] `tests.internal.migrations.test_migrate_role_scope` passes
- [ ] `tests.management.role.test_dual_write` passes
- [ ] Full test suite passes (`tox -e py312-fast`)
- [ ] Parity toolkit runs on ephemeral with ORM-based setup

[RHCLOUD-48809]: https://redhat.atlassian.net/browse/RHCLOUD-48809?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an ephemeral toolkit/CLI to create and tear down RBAC parity test data, including tenants, workspaces, roles, groups, and role bindings.
  - Enhanced the parity toolkit workflow to generate all parity data via in-pod ORM execution and structured JSON state.

- **Bug Fixes**
  - Improved migration behavior when roles are concurrently deleted.
  - Added stricter handling to raise an error for unexpected non-system roles.

- **Documentation**
  - Updated the “State File” section with the revised state-file heading and path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->