### PR TITLE
[RHCLOUD-49587] Update internal tool to bootstrap tenant with existing ungrouped-host…

### DIFF
--- a/.cursor/skills/internal-api/SKILL.md
+++ b/.cursor/skills/internal-api/SKILL.md
@@ -78,10 +78,19 @@ sh .cursor/skills/internal-api/scripts/internal-api.sh stage POST \
 
 ### Bootstrap tenant by org ID
 
+By default returns 404 if the Tenant row is missing. Pass `create_missing=true` to create it. Optional `ungrouped_hosts_id` creates the ungrouped-hosts workspace with that UUID.
+
 ```bash
+# Legacy body (tenant must already exist)
 sh .cursor/skills/internal-api/scripts/internal-api.sh stage POST \
   utils/bootstrap_tenant/ \
   '{"org_ids":["1234567"]}'
+
+# Create missing tenant + optional ungrouped-hosts workspace UUID
+sh .cursor/skills/internal-api/scripts/internal-api.sh stage POST \
+  utils/bootstrap_tenant/ \
+  create_missing=true \
+  '{"tenants":[{"org_id":"1234567","ungrouped_hosts_id":"0194a1b2-c3d4-7890-abcd-ef1234567890"}]}'
 ```
 
 ### Bootstrap pending tenants

--- a/rbac/internal/specs/openapi.json
+++ b/rbac/internal/specs/openapi.json
@@ -1749,8 +1749,8 @@
           "Tenant",
           "Utils"
         ],
-        "summary": "Bootstrap a tenants by org ids",
-        "description": "Bootstrap a tenants by org ids",
+        "summary": "Bootstrap tenants by org ids",
+        "description": "Bootstrap tenants by org ids. By default returns 404 if the Tenant row does not exist; pass create_missing=true to create it. Optionally accepts a tenants array with ungrouped_hosts_id to create the ungrouped-hosts workspace with a caller-supplied UUID.",
         "operationId": "TenantBootstrap",
         "requestBody": {
           "required": true,
@@ -1764,12 +1764,52 @@
                     "items": {
                       "type": "string"
                     },
-                    "description": "A list of organization IDs to bootstrap."
+                    "description": "Legacy: list of organization IDs to bootstrap. Mutually exclusive with tenants."
+                  },
+                  "tenants": {
+                    "type": "array",
+                    "description": "List of tenants to bootstrap. Mutually exclusive with org_ids.",
+                    "items": {
+                      "type": "object",
+                      "required": [
+                        "org_id"
+                      ],
+                      "properties": {
+                        "org_id": {
+                          "type": "string",
+                          "description": "Organization ID to bootstrap."
+                        },
+                        "ungrouped_hosts_id": {
+                          "type": "string",
+                          "format": "uuid",
+                          "description": "Optional UUID for the ungrouped-hosts workspace. When set, creates that workspace under the default workspace."
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "examples": {
+                "org_ids": {
+                  "summary": "Legacy org_ids body",
+                  "value": {
+                    "org_ids": [
+                      "12345",
+                      "67890"
+                    ]
                   }
                 },
-                "required": [
-                  "org_ids"
-                ]
+                "tenants_with_ungrouped": {
+                  "summary": "Create tenant with supplied ungrouped-hosts id",
+                  "value": {
+                    "tenants": [
+                      {
+                        "org_id": "12345",
+                        "ungrouped_hosts_id": "0194a1b2-c3d4-7890-abcd-ef1234567890"
+                      }
+                    ]
+                  }
+                }
               }
             }
           }
@@ -1790,6 +1830,16 @@
             "in": "query",
             "required": false,
             "description": "Re-replicate only admin default bindings. This is SAFE even when replication is on because admin default bindings are NOT customizable (unlike platform default bindings). Use this to fix tenants that were bootstrapped before admin default groups were seeded.",
+            "schema": {
+              "default": false,
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "create_missing",
+            "in": "query",
+            "required": false,
+            "description": "When true, create a Tenant row if one does not exist for the org_id, then bootstrap it. Default false returns 404 for missing tenants to avoid accidental creation.",
             "schema": {
               "default": false,
               "type": "boolean"
@@ -1838,7 +1888,17 @@
             }
           },
           "400": {
-            "description": "Invalid request, must supply the 'org_id' query parameter.",
+            "description": "Invalid request body, invalid ungrouped_hosts_id, workspace ID conflict, or force=true while replication is enabled.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Tenant not found for the given org_id when create_missing is false (default).",
             "content": {
               "application/json": {
                 "schema": {

--- a/rbac/internal/utils.py
+++ b/rbac/internal/utils.py
@@ -28,7 +28,7 @@ from typing import Optional
 
 import jsonschema
 from django.conf import settings
-from django.db import transaction
+from django.db import IntegrityError, transaction
 from django.db.models import Q
 from django.urls import resolve
 from internal.pg_notify_wait import replicate_with_notify
@@ -900,25 +900,90 @@ def clean_invalid_workspace_resource_definitions(dry_run: bool = False) -> dict:
     return results
 
 
+class UngroupedWorkspaceError(ValueError):
+    """Raised when ungrouped-hosts workspace cannot be created with the requested ID."""
+
+
 @transaction.atomic
-def get_or_create_ungrouped_workspace(tenant: str) -> Workspace:
+def get_or_create_ungrouped_workspace(tenant: Tenant, workspace_id: Optional[uuid.UUID] = None) -> Workspace:
     """
-    Retrieve the ungrouped workspace for the given tenant.
+    Retrieve or create the ungrouped-hosts workspace for the given tenant.
 
     Args:
-        tenant (str): The tenant for which to retrieve the ungrouped workspace.
+        tenant: The tenant for which to retrieve/create the ungrouped workspace.
+        workspace_id: Optional UUID to use when creating the workspace. When the tenant
+            already has an ungrouped-hosts workspace, it must match this ID if provided.
+
     Returns:
         Workspace: The ungrouped workspace object for the given tenant.
+
+    Raises:
+        UngroupedWorkspaceError: If workspace_id conflicts with an existing workspace.
     """
-    # fetch parent only once
     default_ws = Workspace.objects.get(tenant=tenant, type=Workspace.Types.DEFAULT)
 
-    # single select_for_update + get_or_create
-    workspace, created = Workspace.objects.select_for_update().get_or_create(
-        tenant=tenant,
-        type=Workspace.Types.UNGROUPED_HOSTS,
-        defaults={"name": Workspace.SpecialNames.UNGROUPED_HOSTS, "parent": default_ws},
+    existing = (
+        Workspace.objects.select_for_update().filter(tenant=tenant, type=Workspace.Types.UNGROUPED_HOSTS).first()
     )
+    if existing:
+        if workspace_id is not None and existing.id != workspace_id:
+            raise UngroupedWorkspaceError(
+                f"Tenant org_id={tenant.org_id} already has ungrouped-hosts workspace "
+                f"{existing.id}, which does not match requested id {workspace_id}."
+            )
+        return existing
+
+    if workspace_id is not None:
+        conflict = Workspace.objects.filter(id=workspace_id).first()
+        if conflict is not None:
+            raise UngroupedWorkspaceError(
+                f"Workspace id {workspace_id} already exists "
+                f"(tenant org_id={conflict.tenant.org_id}, type={conflict.type})."
+            )
+        workspace = Workspace(
+            id=workspace_id,
+            tenant=tenant,
+            type=Workspace.Types.UNGROUPED_HOSTS,
+            name=Workspace.SpecialNames.UNGROUPED_HOSTS,
+            parent=default_ws,
+            description=Workspace.SpecialDescriptions.UNGROUPED_HOSTS,
+        )
+        try:
+            # Nested savepoint so IntegrityError does not poison the outer atomic block.
+            with transaction.atomic():
+                workspace.save()
+            created = True
+        except IntegrityError:
+            # Savepoint rolled back; outer transaction can continue with retry queries.
+            raced = (
+                Workspace.objects.select_for_update()
+                .filter(tenant=tenant, type=Workspace.Types.UNGROUPED_HOSTS)
+                .first()
+            )
+            if raced is not None:
+                if raced.id != workspace_id:
+                    raise UngroupedWorkspaceError(
+                        f"Tenant org_id={tenant.org_id} already has ungrouped-hosts workspace "
+                        f"{raced.id}, which does not match requested id {workspace_id}."
+                    ) from None
+                workspace = raced
+                created = False
+            else:
+                conflict = Workspace.objects.select_for_update().filter(id=workspace_id).first()
+                if conflict is not None:
+                    raise UngroupedWorkspaceError(
+                        f"Workspace id {workspace_id} already exists "
+                        f"(tenant org_id={conflict.tenant.org_id}, type={conflict.type})."
+                    ) from None
+                raise UngroupedWorkspaceError(
+                    f"Workspace id {workspace_id} conflicted during creation but is no longer found."
+                ) from None
+    else:
+        workspace, created = Workspace.objects.select_for_update().get_or_create(
+            tenant=tenant,
+            type=Workspace.Types.UNGROUPED_HOSTS,
+            defaults={"name": Workspace.SpecialNames.UNGROUPED_HOSTS, "parent": default_ws},
+        )
 
     if created:
         RelationApiDualWriteWorkspaceHandler(
@@ -926,6 +991,52 @@ def get_or_create_ungrouped_workspace(tenant: str) -> Workspace:
         ).replicate_new_workspace()
 
     return workspace
+
+
+def parse_bootstrap_tenant_request(body: dict) -> list[tuple[str, Optional[uuid.UUID]]]:
+    """
+    Parse bootstrap_tenant request body into (org_id, ungrouped_hosts_id) pairs.
+
+    Accepts either:
+      {"org_ids": ["12345", "67890"]}
+      {"tenants": [{"org_id": "12345", "ungrouped_hosts_id": "<uuid>"}]}
+
+    Raises:
+        ValueError: If the body is invalid.
+    """
+    if not isinstance(body, dict):
+        raise ValueError("Invalid request: body must be a JSON object.")  # pyright: ignore[reportUnreachable]
+
+    if "tenants" in body and "org_ids" in body:
+        raise ValueError('Invalid request: supply either "org_ids" or "tenants", not both.')
+
+    if "tenants" in body:
+        tenants = body["tenants"]
+        if not isinstance(tenants, list) or len(tenants) == 0:
+            raise ValueError('Invalid request: the "tenants" array must contain at least one entry.')
+
+        parsed: list[tuple[str, Optional[uuid.UUID]]] = []
+        for entry in tenants:
+            if not isinstance(entry, dict) or not entry.get("org_id"):
+                raise ValueError('Invalid request: each tenants entry must include a non-empty "org_id".')
+            org_id = str(entry["org_id"])
+            raw_id = entry.get("ungrouped_hosts_id")
+            if raw_id is None or raw_id == "":
+                parsed.append((org_id, None))
+                continue
+            try:
+                parsed.append((org_id, as_uuid(raw_id)))
+            except (TypeError, ValueError) as exc:
+                raise ValueError(f'Invalid ungrouped_hosts_id for org_id {org_id}: "{raw_id}".') from exc
+        return parsed
+
+    if "org_ids" in body:
+        org_ids = body["org_ids"]
+        if not isinstance(org_ids, list) or len(org_ids) == 0:
+            raise ValueError('Invalid request: the "org_ids" array in the body must contain at least one org_id')
+        return [(str(org_id), None) for org_id in org_ids]
+
+    raise ValueError('Invalid request: must supply "org_ids" or "tenants" in body.')
 
 
 def validate_relations_input(action, request_data) -> bool:

--- a/rbac/internal/views.py
+++ b/rbac/internal/views.py
@@ -40,10 +40,12 @@ from internal.custom_v2_role_tenant_migration import replicate_custom_v2_role_ow
 from internal.errors import SentryDiagnosticError, UserNotFoundError
 from internal.jwt_utils import JWTManager, JWTProvider
 from internal.utils import (
+    UngroupedWorkspaceError,
     delete_bindings,
     fix_admin_default_bindings,
     get_or_create_ungrouped_workspace,
     load_request_body,
+    parse_bootstrap_tenant_request,
     read_tuples_from_kessel,
     rebuild_tenant_workspace_relations as rebuild_workspace_relations_util,
     validate_inventory_input,
@@ -1114,9 +1116,16 @@ def fetch_replication_data(request):
 def bootstrap_tenant(request):
     """View method for bootstrapping a tenant.
 
-    POST /_private/api/utils/bootstrap_tenant/?force=false&force_admin_only=false
+    POST /_private/api/utils/bootstrap_tenant/?force=false&force_admin_only=false&create_missing=false
 
-    Body: {"org_ids": ["12345", "67890"]}
+    Body (legacy):
+        {"org_ids": ["12345", "67890"]}
+
+    Body (extended):
+        {"tenants": [{"org_id": "12345", "ungrouped_hosts_id": "<uuid>"}]}
+
+    When ungrouped_hosts_id is provided, an ungrouped-hosts workspace is created with
+    that UUID under the default workspace and replicated to Relations.
 
     force:
         Whether or not to force replication to happen, even if the Tenant is already bootstrapped.
@@ -1126,23 +1135,44 @@ def bootstrap_tenant(request):
         Re-replicate only admin default bindings. This is SAFE even when replication is on because
         admin default bindings are NOT customizable (unlike platform default bindings).
         Use this to fix tenants that were bootstrapped before admin default groups were seeded.
+        Ignores ungrouped_hosts_id and create_missing.
+
+    create_missing:
+        When 'true', create a Tenant row if one does not exist for the org_id, then bootstrap it.
+        Default is 'false' (return 404 for missing tenants) to avoid accidental tenant creation.
     """
     if request.method != "POST":
         return HttpResponse('Invalid method, only "POST" is allowed.', status=405)
     logger.info("Running bootstrap tenant.")
 
     if not request.body:
-        return HttpResponse('Invalid request, must supply the "org_ids" in body.', status=400)
+        return HttpResponse('Invalid request, must supply "org_ids" or "tenants" in body.', status=400)
 
-    org_ids_data = json.loads(request.body.decode("utf-8").replace("'", '"'))
+    try:
+        raw_body = request.body.decode("utf-8")
+        try:
+            body = json.loads(raw_body)
+        except json.JSONDecodeError as primary_exc:
+            # Legacy org_ids clients may send single-quoted JSON. Do not apply this
+            # rewrite when the payload uses the tenants format — apostrophes in values
+            # (e.g. org_id "O'Reilly") would be silently corrupted.
+            try:
+                legacy_body = json.loads(raw_body.replace("'", '"'))
+            except json.JSONDecodeError:
+                return HttpResponse(str(primary_exc), status=400, content_type="text/plain")
+            if isinstance(legacy_body, dict) and "tenants" in legacy_body:
+                return HttpResponse(str(primary_exc), status=400, content_type="text/plain")
+            body = legacy_body
+        tenants_to_bootstrap = parse_bootstrap_tenant_request(body)
+    except UnicodeDecodeError:
+        return HttpResponse("Invalid request: body must be valid UTF-8.", status=400, content_type="text/plain")
+    except (json.JSONDecodeError, ValueError) as exc:
+        return HttpResponse(str(exc), status=400, content_type="text/plain")
+
     force = request.GET.get("force", "false").lower() == "true"
     force_admin_only = request.GET.get("force_admin_only", "false").lower() == "true"
-
-    if "org_ids" not in org_ids_data or len(org_ids_data["org_ids"]) == 0:
-        return HttpResponse(
-            'Invalid request: the "org_ids" array in the body must contain at least one org_id', status=400
-        )
-    org_ids = org_ids_data["org_ids"]
+    create_missing = request.GET.get("create_missing", "false").lower() == "true"
+    org_ids = [org_id for org_id, _ in tenants_to_bootstrap]
 
     # force=true has race condition risk with custom default group creation
     # force_admin_only=true is safe because admin default bindings are not customizable
@@ -1158,11 +1188,22 @@ def bootstrap_tenant(request):
         results = [fix_admin_default_bindings(org_id) for org_id in org_ids]
         return JsonResponse({"results": results}, status=200)
 
-    with transaction.atomic():
-        bootstrap_service = V2TenantBootstrapService(OutboxReplicator())
-        for org_id in org_ids:
-            tenant = get_object_or_404(Tenant, org_id=org_id)
-            bootstrap_service.bootstrap_tenant(tenant, force=force)
+    try:
+        with transaction.atomic():
+            bootstrap_service = V2TenantBootstrapService(OutboxReplicator())
+            for org_id, ungrouped_hosts_id in tenants_to_bootstrap:
+                if create_missing:
+                    tenant, _ = Tenant.objects.get_or_create(
+                        org_id=org_id,
+                        defaults={"tenant_name": f"org{org_id}", "ready": False},
+                    )
+                else:
+                    tenant = get_object_or_404(Tenant, org_id=org_id)
+                bootstrap_service.bootstrap_tenant(tenant, force=force)
+                if ungrouped_hosts_id is not None:
+                    get_or_create_ungrouped_workspace(tenant, workspace_id=ungrouped_hosts_id)
+    except UngroupedWorkspaceError as exc:
+        return HttpResponse(str(exc), status=400, content_type="text/plain")
     # Admin action - SEC-MON-REQ-1 compliance (EOI-3 admin_action, EOI-2 system_object_manipulation)
     logger.info(
         "Internal API: Tenant bootstrap completed",
@@ -1174,6 +1215,7 @@ def bootstrap_tenant(request):
             "username": getattr(request.user, "username", None),
             "target_org_ids": org_ids,
             "force": force,
+            "create_missing": create_missing,
         },
     )
     return HttpResponse(f"Bootstrapping tenants with org_ids {org_ids} were finished.", status=200)

--- a/tests/internal/test_views.py
+++ b/tests/internal/test_views.py
@@ -1178,7 +1178,243 @@ class InternalViewsetTests(BaseInternalViewsetTests):
         self.assertIsNotNone(Workspace.objects.root(tenant=tenant))
         self.assertIsNotNone(Workspace.objects.default(tenant=tenant))
         self.assertTrue(getattr(tenant, "tenant_mapping"))
+        self.assertFalse(Workspace.objects.filter(tenant=tenant, type=Workspace.Types.UNGROUPED_HOSTS).exists())
         self.assertEqual(len(tuples), 21)
+
+    def test_bootstrapping_tenant_missing_without_create_missing_returns_404(self):
+        """Default create_missing=false returns 404 for non-existent tenants."""
+        payload = {"org_ids": ["nonexistent-org"]}
+        response = self.client.post(
+            "/_private/api/utils/bootstrap_tenant/",
+            data=payload,
+            **self.request.META,
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertFalse(Tenant.objects.filter(org_id="nonexistent-org").exists())
+
+    def test_bootstrapping_tenant_rejects_single_quoted_tenants_body(self):
+        """tenants payloads must be valid JSON; apostrophe rewrite is not applied."""
+        response = self.client.post(
+            "/_private/api/utils/bootstrap_tenant/?create_missing=true",
+            data="{'tenants':[{'org_id':'12345'}]}",
+            **self.request.META,
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertFalse(Tenant.objects.filter(org_id="12345").exists())
+
+    @patch("management.relation_replicator.outbox_replicator.OutboxReplicator.replicate")
+    def test_bootstrapping_tenant_create_missing(self, replicate):
+        """create_missing=true creates a Tenant row when none exists."""
+        org_id = "create-missing-org"
+
+        tuples = InMemoryTuples()
+        replicator = InMemoryRelationReplicator(tuples)
+        replicate.side_effect = replicator.replicate
+        RbacFixture(V2TenantBootstrapService(replicator))
+        tuples.clear()
+
+        self.assertFalse(Tenant.objects.filter(org_id=org_id).exists())
+        payload = {"org_ids": [org_id]}
+        response = self.client.post(
+            "/_private/api/utils/bootstrap_tenant/?create_missing=true",
+            data=payload,
+            **self.request.META,
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        tenant = Tenant.objects.get(org_id=org_id)
+        self.assertIsNotNone(Workspace.objects.root(tenant=tenant))
+        self.assertIsNotNone(Workspace.objects.default(tenant=tenant))
+        self.assertEqual(len(tuples), 21)
+
+    @patch("management.relation_replicator.outbox_replicator.OutboxReplicator.replicate")
+    def test_bootstrapping_tenant_with_ungrouped_hosts_id(self, replicate):
+        """Bootstrap creates ungrouped-hosts workspace with supplied UUID when create_missing=true."""
+        org_id = "ungrouped-bootstrap-org"
+        ungrouped_id = str(uuid.uuid4())
+
+        tuples = InMemoryTuples()
+        replicator = InMemoryRelationReplicator(tuples)
+        replicate.side_effect = replicator.replicate
+        RbacFixture(V2TenantBootstrapService(replicator))
+        tuples.clear()
+
+        payload = {"tenants": [{"org_id": org_id, "ungrouped_hosts_id": ungrouped_id}]}
+        response = self.client.post(
+            "/_private/api/utils/bootstrap_tenant/?create_missing=true",
+            data=payload,
+            **self.request.META,
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        tenant = Tenant.objects.get(org_id=org_id)
+        ungrouped = Workspace.objects.get(tenant=tenant, type=Workspace.Types.UNGROUPED_HOSTS)
+        self.assertEqual(str(ungrouped.id), ungrouped_id)
+        self.assertEqual(ungrouped.parent, Workspace.objects.default(tenant=tenant))
+        self.assertGreater(len(tuples), 21)
+
+    @patch("management.relation_replicator.outbox_replicator.OutboxReplicator.replicate")
+    def test_bootstrapping_tenant_ungrouped_hosts_id_conflict(self, replicate):
+        """Conflicting ungrouped_hosts_id returns 400."""
+        tuples = InMemoryTuples()
+        replicator = InMemoryRelationReplicator(tuples)
+        replicate.side_effect = replicator.replicate
+        fixture = RbacFixture(V2TenantBootstrapService(replicator))
+        existing = fixture.new_tenant("existing-org")
+        existing_ungrouped = Workspace.objects.create(
+            tenant=existing.tenant,
+            type=Workspace.Types.UNGROUPED_HOSTS,
+            name=Workspace.SpecialNames.UNGROUPED_HOSTS,
+            parent=existing.default_workspace,
+        )
+
+        payload = {
+            "tenants": [
+                {
+                    "org_id": "another-org",
+                    "ungrouped_hosts_id": str(existing_ungrouped.id),
+                }
+            ]
+        }
+        response = self.client.post(
+            "/_private/api/utils/bootstrap_tenant/?create_missing=true",
+            data=payload,
+            **self.request.META,
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("already exists", response.content.decode("utf-8"))
+        self.assertFalse(Tenant.objects.filter(org_id="another-org").exists())
+
+    @patch("management.relation_replicator.outbox_replicator.OutboxReplicator.replicate")
+    def test_bootstrapping_tenant_ungrouped_hosts_id_mismatch(self, replicate):
+        """Same tenant with a different ungrouped_hosts_id returns 400."""
+        tuples = InMemoryTuples()
+        replicator = InMemoryRelationReplicator(tuples)
+        replicate.side_effect = replicator.replicate
+        fixture = RbacFixture(V2TenantBootstrapService(replicator))
+        bootstrapped = fixture.new_tenant("mismatch-org")
+        existing_ungrouped = Workspace.objects.create(
+            tenant=bootstrapped.tenant,
+            type=Workspace.Types.UNGROUPED_HOSTS,
+            name=Workspace.SpecialNames.UNGROUPED_HOSTS,
+            parent=bootstrapped.default_workspace,
+        )
+
+        payload = {
+            "tenants": [
+                {
+                    "org_id": bootstrapped.tenant.org_id,
+                    "ungrouped_hosts_id": str(uuid.uuid4()),
+                }
+            ]
+        }
+        response = self.client.post(
+            "/_private/api/utils/bootstrap_tenant/",
+            data=payload,
+            **self.request.META,
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("does not match requested id", response.content.decode("utf-8"))
+        self.assertEqual(
+            Workspace.objects.get(tenant=bootstrapped.tenant, type=Workspace.Types.UNGROUPED_HOSTS).id,
+            existing_ungrouped.id,
+        )
+
+    @patch("management.relation_replicator.outbox_replicator.OutboxReplicator.replicate")
+    def test_bootstrapping_existing_tenant_with_ungrouped_hosts_id(self, replicate):
+        """ungrouped_hosts_id works on an existing tenant without create_missing."""
+        org_id = "existing-ungrouped-org"
+        ungrouped_id = str(uuid.uuid4())
+
+        tuples = InMemoryTuples()
+        replicator = InMemoryRelationReplicator(tuples)
+        replicate.side_effect = replicator.replicate
+        fixture = RbacFixture(V2TenantBootstrapService(replicator))
+        bootstrapped = fixture.new_tenant(org_id)
+        tuples.clear()
+
+        payload = {"tenants": [{"org_id": org_id, "ungrouped_hosts_id": ungrouped_id}]}
+        response = self.client.post(
+            "/_private/api/utils/bootstrap_tenant/",
+            data=payload,
+            **self.request.META,
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        ungrouped = Workspace.objects.get(tenant=bootstrapped.tenant, type=Workspace.Types.UNGROUPED_HOSTS)
+        self.assertEqual(str(ungrouped.id), ungrouped_id)
+        self.assertEqual(ungrouped.parent, Workspace.objects.default(tenant=bootstrapped.tenant))
+        self.assertGreater(len(tuples), 0)
+
+        # Idempotent re-call with the same ungrouped_hosts_id succeeds and does not recreate.
+        tuples.clear()
+        response = self.client.post(
+            "/_private/api/utils/bootstrap_tenant/",
+            data=payload,
+            **self.request.META,
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            Workspace.objects.filter(tenant=bootstrapped.tenant, type=Workspace.Types.UNGROUPED_HOSTS).count(),
+            1,
+        )
+        self.assertEqual(len(tuples), 0)
+
+    def test_bootstrapping_tenant_invalid_ungrouped_hosts_id(self):
+        """Invalid ungrouped_hosts_id UUID returns 400."""
+        payload = {"tenants": [{"org_id": "12345", "ungrouped_hosts_id": "not-a-uuid"}]}
+        response = self.client.post(
+            "/_private/api/utils/bootstrap_tenant/",
+            data=payload,
+            **self.request.META,
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("Invalid ungrouped_hosts_id", response.content.decode("utf-8"))
+
+    def test_bootstrapping_tenant_rejects_both_body_formats(self):
+        """Supplying both org_ids and tenants returns 400."""
+        payload = {"org_ids": ["12345"], "tenants": [{"org_id": "12345"}]}
+        response = self.client.post(
+            "/_private/api/utils/bootstrap_tenant/",
+            data=payload,
+            **self.request.META,
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("not both", response.content.decode("utf-8"))
+
+    def test_bootstrapping_tenant_rejects_non_object_json_body(self):
+        """Scalar JSON bodies return 400 instead of 500."""
+        for payload in ("123", "true", "null", '["12345"]'):
+            with self.subTest(payload=payload):
+                response = self.client.post(
+                    "/_private/api/utils/bootstrap_tenant/",
+                    data=payload,
+                    **self.request.META,
+                    content_type="application/json",
+                )
+                self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+                self.assertIn("JSON object", response.content.decode("utf-8"))
+
+    def test_bootstrapping_tenant_rejects_invalid_utf8_body(self):
+        """Invalid UTF-8 request bodies return 400 instead of 500."""
+        response = self.client.generic(
+            "POST",
+            "/_private/api/utils/bootstrap_tenant/",
+            data=b'\xff\xfe{"org_ids":["12345"]}',
+            content_type="application/json",
+            **self.request.META,
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("UTF-8", response.content.decode("utf-8"))
 
     @patch("management.relation_replicator.outbox_replicator.OutboxReplicator.replicate")
     def test_bootstrapping_multiple_tenants(self, replicate):


### PR DESCRIPTION
Extend the existing internal API POST /_private/api/utils/bootstrap_tenant/ so operators can bootstrap a tenant from org_id alone (without a pre-existing Tenant row or user), and optionally supply a pre-existing ungrouped-hosts workspace UUID to use instead of generating a new one.

## Link(s) to Jira
- https://redhat.atlassian.net/browse/RHCLOUD-49587

## Description of Intent of Change(s)
Today bootstrap_tenant requires the Tenant row to already exist (404 via get_object_or_404) and only bootstraps root/default workspaces plus default access bindings. It does not create the ungrouped-hosts workspace. That workspace is currently created lazily via the S2S endpoint GET /_private/_s2s/workspaces/ungrouped/ (PSK/JWT auth, not Turnpike internal API) or via get_or_create_ungrouped_workspace() in other code paths.

Ephemeral/DR tooling and other internal workflows currently work around this by inserting a bare api_tenant row in Postgres, calling bootstrap_tenant, then separately handling ungrouped-hosts via S2S or manual steps. We need a single Turnpike-accessible internal API that can create the tenant if missing, bootstrap V2 tenant structure, and create ungrouped-hosts with a caller-supplied UUID when provided.

## Local Testing
Unit test

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `create_missing=true` to auto-create missing tenants during tenant bootstrap.
  - Expanded tenant bootstrap to accept a `tenants` payload with optional `ungrouped_hosts_id` per tenant.
- **Documentation**
  - Updated API docs and examples to describe the new request shape and default missing-tenant behavior (404 unless `create_missing` is enabled).
- **Bug Fixes**
  - Improved conflict/mismatch handling for `ungrouped_hosts_id`, returning clearer 400 responses and preserving existing workspaces when appropriate.
- **Tests**
  - Added/expanded endpoint tests for auto-creation, ungrouped-hosts workspace creation/idempotency, and validation/error cases (including mutually exclusive formats and invalid payloads).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->