### PR TITLE
feat(dr): skip configurable event types during DR reconciliation [RHCLOUD-48297]

### DIFF
--- a/deploy/rbac-clowdapp.yml
+++ b/deploy/rbac-clowdapp.yml
@@ -1741,6 +1741,9 @@ parameters:
 - description: Kafka consumer group ID for DR reconciliation reader
   name: DR_KAFKA_CONSUMER_GROUP_ID
   value: 'rbac-dr-consumer-group'
+- description: Comma-separated replication event types to skip during DR reconciliation (empty to skip none)
+  name: DR_SKIP_EVENT_TYPES
+  value: 'bootstrap_tenant,bulk_bootstrap_tenant,external_user_update,external_user_disable,bulk_external_user_update'
 - name: EXTERNAL_SYNC_TOPIC
   value: 'platform.rbac.sync'
 - name: EXTERNAL_CHROME_TOPIC

--- a/rbac/management/disaster_recovery/service.py
+++ b/rbac/management/disaster_recovery/service.py
@@ -4,7 +4,6 @@ import logging
 import time
 
 from django.conf import settings
-
 from management.disaster_recovery.corrective_writer import (
     generate_corrective_actions,
     write_corrective_events,

--- a/rbac/management/disaster_recovery/service.py
+++ b/rbac/management/disaster_recovery/service.py
@@ -3,6 +3,8 @@
 import logging
 import time
 
+from django.conf import settings
+
 from management.disaster_recovery.corrective_writer import (
     generate_corrective_actions,
     write_corrective_events,
@@ -46,7 +48,18 @@ def reconcile(
         buffer_seconds,
     )
 
-    events = read_events_in_window(start_timestamp_ms, end_timestamp_ms)
+    all_events = read_events_in_window(start_timestamp_ms, end_timestamp_ms)
+
+    skip_event_types = frozenset(settings.DR_SKIP_EVENT_TYPES)
+    skipped_by_type = [e for e in all_events if e.event_type in skip_event_types]
+    events = [e for e in all_events if e.event_type not in skip_event_types]
+
+    if skipped_by_type:
+        logger.info(
+            "Skipped %d event(s) by type (types: %s)",
+            len(skipped_by_type),
+            ", ".join(sorted({e.event_type for e in skipped_by_type})),
+        )
 
     if not events:
         logger.info("No events found in the time window, nothing to reconcile")
@@ -54,6 +67,7 @@ def reconcile(
             "status": "completed",
             "time_window": {"start_ms": start_timestamp_ms, "end_ms": end_timestamp_ms},
             "events_read": 0,
+            "events_skipped_by_type": len(skipped_by_type),
             "tuples_processed": 0,
             "corrective_adds": 0,
             "corrective_removes": 0,
@@ -103,6 +117,7 @@ def reconcile(
             "status": "dry_run",
             "time_window": {"start_ms": start_timestamp_ms, "end_ms": end_timestamp_ms},
             "events_read": len(events),
+            "events_skipped_by_type": len(skipped_by_type),
             "tuples_processed": len(all_tuples),
             "corrective_adds": len(adds),
             "corrective_removes": len(removes),
@@ -133,6 +148,7 @@ def reconcile(
         "status": "completed",
         "time_window": {"start_ms": start_timestamp_ms, "end_ms": end_timestamp_ms},
         "events_read": len(events),
+        "events_skipped_by_type": len(skipped_by_type),
         "tuples_processed": len(all_tuples),
         "duration_seconds": elapsed,
     }

--- a/rbac/rbac/settings.py
+++ b/rbac/rbac/settings.py
@@ -707,6 +707,14 @@ PARITY_CHECK_SCHEDULE = ENVIRONMENT.str("PARITY_CHECK_SCHEDULE", default="0 0 * 
 DR_RELATIONS_RECONCILE_ENABLED = ENVIRONMENT.bool("DR_RELATIONS_RECONCILE_ENABLED", default=False)
 DR_KAFKA_CONSUMER_GROUP_ID = ENVIRONMENT.get_value("DR_KAFKA_CONSUMER_GROUP_ID", default="rbac-dr-consumer-group")
 DR_MAX_EVENTS_PER_RECONCILE = ENVIRONMENT.int("DR_MAX_EVENTS_PER_RECONCILE", default=10000)
+DR_SKIP_EVENT_TYPES = [
+    t.strip()
+    for t in ENVIRONMENT.get_value(
+        "DR_SKIP_EVENT_TYPES",
+        default="bootstrap_tenant,bulk_bootstrap_tenant,external_user_update,external_user_disable,bulk_external_user_update",
+    ).split(",")
+    if t.strip()
+]
 
 # Org level permissons parent role uuids
 SYSTEM_DEFAULT_ROOT_WORKSPACE_ROLE_UUID = ENVIRONMENT.get_value("SYSTEM_DEFAULT_ROOT_WORKSPACE_ROLE_UUID", default="")

--- a/tests/management/disaster_recovery/test_service.py
+++ b/tests/management/disaster_recovery/test_service.py
@@ -3,7 +3,7 @@
 from unittest.mock import patch
 from uuid import uuid4
 
-from django.test import TestCase
+from django.test import TestCase, override_settings
 
 from api.models import Tenant
 from management.disaster_recovery.kafka_reader import ParsedReplicationEvent
@@ -175,6 +175,7 @@ class ReconcileServiceTest(TestCase):
         self.assertEqual(result["time_window"]["start_ms"], 2000000 - 60000)
         self.assertEqual(result["time_window"]["end_ms"], 2000000)
         self.assertIn("events_read", result)
+        self.assertIn("events_skipped_by_type", result)
         self.assertIn("tuples_processed", result)
         self.assertIn("duration_seconds", result)
 
@@ -457,7 +458,7 @@ class ReconcileAllResourceTypesTest(TestCase):
                 offset=0,
                 partition=0,
                 timestamp_ms=1000,
-                event_type="bootstrap_tenant",
+                event_type="update_root_workspace_tenants",
                 relations_to_add=[t],
                 relations_to_remove=[],
             )
@@ -494,13 +495,12 @@ class ReconcileAllResourceTypesTest(TestCase):
         self.assertEqual(len(log), 0)
 
 
-class ReconcileBootstrapTenantTest(TestCase):
-    """Verify reconciliation correctly handles bootstrap_tenant events.
+class ReconcileSkippedEventTypesTest(TestCase):
+    """Verify that bootstrap and external user (UMB) events are skipped during DR.
 
-    Bootstrap events are structurally different: they create many tuples at once
-    across multiple resource types (workspace, group, role_binding, tenant).
-    Groups and role_bindings from bootstrap are "virtual" -- they exist as UUIDs
-    in TenantMapping but not as actual model instances.
+    These event types should not be processed through the corrective truth table:
+    - bootstrap_tenant / bulk_bootstrap_tenant: bulk initialization events
+    - external_user_update / external_user_disable / bulk_external_user_update: UMB-sourced user sync
     """
 
     @classmethod
@@ -534,16 +534,11 @@ class ReconcileBootstrapTenantTest(TestCase):
         super().tearDownClass()
 
     @patch("management.disaster_recovery.service.read_events_in_window")
-    def test_bootstrap_event_with_existing_tenant(self, mock_read):
-        """Bootstrap event where tenant, workspace, and virtual resources all exist -> all SKIP."""
+    def test_bootstrap_event_is_skipped(self, mock_read):
+        """bootstrap_tenant events are filtered out before processing."""
         tuples = [
             _make_tuple(resource_type="workspace", resource_id=str(self.root_ws.id)),
             _make_tuple(resource_type="group", resource_id=str(self.mapping.default_group_uuid)),
-            _make_tuple(resource_type="group", resource_id=str(self.mapping.default_admin_group_uuid)),
-            _make_tuple(resource_type="role_binding", resource_id=str(self.mapping.default_role_binding_uuid)),
-            _make_tuple(
-                resource_type="role_binding", resource_id=str(self.mapping.root_scope_default_role_binding_uuid)
-            ),
             _make_tuple(resource_type="tenant", resource_id=f"localhost/{self.tenant.org_id}"),
         ]
 
@@ -562,23 +557,16 @@ class ReconcileBootstrapTenantTest(TestCase):
         log = InMemoryLog()
         result = reconcile(restore_timestamp_ms=1000000, replicator=OutboxReplicator(log=log))
 
-        self.assertEqual(result["skipped"], len(tuples))
-        self.assertEqual(result["corrective_adds"], 0)
-        self.assertEqual(result["corrective_removes"], 0)
+        self.assertEqual(result["events_read"], 0)
+        self.assertEqual(result["events_skipped_by_type"], 1)
+        self.assertEqual(result["tuples_processed"], 0)
         self.assertEqual(len(log), 0)
 
     @patch("management.disaster_recovery.service.read_events_in_window")
-    def test_bootstrap_event_with_deleted_tenant(self, mock_read):
-        """Bootstrap event where all resources were deleted -> all REMOVE."""
-        fake_ws = str(uuid4())
-        fake_group = str(uuid4())
-        fake_rb = str(uuid4())
-
+    def test_bulk_bootstrap_event_is_skipped(self, mock_read):
+        """bulk_bootstrap_tenant events are filtered out before processing."""
         tuples = [
-            _make_tuple(resource_type="workspace", resource_id=fake_ws),
-            _make_tuple(resource_type="group", resource_id=fake_group),
-            _make_tuple(resource_type="role_binding", resource_id=fake_rb),
-            _make_tuple(resource_type="tenant", resource_id="localhost/deleted-org"),
+            _make_tuple(resource_type="workspace", resource_id=str(self.root_ws.id)),
         ]
 
         mock_read.return_value = [
@@ -586,8 +574,8 @@ class ReconcileBootstrapTenantTest(TestCase):
                 offset=0,
                 partition=0,
                 timestamp_ms=1000,
-                event_type="bootstrap_tenant",
-                org_id="deleted-org",
+                event_type="bulk_bootstrap_tenant",
+                org_id=self.tenant.org_id,
                 relations_to_add=tuples,
                 relations_to_remove=[],
             )
@@ -596,21 +584,15 @@ class ReconcileBootstrapTenantTest(TestCase):
         log = InMemoryLog()
         result = reconcile(restore_timestamp_ms=1000000, replicator=OutboxReplicator(log=log))
 
-        self.assertEqual(result["corrective_removes"], len(tuples))
-        self.assertEqual(result["skipped"], 0)
-        self.assertEqual(len(log), len(tuples))
-        for entry in log:
-            self.assertEqual(entry.event_type, ReplicationEventType.DR_CORRECTIVE_REMOVE)
+        self.assertEqual(result["events_read"], 0)
+        self.assertEqual(result["events_skipped_by_type"], 1)
+        self.assertEqual(result["tuples_processed"], 0)
+        self.assertEqual(len(log), 0)
 
     @patch("management.disaster_recovery.service.read_events_in_window")
-    def test_bootstrap_event_partial_state(self, mock_read):
-        """Bootstrap event: workspace exists, but group was deleted -> mixed SKIP + REMOVE."""
-        fake_group = str(uuid4())
-
-        tuples_add = [
-            _make_tuple(resource_type="workspace", resource_id=str(self.root_ws.id)),
-            _make_tuple(resource_type="group", resource_id=fake_group),
-        ]
+    def test_bootstrap_events_skipped_alongside_regular_events(self, mock_read):
+        """Bootstrap events are skipped but regular events in the same window are processed."""
+        fake_ws = str(uuid4())
 
         mock_read.return_value = [
             ParsedReplicationEvent(
@@ -619,41 +601,112 @@ class ReconcileBootstrapTenantTest(TestCase):
                 timestamp_ms=1000,
                 event_type="bootstrap_tenant",
                 org_id=self.tenant.org_id,
-                relations_to_add=tuples_add,
+                relations_to_add=[_make_tuple(resource_type="workspace", resource_id=str(self.root_ws.id))],
                 relations_to_remove=[],
-            )
+            ),
+            ParsedReplicationEvent(
+                offset=1,
+                partition=0,
+                timestamp_ms=1100,
+                event_type="create_workspace",
+                relations_to_add=[_make_tuple(resource_type="workspace", resource_id=fake_ws)],
+                relations_to_remove=[],
+            ),
         ]
 
         log = InMemoryLog()
         result = reconcile(restore_timestamp_ms=1000000, replicator=OutboxReplicator(log=log))
 
-        self.assertEqual(result["skipped"], 1)
+        self.assertEqual(result["events_read"], 1)
+        self.assertEqual(result["events_skipped_by_type"], 1)
         self.assertEqual(result["corrective_removes"], 1)
         self.assertEqual(len(log), 1)
-        self.assertEqual(log.first().event_type, ReplicationEventType.DR_CORRECTIVE_REMOVE)
 
     @patch("management.disaster_recovery.service.read_events_in_window")
-    def test_bootstrap_event_virtual_role_bindings_via_tenant_mapping(self, mock_read):
-        """All 6 TenantMapping role binding UUIDs are recognized as existing."""
-        tuples = [
-            _make_tuple(resource_type="role_binding", resource_id=str(self.mapping.default_role_binding_uuid)),
-            _make_tuple(resource_type="role_binding", resource_id=str(self.mapping.default_admin_role_binding_uuid)),
-            _make_tuple(
-                resource_type="role_binding", resource_id=str(self.mapping.root_scope_default_role_binding_uuid)
+    def test_multiple_bootstrap_events_all_skipped(self, mock_read):
+        """Multiple bootstrap events of different types are all skipped."""
+        mock_read.return_value = [
+            ParsedReplicationEvent(
+                offset=0,
+                partition=0,
+                timestamp_ms=1000,
+                event_type="bootstrap_tenant",
+                org_id="org-1",
+                relations_to_add=[_make_tuple()],
+                relations_to_remove=[],
             ),
-            _make_tuple(
-                resource_type="role_binding",
-                resource_id=str(self.mapping.root_scope_default_admin_role_binding_uuid),
+            ParsedReplicationEvent(
+                offset=1,
+                partition=0,
+                timestamp_ms=1100,
+                event_type="bulk_bootstrap_tenant",
+                org_id="org-2",
+                relations_to_add=[_make_tuple()],
+                relations_to_remove=[],
             ),
-            _make_tuple(
-                resource_type="role_binding",
-                resource_id=str(self.mapping.tenant_scope_default_role_binding_uuid),
-            ),
-            _make_tuple(
-                resource_type="role_binding",
-                resource_id=str(self.mapping.tenant_scope_default_admin_role_binding_uuid),
+            ParsedReplicationEvent(
+                offset=2,
+                partition=0,
+                timestamp_ms=1200,
+                event_type="bootstrap_tenant",
+                org_id="org-3",
+                relations_to_add=[_make_tuple()],
+                relations_to_remove=[],
             ),
         ]
+
+        log = InMemoryLog()
+        result = reconcile(restore_timestamp_ms=1000000, replicator=OutboxReplicator(log=log))
+
+        self.assertEqual(result["events_read"], 0)
+        self.assertEqual(result["events_skipped_by_type"], 3)
+        self.assertEqual(len(log), 0)
+
+    @patch("management.disaster_recovery.service.read_events_in_window")
+    def test_external_user_events_are_skipped(self, mock_read):
+        """UMB-sourced external_user_update/disable/bulk events are filtered out."""
+        mock_read.return_value = [
+            ParsedReplicationEvent(
+                offset=0,
+                partition=0,
+                timestamp_ms=1000,
+                event_type="external_user_update",
+                org_id="org-1",
+                relations_to_add=[_make_tuple(resource_type="principal", resource_id="localhost/user-1")],
+                relations_to_remove=[],
+            ),
+            ParsedReplicationEvent(
+                offset=1,
+                partition=0,
+                timestamp_ms=1100,
+                event_type="external_user_disable",
+                org_id="org-1",
+                relations_to_add=[],
+                relations_to_remove=[_make_tuple(resource_type="principal", resource_id="localhost/user-2")],
+            ),
+            ParsedReplicationEvent(
+                offset=2,
+                partition=0,
+                timestamp_ms=1200,
+                event_type="bulk_external_user_update",
+                org_id="org-1",
+                relations_to_add=[_make_tuple(resource_type="principal", resource_id="localhost/user-3")],
+                relations_to_remove=[],
+            ),
+        ]
+
+        log = InMemoryLog()
+        result = reconcile(restore_timestamp_ms=1000000, replicator=OutboxReplicator(log=log))
+
+        self.assertEqual(result["events_read"], 0)
+        self.assertEqual(result["events_skipped_by_type"], 3)
+        self.assertEqual(len(log), 0)
+
+    @override_settings(DR_SKIP_EVENT_TYPES=[])
+    @patch("management.disaster_recovery.service.read_events_in_window")
+    def test_empty_skip_list_processes_all_events(self, mock_read):
+        """When DR_SKIP_EVENT_TYPES is empty, bootstrap events are processed normally."""
+        fake_ws = str(uuid4())
 
         mock_read.return_value = [
             ParsedReplicationEvent(
@@ -662,7 +715,7 @@ class ReconcileBootstrapTenantTest(TestCase):
                 timestamp_ms=1000,
                 event_type="bootstrap_tenant",
                 org_id=self.tenant.org_id,
-                relations_to_add=tuples,
+                relations_to_add=[_make_tuple(resource_type="workspace", resource_id=fake_ws)],
                 relations_to_remove=[],
             )
         ]
@@ -670,9 +723,10 @@ class ReconcileBootstrapTenantTest(TestCase):
         log = InMemoryLog()
         result = reconcile(restore_timestamp_ms=1000000, replicator=OutboxReplicator(log=log))
 
-        self.assertEqual(result["skipped"], 6)
-        self.assertEqual(result["corrective_removes"], 0)
-        self.assertEqual(len(log), 0)
+        self.assertEqual(result["events_read"], 1)
+        self.assertEqual(result["events_skipped_by_type"], 0)
+        self.assertEqual(result["corrective_removes"], 1)
+        self.assertEqual(len(log), 1)
 
 
 class ReconcileMultiEventTest(TestCase):


### PR DESCRIPTION
## Link(s) to Jira
- https://issues.redhat.com/browse/RHCLOUD-48297

## Description of Intent of Change(s)

### What
Add a new `DR_SKIP_EVENT_TYPES` environment variable that controls which replication event types are filtered out before the DR corrective truth table runs.

### Why
Bootstrap events (`bootstrap_tenant`, `bulk_bootstrap_tenant`) and UMB-sourced user sync events (`external_user_update`, `external_user_disable`, `bulk_external_user_update`) produce bulk relation tuples that are not meaningful as individual resource changes during disaster recovery. Processing them through the corrective truth table would generate misleading corrective actions — e.g., trying to "correct" relations that are part of normal tenant initialization or external user synchronization.

### How
- **`rbac/rbac/settings.py`**: New `DR_SKIP_EVENT_TYPES` setting parsed from a comma-separated env var. Default includes all 5 event types listed above. Empty string disables skipping entirely.
- **`rbac/management/disaster_recovery/service.py`**: After reading events from Kafka, filters out any events whose `event_type` matches the configured skip list. The result dict includes `events_skipped_by_type` count for operator visibility.
- **`deploy/rbac-clowdapp.yml`**: New Clowder template parameter with the same defaults.
- **Tests**: Rewrote `ReconcileBootstrapTenantTest` → `ReconcileSkippedEventTypesTest` covering bootstrap events, UMB events, mixed windows, and empty skip list via `@override_settings`.

## Local Testing
```bash
# Run DR service tests
tox -r -e py312-fast -- tests.management.disaster_recovery.test_service

# Verify setting parses correctly
DR_SKIP_EVENT_TYPES="" python -c "from rbac.settings import DR_SKIP_EVENT_TYPES; print(DR_SKIP_EVENT_TYPES)"
# Expected: []

# Default (no env var set)
python -c "from rbac.settings import DR_SKIP_EVENT_TYPES; print(DR_SKIP_EVENT_TYPES)"
# Expected: ['bootstrap_tenant', 'bulk_bootstrap_tenant', 'external_user_update', 'external_user_disable', 'bulk_external_user_update']
```

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [x] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices