### PR TITLE
Add skill to call internal-api [RHCLOUD-49407]

### DIFF
--- a/.cursor/skills/internal-api/SKILL.md
+++ b/.cursor/skills/internal-api/SKILL.md
@@ -1,0 +1,211 @@
+---
+name: internal-api
+description: Call RBAC internal API endpoints in stage or prod via Turnpike (same routing as the relationship skill). Use when invoking /_private/api/ utils, tenant, relations, inventory, disaster recovery, or integration endpoints.
+---
+
+# RBAC Internal API Tool
+
+Call RBAC internal endpoints in **stage** or **prod** through Turnpike. This uses the same auth and routing as the [relationship skill](../relationship/SKILL.md).
+
+## URL mapping
+
+Django registers internal routes under `/_private/` (see `rbac/internal/urls.py`). Turnpike exposes them at:
+
+| Django path | Turnpike URL |
+|-------------|--------------|
+| `/_private/api/<rest>` | `${STAGE_DOMAIN}/api/rbac/<rest>` |
+| `/_private/api/relations/read_tuples/` | `${STAGE_DOMAIN}/api/rbac/relations/read_tuples/` |
+| `/_private/api/utils/bootstrap_users_from_user_ids/` | `${STAGE_DOMAIN}/api/rbac/utils/bootstrap_users_from_user_ids/` |
+
+**Not covered by this skill:** `/_private/_s2s/` endpoints (PSK/JWT auth). Use oc exec or service credentials for those.
+
+## Prerequisites
+
+Before calling an endpoint:
+
+0. **Check for config.env** — verify `.cursor/skills/config.env` exists with `STAGE_DOMAIN`, `PROD_DOMAIN`, and `PROXY`.
+1. **Check SESSION** — must be set. If missing, ask the user to open the Turnpike session URL in a browser and copy the token:
+   - Stage: `${STAGE_DOMAIN}/api/turnpike/session/`
+   - Prod: `${PROD_DOMAIN}/api/turnpike/session/`
+   - Then: `export SESSION=<token_value>`
+2. **Confirm environment** — user must specify `stage` or `prod`.
+
+## Usage
+
+Run `.cursor/skills/internal-api/scripts/internal-api.sh`:
+
+```bash
+sh .cursor/skills/internal-api/scripts/internal-api.sh <stage|prod> <METHOD> <path> [query_string] [json_body]
+```
+
+- **path** — everything after `api/` in `rbac/internal/urls.py` (e.g. `utils/bootstrap_users_from_user_ids/`, `relations/read_tuples/`)
+- **query_string** — optional, without `?` (e.g. `dry_run=true`)
+- **json_body** — optional JSON string for POST/PUT/PATCH
+
+If the fourth argument starts with `{` or `[`, it is treated as the JSON body (no query string).
+
+## Workflow
+
+When a user asks to call an internal API:
+
+1. Verify `config.env` exists.
+2. Verify `SESSION` is set; if not, give Turnpike session URL instructions and stop.
+3. Confirm `stage` or `prod`.
+4. Look up the endpoint in `rbac/internal/urls.py` and the view docstring in `rbac/internal/views.py` for method, query params, and body shape.
+5. Prefer **dry_run** query params when the endpoint supports them.
+6. Run the script and interpret the JSON response.
+
+## Common examples
+
+### Bootstrap users from BOP user IDs
+
+Dry run first:
+
+```bash
+sh .cursor/skills/internal-api/scripts/internal-api.sh stage POST \
+  utils/bootstrap_users_from_user_ids/ \
+  dry_run=true \
+  '{"user_ids":["12345678","87654321"]}'
+```
+
+Apply:
+
+```bash
+sh .cursor/skills/internal-api/scripts/internal-api.sh stage POST \
+  utils/bootstrap_users_from_user_ids/ \
+  '{"user_ids":["12345678","87654321"]}'
+```
+
+### Bootstrap tenant by org ID
+
+```bash
+sh .cursor/skills/internal-api/scripts/internal-api.sh stage POST \
+  utils/bootstrap_tenant/ \
+  '{"org_ids":["1234567"]}'
+```
+
+### Bootstrap pending tenants
+
+```bash
+sh .cursor/skills/internal-api/scripts/internal-api.sh stage GET \
+  utils/bootstrap_pending_tenants/
+```
+
+### User lookup
+
+```bash
+sh .cursor/skills/internal-api/scripts/internal-api.sh stage GET \
+  utils/user_lookup/ \
+  username=jdoe
+```
+
+### Relations API
+
+Same endpoints as the relationship skill; use either skill:
+
+```bash
+sh .cursor/skills/internal-api/scripts/internal-api.sh stage POST \
+  relations/read_tuples/ \
+  '{"filter": {"resource_namespace": "rbac", "resource_type": "group", "resource_id": "<group_uuid>", "relation": "member", "subject_filter": {"subject_namespace": "rbac", "subject_type": "principal", "subject_id": ""}}}'
+```
+
+### Disaster recovery
+
+```bash
+sh .cursor/skills/internal-api/scripts/internal-api.sh stage POST \
+  disaster_recovery/reconcile/ \
+  '{"org_ids":["1234567"], "dry_run": true}'
+```
+
+## Endpoint index
+
+Paths below are the **script `path` argument** (after `/api/rbac/`). See `rbac/internal/views.py` for parameters and behavior.
+
+### Tenant
+
+| Path | Methods |
+|------|---------|
+| `tenant/unmodified/` | GET |
+| `tenant/` | GET |
+| `tenant/<org_id>/` | GET, DELETE |
+
+### Utils
+
+| Path | Notes |
+|------|-------|
+| `utils/sync_schemas/` | POST |
+| `utils/set_tenant_ready/` | GET, POST |
+| `utils/populate_tenant_account_id/` | POST |
+| `utils/populate_tenant_org_id/` | POST |
+| `utils/invalid_default_admin_groups/` | GET, DELETE |
+| `utils/get_org_admin/<org_or_account>/` | GET |
+| `utils/user_lookup/` | GET |
+| `utils/bootstrap_tenant/` | POST |
+| `utils/bootstrap_pending_tenants/` | GET |
+| `utils/bootstrap_users_from_user_ids/` | POST (`?dry_run=true`) |
+| `utils/fetch_replication_data/` | GET |
+| `utils/kessel_parity_check/` | POST |
+| `utils/replicate_default_workspaces/` | POST |
+| `utils/replicate_updated_workspaces/` | POST |
+| `utils/recompute_tenant_role_bindings/<org_id>/` | POST |
+| `utils/migrate_role_scope_if_changed/<role_uuid>/` | POST |
+| `utils/cleanup_tenant_orphan_bindings/<org_id>/` | POST |
+| `utils/rebuild_tenant_workspace_relations/<org_id>/` | POST |
+| `utils/kafka_test_message/` | GET |
+
+Many other utils endpoints exist for migrations, cleanup, and destructive operations — check `rbac/internal/urls.py` before running them in prod.
+
+### Relations
+
+| Path |
+|------|
+| `relations/lookup_resource/` |
+| `relations/lookup_subjects/` |
+| `relations/check_relation/` |
+| `relations/read_tuples/` |
+
+### Inventory
+
+| Path |
+|------|
+| `inventory/bootstrap_tenants/<org_id>/` |
+| `inventory/group_assignments/<group_uuid>/` |
+| `inventory/check_workspace/<workspace_uuid>/` |
+| `inventory/check_role/<role_uuid>/` |
+| `inventory/check_cross_account_request/<request_id>/` |
+| `inventory/check/` |
+
+### Disaster recovery
+
+| Path |
+|------|
+| `disaster_recovery/workspaces/` |
+| `disaster_recovery/reconcile/` |
+
+### Integrations (v1)
+
+| Path |
+|------|
+| `v1/integrations/tenant/` |
+| `v1/integrations/tenant/<org_id>/roles/` |
+| `v1/integrations/tenant/<org_id>/groups/` |
+| `v1/integrations/tenant/<org_id>/groups/<uuid>/roles/` |
+| `v1/integrations/tenant/<org_id>/groups/<uuid>/principals/` |
+| `v1/integrations/tenant/<org_id>/principal/<principals>/groups/` |
+| `v1/integrations/tenant/<org_id>/principal/<principals>/groups/<uuid>/roles/` |
+
+### Other
+
+| Path | Notes |
+|------|-------|
+| `migrations/run/` | POST |
+| `migrations/progress/` | GET |
+| `seeds/run/` | POST |
+| `cars/expire/` | POST |
+| `cars/clean/` | GET, POST |
+
+## Related skills
+
+- [relationship](../relationship/SKILL.md) — relations API with pre-built query examples
+- [gabi](../gabi/SKILL.md) — SQL against RBAC Postgres
+- [ephemeral-rbac](../ephemeral-rbac/SKILL.md) — internal API from inside ephemeral pods (no Turnpike)

--- a/.cursor/skills/internal-api/scripts/internal-api.sh
+++ b/.cursor/skills/internal-api/scripts/internal-api.sh
@@ -1,0 +1,149 @@
+#!/bin/bash
+
+# Call RBAC internal API endpoints in stage or prod via Turnpike.
+#
+# Internal Django paths under /_private/api/... are exposed at:
+#   ${STAGE_DOMAIN}/api/rbac/...
+#
+# Example:
+#   sh internal-api.sh stage POST utils/bootstrap_users_from_user_ids/ dry_run=true '{"user_ids":["12345"]}'
+
+set -euo pipefail
+
+usage() {
+    cat <<'EOF'
+Usage: internal-api.sh <stage|prod> <METHOD> <path> [query_string] [json_body]
+
+  path         Path after /api/rbac/ (from rbac/internal/urls.py, drop the leading "api/")
+  query_string Optional query params without leading "?" (e.g. dry_run=true&limit=10)
+  json_body    Optional JSON request body (for POST/PUT/PATCH)
+
+Examples:
+  # GET
+  sh internal-api.sh stage GET utils/bootstrap_pending_tenants/
+
+  # POST with body only (query omitted)
+  sh internal-api.sh stage POST utils/bootstrap_users_from_user_ids/ '{"user_ids":["12345"]}'
+
+  # POST with query and body
+  sh internal-api.sh stage POST utils/bootstrap_users_from_user_ids/ dry_run=true '{"user_ids":["12345"]}'
+
+  # Relations API (same routing as relationship skill)
+  sh internal-api.sh stage POST relations/read_tuples/ '{"filter": {...}}'
+
+Endpoint reference: rbac/internal/urls.py
+EOF
+}
+
+if [ "$#" -lt 3 ]; then
+    usage
+    exit 1
+fi
+
+ENVIRONMENT=$1
+METHOD=$(echo "$2" | tr '[:lower:]' '[:upper:]')
+PATH_SUFFIX=$3
+shift 3
+
+QUERY=""
+BODY=""
+
+if [ "$#" -ge 1 ]; then
+    if [[ "$1" == "{"* || "$1" == "["* ]]; then
+        BODY=$1
+    else
+        QUERY=$1
+        shift
+        if [ "$#" -ge 1 ]; then
+            BODY=$1
+        fi
+    fi
+fi
+
+# Normalize path: accept with or without leading/trailing slashes.
+PATH_SUFFIX="${PATH_SUFFIX#/}"
+PATH_SUFFIX="${PATH_SUFFIX%/}/"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONFIG_FILE="${SCRIPT_DIR}/../../config.env"
+
+if [ ! -f "$CONFIG_FILE" ]; then
+    echo "Error: config.env not found at $CONFIG_FILE"
+    echo "Create .cursor/skills/config.env with STAGE_DOMAIN, PROD_DOMAIN, and PROXY."
+    exit 1
+fi
+
+# shellcheck source=/dev/null
+source "$CONFIG_FILE"
+
+for var in STAGE_DOMAIN PROD_DOMAIN PROXY; do
+    if [ -z "${!var:-}" ]; then
+        echo "Error: $var is not set in config.env"
+        exit 1
+    fi
+done
+
+TURNPIKE_STAGE_URL="${STAGE_DOMAIN}/api/turnpike/session/"
+TURNPIKE_PROD_URL="${PROD_DOMAIN}/api/turnpike/session/"
+
+if [ "$ENVIRONMENT" = "stage" ]; then
+    BASE_URL="${STAGE_DOMAIN}/api/rbac"
+elif [ "$ENVIRONMENT" = "prod" ]; then
+    BASE_URL="${PROD_DOMAIN}/api/rbac"
+else
+    echo "Invalid environment. Use 'stage' or 'prod'."
+    exit 1
+fi
+
+if [ -z "${SESSION:-}" ]; then
+    echo "Error: SESSION environment variable is not set."
+    echo ""
+    echo "Get a Turnpike session token by pasting this URL into your browser:"
+    if [ "$ENVIRONMENT" = "stage" ]; then
+        echo "  $TURNPIKE_STAGE_URL"
+    else
+        echo "  $TURNPIKE_PROD_URL"
+    fi
+    echo ""
+    echo "Then: export SESSION=<token_value>"
+    exit 1
+fi
+
+API_URL="${BASE_URL}/${PATH_SUFFIX}"
+if [ -n "$QUERY" ]; then
+    API_URL="${API_URL}?${QUERY}"
+fi
+
+CURL_ARGS=(
+    -sS
+    -X "$METHOD"
+    -H "Content-Type: application/json"
+    -b "session=$SESSION"
+    -w $'\n%{http_code}'
+    "$API_URL"
+)
+
+if [ -n "$BODY" ]; then
+    CURL_ARGS+=(-d "$BODY")
+fi
+
+if [ "$ENVIRONMENT" = "stage" ]; then
+    RAW=$(curl --proxy "$PROXY" "${CURL_ARGS[@]}")
+else
+    RAW=$(curl "${CURL_ARGS[@]}")
+fi
+
+HTTP_CODE=$(echo "$RAW" | tail -1)
+RESPONSE_BODY=$(echo "$RAW" | sed '$d')
+
+if [ "$HTTP_CODE" -lt 200 ] || [ "$HTTP_CODE" -ge 300 ]; then
+    echo "HTTP $HTTP_CODE" >&2
+    if [ -n "$RESPONSE_BODY" ]; then
+        echo "$RESPONSE_BODY" | jq . 2>/dev/null || echo "$RESPONSE_BODY"
+    fi
+    exit 1
+fi
+
+if [ -n "$RESPONSE_BODY" ]; then
+    echo "$RESPONSE_BODY" | jq . 2>/dev/null || echo "$RESPONSE_BODY"
+fi


### PR DESCRIPTION
## Link(s) to Jira
- https://issues.redhat.com/browse/RHCLOUD-49407

## Description of Intent of Change(s)
The what, why and how.

## Local Testing
How can the feature be exercised?
How can the bug be exploited and fix confirmed?
Is any special local setup required?

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for calling internal RBAC API endpoints in staging and production.
  * Documented authentication prerequisites, request formats, workflows, examples, and available endpoint categories.

* **New Features**
  * Added a command-line utility for making authenticated RBAC API requests.
  * Supports query parameters, JSON request bodies, environment selection, proxy configuration, and formatted response output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
