### PR TITLE
Add CONNECTOR_OFFSETS_RESET parameter to debezium connector template

### DIFF
--- a/deploy/debezium-connector.yml
+++ b/deploy/debezium-connector.yml
@@ -9,6 +9,7 @@ objects:
     name: ${CONNECTOR_NAME}
     annotations:
       strimzi.io/use-connector-resources: "true"
+      strimzi.io/connector-offsets: "${CONNECTOR_OFFSETS_RESET}"
     labels:
       strimzi.io/cluster: ${KAFKA_CONNECT_INSTANCE}
   spec:
@@ -85,3 +86,6 @@ parameters:
 - name: SNAPSHOT_MODE
   value: "initial"
   description: The snapshot mode for the connector
+- name: CONNECTOR_OFFSETS_RESET
+  value: ""
+  description: "Set to 'reset' to clear connector offsets via Strimzi annotation (connector must be stopped first)"


### PR DESCRIPTION
## Summary
- Add `strimzi.io/connector-offsets` annotation to the KafkaConnector CR template, controlled by a new `CONNECTOR_OFFSETS_RESET` parameter
- Defaults to empty string (Strimzi ignores it -- no behavior change for existing deployments)
- When set to `reset` (with `CONNECTOR_STATE=stopped`), Strimzi clears all committed Debezium offsets

## Usage in app-interface
```yaml
parameters:
  CONNECTOR_STATE: stopped
  CONNECTOR_OFFSETS_RESET: reset
```

## Test plan
- [ ] Verify existing deployments are unaffected (empty string annotation is ignored by Strimzi)
- [ ] Test offset reset on stage by setting `CONNECTOR_OFFSETS_RESET: reset` with `CONNECTOR_STATE: stopped`
- [ ] Verify Strimzi removes the annotation after processing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to reset connector offsets through the deployment configuration.
  * Connector offsets can be cleared by setting the new option to `reset` after stopping the connector.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->