### PR TITLE
[RHCLOUD-48737] Allow specifying stream for updated workspace re-replication

### DIFF
--- a/rbac/internal/migrations/migrate_role_scope.py
+++ b/rbac/internal/migrations/migrate_role_scope.py
@@ -242,10 +242,10 @@ def _migrate_bindings_for_scope_change(context: _MigrateContext):
     migrated_groups = 0
     migrated_cars = 0
 
-    for group_batch in itertools.batched(groups, 20):
+    for group_batch in itertools.batched(groups, 10):
         migrated_groups += _migrate_group_batch(context=context, groups=list(group_batch))
 
-    for car_batch in itertools.batched(cars, 20):
+    for car_batch in itertools.batched(cars, 10):
         migrated_cars += _migrate_car_batch(context=context, cars=list(car_batch))
 
     logger.info(

--- a/rbac/internal/migrations/replicate_workspaces.py
+++ b/rbac/internal/migrations/replicate_workspaces.py
@@ -104,6 +104,7 @@ def _do_replicate(
         limited_count = total_count
 
     logger.info(f"About to replicate ~{limited_count} (out of ~{total_count} existing) {description}.")
+    logger.info(f"Replication config: {config}")
 
     replicated_count = 0
 
@@ -174,6 +175,7 @@ def replicate_default_workspaces(replicator: Optional[RelationReplicator] = None
 
 def replicate_updated_workspaces(
     since: datetime.datetime,
+    stream: WorkspaceEventStream,
     replicator: Optional[RelationReplicator] = None,
     exclude_unchanged_default_workspaces: bool = False,
 ):
@@ -207,7 +209,7 @@ def replicate_updated_workspaces(
             Q(type=Workspace.Types.DEFAULT) & LessThanOrEqual((F("modified") - F("created")), "00:00:00.001")
         )
 
-    config = _ReplicateConfig(event_stream=WorkspaceEventStream.STANDARD, with_update_event=True)
+    config = _ReplicateConfig(event_stream=stream, with_update_event=True)
 
     _do_replicate(
         replicator=replicator,

--- a/rbac/internal/views.py
+++ b/rbac/internal/views.py
@@ -2950,6 +2950,12 @@ def replicate_updated_workspaces(request):
     Returns:
         JSON response indicating the task has been queued
     """
+    if "since" not in request.GET:
+        return JsonResponse({"field": "since", "detail": 'missing query parameter "since"'}, status=400)
+
+    if "stream" not in request.GET:
+        return JsonResponse({"field": "since", "detail": 'missing query parameter "stream"'}, status=400)
+
     since = request.GET["since"]
     stream = request.GET["stream"]
     exclude_unchanged_default_workspaces = (

--- a/rbac/internal/views.py
+++ b/rbac/internal/views.py
@@ -2954,7 +2954,7 @@ def replicate_updated_workspaces(request):
         return JsonResponse({"field": "since", "detail": 'missing query parameter "since"'}, status=400)
 
     if "stream" not in request.GET:
-        return JsonResponse({"field": "since", "detail": 'missing query parameter "stream"'}, status=400)
+        return JsonResponse({"field": "stream", "detail": 'missing query parameter "stream"'}, status=400)
 
     since = request.GET["since"]
     stream = request.GET["stream"]

--- a/rbac/internal/views.py
+++ b/rbac/internal/views.py
@@ -2939,14 +2939,19 @@ def replicate_default_workspaces(request):
 def replicate_updated_workspaces(request):
     """Replicate workspaces updated since the provided time.
 
-    POST /_private/api/utils/replicate_updated_workspaces/?since=<timestamp>&exclude_unchanged_default_workspaces=<bool>
+    POST /_private/api/utils/replicate_updated_workspaces/
+        ?since=<timestamp>
+        &stream=<stream>
+        &exclude_unchanged_default_workspaces=<bool>
 
     since must be an ISO 8601 datetime string (e.g. 2026-01-01T18:00:00Z).
+    stream must be either "standard" or "bulk".
 
     Returns:
         JSON response indicating the task has been queued
     """
     since = request.GET["since"]
+    stream = request.GET["stream"]
     exclude_unchanged_default_workspaces = (
         request.GET.get("exclude_unchanged_default_workspaces", "false").lower() == "true"
     )
@@ -2956,14 +2961,21 @@ def replicate_updated_workspaces(request):
     except ValueError as e:
         return JsonResponse({"field": "since", "detail": f"invalid datetime: {str(e)}"}, status=400)
 
+    if stream not in ("standard", "bulk"):
+        return JsonResponse({"field": "stream", "detail": f"invalid stream name: {stream}"}, status=400)
+
     try:
         replicate_updated_workspaces_in_worker.delay(
-            since=since, exclude_unchanged_default_workspaces=exclude_unchanged_default_workspaces
+            since=since,
+            stream=stream,
+            exclude_unchanged_default_workspaces=exclude_unchanged_default_workspaces,
         )
+
         return JsonResponse(
             {
                 "message": "Replication enqueued in background worker.",
                 "since": since,
+                "stream": stream,
                 "exclude_unchanged_default_workspaces": exclude_unchanged_default_workspaces,
             },
             status=202,

--- a/rbac/management/tasks.py
+++ b/rbac/management/tasks.py
@@ -448,9 +448,10 @@ def replicate_default_workspaces_in_worker(limit: Optional[int] = None):
 
 
 @shared_task
-def replicate_updated_workspaces_in_worker(since: str, exclude_unchanged_default_workspaces: bool):
+def replicate_updated_workspaces_in_worker(since: str, stream: str, exclude_unchanged_default_workspaces: bool):
     """Celery task to replicate updated workspaces."""
     from internal.migrations.replicate_workspaces import replicate_updated_workspaces
+    from management.relation_replicator.relation_replicator import WorkspaceEventStream
 
     # Admin action - SEC-MON-REQ-1 compliance (EOI-3 admin_action, EOI-2 system_object_manipulation)
     logger.info(
@@ -461,12 +462,23 @@ def replicate_updated_workspaces_in_worker(since: str, exclude_unchanged_default
             "outcome": "in_progress",
             "principal": "system:celery:replicate_updated_workspaces",
             "since": since,
+            "stream": stream,
         },
     )
+
+    if stream == "standard":
+        parsed_stream = WorkspaceEventStream.STANDARD
+    elif stream == "bulk":
+        parsed_stream = WorkspaceEventStream.BULK
+    else:
+        raise ValueError(f"Unknown stream name: {stream}")
+
     result = replicate_updated_workspaces(
         since=datetime.datetime.fromisoformat(since),
+        stream=parsed_stream,
         exclude_unchanged_default_workspaces=exclude_unchanged_default_workspaces,
     )
+
     logger.info(
         "Celery task completed: Replicate updated workspaces",
         extra={
@@ -476,6 +488,7 @@ def replicate_updated_workspaces_in_worker(since: str, exclude_unchanged_default
             "principal": "system:celery:replicate_updated_workspaces",
         },
     )
+
     return result
 
 

--- a/tests/internal/migrations/test_replicate_workspaces.py
+++ b/tests/internal/migrations/test_replicate_workspaces.py
@@ -103,12 +103,15 @@ class ReplicateUpdatedWorkspacesTest(TestCase):
         self.workspace.modified = "2026-06-25T00:00:00Z"
         self.workspace.save()
 
-    def _do_replicate(self, **kwargs) -> list[WorkspaceEvent]:
+    def _do_replicate(self, stream: WorkspaceEventStream, **kwargs) -> list[WorkspaceEvent]:
         replicator = WorkspaceCacheReplicator(NoopReplicator())
-        replicate_updated_workspaces(replicator=replicator, **kwargs)
+        replicate_updated_workspaces(replicator=replicator, stream=stream, **kwargs)
 
-        self.assertEqual(len(replicator.workspace_events_for(WorkspaceEventStream.BULK)), 0)
-        return replicator.workspace_events_for(WorkspaceEventStream.STANDARD)
+        for possible_stream in WorkspaceEventStream:
+            if possible_stream != stream:
+                self.assertCountEqual([], replicator.workspace_events_for(possible_stream))
+
+        return replicator.workspace_events_for(stream)
 
     def _assert_event_ids(self, events: list[WorkspaceEvent], ids: Iterable[str]):
         ids = set(ids)
@@ -137,16 +140,34 @@ class ReplicateUpdatedWorkspacesTest(TestCase):
         self.assertEqual(ids_created, ids)
 
     def test_replication(self):
-        events = self._do_replicate(since=datetime.datetime.fromisoformat("2026-06-23T00:00:00Z"))
+        events = self._do_replicate(
+            stream=WorkspaceEventStream.STANDARD,
+            since=datetime.datetime.fromisoformat("2026-06-23T00:00:00Z"),
+        )
+
+        self._assert_event_ids(events, [str(self.default_workspace.id), str(self.workspace.id)])
+
+    def test_replication_bulk(self):
+        events = self._do_replicate(
+            stream=WorkspaceEventStream.BULK,
+            since=datetime.datetime.fromisoformat("2026-06-23T00:00:00Z"),
+        )
+
         self._assert_event_ids(events, [str(self.default_workspace.id), str(self.workspace.id)])
 
     def test_exclude_past_modified(self):
-        events = self._do_replicate(since=datetime.datetime.fromisoformat("2026-06-24T12:00:00Z"))
+        events = self._do_replicate(
+            stream=WorkspaceEventStream.STANDARD,
+            since=datetime.datetime.fromisoformat("2026-06-24T12:00:00Z"),
+        )
+
         self._assert_event_ids(events, [str(self.workspace.id)])
 
     def test_exclude_unmodified_default_workspace(self):
         events = self._do_replicate(
-            since=datetime.datetime.fromisoformat("2026-06-23T00:00:00Z"), exclude_unchanged_default_workspaces=True
+            stream=WorkspaceEventStream.STANDARD,
+            since=datetime.datetime.fromisoformat("2026-06-23T00:00:00Z"),
+            exclude_unchanged_default_workspaces=True,
         )
 
         self._assert_event_ids(events, [str(self.workspace.id)])
@@ -156,7 +177,9 @@ class ReplicateUpdatedWorkspacesTest(TestCase):
         self.default_workspace.save()
 
         events = self._do_replicate(
-            since=datetime.datetime.fromisoformat("2026-06-24T12:00:00Z"), exclude_unchanged_default_workspaces=True
+            stream=WorkspaceEventStream.STANDARD,
+            since=datetime.datetime.fromisoformat("2026-06-24T12:00:00Z"),
+            exclude_unchanged_default_workspaces=True,
         )
 
         self._assert_event_ids(events, [str(self.default_workspace.id), str(self.workspace.id)])


### PR DESCRIPTION
## Link(s) to Jira
[RHCLOUD-48737](https://redhat.atlassian.net/browse/RHCLOUD-48737)

## Description of Intent of Change(s)
In order to avoid replication lag, we want to avoid replicating hundreds of thousands of workspace events to the standard stream. To do this, we can replicate any workspaces updated since the initial relevant time to the BULK stream (potentially introducing inconsistency for any workspaces updated since the migration started), then, once the migration finishes, only replicate any workspaces updated *since the first migration started* to the standard stream, avoiding the vast majority of the lag.

[RHCLOUD-48737]: https://redhat.atlassian.net/browse/RHCLOUD-48737?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Workspace replication now supports selecting either the Standard or Bulk event stream.
  - Replication responses include the selected stream for clearer status tracking.

- **Bug Fixes**
  - Requests missing the required `since` parameter now return a clear validation error.
  - Invalid stream values are rejected with an appropriate error instead of being processed.
  - Replication events are now routed to the selected stream consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->