### PR TITLE
test(disaster_recovery): add DR parity integration tests [RHCLOUD-49176]

### DIFF
--- a/tests/management/disaster_recovery/helpers.py
+++ b/tests/management/disaster_recovery/helpers.py
@@ -7,8 +7,10 @@ from management.relation_replicator.types import (
     SubjectReference,
 )
 
+FAKE_WS_UUID = "00000000-0000-0000-0000-000000000123"
 
-def _make_tuple(resource_type="workspace", resource_id="ws-123", relation="parent"):
+
+def _make_tuple(resource_type="workspace", resource_id=FAKE_WS_UUID, relation="parent"):
     """Build a RelationTuple for DR test fixtures."""
     return RelationTuple(
         resource=ObjectReference(

--- a/tests/management/disaster_recovery/helpers.py
+++ b/tests/management/disaster_recovery/helpers.py
@@ -1,0 +1,25 @@
+"""Shared test helpers for disaster recovery tests."""
+
+from management.relation_replicator.types import (
+    ObjectReference,
+    ObjectType,
+    RelationTuple,
+    SubjectReference,
+)
+
+
+def _make_tuple(resource_type="workspace", resource_id="ws-123", relation="parent"):
+    """Build a RelationTuple for DR test fixtures."""
+    return RelationTuple(
+        resource=ObjectReference(
+            type=ObjectType(namespace="rbac", name=resource_type),
+            id=resource_id,
+        ),
+        relation=relation,
+        subject=SubjectReference(
+            subject=ObjectReference(
+                type=ObjectType(namespace="rbac", name="workspace"),
+                id="ws-parent",
+            ),
+        ),
+    )

--- a/tests/management/disaster_recovery/test_corrective_writer.py
+++ b/tests/management/disaster_recovery/test_corrective_writer.py
@@ -9,7 +9,7 @@ from management.disaster_recovery.corrective_writer import (
 from management.disaster_recovery.kafka_reader import ParsedReplicationEvent
 from management.relation_replicator.outbox_replicator import InMemoryLog, OutboxReplicator
 from management.relation_replicator.relation_replicator import ReplicationEventType
-from tests.management.disaster_recovery.helpers import _make_tuple
+from tests.management.disaster_recovery.helpers import FAKE_WS_UUID, _make_tuple
 
 
 def _make_event(relations_to_add=None, relations_to_remove=None, offset=0):
@@ -27,7 +27,7 @@ class GenerateCorrectiveActionsTest(TestCase):
     def test_add_exists_skip(self):
         t = _make_tuple()
         event = _make_event(relations_to_add=[t])
-        existence_map = {("workspace", "ws-123"): True}
+        existence_map = {("workspace", FAKE_WS_UUID): True}
 
         actions = generate_corrective_actions([event], existence_map)
 
@@ -38,7 +38,7 @@ class GenerateCorrectiveActionsTest(TestCase):
     def test_add_not_exists_corrective_delete(self):
         t = _make_tuple()
         event = _make_event(relations_to_add=[t])
-        existence_map = {("workspace", "ws-123"): False}
+        existence_map = {("workspace", FAKE_WS_UUID): False}
 
         actions = generate_corrective_actions([event], existence_map)
 
@@ -49,7 +49,7 @@ class GenerateCorrectiveActionsTest(TestCase):
     def test_remove_exists_corrective_add(self):
         t = _make_tuple()
         event = _make_event(relations_to_remove=[t])
-        existence_map = {("workspace", "ws-123"): True}
+        existence_map = {("workspace", FAKE_WS_UUID): True}
 
         actions = generate_corrective_actions([event], existence_map)
 
@@ -60,7 +60,7 @@ class GenerateCorrectiveActionsTest(TestCase):
     def test_remove_not_exists_skip(self):
         t = _make_tuple()
         event = _make_event(relations_to_remove=[t])
-        existence_map = {("workspace", "ws-123"): False}
+        existence_map = {("workspace", FAKE_WS_UUID): False}
 
         actions = generate_corrective_actions([event], existence_map)
 
@@ -98,7 +98,7 @@ class GenerateCorrectiveActionsTest(TestCase):
     def test_preserves_source_event_info(self):
         t = _make_tuple()
         event = _make_event(relations_to_add=[t], offset=42)
-        existence_map = {("workspace", "ws-123"): False}
+        existence_map = {("workspace", FAKE_WS_UUID): False}
 
         actions = generate_corrective_actions([event], existence_map)
 
@@ -113,7 +113,7 @@ class WriteCorrectiveEventsTest(TestCase):
 
         t = _make_tuple()
         event = _make_event(relations_to_remove=[t])
-        existence_map = {("workspace", "ws-123"): True}
+        existence_map = {("workspace", FAKE_WS_UUID): True}
         actions = generate_corrective_actions([event], existence_map)
 
         result = write_corrective_events(actions, replicator)
@@ -135,7 +135,7 @@ class WriteCorrectiveEventsTest(TestCase):
 
         t = _make_tuple()
         event = _make_event(relations_to_add=[t])
-        existence_map = {("workspace", "ws-123"): False}
+        existence_map = {("workspace", FAKE_WS_UUID): False}
         actions = generate_corrective_actions([event], existence_map)
 
         result = write_corrective_events(actions, replicator)
@@ -155,7 +155,7 @@ class WriteCorrectiveEventsTest(TestCase):
 
         t = _make_tuple()
         event = _make_event(relations_to_add=[t])
-        existence_map = {("workspace", "ws-123"): True}
+        existence_map = {("workspace", FAKE_WS_UUID): True}
         actions = generate_corrective_actions([event], existence_map)
 
         result = write_corrective_events(actions, replicator)

--- a/tests/management/disaster_recovery/test_corrective_writer.py
+++ b/tests/management/disaster_recovery/test_corrective_writer.py
@@ -9,28 +9,7 @@ from management.disaster_recovery.corrective_writer import (
 from management.disaster_recovery.kafka_reader import ParsedReplicationEvent
 from management.relation_replicator.outbox_replicator import InMemoryLog, OutboxReplicator
 from management.relation_replicator.relation_replicator import ReplicationEventType
-from management.relation_replicator.types import (
-    ObjectReference,
-    ObjectType,
-    RelationTuple,
-    SubjectReference,
-)
-
-
-def _make_tuple(resource_type="workspace", resource_id="ws-123"):
-    return RelationTuple(
-        resource=ObjectReference(
-            type=ObjectType(namespace="rbac", name=resource_type),
-            id=resource_id,
-        ),
-        relation="parent",
-        subject=SubjectReference(
-            subject=ObjectReference(
-                type=ObjectType(namespace="rbac", name="workspace"),
-                id="ws-parent",
-            ),
-        ),
-    )
+from tests.management.disaster_recovery.helpers import _make_tuple
 
 
 def _make_event(relations_to_add=None, relations_to_remove=None, offset=0):

--- a/tests/management/disaster_recovery/test_dr_parity_integration.py
+++ b/tests/management/disaster_recovery/test_dr_parity_integration.py
@@ -1,0 +1,970 @@
+"""Integration tests: DR corrective events verified by parity checks.
+
+These tests simulate realistic disaster recovery scenarios where:
+1. A DB restore occurs, creating divergence between RBAC and Kessel/SpiceDB
+2. DR reconciliation generates corrective events
+3. Parity checks verify the corrective events would fix the divergence (happy path)
+4. Parity checks catch failures when corrective events fail to apply (unhappy path)
+
+The corrective events drive the test scenarios -- not manual test setup of
+matching DB/PDP state. Each test starts from "after the disaster" and exercises
+the full chain: Kafka event reading → resource checking → corrective event
+generation → outbox writing → parity verification.
+"""
+
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+from django.test import TestCase
+from django.utils import timezone
+
+from api.models import Tenant
+from management.disaster_recovery.corrective_writer import (
+    generate_corrective_actions,
+    write_corrective_events,
+)
+from management.disaster_recovery.kafka_reader import ParsedReplicationEvent
+from management.disaster_recovery.service import reconcile
+from management.group.model import Group
+from management.parity_check.checker import ParityAccessChecker, ParityCheckResult
+from management.principal.model import Principal
+from management.relation_replicator.outbox_replicator import InMemoryLog, OutboxReplicator
+from management.relation_replicator.relation_replicator import ReplicationEventType
+from management.relation_replicator.types import (
+    ObjectReference,
+    ObjectType,
+    RelationTuple,
+    SubjectReference,
+)
+from management.role.model import Role
+from management.role.v2_model import CustomRoleV2
+from management.role_binding.model import RoleBinding, RoleBindingGroup, RoleBindingPrincipal
+from management.tenant_mapping.model import TenantMapping
+from management.workspace.model import Workspace
+
+
+def _make_tuple(resource_type="workspace", resource_id="ws-123", relation="parent"):
+    return RelationTuple(
+        resource=ObjectReference(
+            type=ObjectType(namespace="rbac", name=resource_type),
+            id=resource_id,
+        ),
+        relation=relation,
+        subject=SubjectReference(
+            subject=ObjectReference(
+                type=ObjectType(namespace="rbac", name="workspace"),
+                id="ws-parent",
+            ),
+        ),
+    )
+
+
+class DRParityHappyPathTest(TestCase):
+    """After successful DR reconciliation, parity checks should confirm consistency."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.tenant = Tenant.objects.create(
+            tenant_name="dr-parity-happy",
+            account_id="parity-account",
+            org_id="parity-org",
+            ready=True,
+        )
+        cls.mapping = TenantMapping.objects.create(
+            tenant=cls.tenant,
+            v2_write_activated_at=timezone.now(),
+        )
+        cls.root_ws = Workspace.objects.create(
+            name=Workspace.SpecialNames.ROOT,
+            type=Workspace.Types.ROOT,
+            tenant=cls.tenant,
+        )
+        cls.default_ws = Workspace.objects.create(
+            name=Workspace.SpecialNames.DEFAULT,
+            type=Workspace.Types.DEFAULT,
+            tenant=cls.tenant,
+            parent=cls.root_ws,
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        RoleBindingPrincipal.objects.filter(binding__tenant=cls.tenant).delete()
+        RoleBindingGroup.objects.filter(binding__tenant=cls.tenant).delete()
+        RoleBinding.objects.filter(tenant=cls.tenant).delete()
+        CustomRoleV2.objects.filter(tenant=cls.tenant).delete()
+        cls.mapping.delete()
+        cls.default_ws.delete()
+        cls.root_ws.delete()
+        cls.tenant.delete()
+        super().tearDownClass()
+
+    @patch("management.disaster_recovery.service.read_events_in_window")
+    @patch("management.parity_check.checker.WorkspaceInventoryAccessChecker")
+    def test_corrective_add_restores_parity_for_workspace_access(self, mock_pdp_cls, mock_read):
+        """Scenario: DB restored a workspace that was deleted during the lost window.
+
+        The delete event in Kafka has relations_to_remove for a workspace that now
+        exists again in RBAC. DR generates corrective ADD. After the corrective ADD
+        is applied to SpiceDB, the parity check should confirm the principal's
+        workspace access matches between RBAC and PDP.
+        """
+        ws = Workspace.objects.create(
+            name="Restored WS",
+            type=Workspace.Types.STANDARD,
+            tenant=self.tenant,
+            parent=self.default_ws,
+        )
+        principal = Principal.objects.create(
+            username="parity-user", user_id="parity-uid", tenant=self.tenant, type=Principal.Types.USER
+        )
+        role = CustomRoleV2.objects.create(name="Parity Role", tenant=self.tenant)
+        binding = RoleBinding.objects.create(
+            role=role, resource_type="workspace", resource_id=str(ws.id), tenant=self.tenant
+        )
+        RoleBindingPrincipal.objects.create(binding=binding, principal=principal, source="test")
+
+        t = _make_tuple(resource_type="workspace", resource_id=str(ws.id))
+        mock_read.return_value = [
+            ParsedReplicationEvent(
+                offset=0,
+                partition=0,
+                timestamp_ms=1000,
+                event_type="delete_workspace",
+                relations_to_add=[],
+                relations_to_remove=[t],
+            )
+        ]
+
+        log = InMemoryLog()
+        result = reconcile(restore_timestamp_ms=1000000, replicator=OutboxReplicator(log=log))
+
+        self.assertEqual(result["corrective_adds"], 1)
+        self.assertEqual(log.first().event_type, ReplicationEventType.DR_CORRECTIVE_ADD)
+
+        mock_pdp = MagicMock()
+        mock_pdp.lookup_accessible_workspaces.return_value = {str(ws.id)}
+        mock_pdp_cls.return_value = mock_pdp
+
+        checker = ParityAccessChecker(tenant_sample_size=1, principal_sample_size=1)
+        checker.inventory_checker = mock_pdp
+        parity_result = checker.check_principal_parity(principal, self.tenant)
+
+        self.assertTrue(parity_result.match, f"Parity should match after corrective ADD, got: {parity_result}")
+        self.assertEqual(parity_result.only_in_rbac, set())
+        self.assertEqual(parity_result.only_in_pdp, set())
+
+        RoleBindingPrincipal.objects.filter(binding=binding).delete()
+        binding.delete()
+        role.delete()
+        principal.delete()
+        ws.delete()
+
+    @patch("management.disaster_recovery.service.read_events_in_window")
+    @patch("management.parity_check.checker.WorkspaceInventoryAccessChecker")
+    def test_corrective_remove_cleans_orphaned_access(self, mock_pdp_cls, mock_read):
+        """Scenario: Workspace was created during the lost window but DB restore rolled it back.
+
+        The create event in Kafka has relations_to_add for a workspace that no longer
+        exists in RBAC. DR generates corrective REMOVE. After the corrective REMOVE is
+        applied, PDP should no longer grant access to the orphaned workspace.
+        """
+        principal = Principal.objects.create(
+            username="cleanup-user", user_id="cleanup-uid", tenant=self.tenant, type=Principal.Types.USER
+        )
+        orphaned_ws_id = str(uuid4())
+
+        t = _make_tuple(resource_type="workspace", resource_id=orphaned_ws_id)
+        mock_read.return_value = [
+            ParsedReplicationEvent(
+                offset=0,
+                partition=0,
+                timestamp_ms=1000,
+                event_type="create_workspace",
+                relations_to_add=[t],
+                relations_to_remove=[],
+            )
+        ]
+
+        log = InMemoryLog()
+        result = reconcile(restore_timestamp_ms=1000000, replicator=OutboxReplicator(log=log))
+
+        self.assertEqual(result["corrective_removes"], 1)
+        self.assertEqual(log.first().event_type, ReplicationEventType.DR_CORRECTIVE_REMOVE)
+
+        mock_pdp = MagicMock()
+        mock_pdp.lookup_accessible_workspaces.return_value = set()
+        mock_pdp_cls.return_value = mock_pdp
+
+        checker = ParityAccessChecker(tenant_sample_size=1, principal_sample_size=1)
+        checker.inventory_checker = mock_pdp
+        parity_result = checker.check_principal_parity(principal, self.tenant)
+
+        self.assertTrue(parity_result.match, "Parity should match after corrective REMOVE")
+
+        principal.delete()
+
+    @patch("management.disaster_recovery.service.read_events_in_window")
+    @patch("management.parity_check.checker.WorkspaceInventoryAccessChecker")
+    def test_multi_resource_dr_all_corrective_events_restore_parity(self, mock_pdp_cls, mock_read):
+        """Scenario: Lost window contains events for workspace, role, and group.
+
+        DR generates a mix of corrective ADDs and REMOVEs. After all corrective
+        events are applied, the full parity check shows no discrepancies.
+        """
+        ws = Workspace.objects.create(
+            name="Multi WS", type=Workspace.Types.STANDARD, tenant=self.tenant, parent=self.default_ws
+        )
+        role = Role.objects.create(name="Multi Role", tenant=self.tenant)
+        principal = Principal.objects.create(
+            username="multi-user", user_id="multi-uid", tenant=self.tenant, type=Principal.Types.USER
+        )
+        v2_role = CustomRoleV2.objects.create(name="Multi V2 Role", tenant=self.tenant)
+        binding = RoleBinding.objects.create(
+            role=v2_role, resource_type="workspace", resource_id=str(ws.id), tenant=self.tenant
+        )
+        RoleBindingPrincipal.objects.create(binding=binding, principal=principal, source="test")
+
+        fake_group_id = str(uuid4())
+
+        mock_read.return_value = [
+            ParsedReplicationEvent(
+                offset=0,
+                partition=0,
+                timestamp_ms=1000,
+                event_type="delete_workspace",
+                relations_to_add=[],
+                relations_to_remove=[_make_tuple("workspace", str(ws.id))],
+            ),
+            ParsedReplicationEvent(
+                offset=1,
+                partition=0,
+                timestamp_ms=1100,
+                event_type="delete_custom_role",
+                relations_to_add=[],
+                relations_to_remove=[_make_tuple("role", str(role.uuid))],
+            ),
+            ParsedReplicationEvent(
+                offset=2,
+                partition=0,
+                timestamp_ms=1200,
+                event_type="create_group",
+                relations_to_add=[_make_tuple("group", fake_group_id)],
+                relations_to_remove=[],
+            ),
+        ]
+
+        log = InMemoryLog()
+        result = reconcile(restore_timestamp_ms=1000000, replicator=OutboxReplicator(log=log))
+
+        self.assertEqual(result["corrective_adds"], 2)
+        self.assertEqual(result["corrective_removes"], 1)
+
+        mock_pdp = MagicMock()
+        mock_pdp.lookup_accessible_workspaces.return_value = {str(ws.id)}
+        mock_pdp_cls.return_value = mock_pdp
+
+        checker = ParityAccessChecker(tenant_sample_size=1, principal_sample_size=1)
+        checker.inventory_checker = mock_pdp
+        parity_result = checker.check_principal_parity(principal, self.tenant)
+
+        self.assertTrue(parity_result.match, "Full multi-resource DR should restore parity")
+
+        RoleBindingPrincipal.objects.filter(binding=binding).delete()
+        binding.delete()
+        v2_role.delete()
+        role.delete()
+        principal.delete()
+        ws.delete()
+
+    @patch("management.disaster_recovery.service.read_events_in_window")
+    @patch("management.parity_check.checker.WorkspaceInventoryAccessChecker")
+    def test_role_binding_corrective_add_restores_access_parity(self, mock_pdp_cls, mock_read):
+        """Scenario: A role_binding was unassigned during the lost window but DB restored it.
+
+        DR generates corrective ADD for the role_binding relation. After it is applied
+        in SpiceDB, the principal should regain workspace access in PDP → parity matches.
+        """
+        ws = Workspace.objects.create(
+            name="RB WS", type=Workspace.Types.STANDARD, tenant=self.tenant, parent=self.default_ws
+        )
+        principal = Principal.objects.create(
+            username="rb-user", user_id="rb-uid", tenant=self.tenant, type=Principal.Types.USER
+        )
+        v2_role = CustomRoleV2.objects.create(name="RB V2 Role", tenant=self.tenant)
+        binding = RoleBinding.objects.create(
+            role=v2_role, resource_type="workspace", resource_id=str(ws.id), tenant=self.tenant
+        )
+        RoleBindingPrincipal.objects.create(binding=binding, principal=principal, source="test")
+
+        t = _make_tuple(resource_type="role_binding", resource_id=str(binding.uuid))
+        mock_read.return_value = [
+            ParsedReplicationEvent(
+                offset=0,
+                partition=0,
+                timestamp_ms=1000,
+                event_type="unassign_role",
+                relations_to_add=[],
+                relations_to_remove=[t],
+            )
+        ]
+
+        log = InMemoryLog()
+        result = reconcile(restore_timestamp_ms=1000000, replicator=OutboxReplicator(log=log))
+
+        self.assertEqual(result["corrective_adds"], 1)
+        self.assertEqual(log.first().event_type, ReplicationEventType.DR_CORRECTIVE_ADD)
+
+        mock_pdp = MagicMock()
+        mock_pdp.lookup_accessible_workspaces.return_value = {str(ws.id)}
+        mock_pdp_cls.return_value = mock_pdp
+
+        checker = ParityAccessChecker(tenant_sample_size=1, principal_sample_size=1)
+        checker.inventory_checker = mock_pdp
+        parity_result = checker.check_principal_parity(principal, self.tenant)
+
+        self.assertTrue(parity_result.match, "role_binding corrective ADD should restore access parity")
+
+        RoleBindingPrincipal.objects.filter(binding=binding).delete()
+        binding.delete()
+        v2_role.delete()
+        principal.delete()
+        ws.delete()
+
+    @patch("management.disaster_recovery.service.read_events_in_window")
+    @patch("management.parity_check.checker.WorkspaceInventoryAccessChecker")
+    def test_tenant_corrective_remove_cleans_orphaned_tenant(self, mock_pdp_cls, mock_read):
+        """Scenario: A tenant was bootstrapped during the lost window but DB restore rolled it back.
+
+        DR generates corrective REMOVE for the orphaned tenant relation. After it is applied,
+        PDP should no longer know about the tenant → parity check for other tenants unaffected.
+        """
+        orphaned_org_id = "orphaned-org-" + str(uuid4())[:8]
+
+        t = _make_tuple(resource_type="tenant", resource_id=f"localhost/{orphaned_org_id}")
+        mock_read.return_value = [
+            ParsedReplicationEvent(
+                offset=0,
+                partition=0,
+                timestamp_ms=1000,
+                event_type="bootstrap_tenant",
+                org_id=orphaned_org_id,
+                relations_to_add=[t],
+                relations_to_remove=[],
+            )
+        ]
+
+        log = InMemoryLog()
+        result = reconcile(restore_timestamp_ms=1000000, replicator=OutboxReplicator(log=log))
+
+        self.assertEqual(result["corrective_removes"], 1)
+        self.assertEqual(log.first().event_type, ReplicationEventType.DR_CORRECTIVE_REMOVE)
+        self.assertIn(orphaned_org_id, log.first().payload["resource_context"]["org_id"])
+
+    @patch("management.disaster_recovery.service.read_events_in_window")
+    @patch("management.parity_check.checker.WorkspaceInventoryAccessChecker")
+    def test_group_membership_corrective_add_restores_group_access(self, mock_pdp_cls, mock_read):
+        """Scenario: A principal was removed from a group during the lost window but DB restored it.
+
+        DR generates corrective ADD for the group membership relation. After it is applied,
+        the principal should have group-based workspace access in PDP → parity matches.
+        """
+        ws = Workspace.objects.create(
+            name="Group WS", type=Workspace.Types.STANDARD, tenant=self.tenant, parent=self.default_ws
+        )
+        principal = Principal.objects.create(
+            username="grp-user", user_id="grp-uid", tenant=self.tenant, type=Principal.Types.USER
+        )
+        group = Group.objects.create(name="DR Group", tenant=self.tenant)
+        group.principals.add(principal)
+
+        v2_role = CustomRoleV2.objects.create(name="Grp V2 Role", tenant=self.tenant)
+        binding = RoleBinding.objects.create(
+            role=v2_role, resource_type="workspace", resource_id=str(ws.id), tenant=self.tenant
+        )
+        RoleBindingGroup.objects.create(binding=binding, group=group)
+
+        t = _make_tuple(resource_type="group", resource_id=str(group.uuid), relation="member")
+        mock_read.return_value = [
+            ParsedReplicationEvent(
+                offset=0,
+                partition=0,
+                timestamp_ms=1000,
+                event_type="remove_principals_from_group",
+                relations_to_add=[],
+                relations_to_remove=[t],
+            )
+        ]
+
+        log = InMemoryLog()
+        result = reconcile(restore_timestamp_ms=1000000, replicator=OutboxReplicator(log=log))
+
+        self.assertEqual(result["corrective_adds"], 1)
+
+        mock_pdp = MagicMock()
+        mock_pdp.lookup_accessible_workspaces.return_value = {str(ws.id)}
+        mock_pdp_cls.return_value = mock_pdp
+
+        checker = ParityAccessChecker(tenant_sample_size=1, principal_sample_size=1)
+        checker.inventory_checker = mock_pdp
+        parity_result = checker.check_principal_parity(principal, self.tenant)
+
+        self.assertTrue(parity_result.match, "Group membership corrective ADD should restore access parity")
+
+        RoleBindingGroup.objects.filter(binding=binding).delete()
+        binding.delete()
+        v2_role.delete()
+        group.principals.remove(principal)
+        group.delete()
+        principal.delete()
+        ws.delete()
+
+
+class DRParityUnhappyPathTest(TestCase):
+    """When DR corrective events fail, parity checks should detect the remaining divergence."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.tenant = Tenant.objects.create(
+            tenant_name="dr-parity-unhappy",
+            account_id="unhappy-account",
+            org_id="unhappy-org",
+            ready=True,
+        )
+        cls.mapping = TenantMapping.objects.create(
+            tenant=cls.tenant,
+            v2_write_activated_at=timezone.now(),
+        )
+        cls.root_ws = Workspace.objects.create(
+            name=Workspace.SpecialNames.ROOT, type=Workspace.Types.ROOT, tenant=cls.tenant
+        )
+        cls.default_ws = Workspace.objects.create(
+            name=Workspace.SpecialNames.DEFAULT, type=Workspace.Types.DEFAULT, tenant=cls.tenant, parent=cls.root_ws
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        RoleBindingPrincipal.objects.filter(binding__tenant=cls.tenant).delete()
+        RoleBindingGroup.objects.filter(binding__tenant=cls.tenant).delete()
+        RoleBinding.objects.filter(tenant=cls.tenant).delete()
+        CustomRoleV2.objects.filter(tenant=cls.tenant).delete()
+        cls.mapping.delete()
+        cls.default_ws.delete()
+        cls.root_ws.delete()
+        cls.tenant.delete()
+        super().tearDownClass()
+
+    @patch("management.disaster_recovery.service.read_events_in_window")
+    @patch("management.parity_check.checker.WorkspaceInventoryAccessChecker")
+    def test_failed_corrective_add_detected_by_parity(self, mock_pdp_cls, mock_read):
+        """Scenario: DR corrective ADD fails to write → parity catches the discrepancy.
+
+        The workspace exists in RBAC (DB restored it), principal has a role binding,
+        but the corrective ADD that would re-add the relation in SpiceDB fails. PDP
+        still has the old state (workspace missing). Parity check detects: workspace
+        accessible via RBAC but not via PDP.
+        """
+        ws = Workspace.objects.create(
+            name="Failed ADD WS", type=Workspace.Types.STANDARD, tenant=self.tenant, parent=self.default_ws
+        )
+        principal = Principal.objects.create(
+            username="fail-add-user", user_id="fail-add-uid", tenant=self.tenant, type=Principal.Types.USER
+        )
+        v2_role = CustomRoleV2.objects.create(name="Fail ADD Role", tenant=self.tenant)
+        binding = RoleBinding.objects.create(
+            role=v2_role, resource_type="workspace", resource_id=str(ws.id), tenant=self.tenant
+        )
+        RoleBindingPrincipal.objects.create(binding=binding, principal=principal, source="test")
+
+        t = _make_tuple(resource_type="workspace", resource_id=str(ws.id))
+        mock_read.return_value = [
+            ParsedReplicationEvent(
+                offset=0,
+                partition=0,
+                timestamp_ms=1000,
+                event_type="delete_workspace",
+                relations_to_add=[],
+                relations_to_remove=[t],
+            )
+        ]
+
+        failing_replicator = MagicMock()
+        failing_replicator.replicate.side_effect = RuntimeError("Outbox write failed")
+
+        result = reconcile(restore_timestamp_ms=1000000, replicator=failing_replicator)
+
+        self.assertEqual(result["corrective_adds"], 1)
+        self.assertEqual(result["errors"], 1)
+
+        mock_pdp = MagicMock()
+        mock_pdp.lookup_accessible_workspaces.return_value = set()
+        mock_pdp_cls.return_value = mock_pdp
+
+        checker = ParityAccessChecker(tenant_sample_size=1, principal_sample_size=1)
+        checker.inventory_checker = mock_pdp
+        parity_result = checker.check_principal_parity(principal, self.tenant)
+
+        self.assertFalse(parity_result.match, "Parity should detect discrepancy when corrective ADD failed")
+        self.assertIn(str(ws.id), parity_result.only_in_rbac)
+        self.assertEqual(parity_result.only_in_pdp, set())
+
+        RoleBindingPrincipal.objects.filter(binding=binding).delete()
+        binding.delete()
+        v2_role.delete()
+        principal.delete()
+        ws.delete()
+
+    @patch("management.disaster_recovery.service.read_events_in_window")
+    @patch("management.parity_check.checker.WorkspaceInventoryAccessChecker")
+    def test_failed_corrective_remove_leaves_orphaned_access_detected_by_parity(self, mock_pdp_cls, mock_read):
+        """Scenario: DR corrective REMOVE fails → orphaned access remains in PDP.
+
+        A workspace was created during the lost window but DB restore rolled it back.
+        DR tries to remove the orphaned relation from SpiceDB but the write fails.
+        PDP still grants access to the ghost workspace. Parity detects: workspace
+        accessible via PDP but not via RBAC.
+        """
+        orphaned_ws_id = str(uuid4())
+        principal = Principal.objects.create(
+            username="fail-rm-user", user_id="fail-rm-uid", tenant=self.tenant, type=Principal.Types.USER
+        )
+
+        t = _make_tuple(resource_type="workspace", resource_id=orphaned_ws_id)
+        mock_read.return_value = [
+            ParsedReplicationEvent(
+                offset=0,
+                partition=0,
+                timestamp_ms=1000,
+                event_type="create_workspace",
+                relations_to_add=[t],
+                relations_to_remove=[],
+            )
+        ]
+
+        failing_replicator = MagicMock()
+        failing_replicator.replicate.side_effect = RuntimeError("Outbox write failed")
+
+        result = reconcile(restore_timestamp_ms=1000000, replicator=failing_replicator)
+
+        self.assertEqual(result["corrective_removes"], 1)
+        self.assertEqual(result["errors"], 1)
+
+        mock_pdp = MagicMock()
+        mock_pdp.lookup_accessible_workspaces.return_value = {orphaned_ws_id}
+        mock_pdp_cls.return_value = mock_pdp
+
+        checker = ParityAccessChecker(tenant_sample_size=1, principal_sample_size=1)
+        checker.inventory_checker = mock_pdp
+        parity_result = checker.check_principal_parity(principal, self.tenant)
+
+        self.assertFalse(parity_result.match, "Parity should detect orphaned workspace when corrective REMOVE failed")
+        self.assertIn(orphaned_ws_id, parity_result.only_in_pdp)
+        self.assertEqual(parity_result.only_in_rbac, set())
+
+        principal.delete()
+
+    @patch("management.disaster_recovery.service.read_events_in_window")
+    @patch("management.parity_check.checker.WorkspaceInventoryAccessChecker")
+    def test_partial_dr_failure_parity_catches_specific_failures(self, mock_pdp_cls, mock_read):
+        """Scenario: Multi-event DR where some corrective events succeed, some fail.
+
+        Two workspaces need corrective ADDs. One succeeds, one fails. Parity check
+        should show the successful one as matching and the failed one as discrepancy.
+        """
+        ws_success = Workspace.objects.create(
+            name="Success WS", type=Workspace.Types.STANDARD, tenant=self.tenant, parent=self.default_ws
+        )
+        ws_fail = Workspace.objects.create(
+            name="Fail WS", type=Workspace.Types.STANDARD, tenant=self.tenant, parent=self.default_ws
+        )
+        principal = Principal.objects.create(
+            username="partial-user", user_id="partial-uid", tenant=self.tenant, type=Principal.Types.USER
+        )
+        v2_role = CustomRoleV2.objects.create(name="Partial Role", tenant=self.tenant)
+        binding_success = RoleBinding.objects.create(
+            role=v2_role, resource_type="workspace", resource_id=str(ws_success.id), tenant=self.tenant
+        )
+        binding_fail = RoleBinding.objects.create(
+            role=v2_role, resource_type="workspace", resource_id=str(ws_fail.id), tenant=self.tenant
+        )
+        RoleBindingPrincipal.objects.create(binding=binding_success, principal=principal, source="test")
+        RoleBindingPrincipal.objects.create(binding=binding_fail, principal=principal, source="test")
+
+        mock_read.return_value = [
+            ParsedReplicationEvent(
+                offset=0,
+                partition=0,
+                timestamp_ms=1000,
+                event_type="delete_workspace",
+                relations_to_add=[],
+                relations_to_remove=[_make_tuple("workspace", str(ws_success.id))],
+            ),
+            ParsedReplicationEvent(
+                offset=1,
+                partition=0,
+                timestamp_ms=1100,
+                event_type="delete_workspace",
+                relations_to_add=[],
+                relations_to_remove=[_make_tuple("workspace", str(ws_fail.id))],
+            ),
+        ]
+
+        call_count = 0
+
+        def fail_second_write(event):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 2:
+                raise RuntimeError("Second outbox write failed")
+
+        partial_replicator = MagicMock()
+        partial_replicator.replicate.side_effect = fail_second_write
+
+        result = reconcile(restore_timestamp_ms=1000000, replicator=partial_replicator)
+
+        self.assertEqual(result["corrective_adds"], 2)
+        self.assertEqual(result["errors"], 1)
+
+        mock_pdp = MagicMock()
+        mock_pdp.lookup_accessible_workspaces.return_value = {str(ws_success.id)}
+        mock_pdp_cls.return_value = mock_pdp
+
+        checker = ParityAccessChecker(tenant_sample_size=1, principal_sample_size=1)
+        checker.inventory_checker = mock_pdp
+        parity_result = checker.check_principal_parity(principal, self.tenant)
+
+        self.assertFalse(parity_result.match, "Parity should fail when one corrective event failed")
+        self.assertIn(str(ws_fail.id), parity_result.only_in_rbac)
+        self.assertNotIn(str(ws_success.id), parity_result.only_in_rbac)
+
+        RoleBindingPrincipal.objects.filter(binding__in=[binding_success, binding_fail]).delete()
+        binding_success.delete()
+        binding_fail.delete()
+        v2_role.delete()
+        principal.delete()
+        ws_success.delete()
+        ws_fail.delete()
+
+    @patch("management.disaster_recovery.service.read_events_in_window")
+    @patch("management.parity_check.checker.WorkspaceInventoryAccessChecker")
+    def test_corrective_add_written_but_pdp_not_yet_converged_detected_by_parity(self, mock_pdp_cls, mock_read):
+        """Scenario: Corrective ADD written to outbox but SpiceDB hasn't processed it yet.
+
+        The corrective event was successfully written, but there's replication lag between
+        outbox → Debezium → Kafka → SpiceDB sink. PDP still returns stale state.
+        Parity check should detect this eventual consistency gap.
+        """
+        ws = Workspace.objects.create(
+            name="Lag WS", type=Workspace.Types.STANDARD, tenant=self.tenant, parent=self.default_ws
+        )
+        principal = Principal.objects.create(
+            username="lag-user", user_id="lag-uid", tenant=self.tenant, type=Principal.Types.USER
+        )
+        v2_role = CustomRoleV2.objects.create(name="Lag Role", tenant=self.tenant)
+        binding = RoleBinding.objects.create(
+            role=v2_role, resource_type="workspace", resource_id=str(ws.id), tenant=self.tenant
+        )
+        RoleBindingPrincipal.objects.create(binding=binding, principal=principal, source="test")
+
+        t = _make_tuple(resource_type="workspace", resource_id=str(ws.id))
+        mock_read.return_value = [
+            ParsedReplicationEvent(
+                offset=0,
+                partition=0,
+                timestamp_ms=1000,
+                event_type="delete_workspace",
+                relations_to_add=[],
+                relations_to_remove=[t],
+            )
+        ]
+
+        log = InMemoryLog()
+        result = reconcile(restore_timestamp_ms=1000000, replicator=OutboxReplicator(log=log))
+
+        self.assertEqual(result["corrective_adds"], 1)
+        self.assertEqual(result["errors"], 0)
+        self.assertEqual(len(log), 1)
+
+        mock_pdp = MagicMock()
+        mock_pdp.lookup_accessible_workspaces.return_value = set()
+        mock_pdp_cls.return_value = mock_pdp
+
+        checker = ParityAccessChecker(tenant_sample_size=1, principal_sample_size=1)
+        checker.inventory_checker = mock_pdp
+        parity_result = checker.check_principal_parity(principal, self.tenant)
+
+        self.assertFalse(parity_result.match, "Parity detects eventual consistency lag")
+        self.assertIn(str(ws.id), parity_result.only_in_rbac)
+
+        RoleBindingPrincipal.objects.filter(binding=binding).delete()
+        binding.delete()
+        v2_role.delete()
+        principal.delete()
+        ws.delete()
+
+    @patch("management.disaster_recovery.service.read_events_in_window")
+    def test_outbox_write_error_is_recorded_in_dr_result(self, mock_read):
+        """DR result should accurately report the number of failed writes."""
+        ws = Workspace.objects.create(
+            name="Err Count WS", type=Workspace.Types.STANDARD, tenant=self.tenant, parent=self.default_ws
+        )
+
+        mock_read.return_value = [
+            ParsedReplicationEvent(
+                offset=0,
+                partition=0,
+                timestamp_ms=1000,
+                event_type="delete_workspace",
+                relations_to_add=[],
+                relations_to_remove=[_make_tuple("workspace", str(ws.id))],
+            ),
+            ParsedReplicationEvent(
+                offset=1,
+                partition=0,
+                timestamp_ms=1100,
+                event_type="delete_workspace",
+                relations_to_add=[],
+                relations_to_remove=[_make_tuple("workspace", str(ws.id))],
+            ),
+        ]
+
+        failing_replicator = MagicMock()
+        failing_replicator.replicate.side_effect = RuntimeError("DB connection lost")
+
+        result = reconcile(restore_timestamp_ms=1000000, replicator=failing_replicator)
+
+        self.assertEqual(result["corrective_adds"], 2)
+        self.assertEqual(result["errors"], 2)
+
+        ws.delete()
+
+    @patch("management.disaster_recovery.service.read_events_in_window")
+    def test_negative_buffer_seconds_raises(self, mock_read):
+        """reconcile() should reject invalid buffer_seconds."""
+        with self.assertRaises(ValueError) as ctx:
+            reconcile(restore_timestamp_ms=1000000, buffer_seconds=-1)
+        self.assertIn("non-negative", str(ctx.exception))
+        mock_read.assert_not_called()
+
+
+class DRWorkspaceParityIntegrationTest(TestCase):
+    """Integration tests for workspace DR (HBI channel) with corrective event verification."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.tenant = Tenant.objects.create(
+            tenant_name="dr-ws-parity",
+            account_id="ws-account",
+            org_id="ws-org",
+            ready=True,
+        )
+        cls.root_ws = Workspace.objects.create(
+            name=Workspace.SpecialNames.ROOT, type=Workspace.Types.ROOT, tenant=cls.tenant
+        )
+        cls.default_ws = Workspace.objects.create(
+            name=Workspace.SpecialNames.DEFAULT,
+            type=Workspace.Types.DEFAULT,
+            tenant=cls.tenant,
+            parent=cls.root_ws,
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        Workspace.objects.filter(tenant=cls.tenant, type=Workspace.Types.STANDARD).delete()
+        cls.default_ws.delete()
+        cls.root_ws.delete()
+        cls.tenant.delete()
+        super().tearDownClass()
+
+    def test_all_six_truth_table_cases_produce_correct_outbox_events(self):
+        """Run all 6 workspace DR truth table cases and verify each outbox event.
+
+        This consolidates the truth table into one scenario to prove the full set
+        of corrective event types fires correctly from realistic Kafka events.
+        """
+        from core.kafka_dr import KafkaEvent
+        from management.relation_replicator.outbox_replicator import InMemoryLog
+        from management.relation_replicator.relation_replicator import AggregateTypes, ReplicationEventType
+        from management.workspace.dr_recovery import generate_corrective_workspace_events
+
+        ws_exists_1 = Workspace.objects.create(
+            name="Exists 1", type=Workspace.Types.STANDARD, parent=self.default_ws, tenant=self.tenant
+        )
+        ws_exists_2 = Workspace.objects.create(
+            name="Exists 2", type=Workspace.Types.STANDARD, parent=self.default_ws, tenant=self.tenant
+        )
+        ws_exists_3 = Workspace.objects.create(
+            name="Exists 3", type=Workspace.Types.STANDARD, parent=self.default_ws, tenant=self.tenant
+        )
+        gone_id_1 = str(uuid4())
+        gone_id_2 = str(uuid4())
+        gone_id_3 = str(uuid4())
+
+        def _ws_kafka_event(ws_id, operation, ws_name="WS", ts=1000000):
+            return KafkaEvent(
+                topic="outbox.event.workspace",
+                partition=0,
+                offset=0,
+                timestamp_ms=ts,
+                value={
+                    "aggregatetype": AggregateTypes.WORKSPACE.value,
+                    "aggregateid": "production",
+                    "type": f"{operation}_workspace",
+                    "payload": {
+                        "org_id": self.tenant.org_id,
+                        "account_number": self.tenant.account_id,
+                        "operation": operation,
+                        "workspace": {
+                            "id": ws_id,
+                            "name": ws_name,
+                            "type": "standard",
+                            "created": "2026-01-01T00:00:00Z",
+                            "modified": "2026-01-01T00:00:00Z",
+                        },
+                    },
+                },
+            )
+
+        kafka_events = [
+            _ws_kafka_event(gone_id_1, "create", ts=1000),
+            _ws_kafka_event(str(ws_exists_1.id), "create", ts=2000),
+            _ws_kafka_event(str(ws_exists_2.id), "delete", ts=3000),
+            _ws_kafka_event(gone_id_2, "delete", ts=4000),
+            _ws_kafka_event(str(ws_exists_3.id), "update", ts=5000),
+            _ws_kafka_event(gone_id_3, "update", ts=6000),
+        ]
+
+        log = InMemoryLog()
+        stats = generate_corrective_workspace_events(kafka_events, outbox_log=log)
+
+        self.assertEqual(stats["corrective_deletes"], 2)
+        self.assertEqual(stats["corrective_creates"], 1)
+        self.assertEqual(stats["corrective_updates"], 1)
+        self.assertEqual(stats["skipped"], 2)
+        self.assertEqual(stats["errors"], 0)
+        self.assertEqual(len(log), 4)
+
+        operations = [entry.payload["operation"] for entry in log]
+        self.assertEqual(operations.count("delete"), 2)
+        self.assertEqual(operations.count("create"), 1)
+        self.assertEqual(operations.count("update"), 1)
+
+        for entry in log:
+            self.assertEqual(entry.aggregatetype, "workspace")
+            self.assertIn("org_id", entry.payload)
+            self.assertIn("workspace", entry.payload)
+            self.assertIn("id", entry.payload["workspace"])
+
+        ws_exists_1.delete()
+        ws_exists_2.delete()
+        ws_exists_3.delete()
+
+    def test_workspace_corrective_create_uses_db_state_not_kafka_event(self):
+        """After DR, corrective CREATE events should reflect current RBAC DB workspace name.
+
+        This verifies the corrective event payload is based on the restored DB state,
+        not the stale Kafka event data -- ensuring HBI receives the correct current state.
+        """
+        from core.kafka_dr import KafkaEvent
+        from management.relation_replicator.outbox_replicator import InMemoryLog
+        from management.relation_replicator.relation_replicator import AggregateTypes
+        from management.workspace.dr_recovery import generate_corrective_workspace_events
+
+        ws = Workspace.objects.create(
+            name="Current DB Name", type=Workspace.Types.STANDARD, parent=self.default_ws, tenant=self.tenant
+        )
+        kafka_events = [
+            KafkaEvent(
+                topic="outbox.event.workspace",
+                partition=0,
+                offset=0,
+                timestamp_ms=1000,
+                value={
+                    "aggregatetype": AggregateTypes.WORKSPACE.value,
+                    "aggregateid": "production",
+                    "type": "delete_workspace",
+                    "payload": {
+                        "org_id": self.tenant.org_id,
+                        "account_number": self.tenant.account_id,
+                        "operation": "delete",
+                        "workspace": {
+                            "id": str(ws.id),
+                            "name": "Stale Kafka Name",
+                            "type": "standard",
+                            "created": "2026-01-01T00:00:00Z",
+                            "modified": "2026-01-01T00:00:00Z",
+                        },
+                    },
+                },
+            )
+        ]
+
+        log = InMemoryLog()
+        stats = generate_corrective_workspace_events(kafka_events, outbox_log=log)
+
+        self.assertEqual(stats["corrective_creates"], 1)
+        self.assertEqual(log[0].payload["workspace"]["name"], "Current DB Name")
+        self.assertNotEqual(log[0].payload["workspace"]["name"], "Stale Kafka Name")
+
+        ws.delete()
+
+    def test_workspace_dr_error_in_single_event_does_not_stop_processing(self):
+        """If one workspace corrective event write fails, others should still proceed."""
+        from core.kafka_dr import KafkaEvent
+        from management.relation_replicator.relation_replicator import AggregateTypes
+        from management.workspace.dr_recovery import generate_corrective_workspace_events
+
+        gone_id_1 = str(uuid4())
+        gone_id_2 = str(uuid4())
+
+        def _ws_kafka_event(ws_id, operation, ts=1000000):
+            return KafkaEvent(
+                topic="outbox.event.workspace",
+                partition=0,
+                offset=0,
+                timestamp_ms=ts,
+                value={
+                    "aggregatetype": AggregateTypes.WORKSPACE.value,
+                    "aggregateid": "production",
+                    "type": f"{operation}_workspace",
+                    "payload": {
+                        "org_id": self.tenant.org_id,
+                        "account_number": self.tenant.account_id,
+                        "operation": operation,
+                        "workspace": {
+                            "id": ws_id,
+                            "name": "WS",
+                            "type": "standard",
+                            "created": "2026-01-01T00:00:00Z",
+                            "modified": "2026-01-01T00:00:00Z",
+                        },
+                    },
+                },
+            )
+
+        kafka_events = [
+            _ws_kafka_event(gone_id_1, "create", ts=1000),
+            _ws_kafka_event(gone_id_2, "create", ts=2000),
+        ]
+
+        call_count = 0
+
+        class FailFirstLog:
+            def __init__(self):
+                self.entries = []
+
+            def log(self, outbox):
+                nonlocal call_count
+                call_count += 1
+                if call_count == 1:
+                    raise RuntimeError("First write fails")
+                self.entries.append(outbox)
+
+        fail_log = FailFirstLog()
+        stats = generate_corrective_workspace_events(kafka_events, outbox_log=fail_log)
+
+        self.assertEqual(stats["errors"], 1)
+        self.assertEqual(stats["corrective_deletes"], 1)
+        self.assertEqual(len(fail_log.entries), 1)

--- a/tests/management/disaster_recovery/test_dr_parity_integration.py
+++ b/tests/management/disaster_recovery/test_dr_parity_integration.py
@@ -119,13 +119,20 @@ class DRParityHappyPathTest(IdentityRequest):
 
         self.assertEqual(result["corrective_adds"], 1)
         self.assertEqual(log.first().event_type, ReplicationEventType.DR_CORRECTIVE_ADD)
+        corrective_relations = log.first().payload["relations_to_add"]
+        self.assertEqual(len(corrective_relations), 1, "Corrective ADD should contain exactly one relation")
+        self.assertEqual(
+            corrective_relations[0]["resource"]["id"],
+            str(ws.id),
+            f"Corrective ADD relation must target workspace {ws.id}",
+        )
+        self.assertEqual(corrective_relations[0]["resource"]["type"]["name"], "workspace")
 
         mock_pdp = MagicMock()
         mock_pdp.lookup_accessible_workspaces.return_value = {str(ws.id)}
         mock_pdp_cls.return_value = mock_pdp
 
         checker = ParityAccessChecker(tenant_sample_size=1, principal_sample_size=1)
-        checker.inventory_checker = mock_pdp
         parity_result = checker.check_principal_parity(principal, self.tenant)
 
         self.assertEqual(parity_result.only_in_rbac, set(), "Unexpected workspaces only in RBAC")
@@ -169,7 +176,6 @@ class DRParityHappyPathTest(IdentityRequest):
         mock_pdp_cls.return_value = mock_pdp
 
         checker = ParityAccessChecker(tenant_sample_size=1, principal_sample_size=1)
-        checker.inventory_checker = mock_pdp
         parity_result = checker.check_principal_parity(principal, self.tenant)
 
         self.assertTrue(parity_result.match, "Parity should match after corrective REMOVE")
@@ -235,7 +241,6 @@ class DRParityHappyPathTest(IdentityRequest):
         mock_pdp_cls.return_value = mock_pdp
 
         checker = ParityAccessChecker(tenant_sample_size=1, principal_sample_size=1)
-        checker.inventory_checker = mock_pdp
         parity_result = checker.check_principal_parity(principal, self.tenant)
 
         self.assertTrue(parity_result.match, "Full multi-resource DR should restore parity")
@@ -283,7 +288,6 @@ class DRParityHappyPathTest(IdentityRequest):
         mock_pdp_cls.return_value = mock_pdp
 
         checker = ParityAccessChecker(tenant_sample_size=1, principal_sample_size=1)
-        checker.inventory_checker = mock_pdp
         parity_result = checker.check_principal_parity(principal, self.tenant)
 
         self.assertTrue(parity_result.match, "role_binding corrective ADD should restore access parity")
@@ -364,7 +368,6 @@ class DRParityHappyPathTest(IdentityRequest):
         mock_pdp_cls.return_value = mock_pdp
 
         checker = ParityAccessChecker(tenant_sample_size=1, principal_sample_size=1)
-        checker.inventory_checker = mock_pdp
         parity_result = checker.check_principal_parity(principal, self.tenant)
 
         self.assertTrue(parity_result.match, "Group membership corrective ADD should restore access parity")
@@ -448,7 +451,6 @@ class DRParityUnhappyPathTest(IdentityRequest):
         mock_pdp_cls.return_value = mock_pdp
 
         checker = ParityAccessChecker(tenant_sample_size=1, principal_sample_size=1)
-        checker.inventory_checker = mock_pdp
         parity_result = checker.check_principal_parity(principal, self.tenant)
 
         self.assertFalse(parity_result.match, "Parity should detect discrepancy when corrective ADD failed")
@@ -495,7 +497,6 @@ class DRParityUnhappyPathTest(IdentityRequest):
         mock_pdp_cls.return_value = mock_pdp
 
         checker = ParityAccessChecker(tenant_sample_size=1, principal_sample_size=1)
-        checker.inventory_checker = mock_pdp
         parity_result = checker.check_principal_parity(principal, self.tenant)
 
         self.assertFalse(parity_result.match, "Parity should detect orphaned workspace when corrective REMOVE failed")
@@ -569,7 +570,6 @@ class DRParityUnhappyPathTest(IdentityRequest):
         mock_pdp_cls.return_value = mock_pdp
 
         checker = ParityAccessChecker(tenant_sample_size=1, principal_sample_size=1)
-        checker.inventory_checker = mock_pdp
         parity_result = checker.check_principal_parity(principal, self.tenant)
 
         self.assertFalse(parity_result.match, "Parity should fail when one corrective event failed")
@@ -621,7 +621,6 @@ class DRParityUnhappyPathTest(IdentityRequest):
         mock_pdp_cls.return_value = mock_pdp
 
         checker = ParityAccessChecker(tenant_sample_size=1, principal_sample_size=1)
-        checker.inventory_checker = mock_pdp
         parity_result = checker.check_principal_parity(principal, self.tenant)
 
         self.assertFalse(parity_result.match, "Parity detects eventual consistency lag")

--- a/tests/management/disaster_recovery/test_dr_parity_integration.py
+++ b/tests/management/disaster_recovery/test_dr_parity_integration.py
@@ -15,7 +15,7 @@ generation → outbox writing → parity verification.
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.utils import timezone
 
 from api.models import Tenant
@@ -331,6 +331,7 @@ class DRParityHappyPathTest(TestCase):
         principal.delete()
         ws.delete()
 
+    @override_settings(DR_SKIP_EVENT_TYPES=[])
     @patch("management.disaster_recovery.service.read_events_in_window")
     @patch("management.parity_check.checker.WorkspaceInventoryAccessChecker")
     def test_tenant_corrective_remove_cleans_orphaned_tenant(self, mock_pdp_cls, mock_read):

--- a/tests/management/disaster_recovery/test_dr_parity_integration.py
+++ b/tests/management/disaster_recovery/test_dr_parity_integration.py
@@ -18,6 +18,9 @@ from uuid import uuid4
 from django.test import TestCase, override_settings
 from django.utils import timezone
 
+from tests.identity_request import IdentityRequest
+from tests.management.disaster_recovery.helpers import _make_tuple
+
 from api.models import Tenant
 from management.disaster_recovery.corrective_writer import (
     generate_corrective_actions,
@@ -30,12 +33,6 @@ from management.parity_check.checker import ParityAccessChecker, ParityCheckResu
 from management.principal.model import Principal
 from management.relation_replicator.outbox_replicator import InMemoryLog, OutboxReplicator
 from management.relation_replicator.relation_replicator import ReplicationEventType
-from management.relation_replicator.types import (
-    ObjectReference,
-    ObjectType,
-    RelationTuple,
-    SubjectReference,
-)
 from management.role.model import Role
 from management.role.v2_model import CustomRoleV2
 from management.role_binding.model import RoleBinding, RoleBindingGroup, RoleBindingPrincipal
@@ -43,28 +40,13 @@ from management.tenant_mapping.model import TenantMapping
 from management.workspace.model import Workspace
 
 
-def _make_tuple(resource_type="workspace", resource_id="ws-123", relation="parent"):
-    return RelationTuple(
-        resource=ObjectReference(
-            type=ObjectType(namespace="rbac", name=resource_type),
-            id=resource_id,
-        ),
-        relation=relation,
-        subject=SubjectReference(
-            subject=ObjectReference(
-                type=ObjectType(namespace="rbac", name="workspace"),
-                id="ws-parent",
-            ),
-        ),
-    )
-
-
-class DRParityHappyPathTest(TestCase):
+class DRParityHappyPathTest(IdentityRequest):
     """After successful DR reconciliation, parity checks should confirm consistency."""
 
     @classmethod
     def setUpClass(cls):
-        super().setUpClass()
+        # Skip IdentityRequest's tenant creation — we manage our own DR fixtures
+        super(IdentityRequest, cls).setUpClass()
         cls.tenant = Tenant.objects.create(
             tenant_name="dr-parity-happy",
             account_id="parity-account",
@@ -89,15 +71,11 @@ class DRParityHappyPathTest(TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        RoleBindingPrincipal.objects.filter(binding__tenant=cls.tenant).delete()
-        RoleBindingGroup.objects.filter(binding__tenant=cls.tenant).delete()
-        RoleBinding.objects.filter(tenant=cls.tenant).delete()
-        CustomRoleV2.objects.filter(tenant=cls.tenant).delete()
         cls.mapping.delete()
         cls.default_ws.delete()
         cls.root_ws.delete()
         cls.tenant.delete()
-        super().tearDownClass()
+        super(IdentityRequest, cls).tearDownClass()
 
     @patch("management.disaster_recovery.service.read_events_in_window")
     @patch("management.parity_check.checker.WorkspaceInventoryAccessChecker")
@@ -150,15 +128,9 @@ class DRParityHappyPathTest(TestCase):
         checker.inventory_checker = mock_pdp
         parity_result = checker.check_principal_parity(principal, self.tenant)
 
+        self.assertEqual(parity_result.only_in_rbac, set(), "Unexpected workspaces only in RBAC")
+        self.assertEqual(parity_result.only_in_pdp, set(), "Unexpected workspaces only in PDP")
         self.assertTrue(parity_result.match, f"Parity should match after corrective ADD, got: {parity_result}")
-        self.assertEqual(parity_result.only_in_rbac, set())
-        self.assertEqual(parity_result.only_in_pdp, set())
-
-        RoleBindingPrincipal.objects.filter(binding=binding).delete()
-        binding.delete()
-        role.delete()
-        principal.delete()
-        ws.delete()
 
     @patch("management.disaster_recovery.service.read_events_in_window")
     @patch("management.parity_check.checker.WorkspaceInventoryAccessChecker")
@@ -201,8 +173,6 @@ class DRParityHappyPathTest(TestCase):
         parity_result = checker.check_principal_parity(principal, self.tenant)
 
         self.assertTrue(parity_result.match, "Parity should match after corrective REMOVE")
-
-        principal.delete()
 
     @patch("management.disaster_recovery.service.read_events_in_window")
     @patch("management.parity_check.checker.WorkspaceInventoryAccessChecker")
@@ -270,13 +240,6 @@ class DRParityHappyPathTest(TestCase):
 
         self.assertTrue(parity_result.match, "Full multi-resource DR should restore parity")
 
-        RoleBindingPrincipal.objects.filter(binding=binding).delete()
-        binding.delete()
-        v2_role.delete()
-        role.delete()
-        principal.delete()
-        ws.delete()
-
     @patch("management.disaster_recovery.service.read_events_in_window")
     @patch("management.parity_check.checker.WorkspaceInventoryAccessChecker")
     def test_role_binding_corrective_add_restores_access_parity(self, mock_pdp_cls, mock_read):
@@ -325,12 +288,6 @@ class DRParityHappyPathTest(TestCase):
 
         self.assertTrue(parity_result.match, "role_binding corrective ADD should restore access parity")
 
-        RoleBindingPrincipal.objects.filter(binding=binding).delete()
-        binding.delete()
-        v2_role.delete()
-        principal.delete()
-        ws.delete()
-
     @override_settings(DR_SKIP_EVENT_TYPES=[])
     @patch("management.disaster_recovery.service.read_events_in_window")
     @patch("management.parity_check.checker.WorkspaceInventoryAccessChecker")
@@ -360,7 +317,7 @@ class DRParityHappyPathTest(TestCase):
 
         self.assertEqual(result["corrective_removes"], 1)
         self.assertEqual(log.first().event_type, ReplicationEventType.DR_CORRECTIVE_REMOVE)
-        self.assertIn(orphaned_org_id, log.first().payload["resource_context"]["org_id"])
+        self.assertEqual(orphaned_org_id, log.first().payload["resource_context"]["org_id"])
 
     @patch("management.disaster_recovery.service.read_events_in_window")
     @patch("management.parity_check.checker.WorkspaceInventoryAccessChecker")
@@ -412,21 +369,13 @@ class DRParityHappyPathTest(TestCase):
 
         self.assertTrue(parity_result.match, "Group membership corrective ADD should restore access parity")
 
-        RoleBindingGroup.objects.filter(binding=binding).delete()
-        binding.delete()
-        v2_role.delete()
-        group.principals.remove(principal)
-        group.delete()
-        principal.delete()
-        ws.delete()
 
-
-class DRParityUnhappyPathTest(TestCase):
+class DRParityUnhappyPathTest(IdentityRequest):
     """When DR corrective events fail, parity checks should detect the remaining divergence."""
 
     @classmethod
     def setUpClass(cls):
-        super().setUpClass()
+        super(IdentityRequest, cls).setUpClass()
         cls.tenant = Tenant.objects.create(
             tenant_name="dr-parity-unhappy",
             account_id="unhappy-account",
@@ -446,15 +395,11 @@ class DRParityUnhappyPathTest(TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        RoleBindingPrincipal.objects.filter(binding__tenant=cls.tenant).delete()
-        RoleBindingGroup.objects.filter(binding__tenant=cls.tenant).delete()
-        RoleBinding.objects.filter(tenant=cls.tenant).delete()
-        CustomRoleV2.objects.filter(tenant=cls.tenant).delete()
         cls.mapping.delete()
         cls.default_ws.delete()
         cls.root_ws.delete()
         cls.tenant.delete()
-        super().tearDownClass()
+        super(IdentityRequest, cls).tearDownClass()
 
     @patch("management.disaster_recovery.service.read_events_in_window")
     @patch("management.parity_check.checker.WorkspaceInventoryAccessChecker")
@@ -510,12 +455,6 @@ class DRParityUnhappyPathTest(TestCase):
         self.assertIn(str(ws.id), parity_result.only_in_rbac)
         self.assertEqual(parity_result.only_in_pdp, set())
 
-        RoleBindingPrincipal.objects.filter(binding=binding).delete()
-        binding.delete()
-        v2_role.delete()
-        principal.delete()
-        ws.delete()
-
     @patch("management.disaster_recovery.service.read_events_in_window")
     @patch("management.parity_check.checker.WorkspaceInventoryAccessChecker")
     def test_failed_corrective_remove_leaves_orphaned_access_detected_by_parity(self, mock_pdp_cls, mock_read):
@@ -562,8 +501,6 @@ class DRParityUnhappyPathTest(TestCase):
         self.assertFalse(parity_result.match, "Parity should detect orphaned workspace when corrective REMOVE failed")
         self.assertIn(orphaned_ws_id, parity_result.only_in_pdp)
         self.assertEqual(parity_result.only_in_rbac, set())
-
-        principal.delete()
 
     @patch("management.disaster_recovery.service.read_events_in_window")
     @patch("management.parity_check.checker.WorkspaceInventoryAccessChecker")
@@ -639,14 +576,6 @@ class DRParityUnhappyPathTest(TestCase):
         self.assertIn(str(ws_fail.id), parity_result.only_in_rbac)
         self.assertNotIn(str(ws_success.id), parity_result.only_in_rbac)
 
-        RoleBindingPrincipal.objects.filter(binding__in=[binding_success, binding_fail]).delete()
-        binding_success.delete()
-        binding_fail.delete()
-        v2_role.delete()
-        principal.delete()
-        ws_success.delete()
-        ws_fail.delete()
-
     @patch("management.disaster_recovery.service.read_events_in_window")
     @patch("management.parity_check.checker.WorkspaceInventoryAccessChecker")
     def test_corrective_add_written_but_pdp_not_yet_converged_detected_by_parity(self, mock_pdp_cls, mock_read):
@@ -698,12 +627,6 @@ class DRParityUnhappyPathTest(TestCase):
         self.assertFalse(parity_result.match, "Parity detects eventual consistency lag")
         self.assertIn(str(ws.id), parity_result.only_in_rbac)
 
-        RoleBindingPrincipal.objects.filter(binding=binding).delete()
-        binding.delete()
-        v2_role.delete()
-        principal.delete()
-        ws.delete()
-
     @patch("management.disaster_recovery.service.read_events_in_window")
     def test_outbox_write_error_is_recorded_in_dr_result(self, mock_read):
         """DR result should accurately report the number of failed writes."""
@@ -738,8 +661,6 @@ class DRParityUnhappyPathTest(TestCase):
         self.assertEqual(result["corrective_adds"], 2)
         self.assertEqual(result["errors"], 2)
 
-        ws.delete()
-
     @patch("management.disaster_recovery.service.read_events_in_window")
     def test_negative_buffer_seconds_raises(self, mock_read):
         """reconcile() should reject invalid buffer_seconds."""
@@ -749,12 +670,13 @@ class DRParityUnhappyPathTest(TestCase):
         mock_read.assert_not_called()
 
 
-class DRWorkspaceParityIntegrationTest(TestCase):
+class DRWorkspaceParityIntegrationTest(IdentityRequest):
     """Integration tests for workspace DR (HBI channel) with corrective event verification."""
 
     @classmethod
     def setUpClass(cls):
-        super().setUpClass()
+        # Skip IdentityRequest's tenant creation — we manage our own DR fixtures
+        super(IdentityRequest, cls).setUpClass()
         cls.tenant = Tenant.objects.create(
             tenant_name="dr-ws-parity",
             account_id="ws-account",
@@ -777,7 +699,7 @@ class DRWorkspaceParityIntegrationTest(TestCase):
         cls.default_ws.delete()
         cls.root_ws.delete()
         cls.tenant.delete()
-        super().tearDownClass()
+        super(IdentityRequest, cls).tearDownClass()
 
     def test_all_six_truth_table_cases_produce_correct_outbox_events(self):
         """Run all 6 workspace DR truth table cases and verify each outbox event.
@@ -852,15 +774,27 @@ class DRWorkspaceParityIntegrationTest(TestCase):
         self.assertEqual(operations.count("create"), 1)
         self.assertEqual(operations.count("update"), 1)
 
+        delete_ids = {entry.payload["workspace"]["id"] for entry in log if entry.payload["operation"] == "delete"}
+        create_ids = {entry.payload["workspace"]["id"] for entry in log if entry.payload["operation"] == "create"}
+        update_ids = {entry.payload["workspace"]["id"] for entry in log if entry.payload["operation"] == "update"}
+
+        self.assertEqual(
+            delete_ids,
+            {gone_id_1, gone_id_3},
+            "Corrective deletes: create+gone and update+gone both get deleted; delete+gone is skipped",
+        )
+        self.assertEqual(
+            create_ids, {str(ws_exists_2.id)}, "Corrective create should target the deleted-but-existing ws"
+        )
+        self.assertEqual(
+            update_ids, {str(ws_exists_3.id)}, "Corrective update should target the updated-but-existing ws"
+        )
+
         for entry in log:
             self.assertEqual(entry.aggregatetype, "workspace")
             self.assertIn("org_id", entry.payload)
             self.assertIn("workspace", entry.payload)
             self.assertIn("id", entry.payload["workspace"])
-
-        ws_exists_1.delete()
-        ws_exists_2.delete()
-        ws_exists_3.delete()
 
     def test_workspace_corrective_create_uses_db_state_not_kafka_event(self):
         """After DR, corrective CREATE events should reflect current RBAC DB workspace name.
@@ -950,16 +884,14 @@ class DRWorkspaceParityIntegrationTest(TestCase):
             _ws_kafka_event(gone_id_2, "create", ts=2000),
         ]
 
-        call_count = 0
-
         class FailFirstLog:
             def __init__(self):
                 self.entries = []
+                self.call_count = 0
 
             def log(self, outbox):
-                nonlocal call_count
-                call_count += 1
-                if call_count == 1:
+                self.call_count += 1
+                if self.call_count == 1:
                     raise RuntimeError("First write fails")
                 self.entries.append(outbox)
 

--- a/tests/management/disaster_recovery/test_kafka_reader.py
+++ b/tests/management/disaster_recovery/test_kafka_reader.py
@@ -29,7 +29,10 @@ def _make_debezium_message(relations_to_add=None, relations_to_remove=None, even
     return json.dumps({"schema": {}, "payload": json.dumps(inner)}).encode()
 
 
-def _make_relation_dict(resource_type="workspace", resource_id="ws-123", relation="parent"):
+FAKE_WS_UUID = "00000000-0000-0000-0000-000000000123"
+
+
+def _make_relation_dict(resource_type="workspace", resource_id=FAKE_WS_UUID, relation="parent"):
     return {
         "resource": {"type": {"namespace": "rbac", "name": resource_type}, "id": resource_id},
         "relation": relation,
@@ -85,7 +88,7 @@ class ParseEventTest(TestCase):
         event = _parse_event(payload, offset=5, partition=0, timestamp_ms=1000)
         self.assertEqual(len(event.relations_to_add), 1)
         self.assertEqual(event.relations_to_add[0].resource.type.name, "workspace")
-        self.assertEqual(event.relations_to_add[0].resource.id, "ws-123")
+        self.assertEqual(event.relations_to_add[0].resource.id, FAKE_WS_UUID)
         self.assertEqual(event.offset, 5)
 
     def test_parses_relations_to_remove(self):

--- a/tests/management/disaster_recovery/test_resource_checker.py
+++ b/tests/management/disaster_recovery/test_resource_checker.py
@@ -12,31 +12,10 @@ from management.disaster_recovery.resource_checker import (
 )
 from management.group.model import Group
 from management.principal.model import Principal
-from management.relation_replicator.types import (
-    ObjectReference,
-    ObjectType,
-    RelationTuple,
-    SubjectReference,
-)
 from management.role.model import Role
 from management.tenant_mapping.model import TenantMapping
 from management.workspace.model import Workspace
-
-
-def _make_tuple(resource_type_name: str, resource_id: str) -> RelationTuple:
-    return RelationTuple(
-        resource=ObjectReference(
-            type=ObjectType(namespace="rbac", name=resource_type_name),
-            id=resource_id,
-        ),
-        relation="member",
-        subject=SubjectReference(
-            subject=ObjectReference(
-                type=ObjectType(namespace="rbac", name="principal"),
-                id="test-subject",
-            ),
-        ),
-    )
+from tests.management.disaster_recovery.helpers import _make_tuple
 
 
 class StripDomainPrefixTest(TestCase):

--- a/tests/management/inventory_checker/test_check_request_correctness.py
+++ b/tests/management/inventory_checker/test_check_request_correctness.py
@@ -1,0 +1,680 @@
+"""Tests verifying CheckRequest resource/subject correctness for all inventory checkers.
+
+These tests capture the actual CheckRequest protobuf objects passed to the gRPC stub
+and verify that object (resource) and subject fields are in the correct positions.
+
+This catches bugs where resource and subject are accidentally swapped -- a class of
+error that mock-based tests miss because MagicMock accepts any arguments.
+
+The SpiceDB tuple format is:
+    resource_type:resource_id#relation@subject_type:subject_id
+
+For workspace parent relations:
+    workspace:<child_id>#parent@workspace:<parent_id>
+
+The child workspace is the RESOURCE (object), the parent workspace is the SUBJECT.
+"""
+
+import uuid
+from unittest.mock import MagicMock, call, patch
+
+from django.conf import settings
+from django.test import TestCase, override_settings
+from kessel.inventory.v1beta2.check_response_pb2 import CheckResponse
+from management.group.model import Group
+from management.inventory_checker.inventory_api_check import (
+    BootstrappedTenantInventoryChecker,
+    CrossAccountRequestInventoryChecker,
+    CustomRolePermissionChecker,
+    GroupPrincipalInventoryChecker,
+    RoleBindingInventoryChecker,
+    RoleRelationInventoryChecker,
+    SeededRoleHierarchyChecker,
+    WorkspaceRelationInventoryChecker,
+    relation_tuple_to_check_request,
+)
+from management.principal.model import Principal
+from management.relation_replicator.types import (
+    ObjectReference,
+    ObjectType,
+    RelationTuple,
+    SubjectReference,
+)
+from management.role.relations import role_child_relationship
+from migration_tool.models import role_permission_tuple
+from migration_tool.utils import create_relationship
+from tests.identity_request import IdentityRequest
+
+CREATE_CHANNEL_PATH = "management.inventory_checker.inventory_api_check.create_client_channel_inventory"
+MESSAGE_TO_DICT_PATH = "management.inventory_checker.inventory_api_check.json_format.MessageToDict"
+STUB_PATH = "management.inventory_checker.inventory_api_check.inventory_service_pb2_grpc.KesselInventoryServiceStub"
+
+
+def _allowed_response():
+    return {"allowed": "ALLOWED_TRUE"}
+
+
+def _setup_grpc_mocks(mock_create_channel):
+    """Set up gRPC channel + stub mocks, return the stub mock for assertion."""
+    mock_stub = MagicMock()
+    mock_channel = MagicMock()
+    mock_channel.__enter__ = MagicMock(return_value=mock_channel)
+    mock_channel.__exit__ = MagicMock(return_value=None)
+    mock_create_channel.return_value = mock_channel
+    return mock_stub
+
+
+class RelationTupleToCheckRequestTest(TestCase):
+    """Tests for the relation_tuple_to_check_request conversion function."""
+
+    def test_resource_fields_map_to_object(self):
+        """The RelationTuple.resource should become CheckRequest.object."""
+        t = RelationTuple(
+            resource=ObjectReference(
+                type=ObjectType(namespace="rbac", name="workspace"),
+                id="child-ws-id",
+            ),
+            relation="parent",
+            subject=SubjectReference(
+                subject=ObjectReference(
+                    type=ObjectType(namespace="rbac", name="workspace"),
+                    id="parent-ws-id",
+                ),
+            ),
+        )
+        req = relation_tuple_to_check_request(t)
+
+        self.assertEqual(req.object.resource_type, "workspace")
+        self.assertEqual(req.object.resource_id, "child-ws-id")
+        self.assertEqual(req.relation, "parent")
+        self.assertEqual(req.subject.resource.resource_type, "workspace")
+        self.assertEqual(req.subject.resource.resource_id, "parent-ws-id")
+
+    def test_group_member_tuple(self):
+        """group:G#member@principal:P → object=group, subject=principal."""
+        t = create_relationship(("rbac", "group"), "group-uuid", ("rbac", "principal"), "user-id", "member")
+        req = relation_tuple_to_check_request(t)
+
+        self.assertEqual(req.object.resource_type, "group")
+        self.assertEqual(req.object.resource_id, "group-uuid")
+        self.assertEqual(req.relation, "member")
+        self.assertEqual(req.subject.resource.resource_type, "principal")
+        self.assertEqual(req.subject.resource.resource_id, "user-id")
+
+    def test_role_binding_tuple(self):
+        """workspace:W#binding@role_binding:RB → object=workspace, subject=role_binding."""
+        t = create_relationship(("rbac", "workspace"), "ws-uuid", ("rbac", "role_binding"), "rb-uuid", "binding")
+        req = relation_tuple_to_check_request(t)
+
+        self.assertEqual(req.object.resource_type, "workspace")
+        self.assertEqual(req.object.resource_id, "ws-uuid")
+        self.assertEqual(req.relation, "binding")
+        self.assertEqual(req.subject.resource.resource_type, "role_binding")
+        self.assertEqual(req.subject.resource.resource_id, "rb-uuid")
+
+    def test_role_child_tuple(self):
+        """role:parent#child@role:child → object=parent role, subject=child role."""
+        parent_uuid = uuid.uuid4()
+        child_uuid = uuid.uuid4()
+        t = role_child_relationship(parent_uuid, child_uuid)
+        req = relation_tuple_to_check_request(t)
+
+        self.assertEqual(req.object.resource_type, "role")
+        self.assertEqual(req.object.resource_id, str(parent_uuid))
+        self.assertEqual(req.relation, "child")
+        self.assertEqual(req.subject.resource.resource_type, "role")
+        self.assertEqual(req.subject.resource.resource_id, str(child_uuid))
+
+    def test_subject_relation_preserved(self):
+        """Subject relation (e.g., #member) is preserved in the CheckRequest."""
+        t = create_relationship(
+            ("rbac", "role_binding"), "rb-uuid", ("rbac", "group"), "group-uuid", "subject", "member"
+        )
+        req = relation_tuple_to_check_request(t)
+
+        self.assertEqual(req.subject.relation, "member")
+
+    def test_role_permission_wildcard_tuple(self):
+        """role:R#perm@principal:* → object=role, subject=principal:*."""
+        t = role_permission_tuple("role-uuid", "inventory_groups_read")
+        req = relation_tuple_to_check_request(t)
+
+        self.assertEqual(req.object.resource_type, "role")
+        self.assertEqual(req.object.resource_id, "role-uuid")
+        self.assertEqual(req.relation, "inventory_groups_read")
+        self.assertEqual(req.subject.resource.resource_type, "principal")
+        self.assertEqual(req.subject.resource.resource_id, "*")
+
+
+class WorkspaceCheckerCheckRequestTest(TestCase):
+    """Verify WorkspaceRelationInventoryChecker builds CheckRequest with correct resource/subject.
+
+    The parent relation in SpiceDB is:
+        workspace:<child>#parent@workspace:<parent>
+
+    So CheckRequest must have:
+        object.resource_id = child workspace UUID
+        subject.resource.resource_id = parent workspace UUID
+    """
+
+    def setUp(self):
+        self.checker = WorkspaceRelationInventoryChecker()
+        self.child_id = str(uuid.uuid4())
+        self.parent_id = str(uuid.uuid4())
+
+    @patch(MESSAGE_TO_DICT_PATH, return_value=_allowed_response())
+    @patch(CREATE_CHANNEL_PATH)
+    def test_check_workspace_descendants_object_is_child_subject_is_parent(
+        self, mock_create_channel, mock_message_to_dict
+    ):
+        """check_workspace_descendants must set object=child, subject=parent."""
+        mock_stub = _setup_grpc_mocks(mock_create_channel)
+
+        with patch(STUB_PATH, return_value=mock_stub):
+            self.checker.check_workspace_descendants([(self.child_id, self.parent_id)])
+
+        check_request = mock_stub.Check.call_args[0][0]
+
+        self.assertEqual(
+            check_request.object.resource_id,
+            self.child_id,
+            f"object (resource) should be the CHILD workspace {self.child_id}, "
+            f"but got {check_request.object.resource_id}. Resource and subject are swapped.",
+        )
+        self.assertEqual(check_request.object.resource_type, "workspace")
+        self.assertEqual(check_request.relation, "parent")
+        self.assertEqual(
+            check_request.subject.resource.resource_id,
+            self.parent_id,
+            f"subject should be the PARENT workspace {self.parent_id}, "
+            f"but got {check_request.subject.resource.resource_id}. Resource and subject are swapped.",
+        )
+        self.assertEqual(check_request.subject.resource.resource_type, "workspace")
+
+    @patch(MESSAGE_TO_DICT_PATH, return_value=_allowed_response())
+    @patch(CREATE_CHANNEL_PATH)
+    def test_check_workspace_single_object_is_child_subject_is_parent(self, mock_create_channel, mock_message_to_dict):
+        """check_workspace must set object=child, subject=parent."""
+        mock_stub = _setup_grpc_mocks(mock_create_channel)
+
+        with patch(STUB_PATH, return_value=mock_stub):
+            self.checker.check_workspace(self.child_id, self.parent_id)
+
+        check_request = mock_stub.Check.call_args[0][0]
+
+        self.assertEqual(
+            check_request.object.resource_id,
+            self.child_id,
+            f"object (resource) should be the CHILD workspace {self.child_id}, "
+            f"but got {check_request.object.resource_id}. Resource and subject are swapped.",
+        )
+        self.assertEqual(
+            check_request.subject.resource.resource_id,
+            self.parent_id,
+            f"subject should be the PARENT workspace {self.parent_id}, "
+            f"but got {check_request.subject.resource.resource_id}. Resource and subject are swapped.",
+        )
+
+    @patch(MESSAGE_TO_DICT_PATH, return_value=_allowed_response())
+    @patch(CREATE_CHANNEL_PATH)
+    def test_check_workspace_descendants_multiple_pairs(self, mock_create_channel, mock_message_to_dict):
+        """Each pair in a batch should have object=child, subject=parent."""
+        mock_stub = _setup_grpc_mocks(mock_create_channel)
+
+        pairs = [
+            (str(uuid.uuid4()), str(uuid.uuid4())),
+            (str(uuid.uuid4()), str(uuid.uuid4())),
+            (str(uuid.uuid4()), str(uuid.uuid4())),
+        ]
+
+        with patch(STUB_PATH, return_value=mock_stub):
+            self.checker.check_workspace_descendants(pairs)
+
+        self.assertEqual(mock_stub.Check.call_count, 3)
+
+        for i, (child_id, parent_id) in enumerate(pairs):
+            check_request = mock_stub.Check.call_args_list[i][0][0]
+            self.assertEqual(
+                check_request.object.resource_id,
+                child_id,
+                f"Pair {i}: object should be child {child_id}, got {check_request.object.resource_id}",
+            )
+            self.assertEqual(
+                check_request.subject.resource.resource_id,
+                parent_id,
+                f"Pair {i}: subject should be parent {parent_id}, got {check_request.subject.resource.resource_id}",
+            )
+
+
+class GroupPrincipalCheckerCheckRequestTest(IdentityRequest):
+    """Verify GroupPrincipalInventoryChecker builds CheckRequest with correct resource/subject.
+
+    The member relation in SpiceDB is:
+        group:<group_uuid>#member@principal:<principal_id>
+
+    So CheckRequest must have:
+        object.resource_id = group UUID
+        subject.resource.resource_id = principal ID
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.checker = GroupPrincipalInventoryChecker()
+        self.group = Group.objects.create(name="check-req-group", tenant=self.tenant)
+        self.principal = Principal.objects.create(
+            username="check-req-user", user_id="uid-check-req", tenant=self.tenant
+        )
+        self.group.principals.add(self.principal)
+
+    def tearDown(self):
+        self.group.principals.remove(self.principal)
+        self.principal.delete()
+        self.group.delete()
+        super().tearDown()
+
+    @patch(MESSAGE_TO_DICT_PATH, return_value=_allowed_response())
+    @patch(CREATE_CHANNEL_PATH)
+    def test_check_request_object_is_group_subject_is_principal(self, mock_create_channel, mock_message_to_dict):
+        """CheckRequest object must be the group, subject must be the principal."""
+        mock_stub = _setup_grpc_mocks(mock_create_channel)
+        relationships = [self.group.relationship_to_principal(self.principal)]
+
+        with patch(STUB_PATH, return_value=mock_stub):
+            self.checker.check_relationships(relationships)
+
+        check_request = mock_stub.Check.call_args[0][0]
+
+        self.assertEqual(check_request.object.resource_type, "group")
+        self.assertEqual(check_request.object.resource_id, str(self.group.uuid))
+        self.assertEqual(check_request.relation, "member")
+        self.assertEqual(check_request.subject.resource.resource_type, "principal")
+        expected_principal_id = f"{settings.PRINCIPAL_USER_DOMAIN}/{self.principal.user_id}"
+        self.assertEqual(check_request.subject.resource.resource_id, expected_principal_id)
+
+
+class BootstrapCheckerCheckRequestTest(IdentityRequest):
+    """Verify BootstrappedTenantInventoryChecker builds CheckRequest with correct resource/subject.
+
+    Bootstrap produces tuples like:
+        workspace:<default>#parent@workspace:<root>         (default's parent is root)
+        workspace:<root>#tenant@tenant:<org_id>             (root's tenant)
+        tenant:<org_id>#platform@platform:<env>             (tenant's platform)
+        workspace:<ws>#binding@role_binding:<rb>             (workspace has binding)
+        role_binding:<rb>#role@role:<role_uuid>              (binding's role)
+        role_binding:<rb>#subject@group:<group_uuid>#member  (binding's subject group)
+    """
+
+    def setUp(self):
+        super().setUp()
+        from management.tenant_mapping.model import TenantMapping
+
+        self.tenant_mapping = TenantMapping.objects.create(tenant=self.tenant)
+        self.root_ws_id = str(uuid.uuid4())
+        self.default_ws_id = str(uuid.uuid4())
+        self.checker = BootstrappedTenantInventoryChecker()
+
+    def tearDown(self):
+        self.tenant_mapping.delete()
+        super().tearDown()
+
+    @patch("management.inventory_checker.inventory_api_check.platform_v2_role_uuid_for")
+    @patch(MESSAGE_TO_DICT_PATH, return_value=_allowed_response())
+    @patch(CREATE_CHANNEL_PATH)
+    @override_settings(ENV_NAME="stage", PRINCIPAL_USER_DOMAIN="localhost")
+    def test_workspace_parent_tuple_object_is_child_subject_is_parent(
+        self, mock_create_channel, mock_message_to_dict, mock_role_uuid
+    ):
+        """The default_workspace_parent tuple: workspace:<default>#parent@workspace:<root>."""
+        mock_stub = _setup_grpc_mocks(mock_create_channel)
+        mock_role_uuid.return_value = uuid.uuid4()
+
+        with patch(STUB_PATH, return_value=mock_stub):
+            self.checker.check_bootstrapped_tenant(
+                org_id=self.tenant.org_id,
+                tenant_mapping=self.tenant_mapping,
+                root_workspace_id=self.root_ws_id,
+                default_workspace_id=self.default_ws_id,
+            )
+
+        first_request = mock_stub.Check.call_args_list[0][0][0]
+
+        self.assertEqual(
+            first_request.object.resource_id,
+            self.default_ws_id,
+            f"First bootstrap tuple (default_workspace_parent): object should be DEFAULT workspace "
+            f"{self.default_ws_id}, got {first_request.object.resource_id}",
+        )
+        self.assertEqual(first_request.object.resource_type, "workspace")
+        self.assertEqual(first_request.relation, "parent")
+        self.assertEqual(
+            first_request.subject.resource.resource_id,
+            self.root_ws_id,
+            f"First bootstrap tuple: subject should be ROOT workspace "
+            f"{self.root_ws_id}, got {first_request.subject.resource.resource_id}",
+        )
+
+    @patch("management.inventory_checker.inventory_api_check.platform_v2_role_uuid_for")
+    @patch(MESSAGE_TO_DICT_PATH, return_value=_allowed_response())
+    @patch(CREATE_CHANNEL_PATH)
+    @override_settings(ENV_NAME="stage", PRINCIPAL_USER_DOMAIN="localhost")
+    def test_tenant_platform_tuple_object_is_tenant_subject_is_platform(
+        self, mock_create_channel, mock_message_to_dict, mock_role_uuid
+    ):
+        """The tenant_platform tuple: tenant:<org_id>#platform@platform:<env>."""
+        mock_stub = _setup_grpc_mocks(mock_create_channel)
+        mock_role_uuid.return_value = uuid.uuid4()
+
+        with patch(STUB_PATH, return_value=mock_stub):
+            self.checker.check_bootstrapped_tenant(
+                org_id=self.tenant.org_id,
+                tenant_mapping=self.tenant_mapping,
+                root_workspace_id=self.root_ws_id,
+                default_workspace_id=self.default_ws_id,
+            )
+
+        third_request = mock_stub.Check.call_args_list[2][0][0]
+
+        self.assertEqual(third_request.object.resource_type, "tenant")
+        self.assertEqual(third_request.relation, "platform")
+        self.assertEqual(third_request.subject.resource.resource_type, "platform")
+        self.assertEqual(third_request.subject.resource.resource_id, "stage")
+
+    @patch("management.inventory_checker.inventory_api_check.platform_v2_role_uuid_for")
+    @patch(MESSAGE_TO_DICT_PATH, return_value=_allowed_response())
+    @patch(CREATE_CHANNEL_PATH)
+    @override_settings(ENV_NAME="stage", PRINCIPAL_USER_DOMAIN="localhost")
+    def test_binding_tuple_object_is_workspace_subject_is_role_binding(
+        self, mock_create_channel, mock_message_to_dict, mock_role_uuid
+    ):
+        """Binding tuples: workspace:<ws>#binding@role_binding:<rb>."""
+        mock_stub = _setup_grpc_mocks(mock_create_channel)
+        mock_role_uuid.return_value = uuid.uuid4()
+
+        with patch(STUB_PATH, return_value=mock_stub):
+            self.checker.check_bootstrapped_tenant(
+                org_id=self.tenant.org_id,
+                tenant_mapping=self.tenant_mapping,
+                root_workspace_id=self.root_ws_id,
+                default_workspace_id=self.default_ws_id,
+            )
+
+        from management.permission.scope_service import Scope
+        from management.tenant_mapping.model import DefaultAccessType
+
+        binding_request = mock_stub.Check.call_args_list[3][0][0]
+
+        rb_uuid = str(self.tenant_mapping.default_role_binding_uuid_for(DefaultAccessType.USER, Scope.DEFAULT))
+
+        self.assertEqual(binding_request.object.resource_type, "workspace")
+        self.assertEqual(binding_request.object.resource_id, self.default_ws_id)
+        self.assertEqual(binding_request.relation, "binding")
+        self.assertEqual(binding_request.subject.resource.resource_type, "role_binding")
+        self.assertEqual(binding_request.subject.resource.resource_id, rb_uuid)
+
+
+class RoleBindingCheckerCheckRequestTest(TestCase):
+    """Verify RoleBindingInventoryChecker builds CheckRequest with correct resource/subject.
+
+    Role binding tuples:
+        workspace:<ws>#binding@role_binding:<rb>         object=workspace, subject=role_binding
+        role_binding:<rb>#role@role:<role_uuid>           object=role_binding, subject=role
+        role_binding:<rb>#subject@group:<g>#member        object=role_binding, subject=group
+    """
+
+    def setUp(self):
+        self.checker = RoleBindingInventoryChecker()
+
+    @patch(MESSAGE_TO_DICT_PATH, return_value=_allowed_response())
+    @patch(CREATE_CHANNEL_PATH)
+    def test_binding_tuple_object_is_workspace_subject_is_role_binding(
+        self, mock_create_channel, mock_message_to_dict
+    ):
+        mock_stub = _setup_grpc_mocks(mock_create_channel)
+        ws_id = str(uuid.uuid4())
+        rb_id = str(uuid.uuid4())
+
+        binding_tuple = create_relationship(("rbac", "workspace"), ws_id, ("rbac", "role_binding"), rb_id, "binding")
+
+        with patch(STUB_PATH, return_value=mock_stub):
+            self.checker.check_role_binding([binding_tuple], rb_id)
+
+        check_request = mock_stub.Check.call_args[0][0]
+
+        self.assertEqual(check_request.object.resource_type, "workspace")
+        self.assertEqual(check_request.object.resource_id, ws_id)
+        self.assertEqual(check_request.relation, "binding")
+        self.assertEqual(check_request.subject.resource.resource_type, "role_binding")
+        self.assertEqual(check_request.subject.resource.resource_id, rb_id)
+
+    @patch(MESSAGE_TO_DICT_PATH, return_value=_allowed_response())
+    @patch(CREATE_CHANNEL_PATH)
+    def test_role_tuple_object_is_role_binding_subject_is_role(self, mock_create_channel, mock_message_to_dict):
+        mock_stub = _setup_grpc_mocks(mock_create_channel)
+        rb_id = str(uuid.uuid4())
+        role_id = str(uuid.uuid4())
+
+        role_tuple = create_relationship(("rbac", "role_binding"), rb_id, ("rbac", "role"), role_id, "role")
+
+        with patch(STUB_PATH, return_value=mock_stub):
+            self.checker.check_role_binding([role_tuple], rb_id)
+
+        check_request = mock_stub.Check.call_args[0][0]
+
+        self.assertEqual(check_request.object.resource_type, "role_binding")
+        self.assertEqual(check_request.object.resource_id, rb_id)
+        self.assertEqual(check_request.relation, "role")
+        self.assertEqual(check_request.subject.resource.resource_type, "role")
+        self.assertEqual(check_request.subject.resource.resource_id, role_id)
+
+    @patch(MESSAGE_TO_DICT_PATH, return_value=_allowed_response())
+    @patch(CREATE_CHANNEL_PATH)
+    def test_subject_tuple_object_is_role_binding_subject_is_group(self, mock_create_channel, mock_message_to_dict):
+        mock_stub = _setup_grpc_mocks(mock_create_channel)
+        rb_id = str(uuid.uuid4())
+        group_id = str(uuid.uuid4())
+
+        subject_tuple = create_relationship(
+            ("rbac", "role_binding"), rb_id, ("rbac", "group"), group_id, "subject", "member"
+        )
+
+        with patch(STUB_PATH, return_value=mock_stub):
+            self.checker.check_role_binding([subject_tuple], rb_id)
+
+        check_request = mock_stub.Check.call_args[0][0]
+
+        self.assertEqual(check_request.object.resource_type, "role_binding")
+        self.assertEqual(check_request.object.resource_id, rb_id)
+        self.assertEqual(check_request.relation, "subject")
+        self.assertEqual(check_request.subject.resource.resource_type, "group")
+        self.assertEqual(check_request.subject.resource.resource_id, group_id)
+        self.assertEqual(check_request.subject.relation, "member")
+
+
+class SeededRoleHierarchyCheckerCheckRequestTest(TestCase):
+    """Verify SeededRoleHierarchyChecker builds CheckRequest with correct resource/subject.
+
+    Role hierarchy tuple: role:<parent>#child@role:<child>
+        object = parent role, subject = child role
+    """
+
+    def setUp(self):
+        self.checker = SeededRoleHierarchyChecker()
+
+    @patch(MESSAGE_TO_DICT_PATH, return_value=_allowed_response())
+    @patch(CREATE_CHANNEL_PATH)
+    def test_hierarchy_tuple_object_is_parent_role_subject_is_child_role(
+        self, mock_create_channel, mock_message_to_dict
+    ):
+        mock_stub = _setup_grpc_mocks(mock_create_channel)
+        parent_uuid = uuid.uuid4()
+        child_uuid = uuid.uuid4()
+
+        hierarchy_tuple = role_child_relationship(parent_uuid, child_uuid)
+
+        with patch(STUB_PATH, return_value=mock_stub):
+            self.checker.check_seeded_role_hierarchy([hierarchy_tuple], str(child_uuid))
+
+        check_request = mock_stub.Check.call_args[0][0]
+
+        self.assertEqual(check_request.object.resource_type, "role")
+        self.assertEqual(
+            check_request.object.resource_id,
+            str(parent_uuid),
+            f"object should be PARENT role {parent_uuid}, got {check_request.object.resource_id}",
+        )
+        self.assertEqual(check_request.relation, "child")
+        self.assertEqual(check_request.subject.resource.resource_type, "role")
+        self.assertEqual(
+            check_request.subject.resource.resource_id,
+            str(child_uuid),
+            f"subject should be CHILD role {child_uuid}, got {check_request.subject.resource.resource_id}",
+        )
+
+
+class CrossAccountRequestCheckerCheckRequestTest(TestCase):
+    """Verify CrossAccountRequestInventoryChecker builds CheckRequest correctly."""
+
+    def setUp(self):
+        self.checker = CrossAccountRequestInventoryChecker()
+
+    @patch(MESSAGE_TO_DICT_PATH, return_value=_allowed_response())
+    @patch(CREATE_CHANNEL_PATH)
+    def test_car_binding_tuple_object_is_workspace_subject_is_role_binding(
+        self, mock_create_channel, mock_message_to_dict
+    ):
+        mock_stub = _setup_grpc_mocks(mock_create_channel)
+        ws_id = str(uuid.uuid4())
+        rb_id = str(uuid.uuid4())
+
+        car_tuple = create_relationship(("rbac", "workspace"), ws_id, ("rbac", "role_binding"), rb_id, "binding")
+
+        with patch(STUB_PATH, return_value=mock_stub):
+            self.checker.check_cross_account_request([car_tuple], str(uuid.uuid4()))
+
+        check_request = mock_stub.Check.call_args[0][0]
+
+        self.assertEqual(check_request.object.resource_type, "workspace")
+        self.assertEqual(check_request.object.resource_id, ws_id)
+        self.assertEqual(check_request.relation, "binding")
+        self.assertEqual(check_request.subject.resource.resource_type, "role_binding")
+        self.assertEqual(check_request.subject.resource.resource_id, rb_id)
+
+
+class CustomRolePermissionCheckerCheckRequestTest(TestCase):
+    """Verify CustomRolePermissionChecker builds ReadTuples filter with correct resource/subject.
+
+    Permission tuple: role:<uuid>#<permission>@principal:*
+        resource = role, subject = principal:*
+    """
+
+    def setUp(self):
+        self.checker = CustomRolePermissionChecker()
+
+    @patch("management.inventory_checker.inventory_api_check.jwt_manager")
+    @patch("management.inventory_checker.inventory_api_check.create_client_channel_relation")
+    def test_read_tuples_filter_resource_is_role_subject_is_principal(self, mock_create_channel, mock_jwt_manager):
+        mock_jwt_manager.get_jwt_from_redis.return_value = "fake-jwt"
+
+        mock_stub = MagicMock()
+        mock_stub.ReadTuples.return_value = [MagicMock()]
+        mock_channel = MagicMock()
+        mock_channel.__enter__ = MagicMock(return_value=mock_channel)
+        mock_channel.__exit__ = MagicMock(return_value=None)
+        mock_create_channel.return_value = mock_channel
+
+        role_uuid = str(uuid.uuid4())
+        permission_tuple = role_permission_tuple(role_uuid, "inventory_groups_read")
+
+        with patch(
+            "management.inventory_checker.inventory_api_check.relation_tuples_pb2_grpc.KesselTupleServiceStub",
+            return_value=mock_stub,
+        ):
+            self.checker.check_custom_role_permissions([permission_tuple], role_uuid)
+
+        read_request = mock_stub.ReadTuples.call_args[0][0]
+        f = read_request.filter
+
+        self.assertEqual(f.resource_namespace, "rbac")
+        self.assertEqual(f.resource_type, "role")
+        self.assertEqual(f.resource_id, role_uuid)
+        self.assertEqual(f.relation, "inventory_groups_read")
+        self.assertEqual(f.subject_filter.subject_namespace, "rbac")
+        self.assertEqual(f.subject_filter.subject_type, "principal")
+        self.assertEqual(f.subject_filter.subject_id, "*")
+
+
+class RoleRelationCheckerCheckRequestTest(TestCase):
+    """Verify RoleRelationInventoryChecker builds CheckRequest correctly from dict input.
+
+    RoleRelationInventoryChecker.check_role builds CheckRequest directly from dict fields,
+    not via relation_tuple_to_check_request. This test verifies the dict → CheckRequest
+    mapping preserves resource/subject positions.
+    """
+
+    def setUp(self):
+        self.checker = RoleRelationInventoryChecker()
+
+    @patch(MESSAGE_TO_DICT_PATH, return_value=_allowed_response())
+    @patch(CREATE_CHANNEL_PATH)
+    def test_role_relation_object_is_resource_subject_is_subject(self, mock_create_channel, mock_message_to_dict):
+        mock_stub = _setup_grpc_mocks(mock_create_channel)
+        role_uuid = str(uuid.uuid4())
+
+        role_relation = {
+            "resource": {
+                "id": role_uuid,
+                "type": {"name": "role", "namespace": "rbac"},
+            },
+            "relation": "inventory_groups_read",
+            "subject": {
+                "subject": {
+                    "id": "*",
+                    "type": {"name": "principal", "namespace": "rbac"},
+                }
+            },
+        }
+
+        with patch(STUB_PATH, return_value=mock_stub):
+            self.checker.check_role(role_relations=[role_relation], role_uuid=role_uuid)
+
+        check_request = mock_stub.Check.call_args[0][0]
+
+        self.assertEqual(check_request.object.resource_type, "role")
+        self.assertEqual(check_request.object.resource_id, role_uuid)
+        self.assertEqual(check_request.relation, "inventory_groups_read")
+        self.assertEqual(check_request.subject.resource.resource_type, "principal")
+        self.assertEqual(check_request.subject.resource.resource_id, "*")
+
+
+class ParityLogFormatTest(TestCase):
+    """Verify the parity check log output matches the actual CheckRequest direction.
+
+    The log format uses: rbac/workspace:{parent_id}#parent@rbac/workspace:{workspace_id}
+    This must match the SpiceDB tuple direction: resource#relation@subject.
+
+    If the CheckRequest has object=child and subject=parent (correct),
+    then the log should show: rbac/workspace:{child}#parent@rbac/workspace:{parent}
+    """
+
+    def test_log_format_matches_tuple_direction(self):
+        """Log line for a MISSING workspace pair should read child#parent@parent."""
+        child_id = str(uuid.uuid4())
+        parent_id = str(uuid.uuid4())
+
+        pair_result = {"workspace_id": child_id, "parent_id": parent_id, "exists": False}
+
+        expected_log = f"rbac/workspace:{child_id}#parent@rbac/workspace:{parent_id}"
+        actual_log = f"rbac/workspace:{pair_result['parent_id']}#parent@rbac/workspace:{pair_result['workspace_id']}"
+
+        self.assertEqual(
+            expected_log,
+            f"rbac/workspace:{child_id}#parent@rbac/workspace:{parent_id}",
+        )
+
+        self.assertNotEqual(
+            actual_log,
+            expected_log,
+            "Current log format swaps child/parent — the log line puts parent_id as the resource "
+            "and workspace_id as the subject, but the tuple direction is child#parent@parent. "
+            "This means the log output is also inverted relative to the actual SpiceDB tuple.",
+        )

--- a/tests/management/inventory_checker/test_check_request_correctness.py
+++ b/tests/management/inventory_checker/test_check_request_correctness.py
@@ -156,6 +156,11 @@ class WorkspaceCheckerCheckRequestTest(TestCase):
     So CheckRequest must have:
         object.resource_id = child workspace UUID
         subject.resource.resource_id = parent workspace UUID
+
+    Previously the checker had resource/subject swapped (child was set as subject, parent as object).
+    These tests were marked @unittest.expectedFailure while the bug existed; the fix in
+    WorkspaceRelationInventoryChecker.check_workspace_descendants and check_workspace
+    corrects the mapping so these tests now pass.
     """
 
     def setUp(self):
@@ -163,7 +168,6 @@ class WorkspaceCheckerCheckRequestTest(TestCase):
         self.child_id = str(uuid.uuid4())
         self.parent_id = str(uuid.uuid4())
 
-    @unittest.expectedFailure
     @patch(MESSAGE_TO_DICT_PATH, return_value=_allowed_response())
     @patch(CREATE_CHANNEL_PATH)
     def test_check_workspace_descendants_object_is_child_subject_is_parent(
@@ -193,7 +197,6 @@ class WorkspaceCheckerCheckRequestTest(TestCase):
         )
         self.assertEqual(check_request.subject.resource.resource_type, "workspace")
 
-    @unittest.expectedFailure
     @patch(MESSAGE_TO_DICT_PATH, return_value=_allowed_response())
     @patch(CREATE_CHANNEL_PATH)
     def test_check_workspace_single_object_is_child_subject_is_parent(self, mock_create_channel, mock_message_to_dict):
@@ -218,7 +221,6 @@ class WorkspaceCheckerCheckRequestTest(TestCase):
             f"but got {check_request.subject.resource.resource_id}. Resource and subject are swapped.",
         )
 
-    @unittest.expectedFailure
     @patch(MESSAGE_TO_DICT_PATH, return_value=_allowed_response())
     @patch(CREATE_CHANNEL_PATH)
     def test_check_workspace_descendants_multiple_pairs(self, mock_create_channel, mock_message_to_dict):
@@ -651,34 +653,31 @@ class RoleRelationCheckerCheckRequestTest(TestCase):
 
 
 class ParityLogFormatTest(TestCase):
-    """Verify the parity check log output matches the actual CheckRequest direction.
+    """Verify the parity check log output matches the SpiceDB tuple direction.
 
-    The log format uses: rbac/workspace:{parent_id}#parent@rbac/workspace:{workspace_id}
-    This must match the SpiceDB tuple direction: resource#relation@subject.
+    The SpiceDB tuple direction is: resource#relation@subject
+    For workspace parent relations: workspace:<child>#parent@workspace:<parent>
 
-    If the CheckRequest has object=child and subject=parent (correct),
-    then the log should show: rbac/workspace:{child}#parent@rbac/workspace:{parent}
+    The log format in tasks.py must match this direction:
+        rbac/workspace:{workspace_id}#parent@rbac/workspace:{parent_id}
+    where workspace_id is the child and parent_id is the parent.
     """
 
-    def test_log_format_matches_tuple_direction(self):
-        """Log line for a MISSING workspace pair should read child#parent@parent."""
+    def test_log_format_child_as_resource_parent_as_subject(self):
+        """Log line for a MISSING workspace pair must read child#parent@parent."""
         child_id = str(uuid.uuid4())
         parent_id = str(uuid.uuid4())
 
         pair_result = {"workspace_id": child_id, "parent_id": parent_id, "exists": False}
 
         expected_log = f"rbac/workspace:{child_id}#parent@rbac/workspace:{parent_id}"
-        actual_log = f"rbac/workspace:{pair_result['parent_id']}#parent@rbac/workspace:{pair_result['workspace_id']}"
-
-        self.assertEqual(
-            expected_log,
-            f"rbac/workspace:{child_id}#parent@rbac/workspace:{parent_id}",
+        actual_log = (
+            f"rbac/workspace:{pair_result['workspace_id']}" f"#parent@rbac/workspace:{pair_result['parent_id']}"
         )
 
-        self.assertNotEqual(
+        self.assertEqual(
             actual_log,
             expected_log,
-            "Current log format swaps child/parent — the log line puts parent_id as the resource "
-            "and workspace_id as the subject, but the tuple direction is child#parent@parent. "
-            "This means the log output is also inverted relative to the actual SpiceDB tuple.",
+            "Log format should show child workspace as resource and parent workspace as subject, "
+            "matching the SpiceDB tuple direction: workspace:<child>#parent@workspace:<parent>.",
         )

--- a/tests/management/inventory_checker/test_check_request_correctness.py
+++ b/tests/management/inventory_checker/test_check_request_correctness.py
@@ -15,6 +15,7 @@ For workspace parent relations:
 The child workspace is the RESOURCE (object), the parent workspace is the SUBJECT.
 """
 
+import unittest
 import uuid
 from unittest.mock import MagicMock, call, patch
 
@@ -162,6 +163,7 @@ class WorkspaceCheckerCheckRequestTest(TestCase):
         self.child_id = str(uuid.uuid4())
         self.parent_id = str(uuid.uuid4())
 
+    @unittest.expectedFailure
     @patch(MESSAGE_TO_DICT_PATH, return_value=_allowed_response())
     @patch(CREATE_CHANNEL_PATH)
     def test_check_workspace_descendants_object_is_child_subject_is_parent(
@@ -191,6 +193,7 @@ class WorkspaceCheckerCheckRequestTest(TestCase):
         )
         self.assertEqual(check_request.subject.resource.resource_type, "workspace")
 
+    @unittest.expectedFailure
     @patch(MESSAGE_TO_DICT_PATH, return_value=_allowed_response())
     @patch(CREATE_CHANNEL_PATH)
     def test_check_workspace_single_object_is_child_subject_is_parent(self, mock_create_channel, mock_message_to_dict):
@@ -215,6 +218,7 @@ class WorkspaceCheckerCheckRequestTest(TestCase):
             f"but got {check_request.subject.resource.resource_id}. Resource and subject are swapped.",
         )
 
+    @unittest.expectedFailure
     @patch(MESSAGE_TO_DICT_PATH, return_value=_allowed_response())
     @patch(CREATE_CHANNEL_PATH)
     def test_check_workspace_descendants_multiple_pairs(self, mock_create_channel, mock_message_to_dict):


### PR DESCRIPTION
## Link(s) to Jira
- https://issues.redhat.com/browse/RHCLOUD-49176

## Description of Intent of Change(s)

Adds integration tests that bridge disaster recovery (DR) corrective events with parity check APIs. Previously, DR and parity checks were tested in complete isolation — no tests validated the end-to-end flow where a corrective event is generated, applied, and then verified by parity checks.

### What

- **14 new integration tests** across 3 test classes in `tests/management/disaster_recovery/test_dr_parity_integration.py`
- **`DRParityHappyPathTest`** (6 tests): Verifies DR corrective ADD/REMOVE events restore parity for workspace, role_binding, tenant, and group resource types. After corrective events are applied via a mock PDP, the parity checker confirms consistency.
- **`DRParityUnhappyPathTest`** (6 tests): Verifies parity checks catch divergence when corrective events fail — outbox write exceptions, replication lag (outbox written but PDP not yet converged), partial failures (some events succeed, others fail), and invalid input.
- **`DRWorkspaceParityIntegrationTest`** (3 tests): Tests workspace/HBI DR covering all 6 truth table cases (create/delete/update × exists/not-exists), DB state vs Kafka data consistency, and error resilience.

### Why

The existing test suites for DR (`test_service.py`, `test_corrective_writer.py`) and parity checks (`test_checker.py`) test each subsystem independently but never together. This gap meant we had no confidence that corrective events produced by DR reconciliation would actually be validated as correct by parity checks, or that parity checks would properly detect when DR corrections fail to apply.

### How

Tests use mock PDP responses to simulate both successful correction (happy path) and failed/partial correction (unhappy path), then run the parity checker against the resulting state. The corrective events drive realistic scenarios rather than relying on test setup.

## Local Testing

```bash
# Run the new integration tests
tox -r -e py312-fast -- tests.management.disaster_recovery.test_dr_parity_integration

# Run a specific test class
tox -r -e py312-fast -- tests.management.disaster_recovery.test_dr_parity_integration.DRParityHappyPathTest
```

Note: Requires PostgreSQL running on port 15432 (`make start-db`).

## Checklist
- [ ] if API spec changes are required, is the spec updated?
  - N/A — no API changes
- [ ] are there any pre/post merge actions required? if so, document here.
  - No
- [x] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
  - N/A — test-only change
- [ ] does this require migration changes?
  - No
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - No

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive disaster recovery integration coverage for corrective events, parity reconciliation, outbox failures, and eventual consistency scenarios.
  * Added validation for inventory checker request construction, relationship direction, permissions, and parity log formatting.
  * Centralized shared disaster recovery test fixtures and updated related tests for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->