### PR TITLE
fix(ci): skip JIRA ticket check for chore(deps) PRs [RHCLOUD-49740]

### DIFF
--- a/.github/workflows/jira-ticket-check.yml
+++ b/.github/workflows/jira-ticket-check.yml
@@ -17,6 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     if: >-
       !contains(github.event.pull_request.labels.*.name, 'bot')
+      && !startsWith(github.event.pull_request.title, 'chore(deps):')
     steps:
       - name: Check PR title for JIRA ticket
         env:


### PR DESCRIPTION
## Link(s) to Jira
- https://issues.redhat.com/browse/RHCLOUD-49740

## Summary
- Skip the JIRA ticket check for PRs with titles starting with `chore(deps):` (dependency consolidation PRs don't have JIRA tickets)
- Adds a `startsWith` condition alongside the existing `bot` label check

## Test plan
- [ ] Verify PR #3253 (`chore(deps): consolidate ...`) would no longer fail the jira-ticket-check
- [ ] Verify regular PRs without `[RHCLOUD-XXXXX]` still fail the check