### PR TITLE
RHCLOUD-49052 - RBAC scheduler - change timeout to 20s after hummingbird migration

### DIFF
--- a/deploy/rbac-clowdapp.yml
+++ b/deploy/rbac-clowdapp.yml
@@ -337,7 +337,7 @@ objects:
           initialDelaySeconds: ${{CELERY_INITIAL_DELAY_SEC}}
           periodSeconds: ${{CELERY_PERIOD_SEC}}
           successThreshold: 1
-          timeoutSeconds: 10
+          timeoutSeconds: 20
         readinessProbe:
           exec:
             command:
@@ -349,7 +349,7 @@ objects:
           failureThreshold: 3
           periodSeconds: ${{CELERY_PERIOD_SEC}}
           successThreshold: 1
-          timeoutSeconds: 10
+          timeoutSeconds: 20
         resources:
           limits:
             cpu: ${CELERY_SCHEDULER_CPU_LIMIT}


### PR DESCRIPTION
## Link(s) to Jira
https://redhat.atlassian.net/browse/RHCLOUD-49052

## Description of Intent of Change(s)
After the Hummingbird migration to core-runtime (distroless), celery inspect ping takes longer due to increased
cold-start latency in the minimal runtime environment. The 10s timeout was causing intermittent probe failures and pod
restarts.

Test plan

- [ ] Verify scheduler pods stay healthy in stage

## Local Testing
How can the feature be exercised?
How can the bug be exploited and fix confirmed?
Is any special local setup required?

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
