### PR TITLE
[RHCLOUD-49424] User python instead of curl to check debezium status

### DIFF
--- a/deploy/check_debezium.py
+++ b/deploy/check_debezium.py
@@ -1,0 +1,24 @@
+"""Check if the rbac-debezium Kafka Connect connector and its task are RUNNING.
+
+Usage: python3 check_debezium.py <kafka_connect_url>
+Exit 0 if both are RUNNING, exit 1 otherwise.
+"""
+
+import json
+import sys
+import urllib.error
+import urllib.request
+
+try:
+    base_url = sys.argv[1]
+    if not (base_url.startswith("http://") or base_url.startswith("https://")):
+        sys.exit(1)
+    url = f"{base_url}/connectors/rbac-debezium/status"
+    with urllib.request.urlopen(url, timeout=5) as response:
+        data = json.load(response)
+    connector = data.get("connector", {}).get("state", "")
+    tasks = data.get("tasks") or []
+    task = tasks[0].get("state", "") if tasks else ""
+    sys.exit(0 if connector == "RUNNING" and task == "RUNNING" else 1)
+except (urllib.error.URLError, TimeoutError, json.JSONDecodeError, IndexError, KeyError, TypeError, AttributeError):
+    sys.exit(1)

--- a/deploy/init-container-setup.sh
+++ b/deploy/init-container-setup.sh
@@ -21,14 +21,9 @@ then
         # In ephemeral, the connect instance is the same as the namespace
         KAFKA_CONNECT_URL="http://kessel-kafka-connect-connect-api:8083"
         while [[ $ELAPSED -lt $MAX_WAIT ]]; do
-            RESPONSE=$(curl -sf "${KAFKA_CONNECT_URL}/connectors/rbac-debezium/status") || true
-            if [[ -n "$RESPONSE" ]]; then
-                STATUS=$(echo "$RESPONSE" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['connector']['state'])")
-                TASK_STATUS=$(echo "$RESPONSE" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['tasks'][0]['state'] if d.get('tasks') else '')")
-                if [[ "$STATUS" == "RUNNING" && "$TASK_STATUS" == "RUNNING" ]]; then
-                    echo "rbac-debezium connector and task are RUNNING."
-                    break
-                fi
+            if python3 /opt/rbac/deploy/check_debezium.py "$KAFKA_CONNECT_URL"; then
+                echo "rbac-debezium connector and task are RUNNING."
+                break
             fi
             sleep 2
             ELAPSED=$((ELAPSED + 2))
@@ -39,12 +34,7 @@ then
     fi
 
     echo "Running seeds <-------"
-    # TODO: Remove this once we have the above waiting deployed to prod
-    if [[ "${EPH_ENV}" == "True" ]]; then
-        python /opt/rbac/rbac/manage.py seeds --force-create-relationships
-    else
-        python /opt/rbac/rbac/manage.py seeds
-    fi
+    python /opt/rbac/rbac/manage.py seeds
 else
     echo "Migrations should not be run <----"
 fi


### PR DESCRIPTION
## Link(s) to Jira
- https://redhat.atlassian.net/browse/RHCLOUD-49424

## Description of Intent of Change(s)
Recent image migration get rid of support of curl command, some of the curl command is not working any more, have to use python instead.

## Local Testing
bonfire deployment

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Debezium/Kafka Connect readiness checks during deployment by using a centralized readiness probe and more reliable success criteria before proceeding.
  * Enhanced deployment seeding behavior to run seed initialization consistently across environments, removing environment-specific branching that could lead to missing setup steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->