### PR TITLE
[RHCLOUD-49425] fix(docker): replace curl healthcheck with python urllib

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,7 +66,7 @@ services:
         rbac-scheduler:
           condition: service_healthy
       healthcheck:
-        test: curl -q http://localhost:8080/metrics
+        test: ["CMD-SHELL", "python3 -c \"import urllib.request; urllib.request.urlopen('http://localhost:8080/metrics')\""]
         interval: 5s
         timeout: 5s
         retries: 10


### PR DESCRIPTION
## Summary
- Replaced curl-based healthcheck in docker-compose.yml with Python urllib one-liner
- The runtime image (hi/core-runtime) does not include curl, causing healthchecks to always fail and dependent services to never start
- Follows the same pattern as RHCLOUD-49424 which fixed curl usage in the init container

## Changes
**docker-compose.yml**: Replaced `curl -q http://localhost:8080/metrics` with `python3 -c "import urllib.request; urllib.request.urlopen('http://localhost:8080/metrics')"` for the rbac-server healthcheck. Python 3 is guaranteed to be present in the runtime image.

**.sova/test-baseline.json**: Updated test baseline (automation metadata, no functional impact).

## Review guidance
- Verify the Python one-liner syntax is correct for a healthcheck test command
- Confirm this matches the pattern from a6e396b9 (RHCLOUD-49424)
- Check that no other docker-compose services use curl in healthchecks

## Test plan
- Local verification with `docker-compose up` using the production Dockerfile to confirm healthcheck passes and dependent services start
- Pattern validated by prior fix in commit 7eabcaab (RHCLOUD-49424)

JIRA: https://redhat.atlassian.net/browse/RHCLOUD-49425

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved container health monitoring by making the metrics endpoint check succeed only when the endpoint responds successfully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->