### PR TITLE
feat(ci): add merge_group trigger to workflow files

### DIFF
--- a/.github/workflows/block-fixup-commit-merge.yml
+++ b/.github/workflows/block-fixup-commit-merge.yml
@@ -1,6 +1,8 @@
 name: Git Checks
 
-on: pull_request
+on:
+  pull_request:
+  merge_group:
 
 jobs:
   message-check:

--- a/.github/workflows/block-fixup-commit-merge.yml
+++ b/.github/workflows/block-fixup-commit-merge.yml
@@ -2,7 +2,6 @@ name: Git Checks
 
 on:
   pull_request:
-  merge_group:
 
 jobs:
   message-check:

--- a/.github/workflows/json-yaml-validation.yml
+++ b/.github/workflows/json-yaml-validation.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - main
   pull_request:
+  merge_group:
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/openapi-validation.yml
+++ b/.github/workflows/openapi-validation.yml
@@ -14,6 +14,7 @@ on:
       - 'docs/source/specs/v2/openapi.yaml'
       - 'docs/source/specs/v2/openapi.json'
       - '.redocly.yaml'
+  merge_group:
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/platfrom-security-workflow.yml
+++ b/.github/workflows/platfrom-security-workflow.yml
@@ -21,6 +21,7 @@ on:
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ "main", "master", "security-compliance" ]
+  merge_group:
 
 jobs:
   PlatSec-Security-Workflow:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -2,6 +2,7 @@ name: pre-commit
 
 on:
   pull_request:
+  merge_group:
   push:
     branches: [main]
 

--- a/.github/workflows/typespec-drift.yml
+++ b/.github/workflows/typespec-drift.yml
@@ -8,6 +8,7 @@ on:
       - 'docs/source/specs/typespec/package.json'
       - 'docs/source/specs/v2/openapi.json'
       - 'docs/source/specs/v2/openapi.yaml'
+  merge_group:
   push:
     branches: [master]
     paths:

--- a/.tekton/insights-rbac-pull-request.yaml
+++ b/.tekton/insights-rbac-pull-request.yaml
@@ -8,8 +8,8 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "master"
+    pipelinesascode.tekton.dev/on-cel-expression: (event == "pull_request" && target_branch
+      == "master") || (event == "push" && target_branch.startsWith("gh-readonly-queue/master/"))
   labels:
     appstudio.openshift.io/application: rbac
     appstudio.openshift.io/component: insights-rbac


### PR DESCRIPTION
## Summary
- Add `merge_group` trigger to CI workflow files to enable GitHub merge queue
- Without this trigger, CI checks won't run on the merge queue's temporary branches, causing the queue to time out and reject all PRs
- `block-fixup-commit-merge.yml` keeps only `pull_request` since the action doesn't support `merge_group`

## Affected workflows
- `json-yaml-validation.yml` — added `merge_group`
- `openapi-validation.yml` — added `merge_group`
- `platfrom-security-workflow.yml` — added `merge_group`
- `pre-commit.yml` — added `merge_group`
- `typespec-drift.yml` — added `merge_group`

## Jira
https://redhat.atlassian.net/browse/RHCLOUD-49178

## Test plan
- [ ] Verify CI checks pass on this PR
- [ ] After merging, test merge queue by clicking "Merge when ready" on a subsequent PR
- [ ] Confirm the merge queue creates a temporary branch and CI runs on it