### PR TITLE
[RHCLOUD-49510] Add feature flag gate for V2 read operations

### DIFF
--- a/rbac/feature_flags.py
+++ b/rbac/feature_flags.py
@@ -41,8 +41,10 @@ class FeatureFlags:
     TOGGLE_WORKSPACE_ACCESS_CHECK_V2 = "rbac.workspace-access-check-v2.enabled"
     # When enabled, use 'role_binding_view' permission; when disabled, use 'view' permission for role binding access.
     TOGGLE_USE_ROLE_BINDING_VIEW_PERMISSION = "rbac.use-role-binding-view-permission.enabled"
-    # Per-org flag: when enabled, the org uses v2 APIs for write operations and v1 write APIs are blocked.
+    # Per-org flag: when enabled, the org uses V2 APIs for write operations and V1 write APIs are blocked.
     TOGGLE_V2_EDIT_API_ENABLED = "platform.rbac.workspaces"
+    # Per-org flag: when enabled, the org can use V2 APIs for read operations.
+    TOGGLE_V2_READ_API_ENABLED = "hbi.rbac-v2"
 
     def __init__(self):
         """Add attributes."""
@@ -168,11 +170,28 @@ class FeatureFlags:
             fallback_function=lambda ignored_toggle_name, ignored_context: settings.USE_ROLE_BINDING_VIEW_PERMISSION,
         )
 
+    def is_v2_read_api_enabled(self, org_id: str) -> bool:
+        """Check whether v2 read APIs are enabled for the given org.
+
+        When enabled, the org can use V2 read APIs. When disabled, the org generally cannot. (See RequiresV2OptIn for
+        the relevant exceptions.)
+
+        Uses orgId in context to match Unleash strategy constraints (contextName: orgId).
+        """
+        return self.is_enabled(
+            feature_name=self.TOGGLE_V2_READ_API_ENABLED,
+            context={"orgId": str(org_id)},
+            fallback_function=lambda ignored_toggle_name, ignored_context: settings.V2_APIS_ENABLED,
+        )
+
     def is_v2_edit_api_enabled(self, org_id: str) -> bool:
         """Check whether v2 write APIs are enabled for the given org.
 
-        When enabled, the org should use v2 APIs and v1 write operations are blocked.
-        When disabled, the org should use v1 APIs and v2 write operations are blocked.
+        When enabled, the org should use V2 write APIs, and V1 write operations are blocked.
+        When disabled, the org should generally use V1 write APIs, and V2 write operations are generally blocked. (See
+        RequiresV2OptIn for the relevant exceptions.)
+
+        It is assumed that the TOGGLE_V2_EDIT_API_ENABLED flag will be set whenever TOGGLE_V2_READ_API_ENABLED is set.
 
         Uses orgId in context to match Unleash strategy constraints (contextName: orgId).
         """

--- a/rbac/management/permissions/v2_edit_api_access.py
+++ b/rbac/management/permissions/v2_edit_api_access.py
@@ -30,12 +30,14 @@ from rest_framework import permissions
 logger = logging.getLogger(__name__)
 
 
+def is_v2_read_enabled_for_request(request) -> bool:
+    """Check if V2 read API is enabled via feature flag OR DB activation state."""
+    return is_v2_write_activated(request.tenant) or FEATURE_FLAGS.is_v2_read_api_enabled(request.user.org_id)
+
+
 def is_v2_edit_enabled_for_request(request) -> bool:
     """Check if V2 edit API is enabled via feature flag OR DB activation state."""
-    if FEATURE_FLAGS.is_v2_edit_api_enabled(request.user.org_id):
-        return True
-
-    return is_v2_write_activated(request.tenant)
+    return is_v2_write_activated(request.tenant) or FEATURE_FLAGS.is_v2_edit_api_enabled(request.user.org_id)
 
 
 class V1WriteBlockedWhenWorkspacesEnabled(permissions.BasePermission):
@@ -105,37 +107,41 @@ class V1ApiBlockedWhenWorkspacesEnabled(permissions.BasePermission):
         return True
 
 
-class V2WriteRequiresWorkspacesEnabled(permissions.BasePermission):
-    """Deny V2 write operations when workspaces (v2 edit API) is NOT enabled for the org.
+class RequiresV2OptIn(permissions.BasePermission):
+    """Deny V2 operations when an org is not opted-in to them.
 
-    Checks both the feature flag and the DB activation state. A tenant that has already
-    written via V2 must remain able to do so even if the feature flag is later disabled;
-    otherwise they would be locked out of both V1 (permanently blocked by assert_v1_write_allowed)
-    and V2 (blocked here).
+    Read and write operations are controlled by different feature flags: see FeatureFlags.is_v2_read_api_enabled and
+    FeatureFlags.is_v2_edit_api_enabled.
 
-    Add to V2 viewsets (RoleV2ViewSet, RoleBindingViewSet) to block write requests
-    for orgs that have not been migrated to workspaces.
+    Notwithstanding whether the feature flag is enabled, this permission will always allow tenants for which
+    TenantMapping.v2_write_activated_at is set, since such a tenant can no longer use the V1 API.
     """
 
-    message = "V2 write operations require the workspaces feature to be enabled for this org."
+    message = "V2 operations require the org to have opted-in."
 
     def has_permission(self, request, view):
         """Allow reads always; deny writes when v2 edit API is disabled for this org."""
-        if request.method in permissions.SAFE_METHODS:
-            return True
-        if not is_v2_edit_enabled_for_request(request):
-            # Authorization failure - SEC-MON-REQ-1 compliance (EOI-8 authorization_failure)
-            logger.warning(
-                "Authorization denied",
-                extra={
-                    "action": request.method,
-                    "resource_type": view.basename if hasattr(view, "basename") else "unknown",
-                    "outcome": "failure",
-                    "org_id": getattr(request.user, "org_id", None),
-                    "username": getattr(request.user, "username", None),
-                    "reason": "v2_write_requires_workspaces_enabled",
-                    "endpoint": request.path,
-                },
-            )
-            return False
-        return True
+        is_write = request.method not in permissions.SAFE_METHODS
+
+        if is_write:
+            if is_v2_edit_enabled_for_request(request):
+                return True
+        else:
+            if is_v2_read_enabled_for_request(request):
+                return True
+
+        # Authorization failure - SEC-MON-REQ-1 compliance (EOI-8 authorization_failure)
+        logger.warning(
+            "Authorization denied",
+            extra={
+                "action": request.method,
+                "resource_type": view.basename if hasattr(view, "basename") else "unknown",
+                "outcome": "failure",
+                "org_id": getattr(request.user, "org_id", None),
+                "username": getattr(request.user, "username", None),
+                "reason": "v2_write_requires_workspaces_enabled" if is_write else "v2_read_requires_api_enabled",
+                "endpoint": request.path,
+            },
+        )
+
+        return False

--- a/rbac/management/role/v2_view.py
+++ b/rbac/management/role/v2_view.py
@@ -23,7 +23,7 @@ from management.audit_log.model import AuditLog
 from management.base_viewsets import BaseV2ViewSet
 from management.notifications.notification_handlers import custom_v2_role_obj_change_notification_handler
 from management.permissions.role_v2_access import RoleV2KesselAccessPermission
-from management.permissions.v2_edit_api_access import V2WriteRequiresWorkspacesEnabled
+from management.permissions.v2_edit_api_access import RequiresV2OptIn
 from management.role.v2_exceptions import CustomRoleRequiredError, RolesNotFoundError
 from management.role.v2_model import RoleV2
 from management.role.v2_serializer import (
@@ -56,7 +56,7 @@ class RoleV2CursorPagination(V2CursorPagination):
 class RoleV2ViewSet(AtomicOperationsMixin, BaseV2ViewSet):
     """RoleV2 ViewSet."""
 
-    permission_classes = (RoleV2KesselAccessPermission, V2WriteRequiresWorkspacesEnabled)
+    permission_classes = (RoleV2KesselAccessPermission, RequiresV2OptIn)
     queryset = RoleV2.objects.exclude(type=RoleV2.Types.PLATFORM)
     serializer_class = RoleV2ResponseSerializer
     pagination_class = RoleV2CursorPagination

--- a/rbac/management/role_binding/view.py
+++ b/rbac/management/role_binding/view.py
@@ -25,7 +25,7 @@ from management.permissions.role_binding_access import (
     RoleBindingKesselAccessPermission,
     RoleBindingSystemUserAccessPermission,
 )
-from management.permissions.v2_edit_api_access import V2WriteRequiresWorkspacesEnabled
+from management.permissions.v2_edit_api_access import RequiresV2OptIn
 from management.v2_mixins import AtomicOperationsMixin
 from rest_framework import status
 from rest_framework.decorators import action
@@ -71,7 +71,7 @@ class RoleBindingViewSet(AtomicOperationsMixin, BaseV2ViewSet):
     permission_classes = (
         RoleBindingSystemUserAccessPermission,
         RoleBindingKesselAccessPermission,
-        V2WriteRequiresWorkspacesEnabled,
+        RequiresV2OptIn,
     )
     pagination_class = V2CursorPagination
 

--- a/tests/management/role/test_v2_view.py
+++ b/tests/management/role/test_v2_view.py
@@ -19,17 +19,13 @@
 import uuid
 from collections.abc import Iterable
 from importlib import reload
-from urllib.parse import urlencode
 from unittest.mock import ANY, patch
+from urllib.parse import urlencode
 
 from django.conf import settings
 from django.test import override_settings
 from django.urls import clear_url_caches, reverse
 from django.utils.dateparse import parse_datetime
-from rest_framework import status
-from rest_framework.test import APIClient
-
-from api.models import Tenant
 from management import v2_urls
 from management.audit_log.model import AuditLog
 from management.models import Permission, Workspace
@@ -40,11 +36,16 @@ from management.role.definer import seed_roles
 from management.role.v2_model import CustomRoleV2, PlatformRoleV2, RoleV2, SeededRoleV2
 from management.role.v2_role_scope import v2_role_excluded_application_permission_ids_cache
 from management.role.v2_service import RoleV2Service
+from management.tenant_mapping.v2_activation import ensure_v2_write_activated
 from management.tenant_service import V2TenantBootstrapService
 from management.utils import PRINCIPAL_CACHE, as_uuid
-from rbac import urls
+from rest_framework import status
+from rest_framework.test import APIClient
 from tests.identity_request import IdentityRequest
 from tests.v2_util import bootstrap_tenant_for_v2_test
+
+from api.models import Tenant
+from rbac import urls
 
 CACHE_PATCH_TARGET = "management.role.v2_service.permission_scope_cache"
 
@@ -955,6 +956,20 @@ class RoleV2ViewSetTests(IdentityRequest):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["data"], [])
 
+    @patch("management.permissions.v2_edit_api_access.FEATURE_FLAGS.is_v2_read_api_enabled", return_value=False)
+    def test_list_blocked_when_feature_flag_disabled(self, mock_is_v2_read_api_enabled):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertIn("opted-in", str(response.data).lower())
+        mock_is_v2_read_api_enabled.assert_called_once_with(self.customer_data["org_id"])
+
+    @patch("management.permissions.v2_edit_api_access.FEATURE_FLAGS.is_v2_read_api_enabled", return_value=False)
+    def test_list_permitted_when_v2_written(self, mock_is_v2_read_api_enabled):
+        ensure_v2_write_activated(self.tenant)
+
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
     # ==========================================================================
     # Tests for GET /api/v2/roles/?resource_type=... (list with resource_type)
     # ==========================================================================
@@ -1228,7 +1243,7 @@ class RoleV2ViewSetTests(IdentityRequest):
         }
         response = self.client.post(self.url, data, format="json")
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-        self.assertIn("workspaces", str(response.data).lower())
+        self.assertIn("opted-in", str(response.data).lower())
         mock_is_v2_edit_enabled.assert_called_once_with(self.customer_data["org_id"])
 
     @override_settings(NOTIFICATIONS_ENABLED=True)

--- a/tests/management/role_binding/test_view.py
+++ b/tests/management/role_binding/test_view.py
@@ -30,28 +30,30 @@ from django.test.utils import override_settings
 from django.urls import clear_url_caches, reverse
 from django.utils import timezone
 from django.utils.dateparse import parse_datetime
-from rest_framework import status
-from rest_framework.test import APIClient
-
-from api.models import Tenant
 from management.audit_log.model import AuditLog
 from management.group.definer import seed_group
 from management.group.platform import GlobalPolicyIdService
 from management.models import Group, Permission, Principal, Workspace
-from management.utils import PROBLEM_TYPES
 from management.permission.scope_service import Scope
 from management.role.definer import seed_roles
 from management.role.platform import platform_v2_role_uuid_for
 from management.role.v2_model import PlatformRoleV2, RoleV2, SeededRoleV2
 from management.role.v2_service import RoleV2Service
 from management.role_binding.model import RoleBinding, RoleBindingGroup, RoleBindingPrincipal
-from management.role_binding.service import RoleBindingService, API_PRINCIPAL_SOURCE
+from management.role_binding.service import API_PRINCIPAL_SOURCE, RoleBindingService
 from management.subject import SubjectType
 from management.tenant_mapping.model import DefaultAccessType, TenantMapping
+from management.tenant_mapping.v2_activation import ensure_v2_write_activated
 from management.tenant_service.v2 import V2TenantBootstrapService
+from management.utils import PROBLEM_TYPES
 from migration_tool.in_memory_tuples import InMemoryRelationReplicator
-from rbac import urls
+from rest_framework import status
+from rest_framework.test import APIClient
 from tests.identity_request import IdentityRequest, TransactionalIdentityRequest
+from tests.v2_util import bootstrap_tenant_for_v2_test
+
+from api.models import Tenant
+from rbac import urls
 
 
 def _coerce_api_datetime(value):
@@ -85,18 +87,11 @@ class RoleBindingListViewSetTest(IdentityRequest):
         super().setUp()
         self.client = APIClient()
 
-        # Create workspace hierarchy (root -> default -> standard)
-        self.root_workspace = Workspace.objects.create(
-            name=Workspace.SpecialNames.ROOT,
-            tenant=self.tenant,
-            type=Workspace.Types.ROOT,
-        )
-        self.default_workspace = Workspace.objects.create(
-            name=Workspace.SpecialNames.DEFAULT,
-            tenant=self.tenant,
-            type=Workspace.Types.DEFAULT,
-            parent=self.root_workspace,
-        )
+        bootstrap_result = bootstrap_tenant_for_v2_test(self.tenant)
+
+        self.default_workspace = bootstrap_result.default_workspace
+        self.root_workspace = bootstrap_result.root_workspace
+
         self.workspace = Workspace.objects.create(
             name="Test Workspace",
             description="Test workspace description",
@@ -403,6 +398,19 @@ class RoleBindingListViewSetTest(IdentityRequest):
             other_binding.delete()
             other_role.delete()
             other_tenant.delete()
+
+    @patch("management.permissions.v2_edit_api_access.FEATURE_FLAGS.is_v2_read_api_enabled", return_value=False)
+    def test_list_blocked_when_feature_flag_disabled(self, mock_is_v2_read_api_enabled):
+        response = self.client.get(self._get_list_url(), **self.headers)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertIn("opted-in", str(response.data))
+
+    @patch("management.permissions.v2_edit_api_access.FEATURE_FLAGS.is_v2_read_api_enabled", return_value=False)
+    def test_list_allowed_when_v2_written(self, mock_is_v2_read_api_enabled):
+        ensure_v2_write_activated(self.tenant)
+
+        response = self.client.get(self._get_list_url(), **self.headers)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     # --- Functional: verify actual data content ---
 
@@ -2012,6 +2020,37 @@ class RoleBindingViewSetTest(IdentityRequest):
         )
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    @patch(
+        "management.permissions.role_binding_access.RoleBindingKesselAccessPermission.has_permission",
+        return_value=True,
+    )
+    @patch("management.permissions.v2_edit_api_access.FEATURE_FLAGS.is_v2_read_api_enabled", return_value=False)
+    def test_by_subject_blocked_when_feature_flag_disabled(self, *args):
+        url = self._get_by_subject_url()
+        response = self.client.get(
+            f"{url}?resource_id={self.workspace.id}&resource_type=workspace",
+            **self.headers,
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertIn("opted-in", str(response.data))
+
+    @patch(
+        "management.permissions.role_binding_access.RoleBindingKesselAccessPermission.has_permission",
+        return_value=True,
+    )
+    @patch("management.permissions.v2_edit_api_access.FEATURE_FLAGS.is_v2_read_api_enabled", return_value=False)
+    def test_by_subject_allowed_when_v2_written(self, *args):
+        ensure_v2_write_activated(self.tenant)
+
+        url = self._get_by_subject_url()
+        response = self.client.get(
+            f"{url}?resource_id={self.workspace.id}&resource_type=workspace",
+            **self.headers,
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     # Ordering tests using dot notation
 


### PR DESCRIPTION
## Link(s) to Jira
[RHCLOUD-49510](https://redhat.atlassian.net/browse/RHCLOUD-49510)

## Description of Intent of Change(s)
Currently, V2 write operations are gated behind an Unleash flag; here, we additionally gate V2 read operations behind a separate flag.

[RHCLOUD-49510]: https://redhat.atlassian.net/browse/RHCLOUD-49510?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ