### PR TITLE
[RHCLOUD-48737] Deleted workspace re-replication fixes

### DIFF
--- a/rbac/internal/migrations/replicate_workspaces.py
+++ b/rbac/internal/migrations/replicate_workspaces.py
@@ -262,5 +262,13 @@ def replicate_deleted_workspaces(since: datetime.datetime, replicator: Optional[
         created__gte=since, resource_type="workspace", action="delete", resource_uuid__isnull=False
     )
 
+    total_count = delete_logs.count()
+    logger.info(f"About to replicate the deletion of ~{total_count} workspaces.")
+
+    replicated_count = 0
+
     for batch in itertools.batched(delete_logs.iterator(), 500):
         _replicate_deleted_batch(replicator, [_DeletedWorkspaceEntry(l.tenant_id, l.resource_uuid) for l in batch])
+
+        replicated_count += len(batch)
+        logger.info(f"Replicated the deletion of {replicated_count}/~{total_count} workspaces.")

--- a/rbac/internal/migrations/replicate_workspaces.py
+++ b/rbac/internal/migrations/replicate_workspaces.py
@@ -222,7 +222,7 @@ def replicate_updated_workspaces(
     )
 
 
-@dataclasses.dataclass()
+@dataclasses.dataclass(frozen=True)
 class _DeletedWorkspaceEntry:
     tenant_id: int
     workspace_id: uuid.UUID

--- a/rbac/internal/migrations/replicate_workspaces.py
+++ b/rbac/internal/migrations/replicate_workspaces.py
@@ -226,6 +226,7 @@ def replicate_updated_workspaces(
 class _DeletedWorkspaceEntry:
     tenant_id: int
     workspace_id: uuid.UUID
+    workspace_name: str
 
     def __post_init__(self):
         if not isinstance(self.tenant_id, int):
@@ -233,6 +234,9 @@ class _DeletedWorkspaceEntry:
 
         if not isinstance(self.workspace_id, uuid.UUID):
             raise TypeError(f"Expected workspace_id to be a UUID, but got: {self.workspace_id!r}")
+
+        if not isinstance(self.workspace_name, str):
+            raise TypeError(f"Expected workspace_name to be a string, but got: {self.workspace_name}")
 
 
 @atomic_with_retry(retries=5)
@@ -249,9 +253,25 @@ def _replicate_deleted_batch(replicator: RelationReplicator, entries: list[_Dele
 
     for entry in entries:
         replicator.replicate_workspace(
-            make_workspace_id_deleted_event(tenant=tenants_by_id[entry.tenant_id], workspace_id=entry.workspace_id),
+            make_workspace_id_deleted_event(
+                tenant=tenants_by_id[entry.tenant_id],
+                workspace_id=entry.workspace_id,
+                workspace_name=entry.workspace_name,
+            ),
             WorkspaceEventStream.BULK,
         )
+
+
+_deleted_workspace_prefix = "Deleted workspace: "
+
+
+def _extract_deleted_workspace_name(log: AuditLog) -> str:
+    description: str = log.description
+
+    if description.startswith(_deleted_workspace_prefix):
+        return description[len(_deleted_workspace_prefix) :]
+
+    return f"[deleted workspace {log.resource_uuid}]"
 
 
 def replicate_deleted_workspaces(since: datetime.datetime, replicator: Optional[RelationReplicator] = None):
@@ -268,7 +288,17 @@ def replicate_deleted_workspaces(since: datetime.datetime, replicator: Optional[
     replicated_count = 0
 
     for batch in itertools.batched(delete_logs.iterator(), 500):
-        _replicate_deleted_batch(replicator, [_DeletedWorkspaceEntry(l.tenant_id, l.resource_uuid) for l in batch])
+        _replicate_deleted_batch(
+            replicator,
+            [
+                _DeletedWorkspaceEntry(
+                    tenant_id=log.tenant_id,
+                    workspace_id=log.resource_uuid,
+                    workspace_name=_extract_deleted_workspace_name(log),
+                )
+                for log in batch
+            ],
+        )
 
         replicated_count += len(batch)
         logger.info(f"Replicated the deletion of {replicated_count}/~{total_count} workspaces.")

--- a/rbac/management/workspace/utils/event.py
+++ b/rbac/management/workspace/utils/event.py
@@ -46,14 +46,16 @@ def make_workspace_event(workspace: Workspace, event_type: ReplicationEventType)
     )
 
 
-def make_workspace_id_deleted_event(tenant: Tenant, workspace_id: uuid.UUID | str) -> WorkspaceEvent:
+def make_workspace_id_deleted_event(
+    tenant: Tenant, workspace_id: uuid.UUID | str, workspace_name: str
+) -> WorkspaceEvent:
     """Create a WorkspaceEvent for deleting a workspace with the provided ID and tenant."""
     workspace_id = str(as_uuid(workspace_id))
 
     return WorkspaceEvent(
         account_number=tenant.account_id,
         org_id=str(tenant.org_id),
-        workspace={"id": workspace_id},
+        workspace={"id": workspace_id, "name": workspace_name},
         event_type=ReplicationEventType.DELETE_WORKSPACE,
         partition_key=PartitionKey.byEnvironment(),
     )

--- a/tests/internal/migrations/test_replicate_workspaces.py
+++ b/tests/internal/migrations/test_replicate_workspaces.py
@@ -200,35 +200,35 @@ class ReplicateDeletedWorkspacesTest(DualWriteTestCase):
         AuditLog.objects.all().delete()
         self.service = WorkspaceService(NoopReplicator())
 
-    def _make_delete_log(self) -> AuditLog:
-        workspace = self.service.create({"name": "a workspace"}, self.tenant)
+    def _make_delete_log(self, name: str) -> AuditLog:
+        workspace = self.service.create({"name": name}, self.tenant)
 
         mock_request = MagicMock()
         mock_request.user.username = "test_user"
         mock_request._user.org_id = self.tenant.org_id
 
         create_log = AuditLog()
-        create_log.log_v2(mock_request, "workspace", AuditLog.CREATE, workspace.id, "")
+        create_log.log_v2(mock_request, "workspace", AuditLog.CREATE, workspace.id, f"Created workspace: {name}")
 
         delete_log = AuditLog()
-        delete_log.log_v2(mock_request, "workspace", AuditLog.DELETE, workspace.id, "")
+        delete_log.log_v2(mock_request, "workspace", AuditLog.DELETE, workspace.id, f"Deleted workspace: {name}")
 
         self.service.destroy(workspace)
         return delete_log
 
     def test_remove(self):
-        log_a = self._make_delete_log()
-        log_b = self._make_delete_log()
+        log_a = self._make_delete_log("a")
+        log_b = self._make_delete_log("b")
 
         self.assertGreater(log_b.created, log_a.created)
 
-        def test_replicate_from(since: datetime.datetime, ids: list[uuid.UUID]):
+        def test_replicate_from(since: datetime.datetime, entries: list[tuple[uuid.UUID, str]]):
             replicator = WorkspaceCacheReplicator(NoopReplicator())
             replicate_deleted_workspaces(since=since, replicator=replicator)
 
             events = replicator.workspace_events_for(WorkspaceEventStream.BULK)
 
-            self.assertCountEqual([{"id": str(u)} for u in ids], [e.workspace for e in events])
+            self.assertCountEqual([{"id": str(e[0]), "name": e[1]} for e in entries], [e.workspace for e in events])
 
             self.assertTrue(all(e.org_id == self.tenant.org_id for e in events))
             self.assertTrue(all(e.account_number == self.tenant.account_id for e in events))
@@ -236,12 +236,12 @@ class ReplicateDeletedWorkspacesTest(DualWriteTestCase):
 
             self.assertCountEqual([], replicator.workspace_events_for(WorkspaceEventStream.STANDARD))
 
-        test_replicate_from(log_a.created, [log_a.resource_uuid, log_b.resource_uuid])
-        test_replicate_from(log_b.created, [log_b.resource_uuid])
+        test_replicate_from(log_a.created, [(log_a.resource_uuid, "a"), (log_b.resource_uuid, "b")])
+        test_replicate_from(log_b.created, [(log_b.resource_uuid, "b")])
         test_replicate_from(log_b.created + datetime.timedelta(minutes=1), [])
 
     def test_error_on_reused_id(self):
-        log = self._make_delete_log()
+        log = self._make_delete_log("workspace")
 
         Workspace.objects.create(
             tenant=self.tenant,


### PR DESCRIPTION
## Link(s) to Jira
[RHCLOUD-48737](https://redhat.atlassian.net/browse/RHCLOUD-48737)

## Description of Intent of Change(s)
Primarily, include the name of the workspace in the deletion event. (We currently do not, and HBI just errors while parsing the message.)

Secondarily, some other small fixes (including adding logging).

[RHCLOUD-48737]: https://redhat.atlassian.net/browse/RHCLOUD-48737?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deleted workspace events now include the workspace name.
  * Workspace replication displays progress for total and newly processed entries.
  * Workspace names are recovered from audit records, with a fallback label when unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->