### PR TITLE
Add CONNECTOR_STATE parameter to debezium-connector template

### DIFF
--- a/deploy/debezium-connector.yml
+++ b/deploy/debezium-connector.yml
@@ -14,6 +14,7 @@ objects:
   spec:
     class: io.debezium.connector.postgresql.PostgresConnector
     tasksMax: ${{MAX_TASKS}}
+    state: ${CONNECTOR_STATE}
     config:
       database.server.name: ${DB_SERVERNAME}
       database.dbname: ${DB_NAME}
@@ -78,6 +79,9 @@ parameters:
 - name: DEBEZIUM_HEARTBEAT_INTERVAL_MS
   value: "300000"
   description: The interval for the Debezium heartbeat in ms
+- name: CONNECTOR_STATE
+  description: "Defines the state the connector should be deployed in ('stopped', 'running', 'paused' only)"
+  value: running
 - name: SNAPSHOT_MODE
   value: "initial"
   description: The snapshot mode for the connector


### PR DESCRIPTION
## Summary
- Add `state: ${CONNECTOR_STATE}` to the KafkaConnector spec in `deploy/debezium-connector.yml`
- Add `CONNECTOR_STATE` parameter definition (defaults to `running` to preserve current behavior)
- Enables stopping/pausing the connector via app-interface saas file parameters without deleting the resource (preserves connector offsets and state)

## Context
Follows the same pattern already used in [kessel-kafka-connect's inventory-api-connector](https://github.com/project-kessel/kessel-kafka-connect/blob/main/deploy/inventory-api-connector.yml).

The Strimzi `KafkaConnector` CRD supports `spec.state` with values: `running`, `stopped`, `paused`.

## Test plan
- [ ] Verify default behavior unchanged (connector starts in `running` state when no override is provided)
- [ ] Verify passing `CONNECTOR_STATE: stopped` via app-interface stops the connector without deleting it
- [ ] Verify connector offsets are preserved when stopped and resumed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for setting a connector’s state during deployment.
  * Available states are `running`, `stopped`, and `paused`, with `running` as the default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->