### PR TITLE
[RHCLOUD-32232] Request service accounts by client ID individually

### DIFF
--- a/rbac/management/principal/it_service.py
+++ b/rbac/management/principal/it_service.py
@@ -16,9 +16,7 @@
 #
 """Class to manage interactions with the IT service accounts service."""
 
-import itertools
 import logging
-import math
 import time
 import uuid
 from typing import Any, Iterable, Optional, Tuple
@@ -44,10 +42,6 @@ IT_PATH_GET_SERVICE_ACCOUNTS = "/service_accounts/v1"
 
 # Maximum number of service accounts to request at once. This is a limit set by the IT service.
 IT_SERVICE_ACCOUNT_BATCH_SIZE = 100
-
-# Maximum number of different service account client IDs to request from IT at once.
-# This is a limit set by the IT service.
-IT_SERVICE_ACCOUNT_MAX_CLIENT_IDS = 10
 
 # Set up the metrics for the IT calls.
 it_request_all_service_accounts_time_tracking = Histogram(
@@ -123,38 +117,33 @@ class ITService:
                 return []
 
             # We want to minimize the number of requests we make. At time of writing, we can request up to 100 service
-            # accounts at once. However, we can only specify at most 10 client IDs as query parameters.
+            # accounts at once. However, we can only specify a single client ID as a query parameter.
             #
-            # So, if we make requests with client IDs, we make ceil(len(client_ids) / 10) requests. If we make requests
-            # without client IDs, we make ceil([# of service accounts in IT] / 100) requests. So, we should only pass
-            # client IDs if the number of IDs is less than 1/10 of all service accounts in IT.
+            # So, if we make requests with client IDs, we make len(client_ids) requests. If we make requests without
+            # client IDs, we make ceil([# of service accounts in IT] / 100) requests. So, we should only pass client
+            # IDs if the number of IDs is less than 1/100 of all service accounts in IT.
             #
             # Unfortunately, we have no way to make an educated guess with only RBAC's database, since RBAC's database
             # is not necessarily in sync with IT. (For instance, at time of writing, stage has a tenant with ~7000
             # service accounts in RBAC's database but only 13 in IT.) So, we make a single request in order to
             # determine which strategy is better (by determining if the number of service accounts in IT is more than
-            # 10 times the number of client IDs).
+            # 100 times the number of client IDs).
             #
-            # As a special case, if we would have to make two or fewer requests using client IDs (i.e. if we care about
-            # fewer than 20 client IDs), then we can always just do that, since we'd always be making at least two
-            # requests anyway (one to see how many service accounts exist and at least one to actually fetch them).
+            # As a special case, if we would have to request at most two client IDs, then we can always just do that,
+            # since we'd always be making at least two requests anyway (one to see how many service accounts exist
+            # and at least one to actually fetch them).
 
-            use_remote_client_ids = len(
-                client_ids
-            ) <= 2 * IT_SERVICE_ACCOUNT_MAX_CLIENT_IDS or self._it_service_account_count_at_least(
+            use_remote_client_ids = len(client_ids) <= 2 or self._it_service_account_count_at_least(
                 bearer_token=bearer_token,
-                count=math.ceil(len(client_ids) / IT_SERVICE_ACCOUNT_MAX_CLIENT_IDS) * IT_SERVICE_ACCOUNT_BATCH_SIZE,
+                count=len(client_ids) * IT_SERVICE_ACCOUNT_BATCH_SIZE,
             )
 
             if use_remote_client_ids:
                 results: list[dict] = []
 
-                for batch in itertools.batched(client_ids, IT_SERVICE_ACCOUNT_MAX_CLIENT_IDS):
+                for client_id in client_ids:
                     results.extend(
-                        self._request_service_accounts_transformed(
-                            bearer_token=bearer_token,
-                            client_ids=list(batch),
-                        )
+                        self._request_service_accounts_transformed(bearer_token=bearer_token, client_id=client_id)
                     )
 
                 return results
@@ -162,35 +151,27 @@ class ITService:
                 # Request every service account and filter them locally.
                 return [
                     account
-                    for account in self._request_service_accounts_transformed(
-                        bearer_token=bearer_token, client_ids=None
-                    )
+                    for account in self._request_service_accounts_transformed(bearer_token=bearer_token)
                     if account["clientId"] in client_ids
                 ]
 
         # Here, we have no client IDs to worry about, so just request every service account.
-        return self._request_service_accounts_transformed(
-            bearer_token=bearer_token,
-            client_ids=None,
-        )
+        return self._request_service_accounts_transformed(bearer_token=bearer_token)
 
     def _request_service_accounts_raw(
-        self, bearer_token: str, client_ids: Optional[list[str]], offset: int, limit: int
+        self, bearer_token: str, client_id: Optional[str], offset: int, limit: int
     ) -> list[dict]:
         """
         Make a single request to IT's service accounts API and return the result.
 
-        This function does not perform any form of iteration or processing of the results. It assumes that its inputs
-        have already been validated. client_ids shall have size no greater than IT_SERVICE_ACCOUNT_MAX_CLIENT_IDS.
+        This function does not perform any form of iteration or processing of the results.
         """
         assert bearer_token
-        assert client_ids is None or len(client_ids) > 0
-        assert client_ids is None or len(client_ids) <= IT_SERVICE_ACCOUNT_MAX_CLIENT_IDS
 
         parameters: dict[str, int | list[str]] = {"first": offset, "max": limit}
 
-        if client_ids is not None:
-            parameters["clientId"] = client_ids
+        if client_id is not None:
+            parameters["clientId"] = [client_id]
 
         # Call IT.
         response = requests.get(
@@ -226,12 +207,11 @@ class ITService:
 
         return response_body
 
-    def _request_service_accounts_transformed(self, bearer_token: str, client_ids: Optional[list[str]]) -> list[dict]:
+    def _request_service_accounts_transformed(self, bearer_token: str, client_id: Optional[str] = None) -> list[dict]:
         """
         Request service accounts for a tenant and return the list that IT has (optionally filtering by client ID).
 
-        If client_ids is None, all service accounts are requested from IT. This assumes that bearer_token and client_ids
-        have already been validated. client_ids shall have size no greater than IT_SERVICE_ACCOUNT_MAX_CLIENT_IDS.
+        If client_id is None, all service accounts are requested from IT.
         """
         received_service_accounts: list[dict] = []
 
@@ -245,7 +225,7 @@ class ITService:
             while continue_fetching:
                 body_contents = self._request_service_accounts_raw(
                     bearer_token=bearer_token,
-                    client_ids=client_ids,
+                    client_id=client_id,
                     offset=offset,
                     limit=limit,
                 )
@@ -256,8 +236,12 @@ class ITService:
                 # Reassess if we need to keep fetching pages from IT. They don't return page metadata, so we need to
                 # keep looping until the incoming body is an empty array.
                 continue_fetching = limit == len(body_contents)
+
                 if continue_fetching:
                     offset = offset + len(body_contents)
+
+                if continue_fetching and (client_id is not None):
+                    raise AssertionError("Should not have to make multiple requests when a client ID is provided")
 
         except requests.exceptions.ConnectionError as exception:
             LOGGER.error(
@@ -302,7 +286,7 @@ class ITService:
         # safe because we have just ensured that count > 0.
 
         body_contents = self._request_service_accounts_raw(
-            bearer_token=bearer_token, client_ids=None, offset=(count - 1), limit=1
+            bearer_token=bearer_token, client_id=None, offset=(count - 1), limit=1
         )
 
         return len(body_contents) > 0

--- a/tests/management/principal/test_it_service.py
+++ b/tests/management/principal/test_it_service.py
@@ -319,24 +319,10 @@ class ITServiceTests(IdentityRequest):
         call_client_ids = call_params.pop("clientId", [])
         call_kwargs["params"] = call_params
 
+        self.assertLessEqual(len(call_client_ids), 1, "IT only supports requesting a single client ID.")
+
         client_ids_assert(call_client_ids)
-        self.assertEqual(kwargs, call_kwargs, "Incorrect keyword arugments for call.")
-
-    def _assert_service_account_mock_called(self, mock: mock.Mock, *args, **kwargs):
-        """Assert that a mock has a call to IT's service accounts endpoint is as expected."""
-        if "params" in kwargs and "clientId" in kwargs["params"]:
-            # We do not care about the order of client IDs.
-
-            actual_client_ids = mock.call_args.kwargs["params"]["clientId"]
-
-            self.assertCountEqual(actual_client_ids, kwargs["params"]["clientId"], "Client IDs did not match call.")
-
-            # Now that the IDs have been verified, just make the expectation match reality.
-            kwargs = dict(kwargs)
-            kwargs["params"] = dict(kwargs["params"])
-            kwargs["params"]["clientId"] = actual_client_ids
-
-        mock.assert_called_with(*args, **kwargs)
+        self.assertEqual(kwargs, call_kwargs, "Incorrect keyword arguments for call.")
 
     class FakeIT:
         _service_accounts: list[dict]
@@ -353,8 +339,11 @@ class ITServiceTests(IdentityRequest):
             raw_client_ids = kwargs["params"].get("clientId", [])
 
             if raw_client_ids:
-                client_ids = set(raw_client_ids)
-                filtered = [account for account in self._service_accounts if account["clientId"] in client_ids]
+                if len(raw_client_ids) > 1:
+                    raise ValueError(f"Only a single clientId is supported, but got: {raw_client_ids}")
+
+                client_id = raw_client_ids[0]
+                filtered = [account for account in self._service_accounts if account["clientId"] == client_id]
             else:
                 filtered = self._service_accounts
 
@@ -371,21 +360,14 @@ class ITServiceTests(IdentityRequest):
         """Test that the function under test can handle fetching a single page of service accounts from IT"""
         # Create a fake IT service with service accounts.
         mocked_service_accounts = self._create_mock_it_service_accounts(5)
-        requested_service_accounts = mocked_service_accounts[0:3]
 
         get.__name__ = "get"
         get.side_effect = ITServiceTests.FakeIT(mocked_service_accounts).get
 
         bearer_token_mock = "bearer-token-mock"
 
-        # client_ids being small means that this will trigger the fast path in request_service_accounts, and only a
-        # single request will be made.
-        client_ids = [account["clientId"] for account in requested_service_accounts]
-
         # Call the function under test.
-        result: list[dict] = self.it_service.request_service_accounts(
-            bearer_token=bearer_token_mock, client_ids=client_ids
-        )
+        result: list[dict] = self.it_service.request_service_accounts(bearer_token=bearer_token_mock)
 
         # Build IT's URL for the function call's assertion.
         it_url = (
@@ -394,11 +376,10 @@ class ITServiceTests(IdentityRequest):
         )
 
         # Build the expected parameters to be seen in the "get" function's assertion call.
-        parameters = {"first": 0, "max": 100, "clientId": client_ids}
+        parameters = {"first": 0, "max": 100}
 
         # Assert that the "get" function was called with the expected arguments.
-        self._assert_service_account_mock_called(
-            get,
+        get.assert_called_with(
             url=it_url,
             headers={"Authorization": f"Bearer {bearer_token_mock}"},
             params=parameters,
@@ -407,7 +388,7 @@ class ITServiceTests(IdentityRequest):
 
         # Assert that the payload is correct.
         self._assert_IT_to_RBAC_model_transformations(
-            it_service_accounts=requested_service_accounts, rbac_service_accounts=result
+            it_service_accounts=mocked_service_accounts, rbac_service_accounts=result
         )
 
     @mock.patch("management.principal.it_service.requests.get")
@@ -415,18 +396,18 @@ class ITServiceTests(IdentityRequest):
         """Test that the function under test uses client IDs when few service accounts are needed."""
         # Create a fake IT service with service accounts.
         mocked_service_accounts = self._create_mock_it_service_accounts(400)
-        requested_service_accounts = mocked_service_accounts[0:5]
+        requested_service_accounts = mocked_service_accounts[0:2]
 
         get.__name__ = "get"
         get.side_effect = ITServiceTests.FakeIT(mocked_service_accounts).get
 
         bearer_token_mock = "bearer-token-mock"
 
-        # Request several additional client IDs to ensure they are properly filtered out.
-        # Ensure the total count is greater than 20 to avoid the fast path.
-        # Ensure the total count is fewer than 40 so that client IDs are used (rather than requesting all accounts).
+        # Request some additional client IDs to ensure they are properly filtered out.
+        # Ensure the total count is greater than 2 to avoid the fast path.
+        # Ensure the total count is at most 4 so that client IDs are used (rather than requesting all accounts).
         client_ids = [account["clientId"] for account in requested_service_accounts] + [
-            str(uuid.uuid4()) for _ in range(20)
+            str(uuid.uuid4()) for _ in range(2)
         ]
 
         # Call the function under test.
@@ -440,16 +421,16 @@ class ITServiceTests(IdentityRequest):
             f"{settings.IT_SERVICE_BASE_PATH}{IT_PATH_GET_SERVICE_ACCOUNTS}"
         )
 
-        # We expect one call to determine what strategy to use, then three additional calls to request actual data.
+        # We expect one call to determine what strategy to use, then four additional calls to request actual data.
         calls = get.call_args_list
-        self.assertEqual(4, len(calls))
+        self.assertEqual(5, len(calls))
 
         # Check for the initial call to determine how many service accounts exist.
         self._assert_service_account_call(
             call=calls[0],
             url=it_url,
             headers={"Authorization": f"Bearer {bearer_token_mock}"},
-            params={"first": 299, "max": 1},
+            params={"first": 399, "max": 1},
             timeout=settings.IT_SERVICE_TIMEOUT_SECONDS,
             client_ids_assert=lambda call_client_ids: self.assertEqual([], call_client_ids),
         )
@@ -486,21 +467,21 @@ class ITServiceTests(IdentityRequest):
 
     @mock.patch("management.principal.it_service.requests.get")
     def test_request_service_accounts_client_ids_large(self, get: mock.Mock):
-        """Test that the function under test uses client IDs when many service accounts are needed."""
+        """Test that the function under test does not use client IDs when many service accounts are needed."""
         # Create a fake IT service with service accounts.
         mocked_service_accounts = self._create_mock_it_service_accounts(400)
-        requested_service_accounts = mocked_service_accounts[0:5]
+        requested_service_accounts = mocked_service_accounts[0:3]
 
         get.__name__ = "get"
         get.side_effect = ITServiceTests.FakeIT(mocked_service_accounts).get
 
         bearer_token_mock = "bearer-token-mock"
 
-        # Request several additional client IDs to ensure they are properly filtered out.
-        # Ensure the total count is greater than 20 to avoid the fast path.
-        # Ensure the total count is greater than 40 so that all service accounts are requested.
+        # Request some additional client IDs to ensure they are properly filtered out.
+        # Ensure the total count is greater than 2 to avoid the fast path.
+        # Ensure the total count is greater than 4 so that all service accounts are requested.
         client_ids = [account["clientId"] for account in requested_service_accounts] + [
-            str(uuid.uuid4()) for _ in range(40)
+            str(uuid.uuid4()) for _ in range(2)
         ]
 
         # Call the function under test.
@@ -639,11 +620,10 @@ class ITServiceTests(IdentityRequest):
         )
 
         bearer_token_mock = "bearer-token-mock"
-        client_ids = [str(uuid.uuid4()), str(uuid.uuid4()), str(uuid.uuid4())]
 
         # Call the function under test.
         try:
-            self.it_service.request_service_accounts(bearer_token=bearer_token_mock, client_ids=client_ids)
+            self.it_service.request_service_accounts(bearer_token=bearer_token_mock)
             self.fail("the function under test should have raised an exception on an unexpected status code")
         except Exception as e:
             self.assertIsInstance(
@@ -659,11 +639,10 @@ class ITServiceTests(IdentityRequest):
         )
 
         # Build the expected parameters to be seen in the "get" function's assertion call.
-        parameters = {"first": 0, "max": 100, "clientId": client_ids}
+        parameters = {"first": 0, "max": 100}
 
         # Assert that the "get" function was called with the expected arguments.
-        self._assert_service_account_mock_called(
-            get,
+        get.assert_called_with(
             url=it_url,
             headers={"Authorization": f"Bearer {bearer_token_mock}"},
             params=parameters,
@@ -677,11 +656,10 @@ class ITServiceTests(IdentityRequest):
         get.side_effect = requests.exceptions.ConnectionError
 
         bearer_token_mock = "bearer-token-mock"
-        client_ids = [str(uuid.uuid4()), str(uuid.uuid4()), str(uuid.uuid4())]
 
         # Call the function under test.
         try:
-            self.it_service.request_service_accounts(bearer_token=bearer_token_mock, client_ids=client_ids)
+            self.it_service.request_service_accounts(bearer_token=bearer_token_mock)
             self.fail(
                 "the function under test should have raised an exception when hitting a connection error with IT"
             )
@@ -699,11 +677,10 @@ class ITServiceTests(IdentityRequest):
         )
 
         # Build the expected parameters to be seen in the "get" function's assertion call.
-        parameters = {"first": 0, "max": 100, "clientId": client_ids}
+        parameters = {"first": 0, "max": 100}
 
         # Assert that the "get" function was called with the expected arguments.
-        self._assert_service_account_mock_called(
-            get,
+        get.assert_called_with(
             url=it_url,
             headers={"Authorization": f"Bearer {bearer_token_mock}"},
             params=parameters,
@@ -717,11 +694,10 @@ class ITServiceTests(IdentityRequest):
         get.side_effect = requests.exceptions.Timeout
 
         bearer_token_mock = "bearer-token-mock"
-        client_ids = [str(uuid.uuid4()), str(uuid.uuid4()), str(uuid.uuid4())]
 
         # Call the function under test.
         try:
-            self.it_service.request_service_accounts(bearer_token=bearer_token_mock, client_ids=client_ids)
+            self.it_service.request_service_accounts(bearer_token=bearer_token_mock)
             self.fail("the function under test should have raised an exception when having a timeout with IT")
         except Exception as e:
             self.assertIsInstance(
@@ -737,11 +713,10 @@ class ITServiceTests(IdentityRequest):
         )
 
         # Build the expected parameters to be seen in the "get" function's assertion call.
-        parameters = {"first": 0, "max": 100, "clientId": client_ids}
+        parameters = {"first": 0, "max": 100}
 
         # Assert that the "get" function was called with the expected arguments.
-        self._assert_service_account_mock_called(
-            get,
+        get.assert_called_with(
             url=it_url,
             headers={"Authorization": f"Bearer {bearer_token_mock}"},
             params=parameters,


### PR DESCRIPTION
## Link(s) to Jira
[RHCLOUD-32232](https://redhat.atlassian.net/browse/RHCLOUD-32232)

## Description of Intent of Change(s)
Per [this Slack thread](https://redhat-internal.slack.com/archives/C03KZTC324T/p1785443758176259), SSO no longer supports looking up multiple `clientId`s at once, so we need to request them one-by-one instead.

[RHCLOUD-32232]: https://redhat.atlassian.net/browse/RHCLOUD-32232?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved service-account retrieval for requests involving specific client IDs.
  * Enhanced filtering and pagination behavior for small and large client selections.
  * Improved handling of status errors, connection failures, and request timeouts.
  * Updated request validation to prevent unsupported multi-client queries and provide more consistent results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->