### PR TITLE
[RHCLOUD-32232] Add additional logging for service account requests

### DIFF
--- a/rbac/management/principal/it_service.py
+++ b/rbac/management/principal/it_service.py
@@ -214,7 +214,17 @@ class ITService:
             raise UnexpectedStatusCodeFromITError()
 
         # Extract the body contents.
-        return response.json()
+        response_body = response.json()
+
+        # TODO: remove when no longer needed
+        LOGGER.info(
+            "Made service-account request: parameters=%s; response: status=%s, body=%s",
+            parameters,
+            response.status_code,
+            response_body,
+        )
+
+        return response_body
 
     def _request_service_accounts_transformed(self, bearer_token: str, client_ids: Optional[list[str]]) -> list[dict]:
         """


### PR DESCRIPTION
## Link(s) to Jira
[RHCLOUD-32232](https://redhat.atlassian.net/browse/RHCLOUD-32232)

## Description of Intent of Change(s)
Add logging for service account requests for debugging an issue in stage.

[RHCLOUD-32232]: https://redhat.atlassian.net/browse/RHCLOUD-32232?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved diagnostic logging for service-account requests, including request details, response status, and response content.
  * No user-facing functionality or behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->