### PR TITLE
fix(dr): stop skipping event types by default in DR reconciliation

### DIFF
--- a/rbac/rbac/settings.py
+++ b/rbac/rbac/settings.py
@@ -711,7 +711,7 @@ DR_SKIP_EVENT_TYPES = [
     t.strip()
     for t in ENVIRONMENT.get_value(
         "DR_SKIP_EVENT_TYPES",
-        default="bootstrap_tenant,bulk_bootstrap_tenant,external_user_update,external_user_disable,bulk_external_user_update",
+        default="",
     ).split(",")
     if t.strip()
 ]

--- a/tests/management/disaster_recovery/test_service.py
+++ b/tests/management/disaster_recovery/test_service.py
@@ -513,10 +513,19 @@ class ReconcileAllResourceTypesTest(TestCase):
         self.assertEqual(len(log), 0)
 
 
+@override_settings(
+    DR_SKIP_EVENT_TYPES=[
+        "bootstrap_tenant",
+        "bulk_bootstrap_tenant",
+        "external_user_update",
+        "external_user_disable",
+        "bulk_external_user_update",
+    ]
+)
 class ReconcileSkippedEventTypesTest(TestCase):
-    """Verify that bootstrap and external user (UMB) events are skipped during DR.
+    """Verify that bootstrap and external user (UMB) events are skipped when configured.
 
-    These event types should not be processed through the corrective truth table:
+    These event types can be excluded via the DR_SKIP_EVENT_TYPES setting:
     - bootstrap_tenant / bulk_bootstrap_tenant: bulk initialization events
     - external_user_update / external_user_disable / bulk_external_user_update: UMB-sourced user sync
     """


### PR DESCRIPTION
## Summary
- Clears the default value of `DR_SKIP_EVENT_TYPES` so that all Kafka events are processed during disaster recovery reconciliation
- Previously, `bootstrap_tenant`, `bulk_bootstrap_tenant`, `external_user_update`, `external_user_disable`, and `bulk_external_user_update` events were skipped by default, causing 136 events to be silently excluded from DR processing
- The setting remains overridable via the `DR_SKIP_EVENT_TYPES` environment variable for environments that need selective filtering

## Test plan
- [ ] Run DR reconciliation dry run and verify all events are now processed (no `events_skipped_by_type`)
- [ ] Verify existing tests pass — they use `@override_settings(DR_SKIP_EVENT_TYPES=...)` so are unaffected by the default change
- [ ] Confirm the env var override still works if specific types need to be skipped in a given environment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disaster-recovery event processing now includes all event types by default unless specific types are configured to be skipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->