### PR TITLE
Fix workspace dr event parsing [RHCLOUD-49293]

### DIFF
--- a/rbac/management/workspace/dr_recovery.py
+++ b/rbac/management/workspace/dr_recovery.py
@@ -73,35 +73,98 @@ class CorrectiveEventStats(TypedDict):
     error_details: list[dict[str, str]]
 
 
+def _extract_workspace_payload(value: dict) -> dict | None:
+    """Extract the workspace event payload from a Kafka message value.
+
+    Handles three Debezium message formats:
+
+    1. Pre-SMT (full outbox row)::
+
+        {"aggregatetype": "workspace", "payload": {…workspace payload…}}
+
+    2. EventRouter + JsonConverter (schema/payload envelope)::
+
+        {"schema": {…}, "payload": {…workspace payload…}}
+
+    3. EventRouter + flat (payload IS the value)::
+
+        {"org_id": "…", "workspace": {…}, "operation": "create"}
+
+    Returns the inner workspace payload dict, or None if unparseable.
+    """
+    import json as _json
+
+    # Format 1: pre-SMT — full outbox row with aggregatetype at top level
+    if value.get("aggregatetype") == AggregateTypes.WORKSPACE.value:
+        payload = value.get("payload")
+        if isinstance(payload, dict):
+            return payload
+        if isinstance(payload, str):
+            try:
+                return _json.loads(payload)
+            except (ValueError, TypeError):
+                return None
+        return None
+
+    # Format 2: Kafka Connect JsonConverter envelope — {"schema": …, "payload": …}
+    if "schema" in value and "payload" in value:
+        payload = value["payload"]
+        if isinstance(payload, dict):
+            return payload
+        if isinstance(payload, str):
+            try:
+                return _json.loads(payload)
+            except (ValueError, TypeError):
+                return None
+        return None
+
+    # Format 3: EventRouter flat — the value IS the payload
+    return value
+
+
 def parse_workspace_kafka_events(kafka_events: list[KafkaEvent]) -> list[WorkspaceKafkaEvent]:
     """Parse raw Kafka events into WorkspaceKafkaEvent dicts.
 
-    Filters to only workspace aggregate type events and deduplicates by workspace ID,
-    keeping only the latest event per workspace (chronological order by Kafka timestamp).
+    Supports all Debezium outbox message formats (pre-SMT, EventRouter with
+    JsonConverter envelope, and EventRouter flat).  See ``_extract_workspace_payload``
+    for format details.
+
+    Deduplicates by workspace ID, keeping only the latest event per workspace.
     """
     workspace_events: dict[str, WorkspaceKafkaEvent] = {}
 
+    if kafka_events:
+        first = kafka_events[0].value
+        logger.info("First Kafka event keys: %s", list(first.keys())[:10])
+
     for event in kafka_events:
         value = event.value
-        aggregate_type = value.get("aggregatetype", "")
-        if aggregate_type != AggregateTypes.WORKSPACE.value:
-            continue
 
-        payload = value.get("payload")
-        if not isinstance(payload, dict):
+        payload = _extract_workspace_payload(value)
+        if payload is None:
+            logger.debug("Skipping Kafka event at offset %d: could not extract payload", event.offset)
             continue
 
         workspace_data = payload.get("workspace", {})
         workspace_id = workspace_data.get("id", "")
         if not workspace_id:
+            logger.debug(
+                "Skipping Kafka event at offset %d: missing workspace id, payload keys: %s",
+                event.offset,
+                list(payload.keys())[:10],
+            )
             continue
 
         operation = payload.get("operation", "")
         if operation not in ("create", "update", "delete"):
+            logger.debug("Skipping Kafka event at offset %d: unsupported operation '%s'", event.offset, operation)
             continue
 
         ws_type = workspace_data.get("type", "")
         if ws_type not in _PROCESSABLE_TYPE_VALUES:
+            logger.debug(
+                "Skipping Kafka event at offset %d: workspace type '%s' not processable", event.offset, ws_type
+            )
             continue
 
         parsed = WorkspaceKafkaEvent(

--- a/tests/management/workspace/test_dr_recovery.py
+++ b/tests/management/workspace/test_dr_recovery.py
@@ -39,30 +39,48 @@ def _make_kafka_event(
     ws_name: str = "Test Workspace",
     ws_type: str = "standard",
     timestamp_ms: int = 1000000,
+    fmt: str = "nested",
 ) -> KafkaEvent:
-    """Build a KafkaEvent that mimics a Debezium workspace outbox message."""
+    """Build a KafkaEvent that mimics a Debezium workspace outbox message.
+
+    fmt="nested" (default): pre-SMT format with aggregatetype + nested payload.
+    fmt="flat": EventRouter SMT format where the payload IS the message value.
+    fmt="envelope": Kafka Connect JsonConverter envelope with schema + payload.
+    """
+    payload = {
+        "org_id": org_id,
+        "account_number": account_number,
+        "operation": operation,
+        "workspace": {
+            "id": workspace_id,
+            "name": ws_name,
+            "type": ws_type,
+            "created": "2026-05-15T10:00:00Z",
+            "modified": "2026-05-15T10:00:00Z",
+        },
+    }
+
+    if fmt == "flat":
+        value = payload
+    elif fmt == "envelope":
+        value = {
+            "schema": {"type": "struct", "fields": []},
+            "payload": payload,
+        }
+    else:
+        value = {
+            "aggregatetype": AggregateTypes.WORKSPACE.value,
+            "aggregateid": "production",
+            "type": f"{operation}_workspace",
+            "payload": payload,
+        }
+
     return KafkaEvent(
         topic="outbox.event.workspace",
         partition=0,
         offset=0,
         timestamp_ms=timestamp_ms,
-        value={
-            "aggregatetype": AggregateTypes.WORKSPACE.value,
-            "aggregateid": "production",
-            "type": f"{operation}_workspace",
-            "payload": {
-                "org_id": org_id,
-                "account_number": account_number,
-                "operation": operation,
-                "workspace": {
-                    "id": workspace_id,
-                    "name": ws_name,
-                    "type": ws_type,
-                    "created": "2026-05-15T10:00:00Z",
-                    "modified": "2026-05-15T10:00:00Z",
-                },
-            },
-        },
+        value=value,
     )
 
 
@@ -135,6 +153,55 @@ class TestParseWorkspaceKafkaEvents(TestCase):
         """Empty event list returns empty result."""
         result = parse_workspace_kafka_events([])
         self.assertEqual(result, [])
+
+    def test_flat_event_router_format(self):
+        """EventRouter SMT format (flat payload) is parsed correctly."""
+        ws_id = str(uuid.uuid4())
+        event = _make_kafka_event(ws_id, "create", fmt="flat")
+        result = parse_workspace_kafka_events([event])
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["workspace_id"], ws_id)
+        self.assertEqual(result[0]["operation"], "create")
+        self.assertEqual(result[0]["org_id"], "12345")
+
+    def test_flat_format_filters_system_types(self):
+        """EventRouter SMT format still filters root and ungrouped-hosts types."""
+        root_event = _make_kafka_event(str(uuid.uuid4()), "create", ws_type="root", fmt="flat")
+        ungrouped_event = _make_kafka_event(str(uuid.uuid4()), "create", ws_type="ungrouped-hosts", fmt="flat")
+        result = parse_workspace_kafka_events([root_event, ungrouped_event])
+        self.assertEqual(result, [])
+
+    def test_flat_format_deduplicates(self):
+        """EventRouter SMT format deduplicates by workspace ID."""
+        ws_id = str(uuid.uuid4())
+        create_event = _make_kafka_event(ws_id, "create", timestamp_ms=1000, fmt="flat")
+        update_event = _make_kafka_event(ws_id, "update", timestamp_ms=2000, fmt="flat")
+        result = parse_workspace_kafka_events([create_event, update_event])
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["operation"], "update")
+
+    def test_json_converter_envelope_format(self):
+        """Kafka Connect JsonConverter envelope (schema + payload) is parsed correctly."""
+        ws_id = str(uuid.uuid4())
+        event = _make_kafka_event(ws_id, "update", fmt="envelope")
+        result = parse_workspace_kafka_events([event])
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["workspace_id"], ws_id)
+        self.assertEqual(result[0]["operation"], "update")
+
+    def test_mixed_all_formats(self):
+        """All three formats (nested, flat, envelope) work together."""
+        ws_id_nested = str(uuid.uuid4())
+        ws_id_flat = str(uuid.uuid4())
+        ws_id_envelope = str(uuid.uuid4())
+        events = [
+            _make_kafka_event(ws_id_nested, "delete", fmt="nested"),
+            _make_kafka_event(ws_id_flat, "create", fmt="flat"),
+            _make_kafka_event(ws_id_envelope, "update", fmt="envelope"),
+        ]
+        result = parse_workspace_kafka_events(events)
+        ws_ids = {e["workspace_id"] for e in result}
+        self.assertEqual(ws_ids, {ws_id_nested, ws_id_flat, ws_id_envelope})
 
 
 class TestGenerateCorrectiveWorkspaceEvents(TestCase):


### PR DESCRIPTION
## Link(s) to Jira
- https://issues.redhat.com/browse/RHCLOUD-49293

## Description of Intent of Change(s)
Fix workspace DR event parsing to handle all Debezium message formats (pre-SMT, EventRouter with JsonConverter envelope, and EventRouter flat). Invalid, incomplete, or unsupported workspace events are now safely skipped. Workspace recovery continues to correctly deduplicate events and retain the latest valid update. Improved handling of mixed event formats for more reliable recovery results.

## Local Testing
How can the feature be exercised?
How can the bug be exploited and fix confirmed?
Is any special local setup required?

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workspace event processing across multiple message formats.
  * Invalid, incomplete, or unsupported workspace events are now safely skipped.
  * Workspace recovery continues to correctly deduplicate events and retain the latest valid update.
  * Improved handling of mixed event formats for more reliable recovery results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->