### PR TITLE
RHCLOUD-48526: Don't migrate role scope when replication is disabled

### DIFF
--- a/rbac/internal/migrations/migrate_role_scope.py
+++ b/rbac/internal/migrations/migrate_role_scope.py
@@ -22,6 +22,8 @@ import itertools
 import logging
 from typing import Optional
 
+from django.conf import settings
+
 from management.atomic_transactions import atomic_block, atomic_with_retry
 from management.group.model import Group
 from management.permission.scope_service import ImplicitResourceService
@@ -147,6 +149,10 @@ def migrate_role_scope_if_changed(v1_role: Role, replicator: Optional[RelationRe
     ImplicitResourceService) would not match the expected scopes in the RoleScopeState (likely because the
     RoleScopeState was updated by an instance with different scope settings).
     """
+    if not settings.REPLICATION_TO_RELATION_ENABLED:
+        logger.info("Not migrating role scope when replication is disabled.")
+        return
+
     if replicator is None:
         replicator = OutboxReplicator()
 

--- a/tests/internal/migrations/test_migrate_role_scope.py
+++ b/tests/internal/migrations/test_migrate_role_scope.py
@@ -96,3 +96,8 @@ class MigrateRoleScopeTest(DualWriteTestCase):
             self._do_migrate()
 
         self.assertFalse(RoleScopeState.objects.filter(role=self.role).exists())
+
+    @override_settings(REPLICATION_TO_RELATION_ENABLED=False)
+    def test_no_migrate_without_replication(self):
+        self._do_migrate()
+        self.assertFalse(RoleScopeState.objects.filter(role=self.role).exists())


### PR DESCRIPTION
## Link(s) to Jira
[RHCLOUD-48526](https://redhat.atlassian.net/browse/RHCLOUD-48526)

## Description of Intent of Change(s)
We shouldn't mark a `RoleScopeState` as migrated if we are not actually going to replicate any changes.

[RHCLOUD-48526]: https://redhat.atlassian.net/browse/RHCLOUD-48526?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ