### PR TITLE
fix(ci): always run JIRA ticket check on edited PRs [RHCLOUD-49150]

### DIFF
--- a/.github/workflows/jira-ticket-check.yml
+++ b/.github/workflows/jira-ticket-check.yml
@@ -16,9 +16,7 @@ jobs:
   jira-ticket-check:
     runs-on: ubuntu-latest
     if: >-
-      !contains(github.event.pull_request.labels.*.name, 'bot') &&
-      (github.event.action == 'opened' ||
-      github.event.changes.title.from != '')
+      !contains(github.event.pull_request.labels.*.name, 'bot')
     steps:
       - name: Check PR title for JIRA ticket
         env:


### PR DESCRIPTION
## Summary

- Fix JIRA ticket check being skipped on PR body edits, which overwrites the previous failure status due to `cancel-in-progress` concurrency
- Remove the `title.from` change guard so the check always runs on both `opened` and `edited` events

## Root Cause

The job condition only ran the check when the PR was opened or when the **title** was changed:

```yaml
if: github.event.action == 'opened' || github.event.changes.title.from != ''
```

When a PR **body** was edited (not the title), the `edited` event fired but the condition evaluated to `false`, causing the job to be **skipped**. Combined with `cancel-in-progress: true` concurrency, the skipped run replaced the previous failure — making the check appear to pass.

## Fix

Remove the title-change guard. The check now runs on every `opened`/`edited` event (still skipped for `bot`-labeled PRs). A body-only edit harmlessly re-runs the title check, keeping the correct pass/fail status.

## Test plan

- [x] Verified PR [#3197](https://github.com/project-kessel/insights-rbac/pull/3197) showed the bug (first run FAILURE, second run SKIPPED)
- [x] After merge, edit a PR body without a JIRA ticket in the title — check should fail, not skip


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pull request validation so checks run consistently unless the pull request has a bot label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->