### PR TITLE
[RHCLOUD-49129] Revert "Merge pull request #3243 from astrozzc/revert"

### DIFF
--- a/docs/source/specs/typespec/main.tsp
+++ b/docs/source/specs/typespec/main.tsp
@@ -554,6 +554,10 @@ namespace Workspaces {
         @doc("Sort by specified field(s), prefix with '-' for descending order. Allowed fields: name, created, modified, type.")
         @example("-created")
         @query order_by?: string = "name";
+
+        @doc("When true, list responses include ancestor workspaces for tree navigation and fallback workspaces (root, default, ungrouped) when the user has no explicit access. When false (default), only workspaces with explicit Inventory permission are returned.")
+        @example(false)
+        @query with_ancestry?: boolean = false;
     ): WorkspaceListResponse | Problems.CommonProblems;
 
     @doc("Create workspace in tenant")
@@ -753,6 +757,9 @@ namespace Workspaces {
 
         @doc("Filter by parent workspace UUID.")
         parent_id?: UUID;
+
+        @doc("Include ancestor and fallback workspaces in the response.")
+        with_ancestry?: boolean = false;
     }
 
     @doc("Query workspaces by a list of IDs")

--- a/docs/source/specs/v2/openapi.json
+++ b/docs/source/specs/v2/openapi.json
@@ -1924,6 +1924,17 @@
               "default": "name"
             },
             "explode": false
+          },
+          {
+            "name": "with_ancestry",
+            "in": "query",
+            "required": false,
+            "description": "When true, list responses include ancestor workspaces for tree navigation and fallback workspaces (root, default, ungrouped) when the user has no explicit access. When false (default), only workspaces with explicit Inventory permission are returned.",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            },
+            "explode": false
           }
         ],
         "responses": {
@@ -4427,6 +4438,11 @@
               }
             ],
             "description": "Filter by parent workspace UUID."
+          },
+          "with_ancestry": {
+            "type": "boolean",
+            "description": "Include ancestor and fallback workspaces in the response.",
+            "default": false
           }
         },
         "example": {

--- a/docs/source/specs/v2/openapi.yaml
+++ b/docs/source/specs/v2/openapi.yaml
@@ -1220,6 +1220,14 @@ paths:
             type: string
             default: name
           explode: false
+        - name: with_ancestry
+          in: query
+          required: false
+          description: When true, list responses include ancestor workspaces for tree navigation and fallback workspaces (root, default, ungrouped) when the user has no explicit access. When false (default), only workspaces with explicit Inventory permission are returned.
+          schema:
+            type: boolean
+            default: false
+          explode: false
       responses:
         '200':
           description: The request has succeeded.
@@ -2885,6 +2893,10 @@ components:
           allOf:
             - $ref: '#/components/schemas/UUID'
           description: Filter by parent workspace UUID.
+        with_ancestry:
+          type: boolean
+          description: Include ancestor and fallback workspaces in the response.
+          default: false
       example:
         ids:
           - e4277742-b91c-43f1-a185-b827e8574345

--- a/rbac/management/permissions/workspace_access.py
+++ b/rbac/management/permissions/workspace_access.py
@@ -181,9 +181,9 @@ class WorkspaceAccessPermission(permissions.BasePermission):
 
         # For list/detail operations, allow request to proceed
         # FilterBackend handles access filtering via queryset
-        # For list: users with no real workspace access get fallback workspaces
-        # (root, default, ungrouped) via FilterBackend instead of 403
-        # This ensures 404 for both non-existing and inaccessible workspaces
+        # For list with with_ancestry=true: users get fallback workspaces (root, default, ungrouped)
+        # For list with with_ancestry=false: FilterBackend raises 403 if user has no access
+        # For detail: 404 for both non-existing and inaccessible workspaces
         return True
 
     def _has_permission_v1(self, request, view, ws_id) -> bool:

--- a/rbac/management/workspace/filters.py
+++ b/rbac/management/workspace/filters.py
@@ -22,6 +22,7 @@ from feature_flags import FEATURE_FLAGS
 from management.workspace.utils import permission_from_request
 from management.workspace.utils.access import is_user_allowed_v2
 from rest_framework import filters
+from rest_framework.exceptions import PermissionDenied
 
 logger = logging.getLogger(__name__)
 
@@ -76,8 +77,9 @@ class WorkspaceAccessFilterBackend(filters.BaseFilterBackend):
         # Call is_user_allowed_v2 - handles both list and detail cases
         # Side effect: when workspace_id is None (list actions), is_user_allowed_v2 sets
         # request.permission_tuples with accessible workspace IDs, used for filtering below
+        with_ancestry = getattr(request, "with_ancestry", False) if workspace_id is None else False
         try:
-            has_access = is_user_allowed_v2(request, relation, workspace_id)
+            has_access = is_user_allowed_v2(request, relation, workspace_id, with_ancestry=with_ancestry)
         except Exception as e:
             logger.exception(
                 "Exception in is_user_allowed_v2: user=%s, org_id=%s, workspace_id=%s, relation=%s, error=%s",
@@ -95,6 +97,8 @@ class WorkspaceAccessFilterBackend(filters.BaseFilterBackend):
 
         # For list actions: check access decision first, then filter by permission_tuples
         if not has_access:
+            if not with_ancestry:
+                raise PermissionDenied("You do not have permission to perform this action.")
             return queryset.none()
 
         # If permission_tuples is set, filter by those IDs

--- a/rbac/management/workspace/serializer.py
+++ b/rbac/management/workspace/serializer.py
@@ -103,6 +103,11 @@ class WorkspaceListInputSerializer(_WorkspaceFilterValidationMixin, serializers.
     )
     parent_id = serializers.CharField(required=False, allow_blank=True, help_text="Filter by parent workspace ID")
     ids = serializers.CharField(required=False, allow_blank=True, help_text="Filter by comma-separated workspace IDs")
+    with_ancestry = serializers.BooleanField(
+        required=False,
+        default=False,
+        help_text="Include ancestor and fallback workspaces (root, default, ungrouped) in the response.",
+    )
 
     def validate_parent_id(self, value: str | None) -> str | None:
         """Return None for empty values, validate UUID format otherwise."""
@@ -161,6 +166,11 @@ class WorkspaceQueryInputSerializer(_WorkspaceFilterValidationMixin, serializers
         ),
     )
     parent_id = serializers.UUIDField(required=False, help_text="Filter by parent workspace ID")
+    with_ancestry = serializers.BooleanField(
+        required=False,
+        default=False,
+        help_text="Include ancestor and fallback workspaces (root, default, ungrouped) in the response.",
+    )
 
     def validate_ids(self, value: list) -> list[str]:
         """Convert UUIDs to lowercase strings and deduplicate."""

--- a/rbac/management/workspace/utils/access.py
+++ b/rbac/management/workspace/utils/access.py
@@ -228,7 +228,7 @@ def is_user_allowed_v1(request, required_operation, target_workspace):
     return any(valid_perm_tuple in tuple_set for valid_perm_tuple in valid_perm_tuples)
 
 
-def is_user_allowed_v2(request, required_operation, target_workspace):
+def is_user_allowed_v2(request, required_operation, target_workspace, with_ancestry=False):
     """
     Check if the user is allowed to perform the required permission on the target workspace using Inventory API.
 
@@ -238,6 +238,10 @@ def is_user_allowed_v2(request, required_operation, target_workspace):
         request: The HTTP request object
         required_operation: The operation/relation to check (view, create, edit, move, delete)
         target_workspace: The workspace ID to check, or None for list operations
+        with_ancestry: For list operations only. When True, include ancestor workspaces for
+            tree navigation and fallback workspaces (root, default, ungrouped) when the user
+            has no explicit access. When False, return only workspaces with explicit Inventory
+            permission.
 
     Returns:
         bool: True if the user has permission, False otherwise
@@ -361,11 +365,6 @@ def is_user_allowed_v2(request, required_operation, target_workspace):
             accessible_workspace_ids = set(accessible_workspace_ids)
 
             if accessible_workspace_ids:
-                # User has actual workspace permissions (not just fallbacks)
-                request.has_real_workspace_access = True
-
-                # Add ancestors only from the top-level workspace(s) in accessible workspaces (for ancestry needs)
-                # Get workspace objects for accessible IDs
                 with record_timing(timings, "db_filter_accessible_workspaces"):
                     accessible_workspaces = Workspace.objects.filter(
                         id__in=accessible_workspace_ids, tenant=request.tenant
@@ -373,40 +372,39 @@ def is_user_allowed_v2(request, required_operation, target_workspace):
 
                 if not accessible_workspaces.exists():
                     # Inventory can return workspace ids that are not present in RBAC for this tenant
-                    # (replication lag, stale tuples, cross-env mismatch). Treat like no workspace access
-                    # so the list API still returns root/default/ungrouped like users with no permissions.
+                    # (replication lag, stale tuples, cross-env mismatch). Treat like no workspace access.
                     logger.info(
                         "StreamedListObjects returned %s workspace id(s) but none exist for this tenant; "
                         "using fallback workspaces",
                         len(accessible_workspace_ids),
                     )
-                    request.has_real_workspace_access = False
-                    with record_timing(timings, "get_fallback_workspace_ids"):
-                        accessible_workspace_ids = get_fallback_workspace_ids(request.tenant)
+                    if with_ancestry:
+                        with record_timing(timings, "get_fallback_workspace_ids"):
+                            accessible_workspace_ids = get_fallback_workspace_ids(request.tenant)
+                    else:
+                        accessible_workspace_ids = set()
                 else:
-                    # Keep only ids that exist for this tenant; drop stale Inventory-only ids
                     accessible_workspace_ids = {str(wid) for wid in accessible_workspaces.values_list("id", flat=True)}
 
-                    # Find the top-level workspace(s) - those that are not children of any other accessible workspace
-                    with record_timing(timings, "filter_top_level_workspaces"):
-                        top_level_workspaces = filter_top_level_workspaces(accessible_workspaces)
+                    if with_ancestry:
+                        with record_timing(timings, "filter_top_level_workspaces"):
+                            top_level_workspaces = filter_top_level_workspaces(accessible_workspaces)
 
-                    with record_timing(timings, "add_ancestor_ids"):
-                        top_level_ids = list(top_level_workspaces.values_list("id", flat=True))
-                        if top_level_ids:
-                            ancestor_ids = Workspace.objects.ancestor_ids_for_workspaces(
-                                top_level_ids, request.tenant.id
-                            )
-                            accessible_workspace_ids.update(ancestor_ids)
-            else:
-                # User has no actual workspace permissions, only fallback access
-                request.has_real_workspace_access = False
-
-                # If no accessible workspaces, attach at least root, default, and ungrouped workspaces
+                        with record_timing(timings, "add_ancestor_ids"):
+                            top_level_ids = list(top_level_workspaces.values_list("id", flat=True))
+                            if top_level_ids:
+                                ancestor_ids = Workspace.objects.ancestor_ids_for_workspaces(
+                                    top_level_ids, request.tenant.id
+                                )
+                                accessible_workspace_ids.update(ancestor_ids)
+            elif with_ancestry:
                 with record_timing(timings, "get_fallback_workspace_ids"):
                     accessible_workspace_ids = get_fallback_workspace_ids(request.tenant)
 
-            # Store permission tuples for later filtering
+            # Store permission tuples for later filtering.
+            # Note: the contents depend on with_ancestry — with_ancestry=true includes
+            # ancestor and fallback IDs, while false includes only explicitly granted IDs.
+            # Do not cache or reuse these tuples across requests with different with_ancestry values.
             request.permission_tuples = [(None, ws_id) for ws_id in accessible_workspace_ids]
 
             result = bool(accessible_workspace_ids)

--- a/rbac/management/workspace/view.py
+++ b/rbac/management/workspace/view.py
@@ -345,6 +345,11 @@ class WorkspaceViewSet(WorkspaceObjectAccessMixin, BaseV2ViewSet):
         queryset-level WorkspaceAccessFilterBackend is intentionally bypassed on cache hit
         because root/default workspaces are never access-restricted within a tenant.
         """
+        # Bridge param to access layer; read by WorkspaceAccessFilterBackend
+        # via getattr(request, "with_ancestry", False) and passed to
+        # is_user_allowed_v2(with_ancestry=...).
+        self.request.with_ancestry = validated_params.get("with_ancestry", False)
+
         org_id = self._get_org_id(self.request)
         cacheable_type = is_cacheable_builtin_type(validated_params)
 

--- a/tests/management/workspace/test_filters.py
+++ b/tests/management/workspace/test_filters.py
@@ -67,7 +67,7 @@ class WorkspaceAccessFilterBackendUnitTests(TransactionTestCase):
         mock_flags.is_workspace_access_check_v2_enabled.return_value = True
 
         # Mock is_user_allowed_v2 to set permission_tuples on request
-        def set_permission_tuples(req, relation, target_workspace):
+        def set_permission_tuples(req, relation, target_workspace, with_ancestry=False):
             req.permission_tuples = [(None, "ws-1"), (None, "ws-2")]
             return True
 
@@ -86,7 +86,7 @@ class WorkspaceAccessFilterBackendUnitTests(TransactionTestCase):
         self.assertIsNone(call_args[0][2])  # target_workspace should be None
 
         # Should filter queryset by accessible IDs
-        queryset.filter.assert_called()
+        queryset.filter.assert_called_once_with(id__in={"ws-1", "ws-2"})
 
     @patch("management.workspace.filters.is_user_allowed_v2")
     @patch("management.workspace.filters.FEATURE_FLAGS")
@@ -373,7 +373,7 @@ class WorkspaceFilterBackendIntegrationTests(TransactionIdentityRequest):
         return_value=True,
     )
     def test_list_returns_fallback_workspaces_when_no_real_access(self, mock_flag, mock_channel):
-        """Test that list returns 200 with fallback workspaces when user has no real workspace access in V2 mode."""
+        """with_ancestry=true returns fallback workspaces when user has no real workspace access."""
         mock_stub = MagicMock()
         mock_channel.return_value.__enter__.return_value = MagicMock()
 
@@ -389,7 +389,7 @@ class WorkspaceFilterBackendIntegrationTests(TransactionIdentityRequest):
 
             url = reverse("v2_management:workspace-list")
             client = APIClient()
-            response = client.get(url, format="json", **headers)
+            response = client.get(f"{url}?with_ancestry=true", format="json", **headers)
 
             # Should return 200 with fallback workspaces (root, default, ungrouped)
             self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -406,7 +406,7 @@ class WorkspaceFilterBackendIntegrationTests(TransactionIdentityRequest):
         return_value=True,
     )
     def test_v2_list_non_admin_without_inventory_access_includes_root_and_default(self, mock_flag, mock_channel):
-        """Users with no workspace relations in Inventory still list root and default (and ungrouped) workspaces."""
+        """with_ancestry=true: users with no Inventory access still list root, default, and ungrouped."""
         mock_stub = MagicMock()
         mock_channel.return_value.__enter__.return_value = MagicMock()
         mock_stub.StreamedListObjects.return_value = iter([])
@@ -417,7 +417,8 @@ class WorkspaceFilterBackendIntegrationTests(TransactionIdentityRequest):
         ):
             request_context = self._create_request_context(self.customer_data, self.user_data, is_org_admin=False)
             headers = request_context["request"].META
-            response = APIClient().get(reverse("v2_management:workspace-list"), format="json", **headers)
+            url = reverse("v2_management:workspace-list")
+            response = APIClient().get(f"{url}?with_ancestry=true", format="json", **headers)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         types_by_id = {str(row["id"]): row["type"] for row in response.data["data"]}
@@ -431,7 +432,7 @@ class WorkspaceFilterBackendIntegrationTests(TransactionIdentityRequest):
         return_value=True,
     )
     def test_list_returns_fallback_when_inventory_ids_missing_in_rbac_db(self, mock_flag, mock_channel):
-        """Inventory IDs with no matching Workspace row for this tenant fall back to root/default/ungrouped."""
+        """with_ancestry=true: stale Inventory IDs fall back to root/default/ungrouped."""
         mock_stub = MagicMock()
         mock_channel.return_value.__enter__.return_value = MagicMock()
         orphan_id = uuid4()
@@ -445,7 +446,8 @@ class WorkspaceFilterBackendIntegrationTests(TransactionIdentityRequest):
         ):
             request_context = self._create_request_context(self.customer_data, self.user_data, is_org_admin=False)
             headers = request_context["request"].META
-            response = APIClient().get(reverse("v2_management:workspace-list"), format="json", **headers)
+            url = reverse("v2_management:workspace-list")
+            response = APIClient().get(f"{url}?with_ancestry=true", format="json", **headers)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         returned_ids = {str(ws["id"]) for ws in response.data["data"]}
@@ -453,6 +455,142 @@ class WorkspaceFilterBackendIntegrationTests(TransactionIdentityRequest):
         self.assertIn(str(self.default_workspace.id), returned_ids)
         self.assertIn(str(self.ungrouped_workspace.id), returned_ids)
         self.assertNotIn(str(orphan_id), returned_ids)
+
+    @patch("management.inventory_client.create_client_channel_inventory")
+    @patch(
+        "feature_flags.FEATURE_FLAGS.is_workspace_access_check_v2_enabled",
+        return_value=True,
+    )
+    def test_list_stale_inventory_ids_returns_403_without_ancestry(self, mock_flag, mock_channel):
+        """with_ancestry=false: stale Inventory IDs return 403, not fallback."""
+        mock_stub = MagicMock()
+        mock_channel.return_value.__enter__.return_value = MagicMock()
+        orphan_id = uuid4()
+        mock_stub.StreamedListObjects.side_effect = lambda *args, **kwargs: iter(
+            self._create_mock_workspace_responses([orphan_id])
+        )
+
+        with patch(
+            "kessel.inventory.v1beta2.inventory_service_pb2_grpc.KesselInventoryServiceStub",
+            return_value=mock_stub,
+        ):
+            request_context = self._create_request_context(self.customer_data, self.user_data, is_org_admin=False)
+            headers = request_context["request"].META
+            url = reverse("v2_management:workspace-list")
+            response = APIClient().get(f"{url}?with_ancestry=false", format="json", **headers)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    @patch("management.inventory_client.create_client_channel_inventory")
+    @patch(
+        "feature_flags.FEATURE_FLAGS.is_workspace_access_check_v2_enabled",
+        return_value=True,
+    )
+    def test_list_defaults_to_without_ancestry_when_param_omitted(self, mock_flag, mock_channel):
+        """Omitting with_ancestry defaults to false: only explicitly accessible workspaces returned."""
+        mock_stub = MagicMock()
+        mock_channel.return_value.__enter__.return_value = MagicMock()
+        mock_stub.StreamedListObjects.side_effect = lambda *args, **kwargs: iter(
+            self._create_mock_workspace_responses([self.standard_workspace.id])
+        )
+
+        with patch(
+            "kessel.inventory.v1beta2.inventory_service_pb2_grpc.KesselInventoryServiceStub",
+            return_value=mock_stub,
+        ):
+            request_context = self._create_request_context(self.customer_data, self.user_data, is_org_admin=False)
+            headers = request_context["request"].META
+            url = reverse("v2_management:workspace-list")
+            response = APIClient().get(url, format="json", **headers)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn("meta", response.data)
+        self.assertIn("data", response.data)
+        returned_ids = {str(ws["id"]) for ws in response.data["data"]}
+        self.assertEqual(returned_ids, {str(self.standard_workspace.id)})
+
+    @patch("management.inventory_client.create_client_channel_inventory")
+    @patch(
+        "feature_flags.FEATURE_FLAGS.is_workspace_access_check_v2_enabled",
+        return_value=True,
+    )
+    def test_list_without_ancestry_returns_only_explicitly_accessible(self, mock_flag, mock_channel):
+        """with_ancestry=false returns only workspaces Inventory explicitly granted, no ancestors."""
+        mock_stub = MagicMock()
+        mock_channel.return_value.__enter__.return_value = MagicMock()
+        mock_stub.StreamedListObjects.side_effect = lambda *args, **kwargs: iter(
+            self._create_mock_workspace_responses([self.standard_workspace.id])
+        )
+
+        with patch(
+            "kessel.inventory.v1beta2.inventory_service_pb2_grpc.KesselInventoryServiceStub",
+            return_value=mock_stub,
+        ):
+            request_context = self._create_request_context(self.customer_data, self.user_data, is_org_admin=False)
+            headers = request_context["request"].META
+            url = reverse("v2_management:workspace-list")
+            response = APIClient().get(f"{url}?with_ancestry=false", format="json", **headers)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn("meta", response.data)
+        self.assertIn("data", response.data)
+        returned_ids = {str(ws["id"]) for ws in response.data["data"]}
+        self.assertEqual(returned_ids, {str(self.standard_workspace.id)})
+
+    @patch("management.inventory_client.create_client_channel_inventory")
+    @patch(
+        "feature_flags.FEATURE_FLAGS.is_workspace_access_check_v2_enabled",
+        return_value=True,
+    )
+    def test_list_without_ancestry_returns_403_when_no_access(self, mock_flag, mock_channel):
+        """with_ancestry=false returns 403 when user has no workspace access."""
+        mock_stub = MagicMock()
+        mock_channel.return_value.__enter__.return_value = MagicMock()
+        mock_stub.StreamedListObjects.return_value = iter([])
+
+        with patch(
+            "kessel.inventory.v1beta2.inventory_service_pb2_grpc.KesselInventoryServiceStub",
+            return_value=mock_stub,
+        ):
+            request_context = self._create_request_context(self.customer_data, self.user_data, is_org_admin=False)
+            headers = request_context["request"].META
+            url = reverse("v2_management:workspace-list")
+            response = APIClient().get(f"{url}?with_ancestry=false", format="json", **headers)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    @patch("management.inventory_client.create_client_channel_inventory")
+    @patch(
+        "feature_flags.FEATURE_FLAGS.is_workspace_access_check_v2_enabled",
+        return_value=True,
+    )
+    def test_list_with_ancestry_excludes_sibling_workspaces(self, mock_flag, mock_channel):
+        """with_ancestry=true includes ancestors but not sibling workspaces the user lacks access to."""
+        sibling_workspace = self.service.create(
+            {"name": "Sibling Workspace", "description": "Sibling", "parent_id": self.default_workspace.id},
+            self.tenant,
+        )
+        mock_stub = MagicMock()
+        mock_channel.return_value.__enter__.return_value = MagicMock()
+        mock_stub.StreamedListObjects.side_effect = lambda *args, **kwargs: iter(
+            self._create_mock_workspace_responses([self.standard_workspace.id])
+        )
+
+        with patch(
+            "kessel.inventory.v1beta2.inventory_service_pb2_grpc.KesselInventoryServiceStub",
+            return_value=mock_stub,
+        ):
+            request_context = self._create_request_context(self.customer_data, self.user_data, is_org_admin=False)
+            headers = request_context["request"].META
+            url = reverse("v2_management:workspace-list")
+            response = APIClient().get(f"{url}?with_ancestry=true", format="json", **headers)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        returned_ids = {str(ws["id"]) for ws in response.data["data"]}
+        self.assertIn(str(self.standard_workspace.id), returned_ids)
+        self.assertIn(str(self.default_workspace.id), returned_ids)
+        self.assertIn(str(self.root_workspace.id), returned_ids)
+        self.assertNotIn(str(sibling_workspace.id), returned_ids)
 
     @patch(
         "feature_flags.FEATURE_FLAGS.is_workspace_access_check_v2_enabled",

--- a/tests/management/workspace/test_serializer.py
+++ b/tests/management/workspace/test_serializer.py
@@ -326,3 +326,29 @@ class WorkspaceListInputSerializerTest(TestCase):
         s = WorkspaceListInputSerializer(data={"ids": "abc\x00def"})
         self.assertFalse(s.is_valid())
         self.assertIn("ids", s.errors)
+
+    # --- with_ancestry ---
+
+    def test_with_ancestry_omitted_defaults_to_false(self):
+        """Test that omitting with_ancestry defaults to false."""
+        s = WorkspaceListInputSerializer(data={})
+        self.assertTrue(s.is_valid(), s.errors)
+        self.assertFalse(s.validated_data["with_ancestry"])
+
+    def test_with_ancestry_true_string(self):
+        """Test that with_ancestry=true is accepted."""
+        s = WorkspaceListInputSerializer(data={"with_ancestry": "true"})
+        self.assertTrue(s.is_valid(), s.errors)
+        self.assertTrue(s.validated_data["with_ancestry"])
+
+    def test_with_ancestry_false_string(self):
+        """Test that with_ancestry=false is accepted."""
+        s = WorkspaceListInputSerializer(data={"with_ancestry": "false"})
+        self.assertTrue(s.is_valid(), s.errors)
+        self.assertFalse(s.validated_data["with_ancestry"])
+
+    def test_with_ancestry_invalid_value(self):
+        """Test that invalid with_ancestry values are rejected."""
+        s = WorkspaceListInputSerializer(data={"with_ancestry": "maybe"})
+        self.assertFalse(s.is_valid())
+        self.assertIn("with_ancestry", s.errors)

--- a/tests/management/workspace/test_view.py
+++ b/tests/management/workspace/test_view.py
@@ -3962,13 +3962,14 @@ class WorkspaceTestsQuery(WorkspaceViewTests):
         self.assertIn("next", links)
         self.assertIn("last", links)
 
-    def test_query_returns_requested_workspace(self):
-        """Query returns workspaces matching the requested IDs."""
+    def test_query_with_ancestry(self):
+        """Query with with_ancestry=true includes ancestor/fallback workspaces."""
         client = APIClient()
         response = client.post(
             self._query_url(),
             data={
                 "ids": [str(self.standard_workspace.id)],
+                "with_ancestry": True,
             },
             format="json",
             **self.headers,
@@ -3976,6 +3977,9 @@ class WorkspaceTestsQuery(WorkspaceViewTests):
         payload = response.data
 
         self.assertSuccessfulList(response, payload)
+        # with_ancestry expands access filter to include ancestors and fallback
+        # workspaces; for admin users with full access the parameter is accepted
+        # and the response still contains the requested workspace
         returned_ids = [ws["id"] for ws in payload["data"]]
         self.assertIn(str(self.standard_workspace.id), returned_ids)
 

--- a/tests/management/workspace/test_workspace_inventory_access.py
+++ b/tests/management/workspace/test_workspace_inventory_access.py
@@ -736,7 +736,7 @@ class WorkspaceInventoryAccessV2Tests(TransactionIdentityRequest):
 
             url = reverse("v2_management:workspace-list")
             client = APIClient()
-            response = client.get(url, format="json", **headers)
+            response = client.get(f"{url}?with_ancestry=true", format="json", **headers)
 
             # Should return 200 with fallback workspaces (root, default, ungrouped)
             self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -1211,7 +1211,7 @@ class WorkspaceInventoryAccessV2Tests(TransactionIdentityRequest):
 
             url = reverse("v2_management:workspace-list")
             client = APIClient()
-            response = client.get(url, format="json", **headers)
+            response = client.get(f"{url}?with_ancestry=true", format="json", **headers)
 
             # Should return 200 with fallback workspaces (root, default, ungrouped)
             self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -1321,7 +1321,7 @@ class WorkspaceInventoryAccessV2Tests(TransactionIdentityRequest):
 
             url = reverse("v2_management:workspace-list")
             client = APIClient()
-            response = client.get(url, format="json", **headers)
+            response = client.get(f"{url}?with_ancestry=true", format="json", **headers)
 
             # Should have access to the workspace and all its ancestors
             self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -1334,6 +1334,38 @@ class WorkspaceInventoryAccessV2Tests(TransactionIdentityRequest):
             self.assertIn(str(self.standard_workspace.id), returned_ids)
             self.assertIn(str(self.default_workspace.id), returned_ids)
             self.assertIn(str(self.root_workspace.id), returned_ids)
+
+    @patch("management.inventory_client.create_client_channel_inventory")
+    @patch(
+        "feature_flags.FEATURE_FLAGS.is_workspace_access_check_v2_enabled",
+        return_value=True,
+    )
+    def test_workspace_list_excludes_ancestors_when_with_ancestry_false(self, mock_flag, mock_channel):
+        """with_ancestry=false returns only the accessible workspace, not its ancestors."""
+        mock_stub = MagicMock()
+        mock_channel.return_value.__enter__.return_value = MagicMock()
+        mock_responses = self._create_mock_workspace_responses([self.standard_sub_workspace.id])
+        mock_stub.StreamedListObjects.side_effect = lambda *args, **kwargs: iter(mock_responses)
+
+        with patch(
+            "kessel.inventory.v1beta2.inventory_service_pb2_grpc.KesselInventoryServiceStub",
+            return_value=mock_stub,
+        ):
+            request_context = self._create_request_context(self.customer_data, self.user_data, is_org_admin=False)
+            headers = request_context["request"].META
+            self._setup_access_for_principal(
+                self.user_data["username"],
+                "inventory:groups:read",
+                workspace_id=str(self.standard_sub_workspace.id),
+                platform_default=False,
+            )
+
+            url = reverse("v2_management:workspace-list")
+            response = APIClient().get(f"{url}?with_ancestry=false", format="json", **headers)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        returned_ids = {str(ws["id"]) for ws in response.data["data"]}
+        self.assertEqual(returned_ids, {str(self.standard_sub_workspace.id)})
 
     @patch("management.inventory_client.create_client_channel_inventory")
     @patch(
@@ -1367,7 +1399,7 @@ class WorkspaceInventoryAccessV2Tests(TransactionIdentityRequest):
 
             url = reverse("v2_management:workspace-list")
             client = APIClient()
-            response = client.get(url, format="json", **headers)
+            response = client.get(f"{url}?with_ancestry=true", format="json", **headers)
 
             # Should return 200 with fallback workspaces (root, default, ungrouped)
             self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -2423,8 +2455,8 @@ class WorkspaceInventoryAccessV2Tests(TransactionIdentityRequest):
         "feature_flags.FEATURE_FLAGS.is_workspace_access_check_v2_enabled",
         return_value=True,
     )
-    def test_workspace_list_type_standard_returns_empty_without_real_access(self, mock_flag, mock_channel):
-        """Test that type=standard returns 200 with empty list when user has no real workspace access in V2 mode."""
+    def test_workspace_list_type_standard_returns_403_without_real_access(self, mock_flag, mock_channel):
+        """Test that type=standard returns 403 when user has no real workspace access and with_ancestry is false."""
         # Mock Inventory API to return empty list (no accessible workspaces)
         mock_stub = MagicMock()
         mock_channel.return_value.__enter__.return_value = MagicMock()
@@ -2443,13 +2475,10 @@ class WorkspaceInventoryAccessV2Tests(TransactionIdentityRequest):
             url = reverse("v2_management:workspace-list")
             client = APIClient()
 
-            # Query with type=standard - should return 200 with empty data
-            # (fallback workspaces are root/default/ungrouped, none are type=standard)
+            # Without with_ancestry, fallback workspaces are not applied
             response = client.get(f"{url}?type=standard", format="json", **headers)
 
-            self.assertEqual(response.status_code, status.HTTP_200_OK)
-            self.assertIn("data", response.data)
-            self.assertEqual(len(response.data["data"]), 0)
+            self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @patch("management.inventory_client.create_client_channel_inventory")
     @patch(
@@ -2476,8 +2505,8 @@ class WorkspaceInventoryAccessV2Tests(TransactionIdentityRequest):
             url = reverse("v2_management:workspace-list")
             client = APIClient()
 
-            # Query with type=all - should return 200 with fallback workspaces
-            response = client.get(f"{url}?type=all", format="json", **headers)
+            # Query with type=all and with_ancestry - should return 200 with fallback workspaces
+            response = client.get(f"{url}?type=all&with_ancestry=true", format="json", **headers)
 
             self.assertEqual(response.status_code, status.HTTP_200_OK)
             self.assertIn("data", response.data)
@@ -2587,8 +2616,8 @@ class WorkspaceInventoryAccessV2Tests(TransactionIdentityRequest):
         "feature_flags.FEATURE_FLAGS.is_workspace_access_check_v2_enabled",
         return_value=True,
     )
-    def test_workspace_list_no_type_returns_fallback_without_real_access(self, mock_flag, mock_channel):
-        """Test that default list (no type filter) returns fallback workspaces when user has no real workspace access."""
+    def test_workspace_list_no_type_returns_403_without_real_access(self, mock_flag, mock_channel):
+        """Test that default list (no type filter) returns 403 when user has no real workspace access."""
         # Mock Inventory API to return empty list (no accessible workspaces)
         mock_stub = MagicMock()
         mock_channel.return_value.__enter__.return_value = MagicMock()
@@ -2607,13 +2636,10 @@ class WorkspaceInventoryAccessV2Tests(TransactionIdentityRequest):
             url = reverse("v2_management:workspace-list")
             client = APIClient()
 
-            # Query without type filter - should return 200 with fallback workspaces
+            # Omitting with_ancestry defaults to false; no Inventory access returns 403
             response = client.get(url, format="json", **headers)
 
-            # Default type filter is 'standard', so fallback workspaces (root, default, ungrouped)
-            # are filtered out, resulting in empty data
-            self.assertEqual(response.status_code, status.HTTP_200_OK)
-            self.assertIn("data", response.data)
+            self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @patch("management.inventory_client.create_client_channel_inventory")
     @patch(
@@ -2640,8 +2666,8 @@ class WorkspaceInventoryAccessV2Tests(TransactionIdentityRequest):
             url = reverse("v2_management:workspace-list")
             client = APIClient()
 
-            # Query with type=root - should return root workspace from fallback
-            response = client.get(f"{url}?type=root", format="json", **headers)
+            # Query with type=root and with_ancestry - should return root workspace from fallback
+            response = client.get(f"{url}?type=root&with_ancestry=true", format="json", **headers)
 
             self.assertEqual(response.status_code, status.HTTP_200_OK)
             self.assertIn("data", response.data)
@@ -2674,8 +2700,8 @@ class WorkspaceInventoryAccessV2Tests(TransactionIdentityRequest):
             url = reverse("v2_management:workspace-list")
             client = APIClient()
 
-            # Query with type=default - should return default workspace from fallback
-            response = client.get(f"{url}?type=default", format="json", **headers)
+            # Query with type=default and with_ancestry - should return default workspace from fallback
+            response = client.get(f"{url}?type=default&with_ancestry=true", format="json", **headers)
 
             self.assertEqual(response.status_code, status.HTTP_200_OK)
             self.assertIn("data", response.data)


### PR DESCRIPTION
This reverts commit 639b96c9ec2b36bfa62c8c9f951feabc5c90fa3e, reversing changes made to a77421652bdc7a879c2e52bf97186661af0eccae.

## Link(s) to Jira
- https://redhat.atlassian.net/browse/RHCLOUD-49129

## Description of Intent of Change(s)
The what, why and how.

## Local Testing
How can the feature be exercised?
How can the bug be exploited and fix confirmed?
Is any special local setup required?

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the optional `with_ancestry` parameter to workspace list and query requests.
  * When enabled, responses can include ancestor and fallback workspaces.
  * By default, responses include only explicitly accessible workspaces.

* **Bug Fixes**
  * Improved access handling, returning permission errors when no explicit workspace access exists and ancestry is disabled.

* **Documentation**
  * Updated API specifications and behavior descriptions for ancestry-aware workspace access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->