### PR TITLE
fix(bootstrap): use valid BOP status parameter value

### DIFF
--- a/rbac/internal/views.py
+++ b/rbac/internal/views.py
@@ -3032,7 +3032,7 @@ def bootstrap_users_from_user_ids(request):
     resp = PROXY.request_filtered_principals(
         user_ids,
         org_id=None,
-        options={"query_by": "user_id", "return_id": True, "status": "enabled,disabled"},
+        options={"query_by": "user_id", "return_id": True, "status": "all"},
     )
 
     if isinstance(resp, dict) and "errors" in resp:


### PR DESCRIPTION
## Summary

- Fix `bootstrap_users_from_user_ids` endpoint returning 400 from BOP
- BOP's OpenAPI spec only accepts a single `status` enum value (`enabled`, `disabled`, or `all`), but the code was sending `status=enabled,disabled`
- Changed to `status=all` which correctly retrieves both enabled and disabled users
- The existing code already handles disabled users locally by checking `user.is_active`

## Test plan

- [ ] Verify `bootstrap_users_from_user_ids` endpoint no longer returns BOP 400 error
- [ ] Verify both enabled and disabled users are returned from BOP
- [ ] Verify disabled users are still skipped via `user.is_active` check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * User bootstrapping now includes eligible accounts across all account statuses, improving consistency when importing users by ID.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->