### PR TITLE
[RHCLOUD-48526] Attempt to address role scope migration serialization errors

### DIFF
--- a/rbac/internal/migrations/migrate_role_scope.py
+++ b/rbac/internal/migrations/migrate_role_scope.py
@@ -20,10 +20,10 @@
 import dataclasses
 import itertools
 import logging
-from typing import Optional
+from typing import Callable, Optional
 
 from django.conf import settings
-
+from django.db import OperationalError
 from management.atomic_transactions import atomic_block, atomic_with_retry
 from management.group.model import Group
 from management.permission.scope_service import ImplicitResourceService
@@ -243,10 +243,10 @@ def _migrate_bindings_for_scope_change(context: _MigrateContext):
     migrated_cars = 0
 
     for group_batch in itertools.batched(groups, 10):
-        migrated_groups += _migrate_group_batch(context=context, groups=list(group_batch))
+        migrated_groups += migrate_batch_with_fallback(_migrate_group_batch, context, list(group_batch))
 
     for car_batch in itertools.batched(cars, 10):
-        migrated_cars += _migrate_car_batch(context=context, cars=list(car_batch))
+        migrated_cars += migrate_batch_with_fallback(_migrate_car_batch, context, list(car_batch))
 
     logger.info(
         "Completed binding migration for system role %s: %d groups and %d CARs migrated successfully",
@@ -254,6 +254,24 @@ def _migrate_bindings_for_scope_change(context: _MigrateContext):
         migrated_groups,
         migrated_cars,
     )
+
+
+def migrate_batch_with_fallback[T](
+    migrate_batch_fn: Callable[[_MigrateContext, list[T]], int], context: _MigrateContext, batch: list[T]
+) -> int:
+    try:
+        # Although migrating each entity is still done individually, it's still worth it to attempt batching because it
+        # saves us having to re-validate the migration for every single entity.
+        return migrate_batch_fn(context, batch)
+    except OperationalError:
+        logger.warning("Falling back to per-model scope migration.", exc_info=True)
+
+        migrated = 0
+
+        for model in batch:
+            migrated += migrate_batch_fn(context, [model])
+
+        return migrated
 
 
 @atomic_with_retry(retries=5)


### PR DESCRIPTION
## Link(s) to Jira
[RHCLOUD-48526](https://redhat.atlassian.net/browse/RHCLOUD-48526)

## Description of Intent of Change(s)
We're consistently experiencing serialization failures when running the role scope migration in prod. To address this, we can try (a) reducing the batch size it uses [thus reducing any contention] and (b) retrying failed batches one-by-one.

(Edit: oops, the batch size decrease was accidentally merged in [a different commit](https://github.com/project-kessel/insights-rbac/commit/c078f681d07c56e37bb590c62df08a6887dbc444), but it was meant to be in this PR.)

[RHCLOUD-48526]: https://redhat.atlassian.net/browse/RHCLOUD-48526?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved role-scope migrations by handling database errors more safely.
  * Added a fallback process that migrates records individually when batch migration is unavailable.
  * Increased migration reliability for group and CAR records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->