### PR TITLE
fix(dr): handle Debezium EventRouter message format in workspace DR parser [RHCLOUD-49270]

### DIFF
--- a/rbac/management/workspace/dr_recovery.py
+++ b/rbac/management/workspace/dr_recovery.py
@@ -76,32 +76,55 @@ class CorrectiveEventStats(TypedDict):
 def parse_workspace_kafka_events(kafka_events: list[KafkaEvent]) -> list[WorkspaceKafkaEvent]:
     """Parse raw Kafka events into WorkspaceKafkaEvent dicts.
 
-    Filters to only workspace aggregate type events and deduplicates by workspace ID,
-    keeping only the latest event per workspace (chronological order by Kafka timestamp).
+    The Debezium outbox EventRouter SMT routes events to topic
+    ``outbox.event.{aggregatetype}`` and sets the Kafka message value to the
+    outbox ``payload`` column content.  So on topic ``outbox.event.workspace``
+    each message value IS the payload dict directly::
+
+        {"org_id": "…", "workspace": {…}, "operation": "create", …}
+
+    This function also supports the pre-SMT format where the full outbox row
+    is the message value (``aggregatetype`` + nested ``payload``), for
+    resilience if the connector configuration changes.
+
+    Deduplicates by workspace ID, keeping only the latest event per workspace.
     """
     workspace_events: dict[str, WorkspaceKafkaEvent] = {}
 
     for event in kafka_events:
         value = event.value
-        aggregate_type = value.get("aggregatetype", "")
-        if aggregate_type != AggregateTypes.WORKSPACE.value:
-            continue
 
-        payload = value.get("payload")
-        if not isinstance(payload, dict):
-            continue
+        if value.get("aggregatetype") == AggregateTypes.WORKSPACE.value:
+            payload = value.get("payload")
+            if not isinstance(payload, dict):
+                if isinstance(payload, str):
+                    try:
+                        import json
+
+                        payload = json.loads(payload)
+                    except (json.JSONDecodeError, TypeError):
+                        continue
+                else:
+                    continue
+        else:
+            payload = value
 
         workspace_data = payload.get("workspace", {})
         workspace_id = workspace_data.get("id", "")
         if not workspace_id:
+            logger.debug("Skipping Kafka event at offset %d: missing workspace id", event.offset)
             continue
 
         operation = payload.get("operation", "")
         if operation not in ("create", "update", "delete"):
+            logger.debug("Skipping Kafka event at offset %d: unsupported operation '%s'", event.offset, operation)
             continue
 
         ws_type = workspace_data.get("type", "")
         if ws_type not in _PROCESSABLE_TYPE_VALUES:
+            logger.debug(
+                "Skipping Kafka event at offset %d: workspace type '%s' not processable", event.offset, ws_type
+            )
             continue
 
         parsed = WorkspaceKafkaEvent(

--- a/tests/management/workspace/test_dr_recovery.py
+++ b/tests/management/workspace/test_dr_recovery.py
@@ -39,30 +39,42 @@ def _make_kafka_event(
     ws_name: str = "Test Workspace",
     ws_type: str = "standard",
     timestamp_ms: int = 1000000,
+    flat: bool = False,
 ) -> KafkaEvent:
-    """Build a KafkaEvent that mimics a Debezium workspace outbox message."""
+    """Build a KafkaEvent that mimics a Debezium workspace outbox message.
+
+    flat=False (default): pre-SMT format with aggregatetype + nested payload.
+    flat=True: EventRouter SMT format where the payload IS the message value.
+    """
+    payload = {
+        "org_id": org_id,
+        "account_number": account_number,
+        "operation": operation,
+        "workspace": {
+            "id": workspace_id,
+            "name": ws_name,
+            "type": ws_type,
+            "created": "2026-05-15T10:00:00Z",
+            "modified": "2026-05-15T10:00:00Z",
+        },
+    }
+
+    if flat:
+        value = payload
+    else:
+        value = {
+            "aggregatetype": AggregateTypes.WORKSPACE.value,
+            "aggregateid": "production",
+            "type": f"{operation}_workspace",
+            "payload": payload,
+        }
+
     return KafkaEvent(
         topic="outbox.event.workspace",
         partition=0,
         offset=0,
         timestamp_ms=timestamp_ms,
-        value={
-            "aggregatetype": AggregateTypes.WORKSPACE.value,
-            "aggregateid": "production",
-            "type": f"{operation}_workspace",
-            "payload": {
-                "org_id": org_id,
-                "account_number": account_number,
-                "operation": operation,
-                "workspace": {
-                    "id": workspace_id,
-                    "name": ws_name,
-                    "type": ws_type,
-                    "created": "2026-05-15T10:00:00Z",
-                    "modified": "2026-05-15T10:00:00Z",
-                },
-            },
-        },
+        value=value,
     )
 
 
@@ -135,6 +147,42 @@ class TestParseWorkspaceKafkaEvents(TestCase):
         """Empty event list returns empty result."""
         result = parse_workspace_kafka_events([])
         self.assertEqual(result, [])
+
+    def test_flat_event_router_format(self):
+        """EventRouter SMT format (flat payload) is parsed correctly."""
+        ws_id = str(uuid.uuid4())
+        event = _make_kafka_event(ws_id, "create", flat=True)
+        result = parse_workspace_kafka_events([event])
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["workspace_id"], ws_id)
+        self.assertEqual(result[0]["operation"], "create")
+        self.assertEqual(result[0]["org_id"], "12345")
+
+    def test_flat_format_filters_system_types(self):
+        """EventRouter SMT format still filters root and ungrouped-hosts types."""
+        root_event = _make_kafka_event(str(uuid.uuid4()), "create", ws_type="root", flat=True)
+        ungrouped_event = _make_kafka_event(str(uuid.uuid4()), "create", ws_type="ungrouped-hosts", flat=True)
+        result = parse_workspace_kafka_events([root_event, ungrouped_event])
+        self.assertEqual(result, [])
+
+    def test_flat_format_deduplicates(self):
+        """EventRouter SMT format deduplicates by workspace ID."""
+        ws_id = str(uuid.uuid4())
+        create_event = _make_kafka_event(ws_id, "create", timestamp_ms=1000, flat=True)
+        update_event = _make_kafka_event(ws_id, "update", timestamp_ms=2000, flat=True)
+        result = parse_workspace_kafka_events([create_event, update_event])
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["operation"], "update")
+
+    def test_mixed_flat_and_nested_formats(self):
+        """Both EventRouter (flat) and pre-SMT (nested) formats work together."""
+        ws_id_flat = str(uuid.uuid4())
+        ws_id_nested = str(uuid.uuid4())
+        flat_event = _make_kafka_event(ws_id_flat, "create", flat=True)
+        nested_event = _make_kafka_event(ws_id_nested, "delete", flat=False)
+        result = parse_workspace_kafka_events([flat_event, nested_event])
+        ws_ids = {e["workspace_id"] for e in result}
+        self.assertEqual(ws_ids, {ws_id_flat, ws_id_nested})
 
 
 class TestGenerateCorrectiveWorkspaceEvents(TestCase):


### PR DESCRIPTION
## Link(s) to Jira
- https://issues.redhat.com/browse/RHCLOUD-49270

## Description of Intent of Change(s)

**Problem**: The workspace DR recovery task reads Kafka events but generates zero corrective events, even when events exist in the recovery window. Logs show `kafka_events_read: 71` but `total_events: 0`.

**Root cause**: The Debezium outbox connector uses the `EventRouter` SMT (`io.debezium.transforms.outbox.EventRouter`), which transforms outbox table rows before publishing to Kafka. It routes events to topic `outbox.event.{aggregatetype}` and sets the Kafka message value to **only the `payload` column content** — the `aggregatetype` field is stripped from the message body and used solely for topic routing.

`parse_workspace_kafka_events()` was checking `value.get("aggregatetype") == "workspace"` as its first filter, but since the EventRouter removes that field from the message, every single event failed this check and was silently dropped.

**Fix**: Auto-detect both message formats:
- **EventRouter (flat) format**: message value IS the payload directly (`{"org_id": "…", "workspace": {…}, "operation": "create"}`)
- **Pre-SMT (nested) format**: message value contains `aggregatetype` + nested `payload` (backward compatibility)

Also adds `logger.debug()` for each filter stage so skipped events are diagnosable.

## Local Testing

1. With the Debezium local stack running, trigger workspace DR recovery:
   ```bash
   curl --request POST \
       --url "http://localhost:8000/_private/api/disaster_recovery/workspaces/" \
       --header 'content-type: application/json' \
       --data '{"restore_timestamp": "2026-07-14T08:00:00Z", "buffer_minutes": 70, "dry_run": true}'
   ```
2. Verify that `total_events` is no longer 0 when workspace events exist in the window.
3. Run unit tests:
   ```bash
   tox -r -e py312-fast -- tests.management.workspace.test_dr_recovery.TestParseWorkspaceKafkaEvents
   ```

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [x] are there any pre/post merge actions required? if so, document here.
- [x] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [x] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

No API spec changes, no migrations. 4 new test cases added covering the EventRouter format.

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices