### PR TITLE
[RHCLOUD-46266] feat: Replace org-admin middleware check with Kessel tenant-level bindings for org-level access

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1899,11 +1899,11 @@
         },
         "cachetools": {
             "hashes": [
-                "sha256:323dc4127934744db5b54eb4924482d7edafbf9554e820d1531c2e08c0e4ef54",
-                "sha256:437f55a4e0c1b01a4f3077cc470e6991d47430970e36fbcb77e2be0df4fc1cd6"
+                "sha256:2c12e255780330af28b91bb7fb96cce4c766f04e38396b9a24510190a5827096",
+                "sha256:c7a79e7f30ba9943c1cefd08cc36f006aaae086e017af9166f1d59d6170c47e1"
             ],
             "markers": "python_version >= '3.10'",
-            "version": "==7.1.4"
+            "version": "==7.1.6"
         },
         "certifi": {
             "hashes": [
@@ -2026,48 +2026,6 @@
             ],
             "markers": "python_version >= '3.10'",
             "version": "==3.5.0"
-        },
-        "chardet": {
-            "hashes": [
-                "sha256:0ac3bf11c645734a1701a3804e43eabd98851838192267d08c353a834ab79fea",
-                "sha256:1173b74051570cf08099d7429d92e4882d375ad4217f92a6e5240ccfb26f231e",
-                "sha256:23163921dccf3103ce59540b0443c106d2c0a0ff2e0503e05196f5e6fdea453f",
-                "sha256:25a862cddc6a9ac07023e808aedd297115345fbaabc2690479481ddc0f980e09",
-                "sha256:27cc23da03630cdecc9aa81a895aa86629c211f995cd57651f0fbc280717bf93",
-                "sha256:29af5999f654e8729d251f1724a62b538b1262d9292cccaefddf8a02aae1ef6a",
-                "sha256:365135eaf37ba65a828f8e668eb0a8c38c479dcbec724dc25f4dfd781049c357",
-                "sha256:3990fffcc6a6045f2234ab72752ad037e3b2d48c72037f244d42738db397eb75",
-                "sha256:457f619882ba66327d4d8d14c6c342269bdb1e4e1c38e8117df941d14d351b04",
-                "sha256:4b2799bd58e7245cfa8d4ab2e8ad1d76a5c3a5b1f32318eb6acca4c69a3e7101",
-                "sha256:4c3da294de1a681097848ab58bd3f2771a674f8039d2d87a5538b28856b815e9",
-                "sha256:4fbff1907925b0c5a1064cffb5e040cd5e338585c9c552625f30de6bc2f3107a",
-                "sha256:5d2879598bc220689e8ce509fe9c3f37ad2fca53a36be9c9bd91abdd91dd364f",
-                "sha256:626f00299ad62dfe937058a09572beed442ccc7b58f87aa667949b20fd3db235",
-                "sha256:6e3bd9f936e04bae89c254262af08d9e5b98f805175ba1e29d454e6cba3107b7",
-                "sha256:7005c88da26fd95d8abb8acbe6281d833e9a9181b03cf49b4546c4555389bd97",
-                "sha256:75d3c65cc16bddf40b8da1fd25ba84fca5f8070f2b14e86083653c1c85aee971",
-                "sha256:93c45e116dd51b66226a53ade3f9f635e870de5399b90e00ce45dcc311093bf4",
-                "sha256:9a4904dd5f071b7a7d7f50b4a67a86db3c902d243bf31708f1d5cde2f68239cb",
-                "sha256:9acd9988a93e09390f3cd231201ea7166c415eb8da1b735928990ffc05cb9fbb",
-                "sha256:9f3504c139a2ad544077dd2d9e412cd08b01786843d76997cd43bb6de311723c",
-                "sha256:a9e4486df251b8962e86ea9f139ca235aa6e0542a00f7844c9a04160afb99aa9",
-                "sha256:acc46d1b8b7d5783216afe15db56d1c179b9a40e5a1558bc13164c4fd20674c4",
-                "sha256:b95c934b9ad59e2ba8abb9be49df70d3ad1b0d95d864b9fdb7588d4fa8bd921c",
-                "sha256:bba8bea1b28d927b3e99e47deafe53658d34497c0a891d95ff1ba8ff6663f01c",
-                "sha256:bfc134b70c846c21ead8e43ada3ae1a805fff732f6922f8abcf2ff27b8f6493d",
-                "sha256:c0c79b13c9908ac7dfe0a74116ebc9a0f28b2319d23c32f3dfcdfbe1279c7eaf",
-                "sha256:c7116b0452994734ccff35e154b44240090eb0f4f74b9106292668133557c175",
-                "sha256:c77867f0c1cb8bd819502249fcdc500364aedb07881e11b743726fa2148e7b6e",
-                "sha256:cc1d4eb92a4ec1c2df3b490836ffa46922e599d34ce0bb75cf41fd2bf6303d56",
-                "sha256:ccc1f83ab4bcfb901cf39e0c4ba6bc6e726fc6264735f10e24ceb5cb47387578",
-                "sha256:cf1efeaf65a6ef2f5b9cc3a1df6f08ba2831b369ccaa4c7018eaf90aa757bb11",
-                "sha256:cfb54563fe5f130da17c44c6a4e2e8052ba628e5ab4eab7ef8190f736f0f8f72",
-                "sha256:d892d3dcd652fdef53e3d6327d39b17c0df40a899dfc919abaeb64c974497531",
-                "sha256:dc50f28bad067393cce0af9091052c3b8df7a23115afd8ba7b2e0947f0cef1f8",
-                "sha256:e1b98790c284ff813f18f7cf7de5f05ea2435a080030c7f1a8318f3a4f80b131"
-            ],
-            "markers": "python_version >= '3.10'",
-            "version": "==7.4.3"
         },
         "charset-normalizer": {
             "hashes": [
@@ -2864,6 +2822,14 @@
             "markers": "python_version >= '3.10'",
             "version": "==1.11.0"
         },
+        "python-discovery": {
+            "hashes": [
+                "sha256:3e014c6327154d3dda27939a9a0dc9c5c000439f1906d3f303b48f984bd2ecef",
+                "sha256:70c4fc61b4e7404e44f01d6fc44a715c4d685ca6cea83d295922f05891877c98"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==1.5.0"
+        },
         "pytokens": {
             "hashes": [
                 "sha256:0fc71786e629cef478cbf29d7ea1923299181d0699dbe7c3c0f4a583811d9fc1",
@@ -3107,14 +3073,22 @@
             "markers": "python_version >= '3.9'",
             "version": "==3.2.2"
         },
+        "tomli-w": {
+            "hashes": [
+                "sha256:188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90",
+                "sha256:2dd14fac5a47c27be9cd4c976af5a12d87fb1f0b4512f81d69cce3b35ae25021"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==1.2.0"
+        },
         "tox": {
             "hashes": [
-                "sha256:2adb83d68f27116812b69aa36676a8d6a52249cb0d173649de0e7d0c2e3e7229",
-                "sha256:73a7240778fabf305aeb05ab8ea26e575e042ab5a18d71d0ed13e343a51d6ce1"
+                "sha256:ab0b126a04dd56bc18e6d216386db09335247f2289b54cf534deb5c4ae3a8d2e",
+                "sha256:dcae21f5f015f3a67658e35644cce0d1aa0dedcd06f3927f95d84e1717f6cea5"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.8'",
-            "version": "==4.11.4"
+            "markers": "python_version >= '3.10'",
+            "version": "==4.58.0"
         },
         "types-pyyaml": {
             "hashes": [
@@ -3144,11 +3118,11 @@
         },
         "virtualenv": {
             "hashes": [
-                "sha256:a00332e0b089ba64edefbf94ef34e6db33f45fe5184df0652cf0b754dcd36190",
-                "sha256:c551ea1072d7717a273dd9a4a0adad8f45571af134b0f63a12430e85f6ac1c08"
+                "sha256:7f9519b9432ff11b6e1a3e94061664efc2ff99ea21780e3cf4f6bd0a5da8b37c",
+                "sha256:a8370c1c5530fbabf955e40b8fbbc68a431648b10f9433faa587db30a06e51dd"
             ],
-            "markers": "python_version >= '3.8'",
-            "version": "==20.39.1"
+            "markers": "python_version >= '3.9'",
+            "version": "==21.7.0"
         }
     }
 }


### PR DESCRIPTION
## Issue Detected

The commit message claims to implement **"Replace org-admin middleware check with Kessel tenant-level bindings for org-level access"** (RHCLOUD-46266), but the actual changes are only:

1. **Dependency updates** in `Pipfile.lock`:
   - Upgraded `cattrs` from 7.1.4 to 7.1.6
   - Removed `chardet` 7.4.3 (now unused)
   - Added `python-discovery` 1.5.0
   - Added `tomli-w` 1.2.0
   - Upgraded `tox` from 4.11.4 to 4.58.0
   - Upgraded `virtualenv` from 20.39.1 to 21.7.0

2. **Test baseline file** (`.sova/test-baseline.json`) with exit code 127

**No actual implementation** of the Kessel tenant-level bindings feature is present. The changes in `rbac/management/permissions/role_binding_access.py` and related files mentioned in the research context are missing.

This appears to be a mislabeled commit. Before creating a PR, you should either:

1. **Amend or rewrite the commit** with the correct message (e.g., `chore(deps): upgrade development dependencies`) and remove the JIRA reference, OR
2. **Add the actual feature implementation** to this branch before creating the PR

Which would you like to do?

JIRA: https://redhat.atlassian.net/browse/RHCLOUD-46266

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a baseline configuration for validating command execution failures.
  * Established an expected exit code of 127 for the baseline scenario.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->