### PR TITLE
[RHCLOUD-48737] Deleted workspace re-replication

### DIFF
--- a/rbac/internal/migrations/replicate_workspaces.py
+++ b/rbac/internal/migrations/replicate_workspaces.py
@@ -8,6 +8,7 @@ from typing import Optional
 from django.db.models import F, Q, QuerySet
 from django.db.models.lookups import LessThanOrEqual
 from management.atomic_transactions import atomic_with_retry
+from management.audit_log.model import AuditLog
 from management.relation_replicator.outbox_replicator import OutboxReplicator
 from management.relation_replicator.relation_replicator import (
     RelationReplicator,
@@ -15,7 +16,9 @@ from management.relation_replicator.relation_replicator import (
     WorkspaceEventStream,
 )
 from management.workspace.model import Workspace
-from management.workspace.utils.event import make_workspace_event
+from management.workspace.utils.event import make_workspace_event, make_workspace_id_deleted_event
+
+from api.models import Tenant
 
 
 @dataclasses.dataclass(frozen=True)
@@ -217,3 +220,47 @@ def replicate_updated_workspaces(
         base_query=base_query,
         description="updated workspaces",
     )
+
+
+@dataclasses.dataclass()
+class _DeletedWorkspaceEntry:
+    tenant_id: int
+    workspace_id: uuid.UUID
+
+    def __post_init__(self):
+        if not isinstance(self.tenant_id, int):
+            raise TypeError(f"Expected tenant_id to be an int, but got: {self.tenant_id!r}")
+
+        if not isinstance(self.workspace_id, uuid.UUID):
+            raise TypeError(f"Expected workspace_id to be a UUID, but got: {self.workspace_id!r}")
+
+
+@atomic_with_retry(retries=5)
+def _replicate_deleted_batch(replicator: RelationReplicator, entries: list[_DeletedWorkspaceEntry]):
+    existing_workspaces = list(Workspace.objects.filter(id__in=(e.workspace_id for e in entries)))
+
+    # Workspace IDs are random UUIDs, so, once a workspace is deleted, its ID should never be reused.
+    if len(existing_workspaces) > 0:
+        raise AssertionError(
+            f"Attempted to re-replicate workspace deletes, but the following IDs still exist: {[str(w.id) for w in existing_workspaces]}"
+        )
+
+    tenants_by_id: dict[int, Tenant] = {t.id: t for t in Tenant.objects.filter(id__in=(e.tenant_id for e in entries))}
+
+    for entry in entries:
+        replicator.replicate_workspace(
+            make_workspace_id_deleted_event(tenant=tenants_by_id[entry.tenant_id], workspace_id=entry.workspace_id),
+            WorkspaceEventStream.BULK,
+        )
+
+
+def replicate_deleted_workspaces(since: datetime.datetime, replicator: Optional[RelationReplicator] = None):
+    if replicator is None:
+        replicator = OutboxReplicator()
+
+    delete_logs = AuditLog.objects.filter(
+        created__gte=since, resource_type="workspace", action="delete", resource_uuid__isnull=False
+    )
+
+    for batch in itertools.batched(delete_logs.iterator(), 500):
+        _replicate_deleted_batch(replicator, [_DeletedWorkspaceEntry(l.tenant_id, l.resource_uuid) for l in batch])

--- a/rbac/internal/urls.py
+++ b/rbac/internal/urls.py
@@ -132,6 +132,7 @@ urlpatterns = [
     ),
     path("api/utils/replicate_default_workspaces/", views.replicate_default_workspaces),
     path("api/utils/replicate_updated_workspaces/", views.replicate_updated_workspaces),
+    path("api/utils/replicate_deleted_workspaces/", views.replicate_deleted_workspaces),
     path("api/utils/recompute_tenant_role_bindings/<str:org_id>/", views.recompute_tenant_role_bindings),
     path("api/utils/migrate_role_scope_if_changed/<str:role_uuid>/", views.migrate_role_scope_if_changed),
     path("api/disaster_recovery/workspaces/", views.recover_workspace_events),

--- a/rbac/internal/views.py
+++ b/rbac/internal/views.py
@@ -109,6 +109,7 @@ from management.tasks import (
     remove_deleted_workspace_bindings_in_worker,
     remove_unassigned_system_binding_mappings_in_worker,
     replicate_default_workspaces_in_worker,
+    replicate_deleted_workspaces_in_worker,
     replicate_updated_workspaces_in_worker,
     run_kessel_parity_checks_in_worker,
     run_migrations_in_worker,
@@ -2989,6 +2990,42 @@ def replicate_updated_workspaces(request):
     except Exception as e:
         logger.exception("Error replicating updated workspaces", exc_info=True)
         return JsonResponse({"detail": f"Error replicating updated workspaces: {str(e)}"}, status=500)
+
+
+@require_http_methods(["POST"])
+def replicate_deleted_workspaces(request):
+    """Replicate the deletion of workspaces deleted since the provided time.
+
+    POST /_private/api/utils/replicate_deleted_workspaces/?since=<timestamp>
+
+    since must be an ISO 8601 datetime string (e.g. 2026-01-01T18:00:00Z).
+
+    Returns:
+        JSON response indicating the task has been queued
+    """
+    if "since" not in request.GET:
+        return JsonResponse({"field": "since", "detail": 'missing query parameter "since"'}, status=400)
+
+    since = request.GET["since"]
+
+    try:
+        datetime.datetime.fromisoformat(since)
+    except ValueError as e:
+        return JsonResponse({"field": "since", "detail": f"invalid datetime: {str(e)}"}, status=400)
+
+    try:
+        replicate_deleted_workspaces_in_worker.delay(since=since)
+
+        return JsonResponse(
+            {
+                "message": "Replication enqueued in background worker.",
+                "since": since,
+            },
+            status=202,
+        )
+    except Exception as e:
+        logger.exception("Error replicating deleted workspaces", exc_info=True)
+        return JsonResponse({"detail": f"Error replicating deleted workspaces: {str(e)}"}, status=500)
 
 
 @require_http_methods(["POST"])

--- a/rbac/internal/views.py
+++ b/rbac/internal/views.py
@@ -2964,7 +2964,10 @@ def replicate_updated_workspaces(request):
     )
 
     try:
-        datetime.datetime.fromisoformat(since)
+        parsed_since = datetime.datetime.fromisoformat(since)
+
+        if parsed_since.tzinfo is None:
+            return JsonResponse({"field": "since", "detail": "since time must have timezone"}, status=400)
     except ValueError as e:
         return JsonResponse({"field": "since", "detail": f"invalid datetime: {str(e)}"}, status=400)
 
@@ -3009,7 +3012,10 @@ def replicate_deleted_workspaces(request):
     since = request.GET["since"]
 
     try:
-        datetime.datetime.fromisoformat(since)
+        parsed_since = datetime.datetime.fromisoformat(since)
+
+        if parsed_since.tzinfo is None:
+            return JsonResponse({"field": "since", "detail": "since time must have timezone"}, status=400)
     except ValueError as e:
         return JsonResponse({"field": "since", "detail": f"invalid datetime: {str(e)}"}, status=400)
 

--- a/rbac/management/tasks.py
+++ b/rbac/management/tasks.py
@@ -493,6 +493,38 @@ def replicate_updated_workspaces_in_worker(since: str, stream: str, exclude_unch
 
 
 @shared_task
+def replicate_deleted_workspaces_in_worker(since: str):
+    """Celery task to replicate deleted workspaces."""
+    from internal.migrations.replicate_workspaces import replicate_deleted_workspaces
+
+    # Admin action - SEC-MON-REQ-1 compliance (EOI-3 admin_action, EOI-2 system_object_manipulation)
+    logger.info(
+        "Celery task: Replicate deleted workspaces",
+        extra={
+            "action": "REPLICATE",
+            "resource_type": "workspace",
+            "outcome": "in_progress",
+            "principal": "system:celery:replicate_deleted_workspaces",
+            "since": since,
+        },
+    )
+
+    result = replicate_deleted_workspaces(since=datetime.datetime.fromisoformat(since))
+
+    logger.info(
+        "Celery task completed: Replicate deleted workspaces",
+        extra={
+            "action": "REPLICATE",
+            "resource_type": "workspace",
+            "outcome": "success",
+            "principal": "system:celery:replicate_deleted_workspaces",
+        },
+    )
+
+    return result
+
+
+@shared_task
 def recompute_tenant_role_bindings_in_worker(org_id: str):
     """Celery task to recompute role bindings for tenant."""
     from api.models import Tenant

--- a/rbac/management/workspace/utils/event.py
+++ b/rbac/management/workspace/utils/event.py
@@ -16,11 +16,16 @@
 #
 """Workspace event utilities."""
 
+import uuid
+
 from management.relation_replicator.relation_replicator import PartitionKey, ReplicationEventType, WorkspaceEvent
+from management.utils import as_uuid
 from management.workspace.model import Workspace
 
+from api.models import Tenant
 
-def make_workspace_event(workspace: Workspace, event_type: ReplicationEventType):
+
+def make_workspace_event(workspace: Workspace, event_type: ReplicationEventType) -> WorkspaceEvent:
     """Create a WorkspaceEvent with the provided workspace and event type."""
     # To avoid circular dependency.
     from management.workspace.serializer import WorkspaceEventSerializer
@@ -37,5 +42,18 @@ def make_workspace_event(workspace: Workspace, event_type: ReplicationEventType)
         org_id=str(workspace.tenant.org_id),
         workspace=WorkspaceEventSerializer(workspace).data,
         event_type=event_type,
+        partition_key=PartitionKey.byEnvironment(),
+    )
+
+
+def make_workspace_id_deleted_event(tenant: Tenant, workspace_id: uuid.UUID | str) -> WorkspaceEvent:
+    """Create a WorkspaceEvent for deleting a workspace with the provided ID and tenant."""
+    workspace_id = str(as_uuid(workspace_id))
+
+    return WorkspaceEvent(
+        account_number=tenant.account_id,
+        org_id=str(tenant.org_id),
+        workspace={"id": workspace_id},
+        event_type=ReplicationEventType.DELETE_WORKSPACE,
         partition_key=PartitionKey.byEnvironment(),
     )

--- a/tests/internal/migrations/test_replicate_workspaces.py
+++ b/tests/internal/migrations/test_replicate_workspaces.py
@@ -1,9 +1,15 @@
 import datetime
+import uuid
 from collections.abc import Iterable
-from datetime import timezone
+from unittest.mock import MagicMock
 
 from django.test import TestCase, override_settings
-from internal.migrations.replicate_workspaces import replicate_default_workspaces, replicate_updated_workspaces
+from internal.migrations.replicate_workspaces import (
+    replicate_default_workspaces,
+    replicate_deleted_workspaces,
+    replicate_updated_workspaces,
+)
+from management.audit_log.model import AuditLog
 from management.relation_replicator.noop_replicator import NoopReplicator
 from management.relation_replicator.relation_replicator import (
     PartitionKey,
@@ -14,6 +20,7 @@ from management.relation_replicator.relation_replicator import (
 from management.tenant_service import V2TenantBootstrapService
 from management.workspace.model import Workspace
 from management.workspace.service import WorkspaceService
+from tests.management.role.test_dual_write import DualWriteTestCase
 from tests.v2_util import WorkspaceCacheReplicator, bootstrap_tenant_for_v2_test
 
 from api.models import Tenant
@@ -183,3 +190,65 @@ class ReplicateUpdatedWorkspacesTest(TestCase):
         )
 
         self._assert_event_ids(events, [str(self.default_workspace.id), str(self.workspace.id)])
+
+
+@override_settings(ATOMIC_RETRY_DISABLED=True)
+class ReplicateDeletedWorkspacesTest(DualWriteTestCase):
+    def setUp(self):
+        super().setUp()
+
+        AuditLog.objects.all().delete()
+        self.service = WorkspaceService(NoopReplicator())
+
+    def _make_delete_log(self) -> AuditLog:
+        workspace = self.service.create({"name": "a workspace"}, self.tenant)
+
+        mock_request = MagicMock()
+        mock_request.user.username = "test_user"
+        mock_request._user.org_id = self.tenant.org_id
+
+        create_log = AuditLog()
+        create_log.log_v2(mock_request, "workspace", AuditLog.CREATE, workspace.id, "")
+
+        delete_log = AuditLog()
+        delete_log.log_v2(mock_request, "workspace", AuditLog.DELETE, workspace.id, "")
+
+        self.service.destroy(workspace)
+        return delete_log
+
+    def test_remove(self):
+        log_a = self._make_delete_log()
+        log_b = self._make_delete_log()
+
+        self.assertGreater(log_b.created, log_a.created)
+
+        def test_replicate_from(since: datetime.datetime, ids: list[uuid.UUID]):
+            replicator = WorkspaceCacheReplicator(NoopReplicator())
+            replicate_deleted_workspaces(since=since, replicator=replicator)
+
+            events = replicator.workspace_events_for(WorkspaceEventStream.BULK)
+
+            self.assertCountEqual([{"id": str(u)} for u in ids], [e.workspace for e in events])
+
+            self.assertTrue(all(e.org_id == self.tenant.org_id for e in events))
+            self.assertTrue(all(e.account_number == self.tenant.account_id for e in events))
+            self.assertTrue(all(e.event_type == ReplicationEventType.DELETE_WORKSPACE for e in events))
+
+            self.assertCountEqual([], replicator.workspace_events_for(WorkspaceEventStream.STANDARD))
+
+        test_replicate_from(log_a.created, [log_a.resource_uuid, log_b.resource_uuid])
+        test_replicate_from(log_b.created, [log_b.resource_uuid])
+        test_replicate_from(log_b.created + datetime.timedelta(minutes=1), [])
+
+    def test_error_on_reused_id(self):
+        log = self._make_delete_log()
+
+        Workspace.objects.create(
+            tenant=self.tenant,
+            id=log.resource_uuid,
+            name="test workspace",
+            parent=Workspace.objects.default(tenant=self.tenant),
+        )
+
+        with self.assertRaises(AssertionError):
+            replicate_deleted_workspaces(since=log.created, replicator=NoopReplicator())


### PR DESCRIPTION
## Link(s) to Jira
[RHCLOUD-48737](https://redhat.atlassian.net/browse/RHCLOUD-48737)

## Description of Intent of Change(s)
With #3114 and #3249, we've handled re-replicating any workspaces that still exist, but workspace deletion events could also have been dropped (see the ticket). So, here we add a second job to re-replicate deletion events.

[RHCLOUD-48737]: https://redhat.atlassian.net/browse/RHCLOUD-48737?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added background replication for deleted workspaces based on audit history.
  - Added an internal endpoint to trigger deletion replication from a specified timestamp.
  - Deleted workspace events now include the workspace identifier and are published to the bulk event stream.

- **Bug Fixes**
  - Added safeguards to prevent replication when a deleted workspace identifier has been reused.

- **Tests**
  - Added coverage for successful replication, timestamp filtering, event-stream routing, and identifier reuse failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->