### PR TITLE
fix(dr): filter producer-only keys from KAFKA_AUTH in DR consumer [RHCLOUD-49268]

### DIFF
--- a/rbac/core/kafka_dr.py
+++ b/rbac/core/kafka_dr.py
@@ -54,7 +54,16 @@ def _create_consumer(group_id: str = DR_CONSUMER_GROUP) -> KafkaConsumer:
 
     kafka_auth = getattr(settings, "KAFKA_AUTH", None)
     if kafka_auth:
-        kwargs.update(kafka_auth)
+        for key in (
+            "bootstrap_servers",
+            "sasl_plain_username",
+            "sasl_plain_password",
+            "sasl_mechanism",
+            "security_protocol",
+            "ssl_cafile",
+        ):
+            if key in kafka_auth:
+                kwargs[key] = kafka_auth[key]
     elif getattr(settings, "KAFKA_SERVERS", None):
         kwargs["bootstrap_servers"] = settings.KAFKA_SERVERS
     else:


### PR DESCRIPTION
## Link(s) to Jira
- https://issues.redhat.com/browse/RHCLOUD-49268

## Summary

- Fix `KafkaConfigurationError: Unrecognized configs: {'retries'}` in the DR workspace event recovery task (`recover_workspace_events_in_worker`)
- `KAFKA_AUTH` contains `retries: 5` which is a producer-only config; `_create_consumer()` in `kafka_dr.py` was blindly passing the entire dict to `KafkaConsumer`
- Switch to an explicit allowlist of consumer-compatible keys, matching the pattern already used in `kafka_reader.py`

## Test plan

- [ ] Verify the DR workspace recovery endpoint no longer raises `KafkaConfigurationError` when `KAFKA_AUTH` includes `retries`
- [ ] Confirm SASL auth settings are still correctly forwarded to the consumer