### PR TITLE
chore(deps): consolidate 5 npm dependency updates

### DIFF
--- a/docs/source/specs/typespec/package-lock.json
+++ b/docs/source/specs/typespec/package-lock.json
@@ -8,21 +8,21 @@
       "name": "Role Based Access Control",
       "version": "0.1.0",
       "dependencies": {
-        "@typespec/http": "1.13.0",
-        "@typespec/json-schema": "1.13.0",
+        "@typespec/http": "1.14.0",
+        "@typespec/json-schema": "1.14.0",
         "@typespec/openapi": "^1.12.0",
         "@typespec/openapi3": "^1.11.0",
-        "@typespec/rest": "^0.83.0",
-        "@typespec/versioning": "^0.83.0"
+        "@typespec/rest": "^0.84.0",
+        "@typespec/versioning": "^0.84.0"
       },
       "devDependencies": {
-        "@typespec/compiler": "1.13.0"
+        "@typespec/compiler": "1.14.0"
       },
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "1.13.0"
+        "@typespec/compiler": "1.14.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -466,9 +466,9 @@
       }
     },
     "node_modules/@typespec/compiler": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@typespec/compiler/-/compiler-1.13.0.tgz",
-      "integrity": "sha512-DonoHiyAMx0UjSmssqTrFtya+v97wny1aHcTLU5QF2wFzLATtcwUU9hbPC+eXhepuTunMOCHf8yk3pEsH6PZYA==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@typespec/compiler/-/compiler-1.14.0.tgz",
+      "integrity": "sha512-RRN0LGVDlonG/IbB2b4mvRjdCo6LywwB9/J8lOp6UaH7vtaFnKe5FL+rpxhof4rXx/zI/4OWnQO6c01bTCz4/Q==",
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@inquirer/prompts": "^8.4.1",
@@ -481,8 +481,8 @@
         "prettier": "^3.8.1",
         "semver": "^7.7.4",
         "tar": "^7.5.13",
-        "temporal-polyfill": "^0.3.2",
-        "vscode-languageserver": "^9.0.1",
+        "temporal-polyfill": "^1.0.1",
+        "vscode-languageserver": "^10.0.0",
         "vscode-languageserver-textdocument": "^1.0.12",
         "yaml": "^2.8.3",
         "yargs": "^18.0.0"
@@ -496,15 +496,15 @@
       }
     },
     "node_modules/@typespec/http": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@typespec/http/-/http-1.13.0.tgz",
-      "integrity": "sha512-tf8XFddU6g1MZSAVCLC/0Xa4fNfUO0CcHe6PWpmC3bvUojxMnpRcERI2DdoRJ+aycB9Q+Z8wN8bJO3up6u+sCw==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@typespec/http/-/http-1.14.0.tgz",
+      "integrity": "sha512-W+heCzu8K63AVcoX8MachVWaRxSAMFWOI1yBTc2Kq8QHaJeDiLL5JbU8VfTZ4tL/6EoGSdKfIT5ZNRW7oVCzhg==",
       "engines": {
         "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.13.0",
-        "@typespec/streams": "^0.83.0"
+        "@typespec/compiler": "^1.14.0",
+        "@typespec/streams": "^0.84.0"
       },
       "peerDependenciesMeta": {
         "@typespec/streams": {
@@ -513,9 +513,9 @@
       }
     },
     "node_modules/@typespec/json-schema": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@typespec/json-schema/-/json-schema-1.13.0.tgz",
-      "integrity": "sha512-o5yxs4aGhfFTkVNAkpFlO3LP2O8kWHQUgBzZ0s6tcbFlElGH86jUsdesT8O5ijoA0Cpa//m39wwxIcmBB2DiiA==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@typespec/json-schema/-/json-schema-1.14.0.tgz",
+      "integrity": "sha512-YNp0k+HV5eXzzXbAgxOGj01h+Asg1Ljo2EeaqQWFgS6o1Hxg7M4nQZeLs59v9IUxYvtJCHSkmeMADRjpCatrPw==",
       "dependencies": {
         "@typespec/asset-emitter": "^0.79.1",
         "yaml": "^2.8.3"
@@ -524,7 +524,7 @@
         "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.13.0"
+        "@typespec/compiler": "^1.14.0"
       }
     },
     "node_modules/@typespec/openapi": {
@@ -590,26 +590,26 @@
       }
     },
     "node_modules/@typespec/rest": {
-      "version": "0.83.0",
-      "resolved": "https://registry.npmjs.org/@typespec/rest/-/rest-0.83.0.tgz",
-      "integrity": "sha512-WMEwEe1kdaOdZ0c+ct5BVmTSBXkrPniUYDWCz3K52T4in2dNc7J6YGP6tL8bXgQz5B0CsP0VNO12N+UysQDsLw==",
+      "version": "0.84.0",
+      "resolved": "https://registry.npmjs.org/@typespec/rest/-/rest-0.84.0.tgz",
+      "integrity": "sha512-9s5dDfRoHRPdtbVvkBasUx/RnMvwWMTuXRieSQDEji4gWGgxVu4Zt4MiEEKSfQrkMr3Aw0QjRCSxBxjMCHIOmA==",
       "engines": {
         "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.13.0",
-        "@typespec/http": "^1.13.0"
+        "@typespec/compiler": "^1.14.0",
+        "@typespec/http": "^1.14.0"
       }
     },
     "node_modules/@typespec/versioning": {
-      "version": "0.83.0",
-      "resolved": "https://registry.npmjs.org/@typespec/versioning/-/versioning-0.83.0.tgz",
-      "integrity": "sha512-nE66ta0ixpHB6FQpSzqnj8QnVfgFsxeK/4Xv+DxYx2nB/w18f6VjkF+hW+A/zs1tZIYvBZVbCNa/Rcr8zM6fhg==",
+      "version": "0.84.0",
+      "resolved": "https://registry.npmjs.org/@typespec/versioning/-/versioning-0.84.0.tgz",
+      "integrity": "sha512-ZoDasTDj4z0mgFK+0cJL2+7DduCaTjvICHL2nQ/RBWc7nLgObaIYCjvXLno8WneDXnpxCAr7larN4/nlHEv9fg==",
       "engines": {
         "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.13.0"
+        "@typespec/compiler": "^1.14.0"
       }
     },
     "node_modules/ajv": {
@@ -1050,49 +1050,50 @@
       }
     },
     "node_modules/temporal-polyfill": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/temporal-polyfill/-/temporal-polyfill-0.3.2.tgz",
-      "integrity": "sha512-TzHthD/heRK947GNiSu3Y5gSPpeUDH34+LESnfsq8bqpFhsB79HFBX8+Z834IVX68P3EUyRPZK5bL/1fh437Eg==",
-      "license": "MIT",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/temporal-polyfill/-/temporal-polyfill-1.0.1.tgz",
+      "integrity": "sha512-N2SoI9olnW7BUsU8RosDphZQl9s+WJ8O7PoJMFCr/e5/1rFkVI4GNOWaSeySG+UoP04foPYsnLWbJmbXOiShZg==",
       "dependencies": {
-        "temporal-spec": "0.3.1"
+        "temporal-spec": "1.0.0",
+        "temporal-utils": "1.0.1"
       }
     },
     "node_modules/temporal-spec": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/temporal-spec/-/temporal-spec-0.3.1.tgz",
-      "integrity": "sha512-B4TUhezh9knfSIMwt7RVggApDRJZo73uZdj8AacL2mZ8RP5KtLianh2MXxL06GN9ESYiIsiuoLQhgVfwe55Yhw==",
-      "license": "ISC"
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/temporal-spec/-/temporal-spec-1.0.0.tgz",
+      "integrity": "sha512-00Ahj1e1ifaERTMOIIGpOCdOo9IEk2m6GGSMedsn9a2SIsGLdOTbmME1Htv6IM82b6VHrzSUTIVc7YHy6hdhFQ=="
+    },
+    "node_modules/temporal-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/temporal-utils/-/temporal-utils-1.0.1.tgz",
+      "integrity": "sha512-HAixuesxFQIUaQk3ptX2jhfO/FsOkgVkDDMawvp6n/fkB1q6BKfs3lURw9I+pK/2e2e/q/vrLrxmeqauBoyGMQ=="
     },
     "node_modules/vscode-jsonrpc": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
-      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
-      "license": "MIT",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-9.0.1.tgz",
+      "integrity": "sha512-rfuA6T75H6m5EkbhtEPzre9pT0HPcDI2MMy4+nPFIBks5J8JBAUHD4tRYSgaBOijIEC7SRkC1kKyXTLqbmh9jw==",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/vscode-languageserver": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-9.0.1.tgz",
-      "integrity": "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==",
-      "license": "MIT",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-10.1.0.tgz",
+      "integrity": "sha512-9gEWpXkYGXoqG7pBnE8O8hx/yP7+Aabn4+peQ3KDicQv6qunHSWyLTud3OF0w4S2+HfDD+5HqYKiXQW9HAU6mA==",
       "dependencies": {
-        "vscode-languageserver-protocol": "3.17.5"
+        "vscode-languageserver-protocol": "3.18.2"
       },
       "bin": {
         "installServerIntoExtension": "bin/installServerIntoExtension"
       }
     },
     "node_modules/vscode-languageserver-protocol": {
-      "version": "3.17.5",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
-      "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
-      "license": "MIT",
+      "version": "3.18.2",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.18.2.tgz",
+      "integrity": "sha512-XRyDbT0Pp3sSNti3JmxVEUMySWCSi1hhM+/KUlCy1hV1zmrqpM1OwO12EAki8blhmLuIMpaJrYbo0OzGVfK2Qg==",
       "dependencies": {
-        "vscode-jsonrpc": "8.2.0",
-        "vscode-languageserver-types": "3.17.5"
+        "vscode-jsonrpc": "9.0.1",
+        "vscode-languageserver-types": "3.18.0"
       }
     },
     "node_modules/vscode-languageserver-textdocument": {
@@ -1102,10 +1103,9 @@
       "license": "MIT"
     },
     "node_modules/vscode-languageserver-types": {
-      "version": "3.17.5",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
-      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
-      "license": "MIT"
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.18.0.tgz",
+      "integrity": "sha512-8TsGPNMIMiiBdkORgRSvLjuiEIiAFtO+KssmYWxQ+uSVvlf7RjK8YKCOjPzZ+YA04jXEV7+7LvkSmHkhpNS99g=="
     },
     "node_modules/wrap-ansi": {
       "version": "9.0.2",

--- a/docs/source/specs/typespec/package.json
+++ b/docs/source/specs/typespec/package.json
@@ -6,18 +6,18 @@
     "node": ">=20.0.0"
   },
   "peerDependencies": {
-    "@typespec/compiler": "1.13.0"
+    "@typespec/compiler": "1.14.0"
   },
   "devDependencies": {
-    "@typespec/compiler": "1.13.0"
+    "@typespec/compiler": "1.14.0"
   },
   "private": true,
   "dependencies": {
-    "@typespec/http": "1.13.0",
-    "@typespec/json-schema": "1.13.0",
+    "@typespec/http": "1.14.0",
+    "@typespec/json-schema": "1.14.0",
     "@typespec/openapi": "^1.12.0",
     "@typespec/openapi3": "^1.11.0",
-    "@typespec/rest": "^0.83.0",
-    "@typespec/versioning": "^0.83.0"
+    "@typespec/rest": "^0.84.0",
+    "@typespec/versioning": "^0.84.0"
   }
 }


### PR DESCRIPTION
## Summary

Consolidates 5 npm dependency update PRs from `red-hat-konflux[bot]` into a single PR for easier review.

## Consolidated PRs

- #3211: fix(deps): update dependency @typespec/versioning to ^0.84.0
- #3210: fix(deps): update dependency @typespec/rest to ^0.84.0
- #3209: fix(deps): update dependency @typespec/json-schema to v1.14.0
- #3208: fix(deps): update dependency @typespec/http to v1.14.0
- #3207: chore(deps): update dependency @typespec/compiler to v1.14.0

## Why consolidate?

- Reduces CI/CD load from multiple small PRs
- Easier to review related dependency updates together
- Single merge commit instead of many

## Testing

- [ ] CI passes
- [ ] No breaking changes from dependency updates
